### PR TITLE
Capture per-parameter verdicts for tool-call tests (exact + llm)

### DIFF
--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -713,7 +713,7 @@ def _collect_arg_diffs(
         path = f"{prefix}.{key}" if prefix else key
         in_act = key in actual
         if key not in expected:
-            detail = f"unexpected key in actual output (value {actual[key]!r})"
+            detail = f"unexpected key in actual output (value={actual[key]!r})"
             lines.append(f"  {path}: {detail}")
             if records is not None:
                 records.append(

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -849,6 +849,9 @@ def _detailed_call_lines(records: List[dict], *, tool: Optional[str] = None) -> 
     parameter, then every failing parameter (exact or judged). Used for both the
     all-passed reasoning and the per-call mismatch message so the agent's output
     is reported the same way whether the call passed or failed.
+
+    ``tool`` is only supplied for the all-passed consolidation (which has no
+    failing parameters), so the failing-line branch never needs a tool prefix.
     """
     lines: List[str] = []
     matched = _matched_exact_line(records, tool=tool)
@@ -860,10 +863,7 @@ def _detailed_call_lines(records: List[dict], *, tool: Optional[str] = None) -> 
             lines.append(f"  {param}: criteria met — {r.get('reasoning', '')}")
     for r in records:
         if not r.get("match"):
-            line = _render_failing_param_line(r)
-            if tool:
-                line = f"  {tool}.{line.strip()}"
-            lines.append(line)
+            lines.append(_render_failing_param_line(r))
     return lines
 
 

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -534,18 +534,27 @@ def _sorted_union_dict_keys(left: dict, right: dict) -> List[Any]:
     return sorted(set(left) | set(right), key=lambda k: (type(k).__name__, repr(k)))
 
 
-def _tool_call_argument_value_mismatch_line(key_path: str, expected, actual) -> str:
-    """One human-readable line explaining why ``expected`` and ``actual`` differ."""
+def _value_mismatch_detail(expected, actual) -> str:
+    """The reason (no ``path`` prefix) two leaf values differ.
+
+    Returned standalone so it can be both stored as a record's ``reasoning`` and
+    composed into a display line, without re-parsing the rendered line.
+    """
     exp_t = type(expected).__name__
     act_t = type(actual).__name__
     if type(expected) is not type(actual):
         same_as_str = str(expected) == str(actual)
         note = " (same string form)" if same_as_str else ""
         return (
-            f"  {key_path}: type mismatch — expected {exp_t} {expected!r}, "
+            f"type mismatch — expected {exp_t} {expected!r}, "
             f"got {act_t} {actual!r}{note}"
         )
-    return f"  {key_path}: value mismatch — expected {expected!r}, got {actual!r}"
+    return f"value mismatch — expected {expected!r}, got {actual!r}"
+
+
+def _tool_call_argument_value_mismatch_line(key_path: str, expected, actual) -> str:
+    """One human-readable line explaining why ``expected`` and ``actual`` differ."""
+    return f"  {key_path}: {_value_mismatch_detail(expected, actual)}"
 
 
 def _tool_call_arguments_diff_lines(
@@ -804,15 +813,15 @@ def _collect_arg_diffs(
                     records=records,
                 )
             continue
-        mismatch_line = _tool_call_argument_value_mismatch_line(path, ev, av)
-        lines.append(mismatch_line)
+        detail = _value_mismatch_detail(ev, av)
+        lines.append(f"  {path}: {detail}")
         if records is not None:
             records.append(
                 {
                     "param": path,
                     "match_type": "exact",
                     "match": False,
-                    "reasoning": mismatch_line.strip().split(": ", 1)[1],
+                    "reasoning": detail,
                 }
             )
 

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -683,6 +683,39 @@ async def _judge_tool_call_parameter(
     )
 
 
+def _record_failure(
+    path: str,
+    detail: str,
+    lines: List[str],
+    records: Optional[List[dict]],
+    *,
+    match_type: str = "exact",
+    criteria: Optional[str] = None,
+    missing: bool = False,
+) -> None:
+    """Append a failing parameter's display line and (when collecting) its record.
+
+    The shared shape behind the non-judged failure branches of
+    :func:`_collect_arg_diffs`: each renders ``  path: detail`` and, when
+    ``records`` is being collected, stores a ``match=False`` record carrying the
+    same ``detail`` as its reasoning (plus optional ``criteria`` / ``missing``).
+    """
+    lines.append(f"  {path}: {detail}")
+    if records is None:
+        return
+    record: dict = {
+        "param": path,
+        "match_type": match_type,
+        "match": False,
+        "reasoning": detail,
+    }
+    if criteria is not None:
+        record["criteria"] = criteria
+    if missing:
+        record["missing"] = True
+    records.append(record)
+
+
 def _collect_arg_diffs(
     expected: dict,
     actual: dict,
@@ -722,35 +755,26 @@ def _collect_arg_diffs(
         path = f"{prefix}.{key}" if prefix else key
         in_act = key in actual
         if key not in expected:
-            detail = f"unexpected key in actual output (value={actual[key]!r})"
-            lines.append(f"  {path}: {detail}")
-            if records is not None:
-                records.append(
-                    {
-                        "param": path,
-                        "match_type": "exact",
-                        "match": False,
-                        "reasoning": detail,
-                    }
-                )
+            _record_failure(
+                path,
+                f"unexpected key in actual output (value={actual[key]!r})",
+                lines,
+                records,
+            )
             continue
 
         spec = _param_criteria_spec(expected[key], path) if criteria_aware else None
         if spec is not None and spec["match_type"] == "llm_judge":
             if not in_act:
-                detail = f"missing in actual output (criteria: {spec['criteria']})"
-                lines.append(f"  {path}: {detail}")
-                if records is not None:
-                    records.append(
-                        {
-                            "param": path,
-                            "match_type": "llm_judge",
-                            "criteria": spec["criteria"],
-                            "match": False,
-                            "reasoning": detail,
-                            "missing": True,
-                        }
-                    )
+                _record_failure(
+                    path,
+                    f"missing in actual output (criteria: {spec['criteria']})",
+                    lines,
+                    records,
+                    match_type="llm_judge",
+                    criteria=spec["criteria"],
+                    missing=True,
+                )
             else:
                 record = None
                 if records is not None:
@@ -765,18 +789,13 @@ def _collect_arg_diffs(
 
         ev = spec["value"] if spec is not None else expected[key]
         if not in_act:
-            detail = f"missing in actual output (expected {ev!r})"
-            lines.append(f"  {path}: {detail}")
-            if records is not None:
-                records.append(
-                    {
-                        "param": path,
-                        "match_type": "exact",
-                        "match": False,
-                        "reasoning": detail,
-                        "missing": True,
-                    }
-                )
+            _record_failure(
+                path,
+                f"missing in actual output (expected {ev!r})",
+                lines,
+                records,
+                missing=True,
+            )
             continue
         av = actual[key]
         if ev == av:
@@ -813,17 +832,7 @@ def _collect_arg_diffs(
                     records=records,
                 )
             continue
-        detail = _value_mismatch_detail(ev, av)
-        lines.append(f"  {path}: {detail}")
-        if records is not None:
-            records.append(
-                {
-                    "param": path,
-                    "match_type": "exact",
-                    "match": False,
-                    "reasoning": detail,
-                }
-            )
+        _record_failure(path, _value_mismatch_detail(ev, av), lines, records)
 
 
 def _param_path(record: dict, tool: Optional[str]) -> str:

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -817,13 +817,23 @@ def _collect_arg_diffs(
             )
 
 
-def _render_failing_param_line(record: dict) -> str:
+def _param_path(record: dict, tool: Optional[str]) -> str:
+    """The parameter's display path, prefixed ``tool.param`` when ``tool`` is set.
+
+    The single place the tool-name prefix is applied, so every reasoning line
+    qualifies parameter names the same way.
+    """
+    return f"{tool}.{record['param']}" if tool else record["param"]
+
+
+def _render_failing_param_line(record: dict, *, tool: Optional[str] = None) -> str:
     """One ``  path: detail`` line for a failing parameter record."""
+    path = _param_path(record, tool)
     if record.get("missing"):
-        return f"  {record['param']}: {record['reasoning']}"
+        return f"  {path}: {record['reasoning']}"
     if record["match_type"] == "llm_judge":
-        return f"  {record['param']}: criteria not met — {record.get('reasoning', '')}"
-    return f"  {record['param']}: {record.get('reasoning', '')}"
+        return f"  {path}: criteria not met — {record.get('reasoning', '')}"
+    return f"  {path}: {record.get('reasoning', '')}"
 
 
 def _matched_exact_line(records: List[dict], *, tool: Optional[str] = None) -> Optional[str]:
@@ -833,7 +843,7 @@ def _matched_exact_line(records: List[dict], *, tool: Optional[str] = None) -> O
     unambiguous across multiple tool calls.
     """
     names = [
-        f"{tool}.{r['param']}" if tool else r["param"]
+        _param_path(r, tool)
         for r in records
         if r["match_type"] == "exact" and r.get("match")
     ]
@@ -849,9 +859,6 @@ def _detailed_call_lines(records: List[dict], *, tool: Optional[str] = None) -> 
     parameter, then every failing parameter (exact or judged). Used for both the
     all-passed reasoning and the per-call mismatch message so the agent's output
     is reported the same way whether the call passed or failed.
-
-    ``tool`` is only supplied for the all-passed consolidation (which has no
-    failing parameters), so the failing-line branch never needs a tool prefix.
     """
     lines: List[str] = []
     matched = _matched_exact_line(records, tool=tool)
@@ -859,11 +866,10 @@ def _detailed_call_lines(records: List[dict], *, tool: Optional[str] = None) -> 
         lines.append(matched)
     for r in records:
         if r["match_type"] == "llm_judge" and r.get("match"):
-            param = f"{tool}.{r['param']}" if tool else r["param"]
-            lines.append(f"  {param}: criteria met — {r.get('reasoning', '')}")
+            lines.append(f"  {_param_path(r, tool)}: criteria met — {r.get('reasoning', '')}")
     for r in records:
         if not r.get("match"):
-            lines.append(_render_failing_param_line(r))
+            lines.append(_render_failing_param_line(r, tool=tool))
     return lines
 
 

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -682,6 +682,7 @@ def _collect_arg_diffs(
     judge_jobs: List[tuple],
     *,
     criteria_aware: bool = True,
+    records: Optional[List[dict]] = None,
 ) -> None:
     """Recursively diff expected vs. actual argument dicts.
 
@@ -698,128 +699,303 @@ def _collect_arg_diffs(
 
     Mismatch lines (with dotted ``path`` prefixes) are appended to ``lines``.
     Synchronous: judging runs afterwards so all calls can be issued at once.
+
+    When ``records`` is provided (criteria-aware path only) a structured record
+    is appended for **every** leaf parameter — matched or not, exact or judged —
+    so the caller can report on all of them, not just the failures. Each record
+    is ``{"param", "match_type", "match", ...}``; for a present ``llm_judge``
+    parameter a placeholder record (no ``match``/``reasoning`` yet) is appended
+    and also linked into ``judge_jobs`` so the verdict can be filled in after the
+    concurrent judging completes. Nested objects contribute their leaves' records
+    (the container itself gets none).
     """
     for key in _sorted_union_dict_keys(expected, actual):
         path = f"{prefix}.{key}" if prefix else key
         in_act = key in actual
         if key not in expected:
-            lines.append(
-                f"  {path}: unexpected key in actual output (value {actual[key]!r})"
-            )
+            detail = f"unexpected key in actual output (value {actual[key]!r})"
+            lines.append(f"  {path}: {detail}")
+            if records is not None:
+                records.append(
+                    {
+                        "param": path,
+                        "match_type": "exact",
+                        "match": False,
+                        "reasoning": detail,
+                    }
+                )
             continue
 
         spec = _param_criteria_spec(expected[key], path) if criteria_aware else None
         if spec is not None and spec["match_type"] == "llm_judge":
             if not in_act:
-                lines.append(
-                    f"  {path}: missing in actual output (criteria: {spec['criteria']})"
-                )
+                detail = f"missing in actual output (criteria: {spec['criteria']})"
+                lines.append(f"  {path}: {detail}")
+                if records is not None:
+                    records.append(
+                        {
+                            "param": path,
+                            "match_type": "llm_judge",
+                            "criteria": spec["criteria"],
+                            "match": False,
+                            "reasoning": detail,
+                            "missing": True,
+                        }
+                    )
             else:
-                judge_jobs.append((path, spec, actual[key]))
+                record = None
+                if records is not None:
+                    record = {
+                        "param": path,
+                        "match_type": "llm_judge",
+                        "criteria": spec["criteria"],
+                    }
+                    records.append(record)
+                judge_jobs.append((path, spec, actual[key], record))
             continue
 
         ev = spec["value"] if spec is not None else expected[key]
         if not in_act:
-            lines.append(f"  {path}: missing in actual output (expected {ev!r})")
+            detail = f"missing in actual output (expected {ev!r})"
+            lines.append(f"  {path}: {detail}")
+            if records is not None:
+                records.append(
+                    {
+                        "param": path,
+                        "match_type": "exact",
+                        "match": False,
+                        "reasoning": detail,
+                        "missing": True,
+                    }
+                )
             continue
         av = actual[key]
         if ev == av:
+            if records is not None:
+                records.append(
+                    {"param": path, "match_type": "exact", "match": True}
+                )
             continue
         if isinstance(ev, dict) and isinstance(av, dict):
             if spec is not None:
                 # exact spec → compare its value literally (specs inside an
                 # exact value are not re-interpreted)
-                lines.extend(_tool_call_arguments_diff_lines(ev, av, path))
+                sub_lines = _tool_call_arguments_diff_lines(ev, av, path)
+                lines.extend(sub_lines)
+                if records is not None:
+                    records.append(
+                        {
+                            "param": path,
+                            "match_type": "exact",
+                            "match": False,
+                            "reasoning": "; ".join(
+                                line.strip() for line in sub_lines
+                            ),
+                        }
+                    )
             else:
                 _collect_arg_diffs(
-                    ev, av, path, lines, judge_jobs, criteria_aware=criteria_aware
+                    ev,
+                    av,
+                    path,
+                    lines,
+                    judge_jobs,
+                    criteria_aware=criteria_aware,
+                    records=records,
                 )
             continue
-        lines.append(_tool_call_argument_value_mismatch_line(path, ev, av))
+        mismatch_line = _tool_call_argument_value_mismatch_line(path, ev, av)
+        lines.append(mismatch_line)
+        if records is not None:
+            records.append(
+                {
+                    "param": path,
+                    "match_type": "exact",
+                    "match": False,
+                    "reasoning": mismatch_line.strip().split(": ", 1)[1],
+                }
+            )
 
 
-async def _tool_call_arguments_mismatch_lines_async(
-    tool_name: str, expected: dict, actual: dict
-) -> List[str]:
-    """Per-field mismatch lines, judging ``llm_judge`` params via an LLM.
+def _render_failing_param_line(record: dict) -> str:
+    """One ``  path: detail`` line for a failing parameter record."""
+    if record.get("missing"):
+        return f"  {record['param']}: {record['reasoning']}"
+    if record["match_type"] == "llm_judge":
+        return f"  {record['param']}: criteria not met — {record.get('reasoning', '')}"
+    return f"  {record['param']}: {record.get('reasoning', '')}"
 
-    Detects criteria specs at any depth (top-level parameters and nested
-    sub-parameters). Literal and ``exact``-spec parameters are diffed
-    synchronously; every ``llm_judge`` parameter found in the walk is evaluated
-    concurrently against its criteria.
+
+def _matched_exact_line(records: List[dict], *, tool: Optional[str] = None) -> Optional[str]:
+    """A single line naming the exact parameters whose values matched, or ``None``.
+
+    When ``tool`` is given each name is prefixed ``tool.param`` so the line is
+    unambiguous across multiple tool calls.
+    """
+    names = [
+        f"{tool}.{r['param']}" if tool else r["param"]
+        for r in records
+        if r["match_type"] == "exact" and r.get("match")
+    ]
+    if not names:
+        return None
+    return f"  {', '.join(names)}: values match the expected values"
+
+
+def _detailed_call_lines(records: List[dict], *, tool: Optional[str] = None) -> List[str]:
+    """Full per-parameter breakdown for a call that involved an ``llm_judge`` param.
+
+    Order: the exact-match summary line first, then each satisfied ``llm_judge``
+    parameter, then every failing parameter (exact or judged). Used for both the
+    all-passed reasoning and the per-call mismatch message so the agent's output
+    is reported the same way whether the call passed or failed.
     """
     lines: List[str] = []
+    matched = _matched_exact_line(records, tool=tool)
+    if matched:
+        lines.append(matched)
+    for r in records:
+        if r["match_type"] == "llm_judge" and r.get("match"):
+            param = f"{tool}.{r['param']}" if tool else r["param"]
+            lines.append(f"  {param}: criteria met — {r.get('reasoning', '')}")
+    for r in records:
+        if not r.get("match"):
+            line = _render_failing_param_line(r)
+            if tool:
+                line = f"  {tool}.{line.strip()}"
+            lines.append(line)
+    return lines
+
+
+async def _tool_call_arguments_eval_async(
+    tool_name: str, expected, actual
+) -> dict:
+    """Evaluate one tool call's arguments, returning a structured result.
+
+    Returns ``{"message", "records", "had_llm"}``:
+
+    - ``message`` — a multi-line mismatch reason, or ``None`` when the arguments
+      match. Built from the per-parameter records: when any ``llm_judge`` param
+      is involved the full breakdown (matched exacts + judged verdicts) is shown;
+      otherwise only the failing lines are listed (the original exact-only form).
+    - ``records`` — one entry per leaf parameter (exact and judged, matched and
+      failed); see :func:`_collect_arg_diffs`. Empty for the non-dict edge cases.
+    - ``had_llm`` — whether any parameter was graded by an LLM judge.
+    """
+    header = "Tool call arguments mismatch:"
+    if not isinstance(expected, dict):
+        return {
+            "message": (
+                f"{header}\n"
+                f"  arguments: cannot diff — expected non-dict "
+                f"{type(expected).__name__} {expected!r}, got "
+                f"{type(actual).__name__} {actual!r}"
+            ),
+            "records": [],
+            "had_llm": False,
+        }
+    if not isinstance(actual, dict):
+        return {
+            "message": (
+                f"{header}\n"
+                f"  arguments: expected dict {expected!r}, "
+                f"got {type(actual).__name__} {actual!r}"
+            ),
+            "records": [],
+            "had_llm": False,
+        }
+
+    lines: List[str] = []
     judge_jobs: List[tuple] = []
-    _collect_arg_diffs(expected, actual, "", lines, judge_jobs)
+    records: List[dict] = []
+    _collect_arg_diffs(expected, actual, "", lines, judge_jobs, records=records)
 
     if judge_jobs:
         judge_results = await asyncio.gather(
             *[
                 _judge_tool_call_parameter(tool_name, path, spec, value)
-                for path, spec, value in judge_jobs
+                for path, spec, value, _record in judge_jobs
             ]
         )
-        for (path, _spec, _value), result in zip(judge_jobs, judge_results):
-            if not result.get("match"):
-                lines.append(
-                    f"  {path}: criteria not met — {result.get('reasoning', '')}"
-                )
-    return lines
+        for (_path, _spec, _value, record), result in zip(judge_jobs, judge_results):
+            if record is not None:
+                record["match"] = bool(result.get("match"))
+                record["reasoning"] = result.get("reasoning", "")
 
+    had_llm = any(r["match_type"] == "llm_judge" for r in records)
+    failures = [r for r in records if not r.get("match")]
+    if not failures:
+        return {"message": None, "records": records, "had_llm": had_llm}
 
-async def _tool_call_arguments_mismatch_message_async(
-    tool_name: str, expected, actual
-) -> Optional[str]:
-    """Async variant of :func:`_tool_call_arguments_mismatch_message`.
-
-    Returns ``None`` when the arguments match (including when every
-    ``llm_judge`` parameter satisfies its criteria), else a multi-line reason.
-    """
-    header = "Tool call arguments mismatch:"
-    if not isinstance(expected, dict):
-        return (
-            f"{header}\n"
-            f"  arguments: cannot diff — expected non-dict {type(expected).__name__} "
-            f"{expected!r}, got {type(actual).__name__} {actual!r}"
-        )
-    if not isinstance(actual, dict):
-        return (
-            f"{header}\n"
-            f"  arguments: expected dict {expected!r}, "
-            f"got {type(actual).__name__} {actual!r}"
-        )
-    detail_lines = await _tool_call_arguments_mismatch_lines_async(
-        tool_name, expected, actual
-    )
-    if not detail_lines:
-        return None
-    return header + "\n" + "\n".join(detail_lines)
+    if had_llm:
+        body = _detailed_call_lines(records)
+    else:
+        body = [_render_failing_param_line(r) for r in failures]
+    return {
+        "message": header + "\n" + "\n".join(body),
+        "records": records,
+        "had_llm": had_llm,
+    }
 
 
 async def _tool_call_pair_mismatch_async(
     output_tool_call: dict, evaluation_tool_call: dict
-) -> Optional[str]:
+) -> dict:
     """Async pair matcher supporting per-parameter ``llm_judge`` criteria.
 
-    Equivalent to :func:`_tool_call_pair_mismatch` when no parameter carries a
-    criteria spec.
+    Returns ``{"mismatch", "records", "had_llm"}`` — ``mismatch`` is a failure
+    reason string or ``None`` when the pair matches; ``records`` is the
+    per-parameter breakdown (exact + judged); ``had_llm`` flags whether any
+    parameter was judged. Equivalent to :func:`_tool_call_pair_mismatch` when no
+    parameter carries a criteria spec.
     """
     if output_tool_call["tool"] != evaluation_tool_call["tool"]:
-        return (
-            f"Tool call mismatch - expected tool call: {evaluation_tool_call['tool']} "
-            f"but got: {output_tool_call['tool']}"
-        )
+        return {
+            "mismatch": (
+                f"Tool call mismatch - expected tool call: "
+                f"{evaluation_tool_call['tool']} but got: {output_tool_call['tool']}"
+            ),
+            "records": [],
+            "had_llm": False,
+        }
     if "arguments" not in evaluation_tool_call:
-        return None
+        return {"mismatch": None, "records": [], "had_llm": False}
     exp_args = evaluation_tool_call.get("arguments")
     if exp_args is None:
-        return None
+        return {"mismatch": None, "records": [], "had_llm": False}
     out_args = output_tool_call.get("arguments")
     if out_args == exp_args:
-        return None
-    return await _tool_call_arguments_mismatch_message_async(
+        return {"mismatch": None, "records": [], "had_llm": False}
+    result = await _tool_call_arguments_eval_async(
         evaluation_tool_call["tool"], exp_args, out_args
     )
+    return {
+        "mismatch": result["message"],
+        "records": result["records"],
+        "had_llm": result["had_llm"],
+    }
+
+
+def _consolidated_pass_reasoning(pass_blocks: List[tuple], *, multi: bool) -> str:
+    """Build the all-passed reasoning string for a ``tool_call`` evaluation.
+
+    ``pass_blocks`` is a list of ``(tool_name, records)`` for every passing tool
+    call that involved at least one ``llm_judge`` parameter. When it is empty —
+    i.e. every parameter was matched exactly — the flat success message is
+    returned. Otherwise each call contributes a line naming its exact-matched
+    parameters plus one ``criteria met`` line per judged parameter, so both the
+    exact and the LLM-based matches are consolidated into the overall output.
+
+    When ``multi`` (more than one expected tool call) each parameter name is
+    prefixed with its tool so the lines stay unambiguous.
+    """
+    base = "The agent's tools calls matches the expected tool calls"
+    if not pass_blocks:
+        return base
+    lines = [base + ":"]
+    for tool_name, records in pass_blocks:
+        lines.extend(_detailed_call_lines(records, tool=tool_name if multi else None))
+    return "\n".join(lines)
 
 
 async def evaluate_tool_calls(output_tool_calls, evaluation_tool_calls):
@@ -831,7 +1007,19 @@ async def evaluate_tool_calls(output_tool_calls, evaluation_tool_calls):
 
     Returns ``passed`` / ``reasoning`` plus ``tool_call_results`` — a per-slot
     ``[{"tool": name, "passed": bool}]`` list (sorted order, missing output
-    slots marked failed) consumed by :func:`_aggregate_tool_calls`.
+    slots marked failed) consumed by :func:`_aggregate_tool_calls`. A slot whose
+    call involved at least one ``llm_judge`` parameter additionally carries a
+    ``param_judgments`` list — one record per leaf parameter, exact *and* judged,
+    matched *and* failed (``{"param", "match_type", "match", ...}``) — so the
+    full per-parameter verdict survives into ``results.json``.
+
+    Reasoning rules:
+    - Every parameter matched exactly (no judge involved) and all passed → the
+      flat ``"The agent's tools calls matches the expected tool calls"``.
+    - Any ``llm_judge`` parameter involved → the verdict is spelled out: each
+      judged parameter's met/not-met reasoning plus a line stating that the
+      exact-matched parameters' values match the expected values (see
+      :func:`_consolidated_pass_reasoning` / :func:`_detailed_call_lines`).
     """
     evaluation_sorted = sort_tool_calls(evaluation_tool_calls or [])
 
@@ -847,22 +1035,30 @@ async def evaluate_tool_calls(output_tool_calls, evaluation_tool_calls):
         }
 
     output_sorted = sort_tool_calls(output_tool_calls)
+    multi = len(evaluation_sorted) > 1
 
     tool_call_results: List[dict] = []
     first_failure: Optional[str] = None
+    pass_blocks: List[tuple] = []
     for i, evaluation_tool_call in enumerate(evaluation_sorted):
         name = evaluation_tool_call.get("tool")
         if i >= len(output_sorted):
             if name:
                 tool_call_results.append({"tool": name, "passed": False})
             continue
-        mismatch = await _tool_call_pair_mismatch_async(
+        evaluated = await _tool_call_pair_mismatch_async(
             output_sorted[i], evaluation_tool_call
         )
+        mismatch = evaluated["mismatch"]
         if name:
-            tool_call_results.append({"tool": name, "passed": mismatch is None})
+            slot: dict = {"tool": name, "passed": mismatch is None}
+            if evaluated["had_llm"] and evaluated["records"]:
+                slot["param_judgments"] = evaluated["records"]
+            tool_call_results.append(slot)
         if mismatch and first_failure is None:
             first_failure = mismatch
+        if mismatch is None and evaluated["had_llm"] and name:
+            pass_blocks.append((name, evaluated["records"]))
 
     if first_failure is not None:
         return {
@@ -873,7 +1069,7 @@ async def evaluate_tool_calls(output_tool_calls, evaluation_tool_calls):
 
     return {
         "passed": True,
-        "reasoning": "Tool calls matched expected",
+        "reasoning": _consolidated_pass_reasoning(pass_blocks, multi=multi),
         "tool_call_results": tool_call_results,
     }
 

--- a/examples/llm/tool_call_scenarios/README.md
+++ b/examples/llm/tool_call_scenarios/README.md
@@ -1,0 +1,58 @@
+# Tool-call matching scenarios
+
+Test fixtures that exercise per-parameter tool-call matching.
+
+## Files
+
+- **`config.json`** — clinic-assistant system prompt + tools, plus a few
+  `tool_call` test cases for a live run against a real model.
+- **`eval_only_dataset.json`** — 12 `(test_case, output)` pairs that pin the
+  agent's output, so you see the exact pass/fail + reasoning each scenario
+  produces. The `_scenario` field on each item just labels what it demonstrates.
+
+## Run it (eval-only — recommended)
+
+Eval-only skips model inference and runs the evaluator on the pinned outputs.
+Exact-only scenarios need no API; the `llm_judge` scenarios call the judge model
+(needs `OPENROUTER_API_KEY`).
+
+```bash
+python -m calibrate.llm.run_tests --eval-only \
+  --config  examples/llm/tool_call_scenarios/config.json \
+  --dataset examples/llm/tool_call_scenarios/eval_only_dataset.json \
+  -o ./out/tool_call_scenarios
+```
+
+## Run it (live — against a model)
+
+```bash
+python -m calibrate.llm.run_tests \
+  --config examples/llm/tool_call_scenarios/config.json \
+  -m openai/gpt-4.1 -p openrouter \
+  -o ./out/tool_call_scenarios_live
+```
+
+## Where to look
+
+- `out/.../results.json` — per-case `output` + `metrics`. Tool calls that
+  involved an `llm_judge` parameter carry a `param_judgments` list (one record
+  per parameter, exact and judged, with the judge's reasoning).
+- `out/.../metrics.json` — per-tool pass rates.
+- `out/.../results.log` — the pass/fail + reasoning lines, mirrored from stdout.
+
+## What each scenario shows
+
+| id                     | What it demonstrates                     | Outcome                            |
+| ---------------------- | ---------------------------------------- | ---------------------------------- |
+| `exact-all-pass`       | all exact, all match                     | pass (flat message)                |
+| `exact-value-mismatch` | one exact value wrong                    | fail                               |
+| `exact-unexpected-key` | agent sent an extra arg                  | fail (`value=True`)                |
+| `exact-missing-key`    | required arg missing                     | fail                               |
+| `judge-pass`           | one `llm_judge` param, satisfied         | pass                               |
+| `judge-fail`           | one `llm_judge` param, not satisfied     | fail                               |
+| `mixed-pass`           | exact + judge, both ok                   | pass (names exact + judge verdict) |
+| `mixed-exact-fail`     | exact wrong, judge ok                    | fail (judge still captured)        |
+| `exact-spec-wrap`      | `match_type: exact` verbatim compare     | pass                               |
+| `nested-object`        | exact + judged sub-fields (dotted paths) | pass                               |
+| `wrong-tool`           | agent called a different tool            | fail                               |
+| `multi-call`           | two tool calls, each judged              | pass (tool-prefixed lines)         |

--- a/examples/llm/tool_call_scenarios/config.json
+++ b/examples/llm/tool_call_scenarios/config.json
@@ -1,0 +1,101 @@
+{
+  "system_prompt": "You are a scheduling assistant for a medical clinic.\n\nYou can:\n1. Book appointments with `book_appointment`.\n2. Send SMS confirmations with `send_sms`.\n3. Record a short note about each interaction with `log_interaction`.\n\nCall the appropriate tool when the user's request clearly maps to one. Be concise and friendly.",
+  "tools": [
+    {
+      "type": "client",
+      "name": "book_appointment",
+      "description": "Book a clinic appointment for a patient.",
+      "parameters": [
+        { "id": "patient_name", "type": "string", "description": "Full name of the patient", "required": true },
+        { "id": "date", "type": "string", "description": "Appointment date in YYYY-MM-DD", "required": true },
+        { "id": "reason", "type": "string", "description": "Short reason for the visit", "required": true }
+      ]
+    },
+    {
+      "type": "client",
+      "name": "send_sms",
+      "description": "Send an SMS message to a phone number.",
+      "parameters": [
+        { "id": "to", "type": "string", "description": "Destination phone number in E.164 format", "required": true },
+        { "id": "message", "type": "string", "description": "The text body of the SMS", "required": true }
+      ]
+    },
+    {
+      "type": "client",
+      "name": "log_interaction",
+      "description": "Record a short note about the interaction.",
+      "parameters": [
+        { "id": "interaction_type", "type": "string", "description": "booking, cancellation, question, or complaint", "required": true },
+        { "id": "sentiment", "type": "string", "description": "positive, neutral, or negative", "required": true },
+        { "id": "summary", "type": "string", "description": "Free-text summary of what the patient said", "required": true }
+      ]
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "live-exact-only",
+      "history": [
+        { "role": "assistant", "content": "Hi! How can I help you today?" },
+        { "role": "user", "content": "Please book an appointment for John Doe on 2026-06-10 for a fever." }
+      ],
+      "evaluation": {
+        "type": "tool_call",
+        "tool_calls": [
+          {
+            "tool": "book_appointment",
+            "arguments": {
+              "patient_name": "John Doe",
+              "date": "2026-06-10",
+              "reason": "fever"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "live-judged-message",
+      "history": [
+        { "role": "assistant", "content": "Hi! How can I help you today?" },
+        { "role": "user", "content": "Text +15551234567 to confirm John's appointment is booked for June 10th." }
+      ],
+      "evaluation": {
+        "type": "tool_call",
+        "tool_calls": [
+          {
+            "tool": "send_sms",
+            "arguments": {
+              "to": "+15551234567",
+              "message": {
+                "match_type": "llm_judge",
+                "criteria": "Confirms an appointment is booked and mentions the date (June 10)."
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "live-mixed-exact-and-judge",
+      "history": [
+        { "role": "assistant", "content": "Hi! How can I help you today?" },
+        { "role": "user", "content": "I'm really happy you fit me in! Please log this as a positive booking." }
+      ],
+      "evaluation": {
+        "type": "tool_call",
+        "tool_calls": [
+          {
+            "tool": "log_interaction",
+            "arguments": {
+              "interaction_type": "booking",
+              "sentiment": "positive",
+              "summary": {
+                "match_type": "llm_judge",
+                "criteria": "States the patient is happy or grateful about getting an appointment."
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/llm/tool_call_scenarios/eval_only_dataset.json
+++ b/examples/llm/tool_call_scenarios/eval_only_dataset.json
@@ -1,0 +1,232 @@
+[
+  {
+    "_scenario": "1. ALL EXACT — pass. Flat reasoning, no param_judgments.",
+    "test_case": {
+      "id": "exact-all-pass",
+      "history": [{ "role": "user", "content": "Book John Doe on 2026-06-10 for a fever." }],
+      "evaluation": {
+        "type": "tool_call",
+        "tool_calls": [
+          { "tool": "book_appointment", "arguments": { "patient_name": "John Doe", "date": "2026-06-10", "reason": "fever" } }
+        ]
+      }
+    },
+    "output": {
+      "response": "",
+      "tool_calls": [
+        { "tool": "book_appointment", "arguments": { "patient_name": "John Doe", "date": "2026-06-10", "reason": "fever" } }
+      ]
+    }
+  },
+  {
+    "_scenario": "2. ALL EXACT — value mismatch (fail). Only the wrong field is listed.",
+    "test_case": {
+      "id": "exact-value-mismatch",
+      "history": [{ "role": "user", "content": "Book John Doe on 2026-06-10 for a fever." }],
+      "evaluation": {
+        "type": "tool_call",
+        "tool_calls": [
+          { "tool": "book_appointment", "arguments": { "patient_name": "John Doe", "date": "2026-06-10", "reason": "fever" } }
+        ]
+      }
+    },
+    "output": {
+      "response": "",
+      "tool_calls": [
+        { "tool": "book_appointment", "arguments": { "patient_name": "John Doe", "date": "2026-06-10", "reason": "checkup" } }
+      ]
+    }
+  },
+  {
+    "_scenario": "3. ALL EXACT — unexpected extra key (fail). Shows 'unexpected key in actual output (value=True)'.",
+    "test_case": {
+      "id": "exact-unexpected-key",
+      "history": [{ "role": "user", "content": "Book John Doe on 2026-06-10." }],
+      "evaluation": {
+        "type": "tool_call",
+        "tool_calls": [
+          { "tool": "book_appointment", "arguments": { "patient_name": "John Doe", "date": "2026-06-10", "reason": "fever" } }
+        ]
+      }
+    },
+    "output": {
+      "response": "",
+      "tool_calls": [
+        { "tool": "book_appointment", "arguments": { "patient_name": "John Doe", "date": "2026-06-10", "reason": "fever", "skip_question": true } }
+      ]
+    }
+  },
+  {
+    "_scenario": "4. ALL EXACT — required field missing (fail). Shows 'missing in actual output'.",
+    "test_case": {
+      "id": "exact-missing-key",
+      "history": [{ "role": "user", "content": "Book John Doe on 2026-06-10 for a fever." }],
+      "evaluation": {
+        "type": "tool_call",
+        "tool_calls": [
+          { "tool": "book_appointment", "arguments": { "patient_name": "John Doe", "date": "2026-06-10", "reason": "fever" } }
+        ]
+      }
+    },
+    "output": {
+      "response": "",
+      "tool_calls": [
+        { "tool": "book_appointment", "arguments": { "patient_name": "John Doe", "date": "2026-06-10" } }
+      ]
+    }
+  },
+  {
+    "_scenario": "5. LLM JUDGE — single param pass (needs OPENROUTER_API_KEY). param_judgments carries the verdict.",
+    "test_case": {
+      "id": "judge-pass",
+      "history": [{ "role": "user", "content": "Text +15551234567 confirming the June 10 appointment." }],
+      "evaluation": {
+        "type": "tool_call",
+        "tool_calls": [
+          { "tool": "send_sms", "arguments": { "to": "+15551234567", "message": { "match_type": "llm_judge", "criteria": "Confirms an appointment is booked and mentions June 10." } } }
+        ]
+      }
+    },
+    "output": {
+      "response": "",
+      "tool_calls": [
+        { "tool": "send_sms", "arguments": { "to": "+15551234567", "message": "Your appointment is confirmed for June 10. See you then!" } }
+      ]
+    }
+  },
+  {
+    "_scenario": "6. LLM JUDGE — single param fail (needs OPENROUTER_API_KEY). Shows 'criteria not met — <judge reasoning>'.",
+    "test_case": {
+      "id": "judge-fail",
+      "history": [{ "role": "user", "content": "Text +15551234567 confirming the June 10 appointment." }],
+      "evaluation": {
+        "type": "tool_call",
+        "tool_calls": [
+          { "tool": "send_sms", "arguments": { "to": "+15551234567", "message": { "match_type": "llm_judge", "criteria": "Confirms an appointment is booked and mentions June 10." } } }
+        ]
+      }
+    },
+    "output": {
+      "response": "",
+      "tool_calls": [
+        { "tool": "send_sms", "arguments": { "to": "+15551234567", "message": "Your one-time login code is 4821." } }
+      ]
+    }
+  },
+  {
+    "_scenario": "7. MIXED exact + judge — all pass. Reasoning names the exact params AND the judged verdict.",
+    "test_case": {
+      "id": "mixed-pass",
+      "history": [{ "role": "user", "content": "Text +15551234567 to confirm John's June 10 booking." }],
+      "evaluation": {
+        "type": "tool_call",
+        "tool_calls": [
+          { "tool": "send_sms", "arguments": { "to": "+15551234567", "message": { "match_type": "llm_judge", "criteria": "Confirms a booking and mentions June 10." } } }
+        ]
+      }
+    },
+    "output": {
+      "response": "",
+      "tool_calls": [
+        { "tool": "send_sms", "arguments": { "to": "+15551234567", "message": "Booking confirmed for June 10 — thanks!" } }
+      ]
+    }
+  },
+  {
+    "_scenario": "8. MIXED — exact wrong, judge passes (fail). Exact mismatch is the headline; judge verdict still captured in param_judgments.",
+    "test_case": {
+      "id": "mixed-exact-fail",
+      "history": [{ "role": "user", "content": "Text +15551234567 to confirm John's June 10 booking." }],
+      "evaluation": {
+        "type": "tool_call",
+        "tool_calls": [
+          { "tool": "send_sms", "arguments": { "to": "+15551234567", "message": { "match_type": "llm_judge", "criteria": "Confirms a booking and mentions June 10." } } }
+        ]
+      }
+    },
+    "output": {
+      "response": "",
+      "tool_calls": [
+        { "tool": "send_sms", "arguments": { "to": "+19998887777", "message": "Booking confirmed for June 10 — thanks!" } }
+      ]
+    }
+  },
+  {
+    "_scenario": "9. EXACT SPEC — match_type=exact compares the wrapped value verbatim (pass). No judge call.",
+    "test_case": {
+      "id": "exact-spec-wrap",
+      "history": [{ "role": "user", "content": "Log this booking as a positive interaction." }],
+      "evaluation": {
+        "type": "tool_call",
+        "tool_calls": [
+          { "tool": "log_interaction", "arguments": { "interaction_type": { "match_type": "exact", "value": "booking" }, "sentiment": "positive", "summary": { "match_type": "llm_judge", "criteria": "Mentions a booking." } } }
+        ]
+      }
+    },
+    "output": {
+      "response": "",
+      "tool_calls": [
+        { "tool": "log_interaction", "arguments": { "interaction_type": "booking", "sentiment": "positive", "summary": "Patient booked an appointment." } }
+      ]
+    }
+  },
+  {
+    "_scenario": "10. NESTED object — exact sub-field + judged sub-field (pass). Dotted paths like patient.note.",
+    "test_case": {
+      "id": "nested-object",
+      "history": [{ "role": "user", "content": "Book John Doe, he has had a severe headache since morning." }],
+      "evaluation": {
+        "type": "tool_call",
+        "tool_calls": [
+          { "tool": "book_appointment", "arguments": { "patient_name": "John Doe", "date": "2026-06-10", "reason": { "match_type": "llm_judge", "criteria": "Describes a medical symptom." } } }
+        ]
+      }
+    },
+    "output": {
+      "response": "",
+      "tool_calls": [
+        { "tool": "book_appointment", "arguments": { "patient_name": "John Doe", "date": "2026-06-10", "reason": "severe headache since this morning" } }
+      ]
+    }
+  },
+  {
+    "_scenario": "11. WRONG TOOL — agent called a different tool (fail). 'Tool call mismatch'.",
+    "test_case": {
+      "id": "wrong-tool",
+      "history": [{ "role": "user", "content": "Book John Doe on 2026-06-10 for a fever." }],
+      "evaluation": {
+        "type": "tool_call",
+        "tool_calls": [
+          { "tool": "book_appointment", "arguments": { "patient_name": "John Doe", "date": "2026-06-10", "reason": "fever" } }
+        ]
+      }
+    },
+    "output": {
+      "response": "",
+      "tool_calls": [
+        { "tool": "send_sms", "arguments": { "to": "+15551234567", "message": "Booked!" } }
+      ]
+    }
+  },
+  {
+    "_scenario": "12. MULTIPLE tool calls — each judged (pass). Reasoning prefixes each line with its tool.",
+    "test_case": {
+      "id": "multi-call",
+      "history": [{ "role": "user", "content": "I'm grateful you booked me — please text me a confirmation." }],
+      "evaluation": {
+        "type": "tool_call",
+        "tool_calls": [
+          { "tool": "log_interaction", "arguments": { "interaction_type": "booking", "sentiment": "positive", "summary": { "match_type": "llm_judge", "criteria": "Patient is grateful about the booking." } } },
+          { "tool": "send_sms", "arguments": { "to": "+15551234567", "message": { "match_type": "llm_judge", "criteria": "Confirms the appointment." } } }
+        ]
+      }
+    },
+    "output": {
+      "response": "",
+      "tool_calls": [
+        { "tool": "log_interaction", "arguments": { "interaction_type": "booking", "sentiment": "positive", "summary": "Patient said they were grateful to be booked in." } },
+        { "tool": "send_sms", "arguments": { "to": "+15551234567", "message": "Your appointment is confirmed!" } }
+      ]
+    }
+  }
+]

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -890,6 +890,60 @@ class TestNestedToolCallCriteria(unittest.TestCase):
         self.assertIn("missing in actual", result["reasoning"])
         mock_judge.assert_not_called()
 
+    def test_multi_call_pass_prefixes_tool_in_reasoning(self):
+        # With more than one expected tool call, each parameter in the
+        # consolidated pass reasoning is prefixed with its tool so the lines
+        # stay unambiguous (exact-matched line and judged-param line alike).
+        from calibrate.llm.run_tests import evaluate_tool_calls
+
+        with patch(
+            "calibrate.llm.run_tests.text_judge", side_effect=self._judge(True, "ok")
+        ):
+            result = asyncio.run(evaluate_tool_calls(
+                [
+                    {"tool": "log", "arguments": {"id": 1, "note": "fever"}},
+                    {"tool": "sms", "arguments": {"msg": "hello there"}},
+                ],
+                [
+                    {"tool": "log", "arguments": {
+                        "id": 1,
+                        "note": {"match_type": "llm_judge", "criteria": "a symptom"}}},
+                    {"tool": "sms", "arguments": {
+                        "msg": {"match_type": "llm_judge", "criteria": "a greeting"}}},
+                ],
+            ))
+        self.assertTrue(result["passed"])
+        self.assertIn("log.id: values match the expected values", result["reasoning"])
+        self.assertIn("log.note: criteria met", result["reasoning"])
+        self.assertIn("sms.msg: criteria met", result["reasoning"])
+
+    def test_exact_spec_wrapping_dict_mismatch(self):
+        # An `exact` spec whose value is a dict is compared verbatim; on a
+        # mismatch the per-parameter record captures the nested diff.
+        from calibrate.llm.run_tests import evaluate_tool_calls
+
+        result = asyncio.run(evaluate_tool_calls(
+            [{"tool": "a", "arguments": {"loc": {"city": "Lyon"}}}],
+            [{"tool": "a", "arguments": {
+                "loc": {"match_type": "exact", "value": {"city": "Paris"}}}}],
+        ))
+        self.assertFalse(result["passed"])
+        self.assertIn("loc", result["reasoning"])
+        self.assertIn("Paris", result["reasoning"])
+
+    def test_exact_param_missing_in_actual(self):
+        # A required exact parameter absent from the output is reported as
+        # missing (no judge involved, plain exact-only mismatch message).
+        from calibrate.llm.run_tests import evaluate_tool_calls
+
+        result = asyncio.run(evaluate_tool_calls(
+            [{"tool": "a", "arguments": {}}],
+            [{"tool": "a", "arguments": {"x": 1}}],
+        ))
+        self.assertFalse(result["passed"])
+        self.assertIn("x: missing in actual output", result["reasoning"])
+        self.assertEqual(result["tool_call_results"], [{"tool": "a", "passed": False}])
+
     def test_collect_arg_diffs_no_specs_matches_sync_differ(self):
         # With no criteria specs anywhere, the recursive walk must produce the
         # same lines as the original synchronous differ.

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -959,6 +959,28 @@ class TestNestedToolCallCriteria(unittest.TestCase):
         self.assertEqual(jobs, [])
         self.assertEqual(lines, _tool_call_arguments_diff_lines(expected, actual))
 
+    def test_value_mismatch_record_reasoning_handles_colon_in_key(self):
+        # The stored reasoning is the mismatch detail itself, not the display
+        # line re-parsed — so a key containing ": " does not garble it.
+        from calibrate.llm.run_tests import _collect_arg_diffs
+
+        expected = {"time: start": 9}
+        actual = {"time: start": 5}
+        lines, jobs, records = [], [], []
+        _collect_arg_diffs(expected, actual, "", lines, jobs, records=records)
+        self.assertEqual(
+            records,
+            [
+                {
+                    "param": "time: start",
+                    "match_type": "exact",
+                    "match": False,
+                    "reasoning": "value mismatch — expected 9, got 5",
+                }
+            ],
+        )
+        self.assertEqual(lines, ["  time: start: value mismatch — expected 9, got 5"])
+
     def test_literal_differ_does_not_interpret_specs(self):
         # The criteria-agnostic wrapper (used by the aggregation fallback and by
         # `exact` values) must treat a spec-looking dict as a literal, never as

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -454,8 +454,30 @@ class TestEvaluateToolCallsCriteria(unittest.TestCase):
                                 "criteria": "a friendly greeting"}}}],
             ))
         self.assertTrue(result["passed"])
-        self.assertEqual(result["tool_call_results"],
-                         [{"tool": "send_sms", "passed": True}])
+        # A passing llm_judge parameter now retains its verdict + reasoning.
+        self.assertEqual(
+            result["tool_call_results"],
+            [
+                {
+                    "tool": "send_sms",
+                    "passed": True,
+                    "param_judgments": [
+                        {
+                            "param": "message",
+                            "match_type": "llm_judge",
+                            "criteria": "a friendly greeting",
+                            "match": True,
+                            "reasoning": "because",
+                        }
+                    ],
+                }
+            ],
+        )
+        # The judged parameter's reasoning is consolidated into the overall
+        # reasoning rather than discarded.
+        self.assertIn("message", result["reasoning"])
+        self.assertIn("criteria met", result["reasoning"])
+        self.assertIn("because", result["reasoning"])
         # The judge prompt should mention the argument name and actual value.
         prompt = mock_judge.call_args.kwargs.get("user_prompt") or mock_judge.call_args.args[1]
         self.assertIn("send_sms", prompt)
@@ -478,8 +500,25 @@ class TestEvaluateToolCallsCriteria(unittest.TestCase):
         self.assertFalse(result["passed"])
         self.assertIn("message", result["reasoning"])
         self.assertIn("not a greeting", result["reasoning"])
-        self.assertEqual(result["tool_call_results"],
-                         [{"tool": "send_sms", "passed": False}])
+        # A failing llm_judge parameter is captured too.
+        self.assertEqual(
+            result["tool_call_results"],
+            [
+                {
+                    "tool": "send_sms",
+                    "passed": False,
+                    "param_judgments": [
+                        {
+                            "param": "message",
+                            "match_type": "llm_judge",
+                            "criteria": "a friendly greeting",
+                            "match": False,
+                            "reasoning": "not a greeting",
+                        }
+                    ],
+                }
+            ],
+        )
 
     def test_llm_judge_not_invoked_for_exact_params(self):
         from calibrate.llm.run_tests import evaluate_tool_calls
@@ -548,53 +587,116 @@ class TestEvaluateToolCallsCriteria(unittest.TestCase):
             ))
         self.assertFalse(result["passed"])
         self.assertIn("id", result["reasoning"])
+        # Both params are captured on the failing slot: the failing exact one
+        # and the passing judged one.
+        self.assertEqual(
+            result["tool_call_results"][0]["param_judgments"],
+            [
+                {
+                    "param": "id",
+                    "match_type": "exact",
+                    "match": False,
+                    "reasoning": "value mismatch — expected 7, got 9",
+                },
+                {
+                    "param": "note",
+                    "match_type": "llm_judge",
+                    "criteria": "positive",
+                    "match": True,
+                    "reasoning": "because",
+                },
+            ],
+        )
+
+    def test_exact_only_pass_uses_flat_message(self):
+        from calibrate.llm.run_tests import evaluate_tool_calls
+
+        with patch("calibrate.llm.run_tests.text_judge") as mock_judge:
+            result = asyncio.run(evaluate_tool_calls(
+                [{"tool": "a", "arguments": {"x": 1}}],
+                [{"tool": "a", "arguments": {"x": 1}}],
+            ))
+        self.assertTrue(result["passed"])
+        self.assertEqual(
+            result["reasoning"],
+            "The agent's tools calls matches the expected tool calls",
+        )
+        # No judged params → no param_judgments key on the slot.
+        self.assertEqual(result["tool_call_results"], [{"tool": "a", "passed": True}])
+        mock_judge.assert_not_called()
+
+    def test_pass_reasoning_consolidates_judged_params(self):
+        from calibrate.llm.run_tests import evaluate_tool_calls
+
+        with patch(
+            "calibrate.llm.run_tests.text_judge",
+            side_effect=self._judge_returning(True, "reads as friendly"),
+        ):
+            result = asyncio.run(evaluate_tool_calls(
+                [{"tool": "send_sms", "arguments": {"id": 7, "message": "Hi!"}}],
+                [{"tool": "send_sms", "arguments": {
+                    "id": 7,
+                    "message": {"match_type": "llm_judge",
+                                "criteria": "a friendly greeting"}}}],
+            ))
+        self.assertTrue(result["passed"])
+        # Consolidated: base sentence, the exact-matched param line, and the
+        # judged parameter's verdict/reasoning.
+        self.assertIn(
+            "The agent's tools calls matches the expected tool calls",
+            result["reasoning"],
+        )
+        self.assertIn("id: values match the expected values", result["reasoning"])
+        self.assertIn("message: criteria met", result["reasoning"])
+        self.assertIn("reads as friendly", result["reasoning"])
 
 
 class TestToolCallAsyncMatchers(unittest.TestCase):
     def test_pair_async_wrong_tool(self):
         from calibrate.llm.run_tests import _tool_call_pair_mismatch_async
 
-        reason = asyncio.run(_tool_call_pair_mismatch_async(
+        res = asyncio.run(_tool_call_pair_mismatch_async(
             {"tool": "a", "arguments": {}},
             {"tool": "b", "arguments": {}},
         ))
-        self.assertIn("Tool call mismatch", reason)
+        self.assertIn("Tool call mismatch", res["mismatch"])
+        self.assertEqual(res["records"], [])
+        self.assertFalse(res["had_llm"])
 
     def test_pair_async_no_arguments_key(self):
         from calibrate.llm.run_tests import _tool_call_pair_mismatch_async
 
-        self.assertIsNone(asyncio.run(_tool_call_pair_mismatch_async(
+        self.assertEqual(asyncio.run(_tool_call_pair_mismatch_async(
             {"tool": "a", "arguments": {"x": 1}},
             {"tool": "a"},
-        )))
+        )), {"mismatch": None, "records": [], "had_llm": False})
 
     def test_pair_async_none_arguments(self):
         from calibrate.llm.run_tests import _tool_call_pair_mismatch_async
 
-        self.assertIsNone(asyncio.run(_tool_call_pair_mismatch_async(
+        self.assertEqual(asyncio.run(_tool_call_pair_mismatch_async(
             {"tool": "a", "arguments": {"x": 1}},
             {"tool": "a", "arguments": None},
-        )))
+        )), {"mismatch": None, "records": [], "had_llm": False})
 
     def test_message_async_expected_non_dict(self):
-        from calibrate.llm.run_tests import (
-            _tool_call_arguments_mismatch_message_async,
-        )
+        from calibrate.llm.run_tests import _tool_call_arguments_eval_async
 
-        reason = asyncio.run(_tool_call_arguments_mismatch_message_async(
+        res = asyncio.run(_tool_call_arguments_eval_async(
             "a", "not-a-dict", {"x": 1},
         ))
-        self.assertIn("cannot diff", reason)
+        self.assertIn("cannot diff", res["message"])
+        self.assertEqual(res["records"], [])
+        self.assertFalse(res["had_llm"])
 
     def test_message_async_actual_non_dict(self):
-        from calibrate.llm.run_tests import (
-            _tool_call_arguments_mismatch_message_async,
-        )
+        from calibrate.llm.run_tests import _tool_call_arguments_eval_async
 
-        reason = asyncio.run(_tool_call_arguments_mismatch_message_async(
+        res = asyncio.run(_tool_call_arguments_eval_async(
             "a", {"x": 1}, "not-a-dict",
         ))
-        self.assertIn("expected dict", reason)
+        self.assertIn("expected dict", res["message"])
+        self.assertEqual(res["records"], [])
 
     def test_evaluate_fewer_output_than_expected(self):
         from calibrate.llm.run_tests import evaluate_tool_calls
@@ -688,6 +790,27 @@ class TestNestedToolCallCriteria(unittest.TestCase):
                                  "criteria": "describes a symptom"}}}}],
             ))
         self.assertTrue(result["passed"])
+        # Both nested leaves are captured with their dotted paths: the exact
+        # name match and the judged note.
+        self.assertEqual(
+            result["tool_call_results"][0]["param_judgments"],
+            [
+                {
+                    "param": "patient.name",
+                    "match_type": "exact",
+                    "match": True,
+                },
+                {
+                    "param": "patient.note",
+                    "match_type": "llm_judge",
+                    "criteria": "describes a symptom",
+                    "match": True,
+                    "reasoning": "r",
+                },
+            ],
+        )
+        self.assertIn("patient.name: values match the expected values", result["reasoning"])
+        self.assertIn("patient.note", result["reasoning"])
         # The judge prompt should carry the dotted path as the argument name.
         prompt = mock_judge.call_args.kwargs.get("user_prompt") or mock_judge.call_args.args[1]
         self.assertIn("patient.note", prompt)


### PR DESCRIPTION
## What

When an LLM tool-call test passed, the per-parameter LLM-judge reasoning was thrown away — you only ever saw the generic `Tool calls matched expected`. This PR makes per-parameter verdicts first-class and extends them to exact-matched params too.

## Why

On a passing `tool_call` test there was no way to see *why* an `llm_judge` parameter was accepted — the judge's reasoning never made it into `results.json`. Unlike `response`/`conversation` tests (which always store `judge_results`), tool-call passes were opaque.

## Behavior

`evaluate_tool_calls` now collects a structured record for **every** leaf parameter (exact and `llm_judge`, matched and failed) during the recursive argument walk.

- A tool call that involved any `llm_judge` parameter carries a `param_judgments` list on its slot — one `{param, match_type, match, [criteria], [reasoning]}` entry per leaf — surviving into `results.json` on pass **and** fail.
- Reasoning rules:
  - **all exact + all pass** → flat `The agent's tools calls matches the expected tool calls`
  - **any `llm_judge` involved** → full breakdown: each judged param's met/not-met reasoning, plus a line naming the exact-matched params (`<a>, <b>: values match the expected values`)
  - **all-exact failures** keep the original mismatch-only output (no `param_judgments`)
- Renamed the flat success string from `Tool calls matched expected` → `The agent's tools calls matches the expected tool calls`.

### Example (mixed exact + llm, pass)
```
The agent's tools calls matches the expected tool calls:
  city, id: values match the expected values
  message: criteria met — warm, welcoming tone
```

## Implementation notes for reviewers

- `_collect_arg_diffs` gains an optional `records` collector (criteria-aware path only); it still produces the same `lines`/`judge_jobs` so the criteria-agnostic differ and aggregation fallback are unchanged.
- `_tool_call_arguments_mismatch_message_async` → replaced by `_tool_call_arguments_eval_async` (returns `{message, records, had_llm}`); `_tool_call_pair_mismatch_async` now returns a dict.
- Sync `_tool_call_pair_mismatch`, `_tool_call_arguments_diff_lines`, and `_aggregate_tool_calls` are untouched — `param_judgments` is additive and ignored by per-slot aggregation.
- Pure-exact calls (pass or fail) keep their existing minimal slot shape `{tool, passed}`.

## Tests

`tests/llm/test_run_tests_extra.py` updated for the new return shapes and `param_judgments`, with added coverage for the flat exact-only message, consolidated pass reasoning, exact+llm mixes, and nested dotted-path capture. Full `tests/llm` suite passes (275).

🤖 Generated with [Claude Code](https://claude.com/claude-code)