### PR TITLE
Add optional tool-call output for agent connections

### DIFF
--- a/calibrate/connections.py
+++ b/calibrate/connections.py
@@ -57,6 +57,13 @@ class TextAgentConnection:
         • Tool call only   → ``{"response": null,  "tool_calls": [{...}]}``
         • Both             → ``{"response": "...", "tool_calls": [{...}]}``
 
+        Each tool call may optionally carry an ``output`` field — the result the
+        tool actually returned when the agent executed it. It is any JSON value
+        and is preserved for display/review only; it never affects evaluation::
+
+            {"tool": "get_weather", "arguments": {"city": "NYC"},
+             "output": {"temp": 72, "condition": "sunny"}}
+
     Use :meth:`verify` to confirm the endpoint is reachable and returns the
     expected format before running a full evaluation.
 
@@ -231,6 +238,8 @@ class TextAgentConnection:
 
         Returns:
             dict with ``response`` (str | None) and ``tool_calls`` (list) keys.
+            Each tool call dict is passed through verbatim, so an optional
+            ``output`` field (the tool's own result) is preserved for review.
 
         Raises:
             RuntimeError: On connection error, timeout, non-200 status, or

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -1241,6 +1241,10 @@ def validate_llm_eval_only_dataset(
     Each item must be ``{"test_case": {history, evaluation}, "output":
     {response, tool_calls}}``. Returns ``(is_valid, error_message)``; the
     caller is expected to surface the message and exit non-zero on failure.
+
+    Each entry in ``output.tool_calls`` may optionally carry an ``output``
+    field (the tool's own result). It is accepted but not validated — it is
+    preserved for display/review only and never affects evaluation.
     """
     if not isinstance(dataset, list):
         return False, "Dataset must be a JSON list of {test_case, output} items"

--- a/docs/core-concepts/agent-connections.mdx
+++ b/docs/core-concepts/agent-connections.mdx
@@ -79,6 +79,24 @@ If your agent also returns tool calls, the expected output format expands to inc
 - `response` — The agent's text reply
 - `tool_calls` — An array of tool invocations, each with a `tool` name and `arguments` object
 
+Each tool call may also include an optional `output` field — the result the
+tool returned when your agent ran it. It can be any JSON value:
+
+```json
+{
+  "tool_calls": [
+    {
+      "tool": "get_schedule",
+      "arguments": { "child_age_weeks": 14 },
+      "output": { "next_visit_weeks": 14, "vaccines": ["OPV", "DPT"] }
+    }
+  ]
+}
+```
+
+`output` is optional and shown in the results view for review only — it never
+affects whether a test passes or fails.
+
 <Warning>
   Your agent's output **must** include either a `response` field or a
   `tool_calls` field

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -626,6 +626,32 @@ class TestValidateLLMEvalOnlyDataset(unittest.TestCase):
         ])
         self.assertTrue(is_valid)
 
+    def test_valid_with_tool_call_output(self):
+        """Optional per-tool-call ``output`` is accepted by the validator."""
+        from calibrate.llm.run_tests import validate_llm_eval_only_dataset
+
+        is_valid, err = validate_llm_eval_only_dataset([
+            {
+                "test_case": {
+                    "history": [{"role": "user", "content": "weather?"}],
+                    "evaluation": {"type": "tool_call", "tool_calls": [
+                        {"tool": "get_weather", "arguments": {"city": "NYC"}}
+                    ]},
+                },
+                "output": {
+                    "response": None,
+                    "tool_calls": [
+                        {
+                            "tool": "get_weather",
+                            "arguments": {"city": "NYC"},
+                            "output": {"temp": 72},
+                        }
+                    ],
+                },
+            }
+        ])
+        self.assertTrue(is_valid, err)
+
     def test_not_a_list(self):
         from calibrate.llm.run_tests import validate_llm_eval_only_dataset
 

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -79,6 +79,30 @@ class TestCallTextAgent(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(result["tool_calls"]), 1)
         self.assertEqual(result["tool_calls"][0]["tool"], "get_weather")
 
+    async def test_preserves_tool_call_output(self):
+        """Optional per-tool-call ``output`` rides through ``call`` verbatim."""
+        from calibrate.connections import TextAgentConnection
+
+        agent = TextAgentConnection(url="http://fake-agent/chat")
+        fake_body = {
+            "response": None,
+            "tool_calls": [
+                {
+                    "tool": "get_weather",
+                    "arguments": {"location": "Mumbai"},
+                    "output": {"temp": 31, "condition": "humid"},
+                }
+            ],
+        }
+
+        ctx, _ = _patch_httpx(fake_body)
+        with ctx:
+            result = await agent.call([{"role": "user", "content": "Weather?"}])
+
+        self.assertEqual(
+            result["tool_calls"][0]["output"], {"temp": 31, "condition": "humid"}
+        )
+
     async def test_sends_auth_header(self):
         from calibrate.connections import TextAgentConnection
 
@@ -288,6 +312,19 @@ class TestTextAgentConnectionVerify(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result["ok"])
         self.assertIsNone(result["sample_output"]["response"])
         self.assertEqual(result["sample_output"]["tool_calls"], [{"tool": "fn", "arguments": {}}])
+
+    async def test_verify_preserves_tool_call_output(self):
+        """``verify`` accepts and echoes an optional per-tool-call ``output``."""
+        from calibrate.connections import TextAgentConnection
+
+        agent = TextAgentConnection(url="http://fake-agent/chat")
+        tool_call = {"tool": "fn", "arguments": {}, "output": {"status": "ok"}}
+        ctx, _ = _patch_httpx({"tool_calls": [tool_call]})
+        with ctx:
+            result = await agent.verify()
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["sample_output"]["tool_calls"], [tool_call])
 
     async def test_verify_fails_empty_response(self):
         from calibrate.connections import TextAgentConnection

--- a/ui/source/llm-app.tsx
+++ b/ui/source/llm-app.tsx
@@ -672,10 +672,21 @@ export function LlmTestsApp({ onBack }: { onBack?: () => void }) {
   };
 
   // ── Format tool calls as string ──
-  const formatToolCalls = (toolCalls: ToolCall[]): string => {
+  // ``includeOutput`` appends the tool's own result (``=> <output>``) when the
+  // agent supplied one. Only used for actual output, not the expected criteria.
+  const formatToolCalls = (
+    toolCalls: ToolCall[],
+    includeOutput = false
+  ): string => {
     if (!toolCalls || toolCalls.length === 0) return "";
     return toolCalls
-      .map((tc) => `${tc.tool}(${JSON.stringify(tc.arguments)})`)
+      .map((tc) => {
+        const call = `${tc.tool}(${JSON.stringify(tc.arguments)})`;
+        if (includeOutput && tc.output !== undefined) {
+          return `${call} => ${JSON.stringify(tc.output)}`;
+        }
+        return call;
+      })
       .join(", ");
   };
 
@@ -723,7 +734,7 @@ export function LlmTestsApp({ onBack }: { onBack?: () => void }) {
             if (r.output?.response) {
               actualOutput = r.output.response;
             } else if (r.output?.tool_calls && r.output.tool_calls.length > 0) {
-              actualOutput = formatToolCalls(r.output.tool_calls);
+              actualOutput = formatToolCalls(r.output.tool_calls, true);
             }
 
             // Build evaluation criteria string. Under the new evaluators

--- a/ui/source/llm-types.ts
+++ b/ui/source/llm-types.ts
@@ -47,6 +47,9 @@ export interface HistoryMessage {
 export interface ToolCall {
   tool: string;
   arguments: Record<string, unknown>;
+  // Optional result the tool returned when an agent connection executed it.
+  // Display-only — never affects evaluation. Internal LLM runs never set it.
+  output?: unknown;
 }
 
 // Per-evaluator result keyed by evaluator name. Binary evaluators have a


### PR DESCRIPTION
## Summary
- Agent connections (`TextAgentConnection`) may now optionally include the result a tool returned (`output`) alongside each tool call in their response.
- The field is **display-only** — surfaced in the Ink UI's "Actual Output" view for review and **never affects evaluation** (judges, `evaluate_tool_calls`, and `format_conversation` are untouched).
- Backward compatible: omitting `output` changes nothing. Internal LLM runs never emit it (stub tool handlers produce no real results).

### Schema
Each tool call may carry an optional `output` (any JSON value):
```json
{ "tool": "get_weather", "arguments": { "city": "NYC" }, "output": { "temp": 72 } }
```

### Changes
- `calibrate/connections.py` — documented `output` in the response schema; it already flows through `call`/`verify` verbatim.
- `calibrate/llm/run_tests.py` — documented that eval-only datasets accept (and ignore-for-scoring) an optional per-tool-call `output`.
- `ui/source/llm-types.ts` — added `output?: unknown` to `ToolCall`.
- `ui/source/llm-app.tsx` — `formatToolCalls` gains an `includeOutput` flag; the "Actual Output" view renders `tool(args) => <output>` when present. Expected-criteria column unchanged.

## Test plan
- [x] `uv run pytest tests/test_connections.py tests/llm/test_run_tests_extra.py::TestValidateLLMEvalOnlyDataset` — 32 passed
- [x] `npx tsc --noEmit` — clean
- [x] UI vitest — no new failures (1 pre-existing failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)