### PR TITLE
more fixes and optimisations for voice sims

### DIFF
--- a/.cursor/rules/app-details.md
+++ b/.cursor/rules/app-details.md
@@ -347,8 +347,8 @@ Full end-to-end voice pipeline testing with STT, LLM, and TTS components.
 ```
 simulation_persona_N_scenario_M/
 ├── audios/
-│   ├── 0_user.wav
 │   ├── 1_bot.wav
+│   ├── 2_user.wav
 │   └── ...
 ├── transcript.json
 ├── evaluation_results.csv   # Includes latency metrics + STT judge
@@ -1296,7 +1296,7 @@ Config builder functions (`buildTestsConfig`, `buildTextSimConfig`, `buildVoiceS
 
 - All audio must be WAV format
 - STT input audio should match the file names in `stt.csv`
-- Voice simulation audio uses 1-based indexing: `1_user.wav`, `1_bot.wav`, etc.
+- Voice simulation audio uses a single 1-based index that matches transcript order across speakers: `1_bot.wav`, `2_user.wav`, `3_bot.wav`, `4_user.wav`, etc.
 
 ### Provider-Specific
 

--- a/calibrate/agent/run_simulation.py
+++ b/calibrate/agent/run_simulation.py
@@ -33,7 +33,10 @@ from calibrate.utils import (
     make_webhook_call,
 )
 from calibrate.llm.metrics import evaluate_simuation, DEFAULT_SIMULATION_JUDGE_MODEL
