### PR TITLE
STT: streaming-only providers, TTFT metric, row-level error handling

### DIFF
--- a/calibrate/rate_limit.py
+++ b/calibrate/rate_limit.py
@@ -64,3 +64,12 @@ class AsyncRateLimiter:
 
 SARVAM_STT_STREAMING_LIMITER = AsyncRateLimiter(max_calls=20, period=60.0)
 SARVAM_TTS_STREAMING_LIMITER = AsyncRateLimiter(max_calls=60, period=60.0)
+
+# Max wall-clock seconds for a single provider STT call before we treat it
+# as stuck and let @backoff retry
+STT_PROVIDER_TIMEOUT_SECONDS = 60.0
+
+# Idle (per-message) timeout for streaming STT providers. A streaming
+# connection that goes silent for this many seconds is treated as stuck and
+# raises ``TimeoutError`` so ``@backoff`` can retry
+STT_STREAMING_IDLE_TIMEOUT_SECONDS = 20.0

--- a/calibrate/stt/benchmark.py
+++ b/calibrate/stt/benchmark.py
@@ -309,14 +309,18 @@ async def main():
             sys.exit(1)
 
         metrics = result.get("metrics", {})
-        wer = metrics.get("wer", 0)
+        wer = metrics.get("wer")
         judge_scores = {
-            k: v["mean"]
+            k: v.get("mean")
             for k, v in metrics.items()
             if isinstance(v, dict) and "type" in v
         }
-        judge_str = ", ".join(f"{k}={v:.4f}" for k, v in judge_scores.items())
-        print(f"  WER={wer:.4f}, {judge_str}")
+
+        def _fmt(v):
+            return f"{v:.4f}" if isinstance(v, (int, float)) else "N/A"
+
+        judge_str = ", ".join(f"{k}={_fmt(v)}" for k, v in judge_scores.items())
+        print(f"  WER={_fmt(wer)}, {judge_str}")
         return
 
     # Benchmark (multi-provider) mode: mirror stdout/stderr into a single
@@ -370,17 +374,22 @@ async def main():
                 has_errors = True
             else:
                 metrics = prov_result.get("metrics", {})
-                wer = metrics.get("wer", 0)
+                wer = metrics.get("wer")
                 # Evaluator entries are dicts carrying a ``type`` field.
                 judge_scores = {
-                    k: v["mean"]
+                    k: v.get("mean")
                     for k, v in metrics.items()
                     if isinstance(v, dict) and "type" in v
                 }
+
+                def _fmt(v):
+                    return f"{v:.4f}" if isinstance(v, (int, float)) else "N/A"
+
+                wer_str = _fmt(wer)
                 judge_str = ", ".join(
-                    f"{k}={v:.4f}" for k, v in judge_scores.items()
+                    f"{k}={_fmt(v)}" for k, v in judge_scores.items()
                 )
-                print(f"  {provider}: WER={wer:.4f}, {judge_str}")
+                print(f"  {provider}: WER={wer_str}, {judge_str}")
 
         if has_errors:
             sys.exit(1)

--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -14,15 +14,14 @@ from urllib.parse import urlencode
 import backoff
 from sarvamai import AsyncSarvamAI
 from openai import AsyncOpenAI
-from elevenlabs.client import AsyncElevenLabs
 from groq import AsyncGroq
-from deepgram import DeepgramClient, PrerecordedOptions, FileSource
 from cartesia import AsyncCartesia
 import uuid
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech as cloud_speech_types
 from google.api_core.client_options import ClientOptions
 
