### PR TITLE
Throttle Sarvam streaming STT/TTS to per-account RPM caps

### DIFF
--- a/calibrate/rate_limit.py
+++ b/calibrate/rate_limit.py
@@ -1,0 +1,60 @@
+"""Async sliding-window rate limiters keyed by provider+endpoint.
+
+Used to keep outbound provider API calls under per-account RPM caps. A
+limiter tracks request timestamps in a deque; ``acquire()`` evicts entries
+older than ``period`` and sleeps until the oldest in-window timestamp ages
+out when the window is full.
+
+Sarvam streaming limits (per account, sourced from the Sarvam dashboard):
+
+- STT streaming (``speech_to_text_streaming.connect``): 20 RPM
+- TTS streaming (``text_to_speech_streaming.connect``): 60 RPM
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+
+
+class AsyncRateLimiter:
+    """Sliding-window async rate limiter.
+
+    ``acquire()`` returns once the call can proceed without exceeding
+    ``max_calls`` over ``period`` seconds. Safe under concurrent awaiters —
+    a single ``asyncio.Lock`` serializes the window check, so two coroutines
+    cannot both observe a free slot and overshoot the cap.
+    """
+
+    def __init__(self, max_calls: int, period: float = 60.0):
+        if max_calls <= 0:
+            raise ValueError("max_calls must be positive")
+        if period <= 0:
+            raise ValueError("period must be positive")
+        self.max_calls = max_calls
+        self.period = period
+        self._calls: deque[float] = deque()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> None:
+        async with self._lock:
+            now = time.monotonic()
+            self._evict(now)
+
+            if len(self._calls) >= self.max_calls:
+                wait_time = self.period - (now - self._calls[0])
+                if wait_time > 0:
+                    await asyncio.sleep(wait_time)
+                self._evict(time.monotonic())
+
+            self._calls.append(time.monotonic())
+
+    def _evict(self, now: float) -> None:
+        cutoff = now - self.period
+        while self._calls and self._calls[0] <= cutoff:
+            self._calls.popleft()
+
+
+SARVAM_STT_STREAMING_LIMITER = AsyncRateLimiter(max_calls=20, period=60.0)
+SARVAM_TTS_STREAMING_LIMITER = AsyncRateLimiter(max_calls=60, period=60.0)

--- a/calibrate/rate_limit.py
+++ b/calibrate/rate_limit.py
@@ -35,10 +35,23 @@ class AsyncRateLimiter:
         self.max_calls = max_calls
         self.period = period
         self._calls: deque[float] = deque()
-        self._lock = asyncio.Lock()
+        self._lock: asyncio.Lock | None = None
+        self._lock_loop: asyncio.AbstractEventLoop | None = None
+
+    def _get_lock(self) -> asyncio.Lock:
+        # ``asyncio.Lock`` binds to whatever loop first awaits it. Module-level
+        # limiters outlive any single ``asyncio.run(...)``, so we lazily
+        # rebuild the lock whenever the running loop changes — otherwise a
+        # second ``asyncio.run`` would inherit a lock bound to a closed loop
+        # and raise ``RuntimeError: ... is bound to a different event loop``.
+        loop = asyncio.get_running_loop()
+        if self._lock is None or self._lock_loop is not loop:
+            self._lock = asyncio.Lock()
+            self._lock_loop = loop
+        return self._lock
 
     async def acquire(self) -> None:
-        async with self._lock:
+        async with self._get_lock():
             now = time.monotonic()
             self._evict(now)
 

--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -47,6 +47,7 @@ from calibrate.langfuse import (
     langfuse,
     langfuse_enabled,
 )
+from calibrate.rate_limit import SARVAM_STT_STREAMING_LIMITER
 
 
 # =============================================================================
@@ -290,6 +291,8 @@ async def transcribe_sarvam(audio_path: Path, language: str) -> str:
     lang_code = get_stt_language_code(language, "sarvam")
 
     audio_data = base64.b64encode(load_audio(audio_path)).decode("utf-8")
+
+    await SARVAM_STT_STREAMING_LIMITER.acquire()
 
     client = AsyncSarvamAI(api_subscription_key=api_key, timeout=120.0)
 

--- a/calibrate/tts/eval.py
+++ b/calibrate/tts/eval.py
@@ -43,6 +43,7 @@ from calibrate.langfuse import (
     langfuse_enabled,
     create_langfuse_audio_media,
 )
+from calibrate.rate_limit import SARVAM_TTS_STREAMING_LIMITER
 
 
 # =============================================================================
@@ -332,6 +333,8 @@ async def synthesize_sarvam(text: str, language: str, audio_path: str) -> Dict:
         raise ValueError("SARVAM_API_KEY environment variable not set")
 
     lang_code = get_tts_language_code(language, "sarvam")
+
+    await SARVAM_TTS_STREAMING_LIMITER.acquire()
 
     client = AsyncSarvamAI(api_subscription_key=api_key)
 

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,181 @@
+import asyncio
+import unittest
+from unittest.mock import patch
+
+from calibrate.rate_limit import (
+    AsyncRateLimiter,
+    SARVAM_STT_STREAMING_LIMITER,
+    SARVAM_TTS_STREAMING_LIMITER,
+)
+
+
+class TestAsyncRateLimiterValidation(unittest.TestCase):
+    def test_rejects_zero_max_calls(self):
+        with self.assertRaises(ValueError):
+            AsyncRateLimiter(max_calls=0)
+
+    def test_rejects_negative_max_calls(self):
+        with self.assertRaises(ValueError):
+            AsyncRateLimiter(max_calls=-1)
+
+    def test_rejects_zero_period(self):
+        with self.assertRaises(ValueError):
+            AsyncRateLimiter(max_calls=5, period=0)
+
+    def test_rejects_negative_period(self):
+        with self.assertRaises(ValueError):
+            AsyncRateLimiter(max_calls=5, period=-1)
+
+
+class TestAsyncRateLimiterBehavior(unittest.IsolatedAsyncioTestCase):
+    async def test_under_limit_does_not_sleep(self):
+        limiter = AsyncRateLimiter(max_calls=3, period=60.0)
+        with patch("calibrate.rate_limit.asyncio.sleep") as mock_sleep:
+            for _ in range(3):
+                await limiter.acquire()
+            mock_sleep.assert_not_called()
+        self.assertEqual(len(limiter._calls), 3)
+
+    async def test_over_limit_sleeps_for_remaining_window(self):
+        # Three timestamps at t=0,1,2 in a 60s window. The 4th call should
+        # sleep for ~58s (60 - (now=2 - oldest=0)).
+        limiter = AsyncRateLimiter(max_calls=3, period=60.0)
+
+        fake_now = [0.0]
+
+        def mono():
+            return fake_now[0]
+
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(seconds):
+            sleep_calls.append(seconds)
+            fake_now[0] += seconds
+
+        with patch("calibrate.rate_limit.time.monotonic", side_effect=mono):
+            with patch(
+                "calibrate.rate_limit.asyncio.sleep", side_effect=fake_sleep
+            ):
+                await limiter.acquire()
+                fake_now[0] = 1.0
+                await limiter.acquire()
+                fake_now[0] = 2.0
+                await limiter.acquire()
+                await limiter.acquire()
+
+        self.assertEqual(len(sleep_calls), 1)
+        self.assertAlmostEqual(sleep_calls[0], 58.0, places=5)
+
+    async def test_evicts_stale_timestamps(self):
+        limiter = AsyncRateLimiter(max_calls=2, period=60.0)
+
+        fake_now = [0.0]
+
+        def mono():
+            return fake_now[0]
+
+        with patch("calibrate.rate_limit.time.monotonic", side_effect=mono):
+            with patch(
+                "calibrate.rate_limit.asyncio.sleep"
+            ) as mock_sleep:
+                await limiter.acquire()
+                fake_now[0] = 1.0
+                await limiter.acquire()
+                fake_now[0] = 62.0
+                await limiter.acquire()
+                mock_sleep.assert_not_called()
+
+        self.assertEqual(len(limiter._calls), 1)
+
+    async def test_concurrent_acquires_serialize(self):
+        # Five awaiters racing for 2 slots should never observe more than 2
+        # in-window timestamps at any point.
+        limiter = AsyncRateLimiter(max_calls=2, period=60.0)
+
+        observed_max = [0]
+
+        async def fake_sleep(seconds):
+            # Simulate window expiry on sleep
+            limiter._calls.clear()
+
+        with patch(
+            "calibrate.rate_limit.asyncio.sleep", side_effect=fake_sleep
+        ):
+
+            async def worker():
+                await limiter.acquire()
+                observed_max[0] = max(observed_max[0], len(limiter._calls))
+
+            await asyncio.gather(*(worker() for _ in range(5)))
+
+        self.assertLessEqual(observed_max[0], 2)
+
+
+class TestSarvamModuleLimiters(unittest.TestCase):
+    def test_stt_streaming_is_20_per_minute(self):
+        self.assertEqual(SARVAM_STT_STREAMING_LIMITER.max_calls, 20)
+        self.assertEqual(SARVAM_STT_STREAMING_LIMITER.period, 60.0)
+
+    def test_tts_streaming_is_60_per_minute(self):
+        self.assertEqual(SARVAM_TTS_STREAMING_LIMITER.max_calls, 60)
+        self.assertEqual(SARVAM_TTS_STREAMING_LIMITER.period, 60.0)
+
+
+class TestSarvamCallsAcquire(unittest.IsolatedAsyncioTestCase):
+    """The sarvam STT/TTS functions must call ``acquire()`` before opening
+    the streaming websocket — otherwise we'd burst past the per-account cap
+    on the first batch of rows in a benchmark run.
+    """
+
+    async def test_transcribe_sarvam_acquires_before_client(self):
+        from pathlib import Path
+        from calibrate.stt import eval as stt_eval
+
+        with patch.dict("os.environ", {"SARVAM_API_KEY": "sk-fake"}):
+            with patch.object(
+                stt_eval.SARVAM_STT_STREAMING_LIMITER, "acquire"
+            ) as mock_acquire:
+                mock_acquire.return_value = None
+
+                async def _mock_acquire():
+                    mock_acquire.called_at = "before_client"
+
+                mock_acquire.side_effect = _mock_acquire
+
+                with patch.object(stt_eval, "load_audio", return_value=b""):
+                    with patch.object(
+                        stt_eval, "AsyncSarvamAI", side_effect=RuntimeError("stop")
+                    ):
+                        with self.assertRaises(RuntimeError):
+                            await stt_eval.transcribe_sarvam(
+                                Path("/tmp/x.wav"), "english"
+                            )
+
+                mock_acquire.assert_awaited_once()
+
+    async def test_synthesize_sarvam_acquires_before_client(self):
+        from calibrate.tts import eval as tts_eval
+
+        with patch.dict("os.environ", {"SARVAM_API_KEY": "sk-fake"}):
+            with patch.object(
+                tts_eval.SARVAM_TTS_STREAMING_LIMITER, "acquire"
+            ) as mock_acquire:
+
+                async def _mock_acquire():
+                    return None
+
+                mock_acquire.side_effect = _mock_acquire
+
+                with patch.object(
+                    tts_eval, "AsyncSarvamAI", side_effect=RuntimeError("stop")
+                ):
+                    with self.assertRaises(RuntimeError):
+                        await tts_eval.synthesize_sarvam(
+                            "hello", "english", "/tmp/out.wav"
+                        )
+
+                mock_acquire.assert_awaited_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -111,6 +111,55 @@ class TestAsyncRateLimiterBehavior(unittest.IsolatedAsyncioTestCase):
         self.assertLessEqual(observed_max[0], 2)
 
 
+class TestAsyncRateLimiterLoopRebind(unittest.TestCase):
+    """A module-level limiter must survive multiple ``asyncio.run(...)``
+    invocations in the same interpreter. ``asyncio.Lock`` binds to the loop
+    that first contends on it, so without rebinding the second run would
+    raise ``RuntimeError: ... is bound to a different event loop``.
+    """
+
+    def test_survives_multiple_asyncio_run_calls(self):
+        limiter = AsyncRateLimiter(max_calls=5, period=60.0)
+
+        async def two_acquires():
+            await limiter.acquire()
+            await limiter.acquire()
+
+        asyncio.run(two_acquires())
+        first_loop = limiter._lock_loop
+
+        asyncio.run(two_acquires())
+        second_loop = limiter._lock_loop
+
+        self.assertIsNotNone(first_loop)
+        self.assertIsNotNone(second_loop)
+        self.assertIsNot(first_loop, second_loop)
+
+    def test_survives_multiple_runs_with_contention(self):
+        # ``asyncio.Lock`` calls ``_get_loop()`` only when a waiter has to
+        # queue (i.e. the lock is already held). Forcing the limiter into
+        # its wait branch and then racing a second acquirer makes the
+        # second one queue, which binds the lock to loop A. A second
+        # ``asyncio.run`` would then raise without the rebind.
+        limiter = AsyncRateLimiter(max_calls=1, period=60.0)
+        real_sleep = asyncio.sleep
+
+        async def fake_sleep(_seconds):
+            await real_sleep(0)  # actually yield so the second acquirer can queue
+            limiter._calls.clear()
+
+        async def race():
+            limiter._calls.clear()
+            with patch(
+                "calibrate.rate_limit.asyncio.sleep", side_effect=fake_sleep
+            ):
+                await limiter.acquire()  # fills the bucket
+                await asyncio.gather(limiter.acquire(), limiter.acquire())
+
+        asyncio.run(race())
+        asyncio.run(race())  # would raise without the rebind
+
+
 class TestSarvamModuleLimiters(unittest.TestCase):
     def test_stt_streaming_is_20_per_minute(self):
         self.assertEqual(SARVAM_STT_STREAMING_LIMITER.max_calls, 20)


### PR DESCRIPTION
Fixes #56 

## Summary

- Adds `calibrate/rate_limit.py` with an `AsyncRateLimiter` (sliding-window, `asyncio.Lock`-serialized) plus module-level instances `SARVAM_STT_STREAMING_LIMITER` (20 RPM) and `SARVAM_TTS_STREAMING_LIMITER` (60 RPM), sourced from the Sarvam account dashboard.
- Wires `await ...LIMITER.acquire()` into `transcribe_sarvam` ([calibrate/stt/eval.py](calibrate/stt/eval.py)) and `synthesize_sarvam` ([calibrate/tts/eval.py](calibrate/tts/eval.py)), placed after the env-var guard and before the SDK opens its websocket.
- New test module [tests/test_rate_limit.py](tests/test_rate_limit.py) with 12 unit tests: input validation, under-limit no-sleep, over-limit sleep duration (using patched `time.monotonic` + `asyncio.sleep`), stale-timestamp eviction, concurrent serialization, the two module limiter caps, and assertions that both sarvam call sites actually invoke `acquire()`.

## Why

The benchmark runner opens the Sarvam streaming STT/TTS websockets row-by-row across providers in parallel. With a small dataset and a fast model, a benchmark can easily burst past 20 STT calls or 60 TTS calls in a minute and start getting 429s mid-run, which the existing `@backoff` retry would mask but not solve. The limiter caps outbound calls *before* the SDK opens its websocket.

## Notes for reviewers

- Placement is intentional: env-var check first (so the missing-key fast-fail path still raises without waiting on a throttle), then `acquire()`, then the SDK client. Each `@backoff` retry re-enters the function and re-acquires — correct, since each retry is a real request against the quota.
- The limiters are module-level singletons, so they're shared across all concurrent rows in a single benchmark run (the benchmark currently caps parallel providers at 2, but rows within a provider also stream).
- Other providers were not touched — their per-account limits weren't in the supplied rate-limit table.
- Full suite passes: **535 passed**.

## Test plan

- [x] `uv run pytest tests/test_rate_limit.py` — 12 new tests pass
- [x] `uv run pytest tests/` — full suite (535) passes
- [ ] Manual: run a Sarvam STT benchmark on a >20-row dataset and confirm no 429s; verify total wall time is >= ceil(N/20) minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)