-from calibrate.stt.metrics import get_llm_judge_score as stt_llm_judge_score, DEFAULT_STT_JUDGE_MODEL
+from calibrate.stt.metrics import (
+    get_llm_judge_score as stt_llm_judge_score,
+    DEFAULT_STT_JUDGE_MODEL,
+)
 from calibrate.judges import (
     DEFAULT_STT_EVALUATOR,
     attach_evaluator_id,
@@ -65,7 +68,32 @@ _BENIGN_GOOGLE_STT_IDLE_TIMEOUT = (
 
 
 def _is_benign_google_stt_idle_error(log_message: str) -> bool:
-    return "GoogleSTTService" in log_message and _BENIGN_GOOGLE_STT_IDLE_TIMEOUT in log_message
+    return (
+        "GoogleSTTService" in log_message
+        and _BENIGN_GOOGLE_STT_IDLE_TIMEOUT in log_message
+    )
+
+
+def count_agent_message_turns(messages: list) -> int:
+    """Count tested-agent speaking turns in the simulation LLM context.
+
+    The remote agent's speech is stored as ``user`` messages; the serialized
+    transcript flips roles so those become ``assistant``. Consecutive ``user``
+    messages (e.g. streaming fragments) count as one turn.
+    """
+    count = 0
+    in_user_run = False
+    for m in messages:
+        if not isinstance(m, dict):
+            continue
+        role = m.get("role")
+        if role == "user":
+            if not in_user_run:
+                count += 1
+                in_user_run = True
+        elif role is not None:
+            in_user_run = False
+    return count
 
 
 # Create a contextual logger with EVAL prefix
@@ -106,6 +134,8 @@ from pipecat.frames.frames import (
     InterruptionFrame,
     InterruptionTaskFrame,
     TTSStoppedFrame,
+    TTSAudioRawFrame,
+    ErrorFrame,
 )
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
@@ -225,23 +255,38 @@ class RTVIMessageFrameAdapter(FrameProcessor):
         output_dir: str,
         audio_save_dir: str,
         agent_speaks_first: bool = True,
+        max_turns: int = DEFAULT_MAX_TURNS,
     ):
         super().__init__(enable_direct_mode=True, name="RTVIMessageFrameAdapter")
         self._context = context
         self._audio_buffer = audio_buffer
         self._agent_speaks_first = agent_speaks_first
+        self._max_turns = max_turns
         self._interrupt_probability = interrupt_probability
         self._tool_calls = tool_calls
         self._output_dir = Path(output_dir)
         self._audio_save_dir = audio_save_dir
-        self._turn_index = 0
+        self._turn_index = (
+            0  # last active transcript line index (for logs / checkpoints)
+        )
+        # Single 1-based line index for WAV names; see _assign_next_transcript_audio_line.
+        self._active_transcript_audio_index = 0
+        # Role that owns ``_active_transcript_audio_index``. Audio chunks are only
+        # saved when the inbound speaker matches this role — prevents a tool-only
+        # bot turn from saving ``{prev_user_idx}_bot.wav`` chunks against a stale
+        # index that still points at the previous sim-user line.
+        self._active_transcript_audio_role: Optional[str] = None
+        self._last_transcript_line_assigned = (
+            0  # strict sequence when context lags commits
+        )
+        self._stt_turn_index = (
+            0  # increments when a bot line is reserved (on first real speech)
+        )
         self._stt_outputs = stt_outputs
         self._ttft = ttft
         self._processing_time = processing_time
         self._text_buffer = ""  # buffer of the text that the bot has generated so far (received stream; used for interrupt completion matching)
-        self._heard_text_buffer = (
-            ""  # buffer of agent text actually spoken (fed to simulated-user STT as what was heard)
-        )
+        self._heard_text_buffer = ""  # buffer of agent text actually spoken (fed to simulated-user STT as what was heard)
         self._spoken_text_buffer = (
             ""  # buffer of the text that the bot has spoken so far
         )
@@ -252,6 +297,83 @@ class RTVIMessageFrameAdapter(FrameProcessor):
         self._serialized_transcript = []  # Store transcripts for return
         self._ended_due_to_max_turns = False
         self._bot_audio_chunk_indices = {}  # Track chunk indices for bot audio per turn
+        self._awaiting_first_bot_audio_chunk = (
+            False  # True after bot-started until first qualifying ``spoken`` RTVI text
+        )
+        # Set by SimulatedUserTurnIndexHook on LLMFullResponseStartFrame; consumed
+        # lazily by SilencePadder when the first sim-user TTS audio frame arrives.
+        # Avoids allocating an index for sim-user turns that get interrupted before
+        # any audio actually flows.
+        self._sim_user_turn_pending = False
+        # Inbound bot audio frames that arrive after ``bot-started-speaking`` but
+        # before the first ``spoken=True`` RTVI confirmation. TTS audio commonly
+        # streams ~1s ahead of its ``spoken`` event, so the first sentence's
+        # audio would otherwise be dropped. Flushed when the bot line is
+        # reserved; cleared on ``bot-stopped-speaking`` for tool-only turns.
+        self._pending_bot_audio_frames: list = []
+
+    async def _ensure_bot_transcript_line_for_current_turn(
+        self, spoken_fragment: str = ""
+    ) -> None:
+        """Reserve the next transcript line only for real agent speech.
+
+        Tool-only turns can still emit ``bot-started-speaking`` and inbound audio
+        without user-facing TTS; we only reserve a line after ``spoken`` RTVI
+        text, and only when there is actual wording (stream buffer or fragment).
+        """
+        if not self._awaiting_first_bot_audio_chunk:
+            return
+        lexical = (self._text_buffer or "").strip() or (spoken_fragment or "").strip()
+        if len(lexical) < 2:
+            return
+        if not any(ch.isalpha() for ch in lexical):
+            return
+        self._awaiting_first_bot_audio_chunk = False
+        if self._active_transcript_audio_role == "bot":
+            # Bot already owns the active line — a single LLM response can be
+            # TTS'd as multiple sentences, each producing its own
+            # bot-started/stopped cycle. Keep appending chunks to the same file
+            # rather than splitting one transcript entry across files.
+            line = self._active_transcript_audio_index
+            eval_logger.info(
+                f"[rtvi] continuing bot transcript audio index (same turn): {line}"
+            )
+        else:
+            self._stt_turn_index += 1
+            line = self._assign_next_transcript_audio_line(role="bot")
+            self._turn_index = line
+            eval_logger.info(f"[rtvi] transcript audio index (bot, on speech): {line}")
+        await self._flush_pending_bot_audio()
+
+    async def _flush_pending_bot_audio(self) -> None:
+        """Save buffered bot audio frames against the just-reserved line."""
+        if not self._pending_bot_audio_frames or not self._audio_save_dir:
+            self._pending_bot_audio_frames = []
+            return
+        turn_index = self._active_transcript_audio_index
+        for frame in self._pending_bot_audio_frames:
+            chunk_index = self._bot_audio_chunk_indices.get(turn_index, 0)
+            self._bot_audio_chunk_indices[turn_index] = chunk_index + 1
+            audio_save_path = os.path.join(
+                self._audio_save_dir, f"{turn_index}_bot_{chunk_index}.wav"
+            )
+            await save_audio_chunk(
+                audio_save_path, frame.audio, frame.sample_rate, frame.num_channels
+            )
+        self._pending_bot_audio_frames = []
+
+    def _assign_next_transcript_audio_line(self, role: str) -> int:
+        """Next 1-based transcript line for ``{N}_bot`` / ``{N}_user`` chunk files.
+
+        Strictly monotonic: each segment that gets a WAV (sim-user LLM start, or
+        first real agent speech for a turn) advances the index so files are
+        ``1_bot``, ``2_user``, ``3_bot``, … in conversation order.
+        """
+        candidate = self._last_transcript_line_assigned + 1
+        self._last_transcript_line_assigned = candidate
+        self._active_transcript_audio_index = candidate
+        self._active_transcript_audio_role = role
+        return candidate
 
     async def _reset_buffers(self):
         concluded_turn = self._turn_index
@@ -336,6 +458,26 @@ class RTVIMessageFrameAdapter(FrameProcessor):
             if message.get("role") in {"user", "assistant"}
         ]
 