+import numpy as np
 import pandas as pd
 
 from calibrate.utils import (
@@ -47,7 +46,11 @@ from calibrate.langfuse import (
     langfuse,
     langfuse_enabled,
 )
-from calibrate.rate_limit import SARVAM_STT_STREAMING_LIMITER
+from calibrate.rate_limit import (
+    STT_PROVIDER_TIMEOUT_SECONDS,
+    STT_STREAMING_IDLE_TIMEOUT_SECONDS,
+    SARVAM_STT_STREAMING_LIMITER,
+)
 
 
 # =============================================================================
@@ -98,36 +101,131 @@ def load_audio(audio_path: Path, as_file: bool = False, raw_pcm: bool = False):
     return out_io.getvalue()
 
 
-async def transcribe_deepgram(audio_path: Path, language: str) -> str:
-    """Transcribe audio using Deepgram's REST API."""
+async def _aiter_with_idle_timeout(aiter, timeout: float):
+    """Async-iterate ``aiter`` enforcing a per-message idle timeout.
+
+    Raises ``asyncio.TimeoutError`` if no next message arrives within
+    ``timeout`` seconds. Useful for STT WebSocket loops where the SDK's
+    own timeout settings don't apply to the receive side and a stalled
+    server can otherwise block forever.
+    """
+    it = aiter.__aiter__() if hasattr(aiter, "__aiter__") else aiter
+    while True:
+        try:
+            msg = await asyncio.wait_for(it.__anext__(), timeout=timeout)
+        except StopAsyncIteration:
+            return
+        yield msg
+
+
+async def transcribe_deepgram_streaming(audio_path: Path, language: str) -> str:
+    """Transcribe audio using Deepgram's live streaming WebSocket API.
+
+    Uses the raw WebSocket protocol (``wss://api.deepgram.com/v1/listen``)
+    rather than the threaded SDK because the SDK's live client is sync /
+    callback-based and doesn't compose with our async pipeline. See
+    https://developers.deepgram.com/docs/live-streaming-audio.
+    """
+    try:
+        from websockets.asyncio.client import connect as websocket_connect
+    except ModuleNotFoundError as e:
+        raise ImportError(
+            "websockets is required for Deepgram streaming STT. "
+            "Install with 'pip install websockets'."
+        ) from e
+
     api_key = os.getenv("DEEPGRAM_API_KEY")
     if not api_key:
         raise ValueError("DEEPGRAM_API_KEY environment variable not set")
 
     lang_code = get_stt_language_code(language, "deepgram")
 
-    client = DeepgramClient(api_key=api_key)
-
-    audio_file = load_audio(audio_path)
-
-    options = PrerecordedOptions(model="nova-3", language=lang_code)
-
-    payload: FileSource = {
-        "buffer": audio_file,
+    endpoint = "wss://api.deepgram.com/v1/listen"
+    params = {
+        "model": "nova-3",
+        "language": lang_code,
+        "encoding": "linear16",
+        "sample_rate": "16000",
+        "channels": "1",
+        "smart_format": "true",
     }
+    ws_url = f"{endpoint}?{urlencode(params)}"
+    headers = {"Authorization": f"Token {api_key}"}
 
-    response = await client.listen.asyncrest.v("1").transcribe_file(
-        source=payload, options=options
-    )
-    transcript = response.results.channels[0].alternatives[0].transcript.strip()
+    audio = load_audio(audio_path, raw_pcm=True)
+    chunk_size = 4096
+
+    async with websocket_connect(ws_url, additional_headers=headers) as ws:
+
+        async def send_audio():
+            for start in range(0, len(audio), chunk_size):
+                chunk = audio[start : start + chunk_size]
+                if chunk:
+                    await ws.send(chunk)
+                    await asyncio.sleep(0.05)
+
+            # Tells Deepgram we've sent all audio so it flushes and closes.
+            await ws.send(json.dumps({"type": "CloseStream"}))
+
+        start_time = time.perf_counter()
+        ttft = None
+        sender = asyncio.create_task(send_audio())
+        transcript_parts = []
+
+        try:
+            async for message in _aiter_with_idle_timeout(
+                ws, STT_STREAMING_IDLE_TIMEOUT_SECONDS
+            ):
+                try:
+                    output = json.loads(message)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+
+                if not isinstance(output, dict):
+                    continue
+
+                msg_type = output.get("type")
+
+                if msg_type == "Results":
+                    alternatives = output.get("channel", {}).get("alternatives") or []
+                    if not alternatives:
+                        continue
+
+                    transcript = alternatives[0].get("transcript", "")
+                    if transcript and ttft is None:
+                        ttft = time.perf_counter() - start_time
+
+                    if output.get("is_final") and transcript:
+                        transcript_parts.append(transcript)
+                elif msg_type == "Metadata":
+                    # Sent after CloseStream once Deepgram has flushed all
+                    # final transcripts — safe to stop reading.
+                    break
+        finally:
+            if sender.done():
+                await sender
+            else:
+                sender.cancel()
+                try:
+                    await sender
+                except asyncio.CancelledError:
+                    pass
 
     return {
-        "transcript": transcript,
+        "transcript": " ".join(
+            part.strip() for part in transcript_parts if part.strip()
+        ),
+        "ttft": ttft,
     }
 
 
-async def transcribe_openai(audio_path: Path, language: str) -> str:
-    """Transcribe audio using OpenAI's Whisper API."""
+async def transcribe_openai_streaming(audio_path: Path, language: str) -> str:
+    """Transcribe audio using OpenAI's transcriptions API with ``stream=True``.
+
+    Streams ``transcript.text.delta`` events as soon as each segment is ready
+    and finishes on ``transcript.text.done`` which carries the full transcript.
+    See https://developers.openai.com/api/docs/guides/speech-to-text#streaming.
+    """
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise ValueError("OPENAI_API_KEY environment variable not set")
@@ -136,13 +234,35 @@ async def transcribe_openai(audio_path: Path, language: str) -> str:
 
     audio_file = load_audio(audio_path, as_file=True)
 
-    response = await client.audio.transcriptions.create(
-        model="gpt-4o-transcribe", file=audio_file
+    stream = await client.audio.transcriptions.create(
+        model="gpt-4o-transcribe",
+        file=audio_file,
+        response_format="text",
+        stream=True,
     )
-    transcript = response.text
+
+    start_time = time.perf_counter()
+    ttft = None
+    transcript = ""
+
+    async for event in _aiter_with_idle_timeout(
+        stream, STT_STREAMING_IDLE_TIMEOUT_SECONDS
+    ):
+        event_type = getattr(event, "type", None)
+
+        if event_type == "transcript.text.delta":
+            if ttft is None and getattr(event, "delta", ""):
+                ttft = time.perf_counter() - start_time
+
+        elif event_type == "transcript.text.done":
+            transcript = getattr(event, "text", "") or ""
+            if ttft is None:
+                ttft = time.perf_counter() - start_time
+            break
 
     return {
         "transcript": transcript,
+        "ttft": ttft,
     }
 
 
@@ -158,12 +278,15 @@ async def transcribe_groq(audio_path: Path, language: str) -> str:
 
     audio_file = load_audio(audio_path, as_file=True)
 
-    transcription = await client.audio.transcriptions.create(
-        file=audio_file,  # Required audio file
-        model="whisper-large-v3-turbo",  # Required model to use for transcription
-        response_format="text",  # Optional
-        language=lang_code,  # Optional
-        temperature=0.0,  # Optional
+    transcription = await asyncio.wait_for(
+        client.audio.transcriptions.create(
+            file=audio_file,  # Required audio file
+            model="whisper-large-v3-turbo",  # Required model to use for transcription
+            response_format="text",  # Optional
+            language=lang_code,  # Optional
+            temperature=0.0,  # Optional
+        ),
+        timeout=STT_PROVIDER_TIMEOUT_SECONDS,
     )
 
     return {
@@ -269,12 +392,15 @@ async def transcribe_google(audio_path: Path, language: str) -> str:
         model = "chirp_3"
         region = "us"
 
-    transcript = await asyncio.to_thread(
-        _transcribe_google_streaming,
-        audio_path,
-        lang_code,
-        model,
-        region,
+    transcript = await asyncio.wait_for(
+        asyncio.to_thread(
+            _transcribe_google_streaming,
+            audio_path,
+            lang_code,
+            model,
+            region,
+        ),
+        timeout=STT_PROVIDER_TIMEOUT_SECONDS,
     )
 
     return {
@@ -294,7 +420,7 @@ async def transcribe_sarvam(audio_path: Path, language: str) -> str:
 
     await SARVAM_STT_STREAMING_LIMITER.acquire()
 
-    client = AsyncSarvamAI(api_subscription_key=api_key, timeout=120.0)
+    client = AsyncSarvamAI(api_subscription_key=api_key)
 
     transcript = ""
     ttft = None
@@ -313,7 +439,9 @@ async def transcribe_sarvam(audio_path: Path, language: str) -> str:
         _log("⚡ Processing forced - getting immediate results")
 
         # Get results
-        async for message in ws:
+        async for message in _aiter_with_idle_timeout(
+            ws, STT_STREAMING_IDLE_TIMEOUT_SECONDS
+        ):
             if getattr(message, "type", None) == "error":
                 error = getattr(message.data, "error", "Unknown Sarvam STT error")
                 raise RuntimeError(error)
@@ -328,31 +456,6 @@ async def transcribe_sarvam(audio_path: Path, language: str) -> str:
     return {
         "transcript": transcript,
         "ttft": ttft,
-    }
-
-
-async def transcribe_elevenlabs(audio_path: Path, language: str) -> str:
-    """Transcribe audio using ElevenLabs' STT API."""
-    api_key = os.getenv("ELEVENLABS_API_KEY")
-    if not api_key:
-        raise ValueError("ELEVENLABS_API_KEY environment variable not set")
-
-    lang_code = get_stt_language_code(language, "elevenlabs")
-
-    elevenlabs = AsyncElevenLabs(api_key=api_key)
-
-    audio_data = load_audio(audio_path)
-
-    response = await elevenlabs.speech_to_text.convert(
-        file=audio_data,
-        model_id="scribe_v2",
-        language_code=lang_code,
-    )
-
-    transcript = response.text
-
-    return {
-        "transcript": transcript,
     }
 
 
@@ -407,80 +510,39 @@ async def transcribe_cartesia(audio_path: Path, language: str) -> str:
             await ws.send("done")
             # print("Audio streaming completed")
 
+        start_time = time.perf_counter()
+        ttft_holder = {"ttft": None}
+
         async def receive_transcripts():
             """Receive and process transcription results with word timestamps"""
             full_transcript = ""
 
-            async for result in ws.receive():
+            async for result in _aiter_with_idle_timeout(
+                ws.receive(), STT_STREAMING_IDLE_TIMEOUT_SECONDS
+            ):
                 if result["type"] == "transcript":
                     text = result["text"]
                     is_final = result["is_final"]
 
+                    if text and ttft_holder["ttft"] is None:
+                        ttft_holder["ttft"] = time.perf_counter() - start_time
+
                     if is_final:
-                        # Final result - this text won't change
                         full_transcript += text + " "
-                        # print(f"FINAL: {text}")
-                    # else:
-                    # Partial result - may change as more audio is processed
-                    # print(f"PARTIAL: {text}")
 
                 elif result["type"] == "done":
-                    # print("Transcription completed")
                     break
 
             return full_transcript.strip()
 
-        # print("Starting streaming STT...")
+        _, final_transcript = await asyncio.gather(send_audio(), receive_transcripts())
 
-        # Use asyncio.gather to run audio sending and transcript receiving concurrently
-        _, (final_transcript) = await asyncio.gather(
-            send_audio(), receive_transcripts()
-        )
-
-        # print(f"\nComplete transcript: {final_transcript}")
-        # print(f"Total words with timestamps: {len(word_timestamps)}")
-
-        # Clean up
         await ws.close()
 
-        return {"transcript": final_transcript}
+        return {"transcript": final_transcript, "ttft": ttft_holder["ttft"]}
 
     finally:
         await client.close()
-
-
-async def transcribe_smallest(audio_path: Path, language: str) -> str:
-    """Transcribe audio using Smallest's STT API."""
-    api_key = os.getenv("SMALLEST_API_KEY")
-    if not api_key:
-        raise ValueError("SMALLEST_API_KEY environment variable not set")
-
-    lang_code = get_stt_language_code(language, "smallest")
-
-    endpoint = "https://api.smallest.ai/waves/v1/pulse/get_text"
-    params = {
-        "model": "pulse",
-        "language": lang_code,
-        "word_timestamps": "false",
-    }
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "audio/wav",
-    }
-
-    audio = load_audio(audio_path)
-
-    async with httpx.AsyncClient(timeout=120.0) as client:
-        response = await client.post(
-            endpoint, params=params, headers=headers, content=audio
-        )
-
-    output = response.json()
-    transcript = output.get("transcription", "")
-
-    return {
-        "transcript": transcript,
-    }
 
 
 async def transcribe_smallest_streaming(audio_path: Path, language: str) -> str:
@@ -527,7 +589,9 @@ async def transcribe_smallest_streaming(audio_path: Path, language: str) -> str:
         transcript_parts = []
 
         try:
-            async for message in ws:
+            async for message in _aiter_with_idle_timeout(
+                ws, STT_STREAMING_IDLE_TIMEOUT_SECONDS
+            ):
                 try:
                     output = json.loads(message)
                 except json.JSONDecodeError:
@@ -567,6 +631,126 @@ async def transcribe_smallest_streaming(audio_path: Path, language: str) -> str:
     }
 
 
+async def transcribe_elevenlabs_streaming(audio_path: Path, language: str) -> str:
+    """Transcribe audio using ElevenLabs' Scribe v2 Realtime WebSocket API.
+
+    Uses the documented raw-WebSocket protocol (manual commit strategy) rather
+    than the SDK's higher-level ``speech_to_text.realtime.connect`` because the
+    installed elevenlabs SDK version doesn't ship the realtime STT client.
+    See https://elevenlabs.io/docs/eleven-api/guides/how-to/speech-to-text/realtime/server-side-streaming.
+    """
+    try:
+        from websockets.asyncio.client import connect as websocket_connect
+    except ModuleNotFoundError as e:
+        raise ImportError(
+            "websockets is required for ElevenLabs streaming STT. "
+            "Install with 'pip install websockets'."
+        ) from e
+
+    api_key = os.getenv("ELEVENLABS_API_KEY")
+    if not api_key:
+        raise ValueError("ELEVENLABS_API_KEY environment variable not set")
+
+    lang_code = get_stt_language_code(language, "elevenlabs")
+
+    endpoint = "wss://api.elevenlabs.io/v1/speech-to-text/realtime"
+    params = {
+        "model_id": "scribe_v2_realtime",
+        "audio_format": "pcm_16000",
+        "commit_strategy": "manual",
+        "language_code": lang_code,
+    }
+    ws_url = f"{endpoint}?{urlencode(params)}"
+    headers = {"xi-api-key": api_key}
+
+    audio = load_audio(audio_path, raw_pcm=True)
+    chunk_size = 32000  # 1s of 16 kHz, 16-bit mono PCM
+
+    async with websocket_connect(ws_url, additional_headers=headers) as ws:
+        # The server emits ``session_started`` before accepting audio.
+        await asyncio.wait_for(ws.recv(), timeout=STT_STREAMING_IDLE_TIMEOUT_SECONDS)
+
+        async def send_audio():
+            for start in range(0, len(audio), chunk_size):
+                chunk = audio[start : start + chunk_size]
+                if chunk:
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "message_type": "input_audio_chunk",
+                                "audio_base_64": base64.b64encode(chunk).decode(
+                                    "utf-8"
+                                ),
+                                "commit": False,
+                                "sample_rate": 16000,
+                            }
+                        )
+                    )
+                    await asyncio.sleep(0.05)
+
+            # Final commit finalises the segment and triggers committed_transcript.
+            await ws.send(
+                json.dumps(
+                    {
+                        "message_type": "input_audio_chunk",
+                        "audio_base_64": "",
+                        "commit": True,
+                        "sample_rate": 16000,
+                    }
+                )
+            )
+
+        start_time = time.perf_counter()
+        ttft = None
+        sender = asyncio.create_task(send_audio())
+        transcript_parts = []
+
+        try:
+            async for message in _aiter_with_idle_timeout(
+                ws, STT_STREAMING_IDLE_TIMEOUT_SECONDS
+            ):
+                try:
+                    output = json.loads(message)
+                except json.JSONDecodeError:
+                    continue
+
+                if not isinstance(output, dict):
+                    continue
+
+                message_type = output.get("message_type")
+
+                if message_type == "input_error":
+                    raise RuntimeError(f"ElevenLabs streaming STT error: {output}")
+
+                if message_type == "partial_transcript":
+                    if output.get("text") and ttft is None:
+                        ttft = time.perf_counter() - start_time
+
+                if message_type == "committed_transcript":
+                    text = output.get("text", "")
+                    if text:
+                        if ttft is None:
+                            ttft = time.perf_counter() - start_time
+                        transcript_parts.append(text)
+                    break
+        finally:
+            if sender.done():
+                await sender
+            else:
+                sender.cancel()
+                try:
+                    await sender
+                except asyncio.CancelledError:
+                    pass
+
+    return {
+        "transcript": " ".join(
+            part.strip() for part in transcript_parts if part.strip()
+        ),
+        "ttft": ttft,
+    }
+
+
 # =============================================================================
 # Main Transcription Router
 # =============================================================================
@@ -583,14 +767,13 @@ async def transcribe_audio(
 ) -> str:
     """Route audio transcription to the appropriate provider."""
     provider_methods = {
-        "deepgram": transcribe_deepgram,
-        "openai": transcribe_openai,
+        "deepgram": transcribe_deepgram_streaming,
+        "openai": transcribe_openai_streaming,
         "groq": transcribe_groq,
         "google": transcribe_google,
         "sarvam": transcribe_sarvam,
-        "elevenlabs": transcribe_elevenlabs,
+        "elevenlabs": transcribe_elevenlabs_streaming,
         "cartesia": transcribe_cartesia,
-        # "smallest": transcribe_smallest,
         "smallest": transcribe_smallest_streaming,
     }
 
@@ -601,6 +784,7 @@ async def transcribe_audio(
     output = await method(audio_path, language)
 
     transcript = output["transcript"].strip()
+    ttft = output.get("ttft")
 
     if langfuse_enabled and langfuse:
         # Download the audio from path and add to input in langfuse
@@ -618,11 +802,12 @@ async def transcribe_audio(
                 "provider": provider,
                 "language": language,
                 "reference": reference,
+                "ttft": ttft,
             },
             session_id=unique_id,
         )
 
-    return transcript
+    return {"transcript": transcript, "ttft": ttft}
 
 
 # =============================================================================
@@ -638,6 +823,12 @@ async def run_stt_eval(
     results_csv_path: Path,
 ) -> int:
     """Process audio files and save results immediately to CSV.
+
+    Row-level failures (after ``transcribe_audio``'s backoff retries are
+    exhausted) are recorded as ``status="failed"`` with an ``error`` message
+    in the CSV row and do NOT abort the run. The loop continues so a single
+    bad row can't sink an otherwise-good benchmark. A summary of all failed
+    rows is logged at the end.
 
     Args:
         gt_data: List of {"id": ..., "gt": ...} for each file to process
@@ -659,6 +850,7 @@ async def run_stt_eval(
         processed_ids = set()
 
     success_count = 0
+    row_errors: List[tuple] = []
 
     unique_id = str(uuid.uuid4())
 
@@ -672,16 +864,26 @@ async def run_stt_eval(
         _log(f"--------------------------------")
         _log(f"Processing audio [{i + 1}/{len(gt_data)}]: {audio_path.name}")
 
+        transcript = ""
+        ttft = None
+        status = "success"
+        error = None
         try:
-            transcript = await transcribe_audio(
+            output = await transcribe_audio(
                 audio_path, gt_info["gt"], provider, language, unique_id
             )
+            transcript = output["transcript"]
+            ttft = output.get("ttft")
             _log(f"\033[33mTranscript: {transcript}\033[0m")
+            if ttft is not None:
+                _log(f"TTFT: {ttft:.3f}s")
             if transcript:
                 success_count += 1
         except Exception as e:
-            _log(f"\033[91mFailed to transcribe {audio_path}: {e}\033[0m")
-            raise
+            status = "failed"
+            error = f"{type(e).__name__}: {e}"
+            row_errors.append((gt_info["id"], error))
+            _log(f"\033[91mFailed to transcribe {audio_path}: {error}\033[0m")
 
         # Save immediately after each file
         results.append(
@@ -689,9 +891,20 @@ async def run_stt_eval(
                 "id": gt_info["id"],
                 "gt": gt_info["gt"],
                 "pred": transcript,
+                "ttft": ttft,
+                "status": status,
+                "error": error,
             }
         )
         pd.DataFrame(results).to_csv(results_csv_path, index=False)
+
+    if row_errors:
+        _log("--------------------------------")
+        _log(
+            f"\033[91m{len(row_errors)} row(s) failed for provider '{provider}':\033[0m"
+        )
+        for row_id, err in row_errors:
+            _log(f"  - {row_id}: {err}")
 
     return success_count
 
@@ -939,7 +1152,14 @@ async def run_single_provider_eval(
                 for gt_info in gt_data:
                     if gt_info["id"] not in processed_ids:
                         results.append(
-                            {"id": gt_info["id"], "gt": gt_info["gt"], "pred": ""}
+                            {
+                                "id": gt_info["id"],
+                                "gt": gt_info["gt"],
+                                "pred": "",
+                                "ttft": None,
+                                "status": "failed",
+                                "error": "not processed (no progress after retry)",
+                            }
                         )
 
                 pd.DataFrame(results).to_csv(results_csv_path, index=False)
@@ -965,6 +1185,23 @@ async def run_single_provider_eval(
         all_gt_transcripts = results_df["gt"].astype(str).tolist()
         all_pred_transcripts = results_df["pred"].fillna("").astype(str).tolist()
 
+        if "ttft" in results_df.columns:
+            all_ttfts = [
+                None if pd.isna(v) else float(v) for v in results_df["ttft"].tolist()
+            ]
+        else:
+            all_ttfts = [None] * len(all_ids)
+        if "status" in results_df.columns:
+            all_statuses = results_df["status"].fillna("success").astype(str).tolist()
+        else:
+            all_statuses = ["success"] * len(all_ids)
+        if "error" in results_df.columns:
+            all_errors = [
+                None if pd.isna(v) else str(v) for v in results_df["error"].tolist()
+            ]
+        else:
+            all_errors = [None] * len(all_ids)
+
         _log(f"gt_transcripts: {all_gt_transcripts}", to_terminal=False)
         _log(f"pred_transcripts: {all_pred_transcripts}", to_terminal=False)
 
@@ -978,6 +1215,9 @@ async def run_single_provider_eval(
             output_dir=provider_output_dir,
             evaluator_config_dir=output_dir,
             judge_evaluators=judge_evaluators,
+            ttfts=all_ttfts,
+            statuses=all_statuses,
+            errors=all_errors,
         )
 
         return {
@@ -1032,6 +1272,9 @@ async def _score_and_write_results(
     output_dir: str,
     evaluator_config_dir: str,
     judge_evaluators: list[dict] = None,
+    ttfts: list = None,
+    statuses: list = None,
+    errors: list = None,
 ) -> dict:
     """Run WER + LLM-judge evaluators over (gt, pred) pairs and write outputs.
 
@@ -1039,41 +1282,87 @@ async def _score_and_write_results(
     resolved evaluator config under ``evaluator_config_dir``. Returns the
     metrics_data dict.
     """
+    n = len(ids)
+    if ttfts is None:
+        ttfts = [None] * n
+    if statuses is None:
+        statuses = ["success"] * n
+    if errors is None:
+        errors = [None] * n
+
     wer_results = get_wer_score(gt_transcripts, pred_transcripts)
-    _log(f"WER: {wer_results['score']}", to_terminal=False)
+    # Exclude failed rows from per-row WER and the corpus aggregate so a
+    # provider timeout/error isn't conflated with a bad transcription.
+    per_row_wer = [
+        wer if status == "success" else None
+        for wer, status in zip(wer_results["per_row"], statuses)
+    ]
+    valid_wer = [w for w in per_row_wer if w is not None]
+    overall_wer = float(np.mean(valid_wer)) if valid_wer else None
+    _log(f"WER: {overall_wer}", to_terminal=False)
 
     _evaluators = judge_evaluators if judge_evaluators else [DEFAULT_STT_EVALUATOR]
     require_unique_evaluator_names(_evaluators)
     write_evaluator_config(evaluator_config_dir, _evaluators)
-    llm_results = await get_llm_judge_score(
-        gt_transcripts,
-        pred_transcripts,
-        evaluators=_evaluators,
-    )
-    for name, score_dict in llm_results["scores"].items():
-        _log(f"  {name}: {score_dict['mean']:.4f}")
+
+    # Only run judges on successful rows — failed rows have empty pred and
+    # would otherwise waste API calls and pollute the aggregate scores.
+    success_idx = [i for i, s in enumerate(statuses) if s == "success"]
+    if success_idx:
+        llm_results = await get_llm_judge_score(
+            [gt_transcripts[i] for i in success_idx],
+            [pred_transcripts[i] for i in success_idx],
+            evaluators=_evaluators,
+        )
+        for name, score_dict in llm_results["scores"].items():
+            _log(f"  {name}: {score_dict['mean']:.4f}")
+    else:
+        llm_results = {"scores": {}, "score": None, "per_row": []}
+
+    # Expand per-row judge results back to full length (None for failed rows).
+    per_row_llm = [None] * n
+    for offset, i in enumerate(success_idx):
+        per_row_llm[i] = llm_results["per_row"][offset]
 
     _evaluators_by_name = {ev["name"]: ev for ev in _evaluators}
 
-    metrics_data = {"wer": wer_results["score"]}
+    metrics_data = {"wer": overall_wer}
     for name, score_dict in llm_results["scores"].items():
         metrics_data[name] = score_dict
 
+    valid_ttfts = [t for t in ttfts if t is not None]
+    if valid_ttfts:
+        metrics_data["ttft"] = {
+            "mean": float(np.mean(valid_ttfts)),
+            "std": float(np.std(valid_ttfts)),
+            "values": [float(t) for t in valid_ttfts],
+        }
+
     data = []
-    for _id, gt_text, pred_text, wer, llm_row in zip(
+    for _id, gt_text, pred_text, wer, llm_row, ttft, status, error in zip(
         ids,
         gt_transcripts,
         pred_transcripts,
-        wer_results["per_row"],
-        llm_results["per_row"],
+        per_row_wer,
+        per_row_llm,
+        ttfts,
+        statuses,
+        errors,
     ):
         row = {
             "id": _id,
             "gt": gt_text,
             "pred": pred_text,
+            "ttft": ttft,
+            "status": status,
+            "error": error,
             "wer": wer,
         }
         for name, ev in _evaluators_by_name.items():
+            if llm_row is None:
+                row[name] = None
+                row[f"{name}_reasoning"] = None
+                continue
             ev_result = llm_row[name]
             if is_rating(ev):
                 row[name] = ev_result["score"]
@@ -1269,16 +1558,20 @@ async def main():
         sys.exit(1)
     else:
         metrics = result.get("metrics", {})
-        wer = metrics.get("wer", 0)
+        wer = metrics.get("wer")
         # Evaluator entries are dicts carrying a ``type`` field; that's the
         # marker we use to pick them out from other top-level metrics.
         judge_scores = {
-            k: v["mean"]
+            k: v.get("mean")
             for k, v in metrics.items()
             if isinstance(v, dict) and "type" in v
         }
-        judge_str = ", ".join(f"{k}={v:.4f}" for k, v in judge_scores.items())
-        print(f"  {provider}: WER={wer:.4f}, {judge_str}")
+
+        def _fmt(v):
+            return f"{v:.4f}" if isinstance(v, (int, float)) else "N/A"
+
+        judge_str = ", ".join(f"{k}={_fmt(v)}" for k, v in judge_scores.items())
+        print(f"  {provider}: WER={_fmt(wer)}, {judge_str}")
 
 
 if __name__ == "__main__":

--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -1202,6 +1202,19 @@ async def run_single_provider_eval(
         else:
             all_errors = [None] * len(all_ids)
 
+        if all_statuses and not any(s == "success" for s in all_statuses):
+            error_msg = (
+                f"All {len(all_statuses)} row(s) failed for provider '{provider}' — "
+                "no successful transcriptions to score."
+            )
+            _log(f"\033[91m{error_msg}\033[0m")
+            return {
+                "provider": provider,
+                "status": "error",
+                "error": error_msg,
+                "output_dir": provider_output_dir,
+            }
+
         _log(f"gt_transcripts: {all_gt_transcripts}", to_terminal=False)
         _log(f"pred_transcripts: {all_pred_transcripts}", to_terminal=False)
 

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -213,18 +213,18 @@ class TestTranscribeAudioRouter(unittest.IsolatedAsyncioTestCase):
     async def test_known_provider_routed(self):
         from calibrate.stt import eval as stt_eval
 
-        fake = AsyncMock(return_value={"transcript": "  hello  "})
+        fake = AsyncMock(return_value={"transcript": "  hello  ", "ttft": 0.5})
         with patch.dict(
             "os.environ", {"DEEPGRAM_API_KEY": "x"}
-        ), patch.object(stt_eval, "transcribe_deepgram", fake):
-            transcript = await stt_eval.transcribe_audio.__wrapped__(
+        ), patch.object(stt_eval, "transcribe_deepgram_streaming", fake):
+            output = await stt_eval.transcribe_audio.__wrapped__(
                 Path("/tmp/x.wav"),
                 "ref",
                 "deepgram",
                 "english",
                 "uid",
             )
-        self.assertEqual(transcript, "hello")
+        self.assertEqual(output, {"transcript": "hello", "ttft": 0.5})
         fake.assert_awaited_once()
 
 

--- a/tests/stt/test_eval_extra.py
+++ b/tests/stt/test_eval_extra.py
@@ -73,20 +73,6 @@ class TestLoadAudio(unittest.TestCase):
 # --- Provider transcribe_* missing-key paths ------------------------------
 
 class TestProviderAPIKeyMissing(unittest.IsolatedAsyncioTestCase):
-    async def test_deepgram_missing_key(self):
-        from calibrate.stt.eval import transcribe_deepgram
-
-        with patch.dict(os.environ, {}, clear=True):
-            with self.assertRaises(ValueError):
-                await transcribe_deepgram(Path("/tmp/x.wav"), "english")
-
-    async def test_openai_missing_key(self):
-        from calibrate.stt.eval import transcribe_openai
-
-        with patch.dict(os.environ, {}, clear=True):
-            with self.assertRaises(ValueError):
-                await transcribe_openai(Path("/tmp/x.wav"), "english")
-
     async def test_groq_missing_key(self):
         from calibrate.stt.eval import transcribe_groq
 
@@ -108,13 +94,6 @@ class TestProviderAPIKeyMissing(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(ValueError):
                 await transcribe_sarvam(Path("/tmp/x.wav"), "english")
 
-    async def test_elevenlabs_missing_key(self):
-        from calibrate.stt.eval import transcribe_elevenlabs
-
-        with patch.dict(os.environ, {}, clear=True):
-            with self.assertRaises(ValueError):
-                await transcribe_elevenlabs(Path("/tmp/x.wav"), "english")
-
     async def test_cartesia_missing_key(self):
         from calibrate.stt.eval import transcribe_cartesia
 
@@ -122,19 +101,181 @@ class TestProviderAPIKeyMissing(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(ValueError):
                 await transcribe_cartesia(Path("/tmp/x.wav"), "english")
 
-    async def test_smallest_missing_key(self):
-        from calibrate.stt.eval import transcribe_smallest
-
-        with patch.dict(os.environ, {}, clear=True):
-            with self.assertRaises(ValueError):
-                await transcribe_smallest(Path("/tmp/x.wav"), "english")
-
     async def test_smallest_streaming_missing_key(self):
         from calibrate.stt.eval import transcribe_smallest_streaming
 
         with patch.dict(os.environ, {}, clear=True):
             with self.assertRaises(ValueError):
                 await transcribe_smallest_streaming(Path("/tmp/x.wav"), "english")
+
+    async def test_elevenlabs_streaming_missing_key(self):
+        from calibrate.stt.eval import transcribe_elevenlabs_streaming
+
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ValueError):
+                await transcribe_elevenlabs_streaming(
+                    Path("/tmp/x.wav"), "english"
+                )
+
+    async def test_openai_streaming_missing_key(self):
+        from calibrate.stt.eval import transcribe_openai_streaming
+
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ValueError):
+                await transcribe_openai_streaming(
+                    Path("/tmp/x.wav"), "english"
+                )
+
+    async def test_deepgram_streaming_missing_key(self):
+        from calibrate.stt.eval import transcribe_deepgram_streaming
+
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ValueError):
+                await transcribe_deepgram_streaming(
+                    Path("/tmp/x.wav"), "english"
+                )
+
+    async def test_elevenlabs_streaming_happy(self):
+        import asyncio as _asyncio
+        import json as _json
+
+        from calibrate.stt import eval as E
+
+        # Fake WS that emits session_started on recv() and yields a
+        # committed_transcript only after the client sends its final commit,
+        # mirroring the real server's protocol order.
+        class FakeWS:
+            def __init__(self):
+                self.sent = []
+                self._commit_received = _asyncio.Event()
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def recv(self):
+                return _json.dumps({"message_type": "session_started"})
+
+            async def send(self, payload):
+                self.sent.append(payload)
+                if '"commit": true' in payload:
+                    self._commit_received.set()
+
+            def __aiter__(self):
+                evt = self._commit_received
+
+                async def gen():
+                    await evt.wait()
+                    yield _json.dumps(
+                        {"message_type": "committed_transcript", "text": "hello"}
+                    )
+
+                return gen()
+
+        fake_ws = FakeWS()
+
+        def _fake_connect(*args, **kwargs):
+            return fake_ws
+
+        with patch.dict(os.environ, {"ELEVENLABS_API_KEY": "k"}), patch.object(
+            E, "load_audio", return_value=b"\x00\x00" * 1000
+        ), patch(
+            "websockets.asyncio.client.connect", side_effect=_fake_connect
+        ):
+            result = await E.transcribe_elevenlabs_streaming(
+                Path("/tmp/x.wav"), "english"
+            )
+
+        self.assertEqual(result["transcript"], "hello")
+        # Final commit must have been sent before we received the transcript.
+        self.assertTrue(any('"commit": true' in s for s in fake_ws.sent))
+
+    async def test_openai_streaming_happy(self):
+        from types import SimpleNamespace
+
+        from calibrate.stt import eval as E
+
+        events = [
+            SimpleNamespace(type="transcript.text.delta", delta="hello "),
+            SimpleNamespace(type="transcript.text.done", text="hello world"),
+        ]
+
+        async def fake_stream():
+            for ev in events:
+                yield ev
+
+        fake_client = MagicMock()
+        fake_client.audio.transcriptions.create = AsyncMock(
+            return_value=fake_stream()
+        )
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "k"}), patch.object(
+            E, "load_audio", return_value=b"\x00" * 100
+        ), patch.object(E, "AsyncOpenAI", return_value=fake_client):
+            result = await E.transcribe_openai_streaming(
+                Path("/tmp/x.wav"), "english"
+            )
+
+        self.assertEqual(result["transcript"], "hello world")
+        self.assertIsNotNone(result["ttft"])
+
+    async def test_deepgram_streaming_happy(self):
+        import json as _json
+
+        from calibrate.stt import eval as E
+
+        # Fake WS that emits a final Results then a Metadata to signal end.
+        class FakeWS:
+            def __init__(self):
+                self.sent = []
+                self._messages = [
+                    _json.dumps(
+                        {
+                            "type": "Results",
+                            "is_final": True,
+                            "channel": {
+                                "alternatives": [{"transcript": "hello world"}]
+                            },
+                        }
+                    ),
+                    _json.dumps({"type": "Metadata"}),
+                ]
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def send(self, payload):
+                self.sent.append(payload)
+
+            def __aiter__(self):
+                msgs = self._messages
+
+                async def gen():
+                    for m in msgs:
+                        yield m
+
+                return gen()
+
+        fake_ws = FakeWS()
+
+        def _fake_connect(*args, **kwargs):
+            return fake_ws
+
+        with patch.dict(os.environ, {"DEEPGRAM_API_KEY": "k"}), patch.object(
+            E, "load_audio", return_value=b"\x00" * 1000
+        ), patch(
+            "websockets.asyncio.client.connect", side_effect=_fake_connect
+        ):
+            result = await E.transcribe_deepgram_streaming(
+                Path("/tmp/x.wav"), "english"
+            )
+
+        self.assertEqual(result["transcript"], "hello world")
 
 
 # --- transcribe_audio router ----------------------------------------------
@@ -153,13 +294,13 @@ class TestTranscribeAudioRouter(unittest.IsolatedAsyncioTestCase):
     async def test_routes_to_provider(self):
         from calibrate.stt import eval as E
 
-        fake_fn = AsyncMock(return_value={"transcript": "hello world"})
+        fake_fn = AsyncMock(return_value={"transcript": "hello world", "ttft": 0.25})
         inner = E.transcribe_audio
         while hasattr(inner, "__wrapped__"):
             inner = inner.__wrapped__
-        with patch.object(E, "transcribe_deepgram", fake_fn):
+        with patch.object(E, "transcribe_deepgram_streaming", fake_fn):
             result = await inner(Path("/tmp/x.wav"), "ref", "deepgram", "english", "u")
-        self.assertEqual(result, "hello world")
+        self.assertEqual(result, {"transcript": "hello world", "ttft": 0.25})
         fake_fn.assert_called_once()
 
     async def test_with_langfuse(self):
@@ -170,7 +311,7 @@ class TestTranscribeAudioRouter(unittest.IsolatedAsyncioTestCase):
         while hasattr(inner, "__wrapped__"):
             inner = inner.__wrapped__
         fake_lf = MagicMock()
-        with patch.object(E, "transcribe_deepgram", fake_fn), \
+        with patch.object(E, "transcribe_deepgram_streaming", fake_fn), \
              patch.object(E, "langfuse_enabled", True), \
              patch.object(E, "langfuse", fake_lf), \
              patch.object(E, "create_langfuse_audio_media", return_value=None):
@@ -371,7 +512,11 @@ class TestRunStteval(unittest.IsolatedAsyncioTestCase):
                 str(results_csv), index=False
             )
 
-            with patch.object(E, "transcribe_audio", AsyncMock(return_value="hello b")):
+            with patch.object(
+                E,
+                "transcribe_audio",
+                AsyncMock(return_value={"transcript": "hello b", "ttft": 0.1}),
+            ):
                 count = await E.run_stt_eval(
                     gt_data=[{"id": "a", "gt": "X"}, {"id": "b", "gt": "Y"}],
                     audio_dir=audio_dir,
@@ -383,6 +528,50 @@ class TestRunStteval(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(count, 1)
             df = pd.read_csv(str(results_csv))
             self.assertEqual(len(df), 2)
+
+    async def test_row_level_error_does_not_abort_run(self):
+        from calibrate.stt import eval as E
+
+        # transcribe_audio raises for "a", succeeds for "b". The run must
+        # complete, recording "a" as failed and "b" as success.
+        async def fake_transcribe(audio_path, *args, **kwargs):
+            if audio_path.name == "a.wav":
+                raise RuntimeError("simulated provider failure")
+            return {"transcript": "hello b", "ttft": 0.2}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp) / "stuff"
+            base.mkdir()
+            audio_dir = base / "audios"
+            audio_dir.mkdir()
+            (audio_dir / "a.wav").write_bytes(b"\x00")
+            (audio_dir / "b.wav").write_bytes(b"\x00")
+            results_csv = base / "results.csv"
+
+            with patch.object(
+                E, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                count = await E.run_stt_eval(
+                    gt_data=[
+                        {"id": "a", "gt": "X"},
+                        {"id": "b", "gt": "Y"},
+                    ],
+                    audio_dir=audio_dir,
+                    provider="deepgram",
+                    language="english",
+                    results_csv_path=str(results_csv),
+                )
+
+            self.assertEqual(count, 1)
+            df = pd.read_csv(str(results_csv))
+            self.assertEqual(len(df), 2)
+            self.assertEqual(set(df["status"].tolist()), {"success", "failed"})
+            failed_row = df[df["id"] == "a"].iloc[0]
+            self.assertEqual(failed_row["status"], "failed")
+            self.assertIn("simulated provider failure", str(failed_row["error"]))
+            success_row = df[df["id"] == "b"].iloc[0]
+            self.assertEqual(success_row["status"], "success")
+            self.assertEqual(success_row["pred"], "hello b")
 
 
 # --- run_single_provider_eval --------------------------------------------
@@ -403,7 +592,7 @@ class TestRunSingleProviderEval(unittest.IsolatedAsyncioTestCase):
             # Pre-existing results.csv to trigger overwrite path
             (output / "deepgram" / "results.csv").write_text("id,gt,pred\na,hello,hi\n")
 
-            with patch.object(E, "transcribe_audio", AsyncMock(return_value="hello")), \
+            with patch.object(E, "transcribe_audio", AsyncMock(return_value={"transcript": "hello", "ttft": 0.3})), \
                  patch.object(E, "get_wer_score", return_value={"score": 0.0, "per_row": [0.0]}), \
                  patch.object(E, "get_llm_judge_score", AsyncMock(return_value={
                      "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
@@ -463,7 +652,7 @@ class TestRunSingleProviderEval(unittest.IsolatedAsyncioTestCase):
             output = Path(tmp) / "out"
             output.mkdir()
 
-            with patch.object(E, "transcribe_audio", AsyncMock(return_value="hello")), \
+            with patch.object(E, "transcribe_audio", AsyncMock(return_value={"transcript": "hello", "ttft": 0.4})), \
                  patch.object(E, "get_wer_score", return_value={"score": 0.0, "per_row": [0.0]}), \
                  patch.object(E, "get_llm_judge_score", AsyncMock(return_value={
                      "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},

--- a/tests/stt/test_eval_extra.py
+++ b/tests/stt/test_eval_extra.py
@@ -611,6 +611,46 @@ class TestRunSingleProviderEval(unittest.IsolatedAsyncioTestCase):
                 )
             self.assertEqual(result["status"], "completed")
 
+    async def test_all_rows_failed_returns_error_status(self):
+        from calibrate.stt import eval as E
+
+        async def always_fail(*args, **kwargs):
+            raise RuntimeError("simulated outage")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            (base / "audios").mkdir()
+            for rid in ["a", "b"]:
+                (base / "audios" / f"{rid}.wav").write_bytes(b"\x00")
+            pd.DataFrame(
+                {"id": ["a", "b"], "text": ["hello", "world"]}
+            ).to_csv(base / "stt.csv", index=False)
+
+            output = Path(tmp) / "out"
+            output.mkdir()
+
+            judge_mock = AsyncMock()
+            with patch.object(
+                E, "transcribe_audio", AsyncMock(side_effect=always_fail)
+            ), patch.object(E, "get_llm_judge_score", judge_mock):
+                result = await E.run_single_provider_eval(
+                    provider="deepgram",
+                    language="english",
+                    input_dir=str(base),
+                    input_file_name="stt.csv",
+                    output_dir=str(output),
+                    debug=False,
+                    debug_count=5,
+                    ignore_retry=True,
+                    overwrite=True,
+                )
+
+            self.assertEqual(result["status"], "error")
+            self.assertIn("All", result["error"])
+            self.assertIn("deepgram", result["error"])
+            # Judges must not be called when every row failed.
+            judge_mock.assert_not_awaited()
+
     async def test_existing_invalid_csv_error(self):
         from calibrate.stt import eval as E
 

--- a/tests/stt/test_eval_providers.py
+++ b/tests/stt/test_eval_providers.py
@@ -19,40 +19,6 @@ def _mock_load_audio(*args, **kwargs):
     return b"RIFF\x00\x00\x00\x00WAVE"
 
 
-class TestTranscribeDeepgram(unittest.IsolatedAsyncioTestCase):
-    async def test_deepgram_happy(self):
-        from calibrate.stt import eval as E
-
-        fake_resp = MagicMock()
-        fake_resp.results.channels[0].alternatives[0].transcript = "hello"
-        fake_client = MagicMock()
-        fake_client.listen.asyncrest.v.return_value.transcribe_file = AsyncMock(
-            return_value=fake_resp
-        )
-
-        with patch.dict(os.environ, {"DEEPGRAM_API_KEY": "k"}), \
-             patch.object(E, "load_audio", side_effect=_mock_load_audio), \
-             patch.object(E, "DeepgramClient", return_value=fake_client):
-            result = await E.transcribe_deepgram(Path("/tmp/x.wav"), "english")
-        self.assertEqual(result["transcript"], "hello")
-
-
-class TestTranscribeOpenAI(unittest.IsolatedAsyncioTestCase):
-    async def test_openai_happy(self):
-        from calibrate.stt import eval as E
-
-        fake_resp = MagicMock()
-        fake_resp.text = "hi"
-        fake_client = MagicMock()
-        fake_client.audio.transcriptions.create = AsyncMock(return_value=fake_resp)
-
-        with patch.dict(os.environ, {"OPENAI_API_KEY": "k"}), \
-             patch.object(E, "load_audio", side_effect=_mock_load_audio), \
-             patch.object(E, "AsyncOpenAI", return_value=fake_client):
-            result = await E.transcribe_openai(Path("/tmp/x.wav"), "english")
-        self.assertEqual(result["transcript"], "hi")
-
-
 class TestTranscribeGroq(unittest.IsolatedAsyncioTestCase):
     async def test_groq_happy(self):
         from calibrate.stt import eval as E
@@ -65,23 +31,6 @@ class TestTranscribeGroq(unittest.IsolatedAsyncioTestCase):
              patch.object(E, "AsyncGroq", return_value=fake_client):
             result = await E.transcribe_groq(Path("/tmp/x.wav"), "english")
         self.assertEqual(result["transcript"], "hello world")
-
-
-class TestTranscribeElevenlabs(unittest.IsolatedAsyncioTestCase):
-    async def test_elevenlabs_happy(self):
-        from calibrate.stt import eval as E
-
-        fake_resp = MagicMock()
-        fake_resp.text = "hello"
-
-        fake_client = MagicMock()
-        fake_client.speech_to_text.convert = AsyncMock(return_value=fake_resp)
-
-        with patch.dict(os.environ, {"ELEVENLABS_API_KEY": "k"}), \
-             patch.object(E, "load_audio", side_effect=_mock_load_audio), \
-             patch.object(E, "AsyncElevenLabs", return_value=fake_client):
-            result = await E.transcribe_elevenlabs(Path("/tmp/x.wav"), "english")
-        self.assertEqual(result["transcript"], "hello")
 
 
 class TestTranscribeSarvam(unittest.IsolatedAsyncioTestCase):
@@ -142,29 +91,6 @@ class TestTranscribeSarvam(unittest.IsolatedAsyncioTestCase):
              patch.object(E, "AsyncSarvamAI", return_value=fake_client):
             with self.assertRaises(RuntimeError):
                 await E.transcribe_sarvam(Path("/tmp/x.wav"), "english")
-
-
-class TestTranscribeSmallest(unittest.IsolatedAsyncioTestCase):
-    async def test_smallest_happy(self):
-        from calibrate.stt import eval as E
-
-        # Mock httpx response
-        fake_resp = MagicMock()
-        fake_resp.json.return_value = {"transcription": "hello"}
-
-        async def fake_post(*args, **kwargs):
-            return fake_resp
-
-        fake_client = MagicMock()
-        fake_client.__aenter__ = AsyncMock(return_value=fake_client)
-        fake_client.__aexit__ = AsyncMock(return_value=False)
-        fake_client.post = AsyncMock(return_value=fake_resp)
-
-        with patch.dict(os.environ, {"SMALLEST_API_KEY": "k"}), \
-             patch.object(E, "load_audio", side_effect=_mock_load_audio), \
-             patch("httpx.AsyncClient", return_value=fake_client):
-            result = await E.transcribe_smallest(Path("/tmp/x.wav"), "english")
-        self.assertEqual(result["transcript"], "hello")
 
 
 class TestTranscribeGoogle(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
Fixes #59 
Fixes #58 

- Switch deepgram/openai/elevenlabs STT to streaming-only (remove non-streaming variants and their tests). Add idle timeout (STT_STREAMING_IDLE_TIMEOUT_SECONDS=20s) for all streaming WebSocket / SSE receives so a silent provider doesn't hang the run; keep STT_PROVIDER_TIMEOUT_SECONDS=60s for the REST-style groq/google calls.
- Return TTFT from all streaming providers (sarvam, deepgram, openai, elevenlabs, cartesia, smallest). The transcribe_audio router now returns {"transcript", "ttft"}. results.csv gets a per-row ttft column and metrics.json gets a ttft aggregate ({mean, std, values}) matching the TTS ttfb shape.
- Row-level errors no longer abort the run. After @backoff's retries, the row is recorded in results.csv with status=failed and an error message; a summary of all failures is logged at the end. Failed rows are excluded from the WER and judge aggregates (and skipped by the judge LLM calls entirely), so a single provider hiccup no longer drags the metrics down.
- Summary prints in benchmark.py / eval.py are now null-safe, so a run where every row failed (wer/judge means absent) still finishes cleanly with N/A instead of a TypeError.