+        # Merge consecutive content messages from the same role into one. Tool-call
+        # entries (no ``content`` key) act as separators and are left untouched.
+        merged_transcript: list[dict] = []
+        for message in serialized_transcript:
+            if (
+                merged_transcript
+                and "content" in message
+                and "content" in merged_transcript[-1]
+                and message.get("role") == merged_transcript[-1].get("role")
+            ):
+                prev = merged_transcript[-1].get("content") or ""
+                curr = message.get("content") or ""
+                if prev and curr:
+                    merged_transcript[-1]["content"] = f"{prev} {curr}"
+                else:
+                    merged_transcript[-1]["content"] = prev or curr
+            else:
+                merged_transcript.append(dict(message))
+        serialized_transcript = merged_transcript
+
         if end_reason:
             serialized_transcript.append(
                 {
@@ -367,12 +509,15 @@ class RTVIMessageFrameAdapter(FrameProcessor):
         reason: Optional[str] = None,
     ):
         """Save intermediate transcript after a checkpoint (turn concluded or user stopped)."""
-        transcript = self._build_serialized_transcript()
+        end_reason = "max_turns" if self._ended_due_to_max_turns else None
+        transcript = self._build_serialized_transcript(end_reason=end_reason)
         self._save_transcript(transcript)
         if reason is not None:
             eval_logger.info(reason)
         elif concluded_turn is not None:
-            eval_logger.info(f"Saved intermediate transcript after turn {concluded_turn}")
+            eval_logger.info(
+                f"Saved intermediate transcript after turn {concluded_turn}"
+            )
 
     async def process_frame(self, frame, direction):
         await super().process_frame(frame, direction)
@@ -380,18 +525,27 @@ class RTVIMessageFrameAdapter(FrameProcessor):
         if isinstance(frame, OutputAudioRawFrame) and self._is_bot_interrupt_triggered:
             # don't forward bot audio frames after the interruption has been triggered
             return
-        elif isinstance(frame, InputAudioRawFrame) and self._turn_index:
-            # log_and_print("Received audio frame from agent")
-            # Save bot audio chunk
-            turn_index = self._turn_index
-            chunk_index = self._bot_audio_chunk_indices.get(turn_index, 0)
-            self._bot_audio_chunk_indices[turn_index] = chunk_index + 1
-            audio_save_path = os.path.join(
-                self._audio_save_dir, f"{turn_index}_bot_{chunk_index}.wav"
-            )
-            await save_audio_chunk(
-                audio_save_path, frame.audio, frame.sample_rate, frame.num_channels
-            )
+        elif isinstance(frame, InputAudioRawFrame):
+            # Never reserve a line from raw inbound audio: tool rounds can still
+            # carry silence or noise. Lines are reserved from ``spoken`` RTVI only.
+            if self._awaiting_first_bot_audio_chunk and self._audio_save_dir:
+                # TTS audio for the first sentence routinely arrives ~1s before
+                # its ``spoken=True`` confirmation. Buffer here; flush once the
+                # bot line is reserved (or drop on tool-only stop).
+                self._pending_bot_audio_frames.append(frame)
+            elif (
+                self._active_transcript_audio_index > 0
+                and self._active_transcript_audio_role == "bot"
+            ):
+                turn_index = self._active_transcript_audio_index
+                chunk_index = self._bot_audio_chunk_indices.get(turn_index, 0)
+                self._bot_audio_chunk_indices[turn_index] = chunk_index + 1
+                audio_save_path = os.path.join(
+                    self._audio_save_dir, f"{turn_index}_bot_{chunk_index}.wav"
+                )
+                await save_audio_chunk(
+                    audio_save_path, frame.audio, frame.sample_rate, frame.num_channels
+                )
 
         if isinstance(frame, InputTransportMessageFrame):
             message = getattr(frame, "message", {}) or {}
@@ -404,18 +558,35 @@ class RTVIMessageFrameAdapter(FrameProcessor):
 
                 if msg_type == "bot-started-speaking":
                     self._audio_buffer._reset_all_audio_buffers()
-                    if self._agent_speaks_first:
-                        self._turn_index += 1
-                        eval_logger.info(f"[rtvi] turn index: {self._turn_index}")
-                    self._pending_user_turn = True
-                    # The bot has the floor: stop the sim user's in-flight TTS
-                    # and flush its assistant aggregator so anything spoken so
-                    # far is committed as its own turn.
-                    await self.push_frame(
-                        InterruptionTaskFrame(), FrameDirection.UPSTREAM
+                    agent_turns_so_far = count_agent_message_turns(
+                        self._context.get_messages()
                     )
-                    generated_frames.append(UserStartedSpeakingFrame())
+                    if agent_turns_so_far >= self._max_turns:
+                        log_and_print(
+                            f"{INTERRUPTION_COLOR}Max turns ({self._max_turns}) reached, ending conversation{RESET_COLOR}"
+                        )
+                        self._ended_due_to_max_turns = True
+                        await self.push_frame(EndTaskFrame(), FrameDirection.UPSTREAM)
+                    else:
+                        self._awaiting_first_bot_audio_chunk = True
+                        self._pending_user_turn = True
+                        # Cancel any pending sim-user line allocation: bot has
+                        # the floor and any in-flight sim-user TTS will be
+                        # killed by the upcoming InterruptionTaskFrame.
+                        self._sim_user_turn_pending = False
+                        # The bot has the floor: stop the sim user's in-flight TTS
+                        # and flush its assistant aggregator so anything spoken so
+                        # far is committed as its own turn.
+                        await self.push_frame(
+                            InterruptionTaskFrame(), FrameDirection.UPSTREAM
+                        )
+                        generated_frames.append(UserStartedSpeakingFrame())
                 elif msg_type == "bot-stopped-speaking" and self._pending_user_turn:
+                    if self._awaiting_first_bot_audio_chunk:
+                        # Tool-only turn: no ``spoken=True`` ever fired, so any
+                        # buffered audio belongs to nothing the user heard.
+                        self._pending_bot_audio_frames = []
+                    self._awaiting_first_bot_audio_chunk = False
                     self._pending_user_turn = False
                     generated_frames.extend(
                         [
@@ -457,6 +628,9 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                             and not self._is_bot_interrupt_triggered  # bot has not been interrupted yet
                         ):
                             if spoken and self._is_bot_interrupt_decided:
+                                await self._ensure_bot_transcript_line_for_current_turn(
+                                    text
+                                )
                                 log_and_print(
                                     f"{GENERAL_LOG_COLOR}Agent speaking the generated message before interruption: {text}{RESET_COLOR}"
                                 )
@@ -470,6 +644,7 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                                 if self._spoken_text_buffer == self._text_buffer:
                                     self._is_bot_interrupt_triggered = True
                                     self._pending_user_turn = False
+                                    self._awaiting_first_bot_audio_chunk = False
 
                                     await self.push_frame(
                                         OutputTransportMessageUrgentFrame(
@@ -507,6 +682,9 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                                 )
                                 self._text_buffer += " " + text
                             elif spoken and not self._is_bot_interrupt_decided:
+                                await self._ensure_bot_transcript_line_for_current_turn(
+                                    text
+                                )
                                 log_and_print(
                                     f"{GENERAL_LOG_COLOR}Agent speaking the generated message: {text}{RESET_COLOR}"
                                 )
@@ -539,6 +717,9 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                                 log_and_print(
                                     f"{GENERAL_LOG_COLOR}Agent speaking the generated message 2: {text}{RESET_COLOR}"
                                 )
+                                await self._ensure_bot_transcript_line_for_current_turn(
+                                    text
+                                )
 
                 for generated_frame in generated_frames:
                     await self.push_frame(generated_frame, direction)
@@ -557,7 +738,15 @@ class RTVIMessageFrameAdapter(FrameProcessor):
             with open(
                 os.path.join(self._output_dir, "stt_outputs.json"), "w"
             ) as stt_outputs_file:
-                json.dump(self._stt_outputs, stt_outputs_file, indent=4)
+                # STTLogger pre-seeds an empty entry to handle the user-speaks-first
+                # case (first transcription lands at index 0). When the agent speaks
+                # first, that slot is never filled and stays "" — strip empties so
+                # the dumped file reflects only real transcriptions.
+                json.dump(
+                    [s for s in self._stt_outputs if s.strip()],
+                    stt_outputs_file,
+                    indent=4,
+                )
 
             # Final cleanup: combine any remaining audio chunks that weren't processed
             if os.path.exists(self._audio_save_dir):
@@ -624,9 +813,9 @@ class STTLogger(FrameProcessor):
                         log_and_print(
                             f"{USER_MESSAGE_COLOR}[User (as transcribed by the agent)]{RESET_COLOR}: {text}"
                         )
-                        if self._rtvi_adapter._turn_index > self.last_turn_index:
+                        if self._rtvi_adapter._stt_turn_index > self.last_turn_index:
                             self._stt_outputs.append(text)
-                            self.last_turn_index = self._rtvi_adapter._turn_index
+                            self.last_turn_index = self._rtvi_adapter._stt_turn_index
                         else:
                             self._stt_outputs[-1] += text
 
@@ -651,12 +840,14 @@ class IOLogger(FrameProcessor):
 
 
 class SimulatedUserTurnIndexHook(FrameProcessor):
-    """Advances simulation turn index when the simulated user starts an LLM turn.
+    """Marks that the sim user has started an LLM turn.
 
-    When the remote agent speaks first, turn index is advanced on
-    ``bot-started-speaking`` instead (see ``RTVIMessageFrameAdapter``). When the
-    simulated user speaks first, we advance here so user/bot audio chunks share
-    the same turn number for a round.
+    Allocation of the transcript line itself is deferred until actual TTS audio
+    is about to be written by ``SilencePadder``. This avoids "orphan" sim-user
+    indices when the bot interrupts before any audio flows — those allocations
+    used to flip the active role to ``"user"`` and break bot continuation
+    role-stickiness, splitting a single bot message across multiple ``_bot.wav``
+    files.
     """
 
     def __init__(self, rtvi_adapter: "RTVIMessageFrameAdapter"):
@@ -666,14 +857,10 @@ class SimulatedUserTurnIndexHook(FrameProcessor):
     async def process_frame(self, frame, direction):
         await super().process_frame(frame, direction)
 
-        if (
-            isinstance(frame, LLMFullResponseStartFrame)
-            and not self._rtvi_adapter._agent_speaks_first
-        ):
-            self._rtvi_adapter._turn_index += 1
-            eval_logger.info(
-                f"[sim user] turn index: {self._rtvi_adapter._turn_index}"
-            )
+        if isinstance(frame, LLMFullResponseStartFrame):
+            # Just signal intent — actual line allocation happens lazily in
+            # SilencePadder when the first audio frame arrives.
+            self._rtvi_adapter._sim_user_turn_pending = True
 
         await self.push_frame(frame, direction)
 
@@ -710,10 +897,28 @@ class SilencePadder(FrameProcessor):
         if isinstance(frame, OutputAudioRawFrame):
             self._last_sample_rate = frame.sample_rate
             self._last_num_channels = frame.num_channels
-            # log_and_print("Sending audio frame from simulated user")
-            # Save user audio chunk
-            if self._audio_save_dir and self._rtvi_message_adapter:
-                turn_index = self._rtvi_message_adapter._turn_index
+            # Lazy allocation: only reserve a sim-user line when we actually have
+            # audio to write. If the sim user got interrupted before any audio
+            # flowed, no line is reserved — preserving bot role-stickiness.
+            if (
+                self._audio_save_dir
+                and self._rtvi_message_adapter
+                and self._rtvi_message_adapter._sim_user_turn_pending
+            ):
+                self._rtvi_message_adapter._sim_user_turn_pending = False
+                if self._rtvi_message_adapter._active_transcript_audio_role != "user":
+                    line = self._rtvi_message_adapter._assign_next_transcript_audio_line(
+                        role="user"
+                    )
+                    self._rtvi_message_adapter._turn_index = line
+                    eval_logger.info(f"[sim user] transcript audio index: {line}")
+            if (
+                self._audio_save_dir
+                and self._rtvi_message_adapter
+                and self._rtvi_message_adapter._active_transcript_audio_index > 0
+                and self._rtvi_message_adapter._active_transcript_audio_role == "user"
+            ):
+                turn_index = self._rtvi_message_adapter._active_transcript_audio_index
                 chunk_index = self._user_audio_chunk_indices.get(turn_index, 0)
                 self._user_audio_chunk_indices[turn_index] = chunk_index + 1
                 audio_save_path = os.path.join(
@@ -750,36 +955,6 @@ class SilencePadder(FrameProcessor):
             )
             await self.push_frame(frame, FrameDirection.DOWNSTREAM)
             await asyncio.sleep(self._chunk_ms / 1000.0)
-
-
-class MaxTurnsEndProcessor(FrameProcessor):
-    """Processor that ends the task after number of assistant messages exceeds max_turns."""
-
-    def __init__(self, max_turns: int, rtvi_adapter, context: LLMContext):
-        super().__init__(enable_direct_mode=True, name="MaxTurnsEndProcessor")
-        self._max_turns = max_turns
-        self._rtvi_adapter = rtvi_adapter
-        self._context = context
-
-    async def process_frame(self, frame, direction):
-        await super().process_frame(frame, direction)
-
-        if isinstance(frame, LLMFullResponseStartFrame):
-            num_assistant_messages = len(
-                [
-                    message
-                    for message in self._context.get_messages()
-                    if message.get("role") == "assistant"
-                ]
-            )
-            if num_assistant_messages == self._max_turns:
-                log_and_print(
-                    f"{INTERRUPTION_COLOR}Max turns ({self._max_turns}) reached, ending conversation{RESET_COLOR}"
-                )
-                self._rtvi_adapter._ended_due_to_max_turns = True
-                await self.push_frame(EndTaskFrame(), FrameDirection.UPSTREAM)
-
-        await self.push_frame(frame, direction)
 
 
 class RTVIFunctionCallResponder(FrameProcessor):
@@ -1053,11 +1228,17 @@ async def _run_simulation_inner(
 
     # ElevenLabs voice IDs for the simulated user. Word-level TTS so that
     # mid-utterance interrupts commit only the words actually spoken.
-    voice_id = (
-        os.getenv("ELEVENLABS_VOICE_ID_FEMALE", "EXAVITQu4vr4xnSDxMaL")
-        if gender == "female"
-        else os.getenv("ELEVENLABS_VOICE_ID_MALE", "pNInz6obpgDQGcFmaJgB")
-    )
+
+    if language == "hindi":
+        if gender == "female":
+            voice_id = "dVTC43Yewy5fAIcmsISI"
+        else:
+            voice_id = "hdkYGMdbdWZpANLZvmnk"
+    else:
+        # Default to English voices
+        voice_id = (
+            "OHY6EjdeHKeQymoihwfz" if gender == "female" else "fPIfC3elMLbN9tNwMXkw"
+        )
     eval_logger.info(f"Using ElevenLabs voice ID: {voice_id}")
     elevenlabs_http_session = aiohttp.ClientSession()
     tts = ElevenLabsHttpTTSService(
@@ -1103,6 +1284,7 @@ async def _run_simulation_inner(
         output_dir,
         audio_save_dir,
         agent_speaks_first=agent_speaks_first,
+        max_turns=max_turns,
     )
 
     simulated_user_turn_index_hook = SimulatedUserTurnIndexHook(rtvi_message_adapter)
@@ -1121,12 +1303,6 @@ async def _run_simulation_inner(
         rtvi_message_adapter=rtvi_message_adapter,
     )
 
-    max_turns_end_processor = MaxTurnsEndProcessor(
-        max_turns,
-        rtvi_message_adapter,
-        context,
-    )
-
     pipeline = Pipeline(
         [
             transport.input(),  # Transport user input
@@ -1138,7 +1314,6 @@ async def _run_simulation_inner(
             context_aggregator.user(),  # User responses
             llm,  # LLM
             simulated_user_turn_index_hook,
-            max_turns_end_processor,  # Check and end after assistant processing if max_turns reached
             tts,  # TTS
             silence_padder,  # Add silence padding after TTS for STT flush
             output_logger,
@@ -1279,8 +1454,7 @@ async def _run_simulation_inner(
         return row
 
     evaluation_results = [
-        _build_eval_row(ev, llm_judge_result[ev["name"]])
-        for ev in evaluators
+        _build_eval_row(ev, llm_judge_result[ev["name"]]) for ev in evaluators
     ]
 
     for row in evaluation_results:

--- a/calibrate/utils.py
+++ b/calibrate/utils.py
@@ -484,10 +484,10 @@ def combine_audio_files(
 
     Uses the transcript to determine the correct order of audio files.
     For each content message in the transcript (skipping tool_calls-only messages),
-    the corresponding audio file is added in order:
-      - assistant content messages map to {N}_bot.wav (N = 1, 2, 3, ...)
-      - user content messages map to {N}_user.wav (N = 1, 2, 3, ...)
-    Bot and user indices are tracked separately.
+    the corresponding audio file is added in order using a single 1-based line
+    index ``N`` that matches ``transcript.json`` order:
+      - ``assistant`` content → ``{N}_bot.wav``
+      - ``user`` content → ``{N}_user.wav``
 
     Falls back to sorting by filename if no transcript is provided.
 
@@ -515,8 +515,7 @@ def combine_audio_files(
     with open(transcript_path, "r") as f:
         transcript = json.load(f)
 
-    bot_index = 1
-    user_index = 1
+    msg_index = 1
 
     for msg in transcript:
         # Skip messages that only have tool_calls and no content
@@ -525,19 +524,19 @@ def combine_audio_files(
 
         role = msg.get("role")
         if role == "assistant":
-            file_path = os.path.join(audio_dir, f"{bot_index}_bot.wav")
+            file_path = os.path.join(audio_dir, f"{msg_index}_bot.wav")
             if os.path.exists(file_path):
                 sorted_files.append(file_path)
             else:
                 logger.warning(f"Expected audio file not found: {file_path}")
-            bot_index += 1
+            msg_index += 1
         elif role == "user":
-            file_path = os.path.join(audio_dir, f"{user_index}_user.wav")
+            file_path = os.path.join(audio_dir, f"{msg_index}_user.wav")
             if os.path.exists(file_path):
                 sorted_files.append(file_path)
             else:
                 logger.warning(f"Expected audio file not found: {file_path}")
-            user_index += 1
+            msg_index += 1
 
     if not sorted_files:
         raise ValueError("No audio files matched from transcript")


### PR DESCRIPTION
1. **Audio files numbered in conversation order**
Before: separate counters for bot and user, so you'd get `1_bot.wav`, `1_user.wav`, `2_bot.wav`, `2_user.wav`.
Now: one shared counter that follows the transcript, so you get `1_bot.wav`, `2_user.wav`, `3_bot.wav`, `4_user.wav`.

2. **No more lost audio at the start of bot replies**
The bot's first sentence used to get cut off because audio arrived before the system was ready to save it. Now early audio is held briefly and saved once the system catches up.

3. **No more empty bot files for tool calls**
When the bot only made a tool call without speaking, an empty bot audio file would still get created. Now we only create a file when the bot actually says something.

4. **One bot reply stays in one file**
If a single bot message gets spoken in multiple breaths, both halves now go into the same file instead of being split.

5. **Sim-user files only created when audio actually plays**
If the simulated user started replying but got interrupted before any sound came out, it used to leave a useless placeholder that broke the numbering. Now we only reserve a file slot once audio is actually flowing.

6. **Conversation stops cleanly at max turns**
Replaced an old separate component with a check inside the main handler that ends the conversation once the bot has spoken its allowed number of times.

7. **Cleaner transcript**
If the same speaker has two messages back-to-back (with no tool call between them), they get merged into one entry.

8. **Cleaner stt_outputs.json**
The empty `""` entry that used to appear at the start when the agent spoke first is now stripped out.

9. The diff also includes a Hindi-vs-English voice ID selection for ElevenLabs that I didn't touch — that's a pre-existing local change in the same file.