### PR TITLE
Retry transient agent connection failures with backoff

### DIFF
--- a/calibrate/connections.py
+++ b/calibrate/connections.py
@@ -39,6 +39,10 @@ _MAX_ATTEMPTS = 4
 _BACKOFF_BASE_SECONDS = 1.0
 
 
+class _AgentRequestError(Exception):
+    """A transient request failure that exhausted all retry attempts."""
+
+
 @dataclass
 class TextAgentConnection:
     """
@@ -126,47 +130,17 @@ class TextAgentConnection:
         """
         input_messages = messages if messages is not None else _DEFAULT_VERIFY_MESSAGES
 
-        req_headers = {"Content-Type": "application/json"}
-        if self.headers:
-            req_headers.update(self.headers)
-
         body: dict = {"messages": input_messages}
         if model is not None:
             body["model"] = model
 
         # ── 1. POST to endpoint (retry transient failures) ───────────────
-        resp = None
-        last_error = None
-        for attempt in range(_MAX_ATTEMPTS):
-            try:
-                async with httpx.AsyncClient(timeout=30.0) as client:
-                    resp = await client.post(
-                        self.url,
-                        json=body,
-                        headers=req_headers,
-                    )
-            except httpx.ConnectError as e:
-                last_error = f"Could not connect to endpoint: {e}"
-            except httpx.TimeoutException:
-                last_error = "Request timed out (30s)"
-            except Exception as e:
-                return {"ok": False, "error": f"Unexpected error during request: {e}"}
-            else:
-                if resp.status_code not in _RETRYABLE_STATUS:
-                    break
-                last_error = (
-                    f"Endpoint returned HTTP {resp.status_code}: {resp.text[:500]}"
-                )
-                resp = None
-
-            if attempt < _MAX_ATTEMPTS - 1:
-                await asyncio.sleep(_BACKOFF_BASE_SECONDS * (2 ** attempt))
-
-        if resp is None:
-            return {
-                "ok": False,
-                "error": f"{last_error} (after {_MAX_ATTEMPTS} attempts)",
-            }
+        try:
+            resp = await self._post_with_retry(body, timeout=30.0)
+        except _AgentRequestError as e:
+            return {"ok": False, "error": str(e)}
+        except Exception as e:
+            return {"ok": False, "error": f"Unexpected error during request: {e}"}
 
         # ── 2. HTTP status ────────────────────────────────────────────────
         if resp.status_code != 200:
@@ -275,18 +249,53 @@ class TextAgentConnection:
                 timeouts, and HTTP 429/502/503/504) are retried with
                 exponential backoff before giving up.
         """
-        req_headers = {"Content-Type": "application/json"}
-        if self.headers:
-            req_headers.update(self.headers)
-
         body: dict = {"messages": messages}
         if model is not None:
             body["model"] = model
 
+        try:
+            resp = await self._post_with_retry(body, timeout=60.0)
+        except _AgentRequestError as e:
+            raise RuntimeError(str(e)) from None
+        except Exception as e:
+            raise RuntimeError(
+                f"Unexpected error calling agent at {self.url}: {e}"
+            ) from e
+
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"Agent returned HTTP {resp.status_code}: {resp.text[:500]}"
+            )
+
+        try:
+            data = resp.json()
+        except Exception:
+            raise RuntimeError(
+                f"Agent response is not valid JSON: {resp.text[:500]}"
+            ) from None
+
+        return {
+            "response": data.get("response"),
+            "tool_calls": data.get("tool_calls", []),
+        }
+
+    async def _post_with_retry(self, body: dict, timeout: float) -> "httpx.Response":
+        """POST ``body`` to the endpoint, retrying transient failures.
+
+        Connection errors, timeouts, and HTTP 429/502/503/504 are retried with
+        exponential backoff (``_MAX_ATTEMPTS`` tries). Returns the first
+        ``httpx.Response`` whose status is not retryable (including a permanent
+        4xx/5xx — the caller decides what to do with it). Raises
+        ``_AgentRequestError`` if every attempt was a transient failure.
+        """
+        req_headers = {"Content-Type": "application/json"}
+        if self.headers:
+            req_headers.update(self.headers)
+
         last_error = None
         for attempt in range(_MAX_ATTEMPTS):
             try:
-                async with httpx.AsyncClient(timeout=60.0) as client:
+                async with httpx.AsyncClient(timeout=timeout) as client:
                     resp = await client.post(
                         self.url,
                         json=body,
@@ -295,27 +304,10 @@ class TextAgentConnection:
             except httpx.ConnectError as e:
                 last_error = f"Could not connect to agent at {self.url}: {e}"
             except httpx.TimeoutException:
-                last_error = f"Agent request timed out (60s): {self.url}"
-            except Exception as e:
-                raise RuntimeError(
-                    f"Unexpected error calling agent at {self.url}: {e}"
-                ) from e
+                last_error = f"Agent request timed out ({timeout:.0f}s): {self.url}"
             else:
-                if resp.status_code == 200:
-                    try:
-                        data = resp.json()
-                    except Exception:
-                        raise RuntimeError(
-                            f"Agent response is not valid JSON: {resp.text[:500]}"
-                        ) from None
-                    return {
-                        "response": data.get("response"),
-                        "tool_calls": data.get("tool_calls", []),
-                    }
                 if resp.status_code not in _RETRYABLE_STATUS:
-                    raise RuntimeError(
-                        f"Agent returned HTTP {resp.status_code}: {resp.text[:500]}"
-                    )
+                    return resp
                 last_error = (
                     f"Agent returned HTTP {resp.status_code}: {resp.text[:500]}"
                 )
@@ -323,10 +315,7 @@ class TextAgentConnection:
             if attempt < _MAX_ATTEMPTS - 1:
                 await asyncio.sleep(_BACKOFF_BASE_SECONDS * (2 ** attempt))
 
-        raise RuntimeError(
-            f"Agent call to {self.url} failed after {_MAX_ATTEMPTS} attempts. "
-            f"Last error: {last_error}"
-        )
+        raise _AgentRequestError(f"{last_error} (after {_MAX_ATTEMPTS} attempts)")
 
 
 __all__ = ["TextAgentConnection"]

--- a/calibrate/connections.py
+++ b/calibrate/connections.py
@@ -21,9 +21,9 @@ Usage:
     result = asyncio.run(simulations.run(agent=agent, personas=[...], ...))
 """
 
-import asyncio
 from dataclasses import dataclass, field
 from typing import Optional
+import backoff
 import httpx
 
 
@@ -138,7 +138,7 @@ class TextAgentConnection:
         try:
             resp = await self._post_with_retry(body, timeout=30.0)
         except _AgentRequestError as e:
-            return {"ok": False, "error": str(e)}
+            return {"ok": False, "error": f"{e} (after {_MAX_ATTEMPTS} attempts)"}
         except Exception as e:
             return {"ok": False, "error": f"Unexpected error during request: {e}"}
 
@@ -256,7 +256,7 @@ class TextAgentConnection:
         try:
             resp = await self._post_with_retry(body, timeout=60.0)
         except _AgentRequestError as e:
-            raise RuntimeError(str(e)) from None
+            raise RuntimeError(f"{e} (after {_MAX_ATTEMPTS} attempts)") from None
         except Exception as e:
             raise RuntimeError(
                 f"Unexpected error calling agent at {self.url}: {e}"
@@ -279,43 +279,44 @@ class TextAgentConnection:
             "tool_calls": data.get("tool_calls", []),
         }
 
+    @backoff.on_exception(
+        backoff.expo,
+        _AgentRequestError,
+        max_tries=_MAX_ATTEMPTS,
+        base=2,
+        factor=_BACKOFF_BASE_SECONDS,
+        jitter=None,
+    )
     async def _post_with_retry(self, body: dict, timeout: float) -> "httpx.Response":
         """POST ``body`` to the endpoint, retrying transient failures.
 
-        Connection errors, timeouts, and HTTP 429/502/503/504 are retried with
-        exponential backoff (``_MAX_ATTEMPTS`` tries). Returns the first
-        ``httpx.Response`` whose status is not retryable (including a permanent
-        4xx/5xx — the caller decides what to do with it). Raises
-        ``_AgentRequestError`` if every attempt was a transient failure.
+        Connection errors, timeouts, and HTTP 429/502/503/504 raise
+        ``_AgentRequestError`` and are retried with exponential backoff. Any
+        other status (200 or a permanent 4xx/5xx) is returned for the caller to
+        handle. After ``_MAX_ATTEMPTS`` transient failures the last
+        ``_AgentRequestError`` propagates.
         """
         req_headers = {"Content-Type": "application/json"}
         if self.headers:
             req_headers.update(self.headers)
 
-        last_error = None
-        for attempt in range(_MAX_ATTEMPTS):
-            try:
-                async with httpx.AsyncClient(timeout=timeout) as client:
-                    resp = await client.post(
-                        self.url,
-                        json=body,
-                        headers=req_headers,
-                    )
-            except httpx.ConnectError as e:
-                last_error = f"Could not connect to agent at {self.url}: {e}"
-            except httpx.TimeoutException:
-                last_error = f"Agent request timed out ({timeout:.0f}s): {self.url}"
-            else:
-                if resp.status_code not in _RETRYABLE_STATUS:
-                    return resp
-                last_error = (
-                    f"Agent returned HTTP {resp.status_code}: {resp.text[:500]}"
-                )
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.post(self.url, json=body, headers=req_headers)
+        except httpx.ConnectError as e:
+            raise _AgentRequestError(
+                f"Could not connect to agent at {self.url}: {e}"
+            ) from e
+        except httpx.TimeoutException as e:
+            raise _AgentRequestError(
+                f"Agent request timed out ({timeout:.0f}s): {self.url}"
+            ) from e
 
-            if attempt < _MAX_ATTEMPTS - 1:
-                await asyncio.sleep(_BACKOFF_BASE_SECONDS * (2 ** attempt))
-
-        raise _AgentRequestError(f"{last_error} (after {_MAX_ATTEMPTS} attempts)")
+        if resp.status_code in _RETRYABLE_STATUS:
+            raise _AgentRequestError(
+                f"Agent returned HTTP {resp.status_code}: {resp.text[:500]}"
+            )
+        return resp
 
 
 __all__ = ["TextAgentConnection"]

--- a/calibrate/connections.py
+++ b/calibrate/connections.py
@@ -21,6 +21,7 @@ Usage:
     result = asyncio.run(simulations.run(agent=agent, personas=[...], ...))
 """
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import Optional
 import httpx
@@ -28,6 +29,14 @@ import httpx
 
 # Default messages used by verify() when no custom input is provided
 _DEFAULT_VERIFY_MESSAGES = [{"role": "user", "content": "Hello, are you there?"}]
+
+# Retry policy for transient agent failures. A flaky upstream (502/503/504 from
+# a reverse proxy, a brief overload returning 429, or a dropped connection)
+# should not abort a whole eval run — retry with exponential backoff. Permanent
+# failures (4xx other than 429, invalid JSON) are NOT retried.
+_RETRYABLE_STATUS = frozenset({429, 502, 503, 504})
+_MAX_ATTEMPTS = 4
+_BACKOFF_BASE_SECONDS = 1.0
 
 
 @dataclass
@@ -117,28 +126,47 @@ class TextAgentConnection:
         """
         input_messages = messages if messages is not None else _DEFAULT_VERIFY_MESSAGES
 
-        # ── 1. POST to endpoint ──────────────────────────────────────────
-        try:
-            req_headers = {"Content-Type": "application/json"}
-            if self.headers:
-                req_headers.update(self.headers)
+        req_headers = {"Content-Type": "application/json"}
+        if self.headers:
+            req_headers.update(self.headers)
 
-            body: dict = {"messages": input_messages}
-            if model is not None:
-                body["model"] = model
+        body: dict = {"messages": input_messages}
+        if model is not None:
+            body["model"] = model
 
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                resp = await client.post(
-                    self.url,
-                    json=body,
-                    headers=req_headers,
+        # ── 1. POST to endpoint (retry transient failures) ───────────────
+        resp = None
+        last_error = None
+        for attempt in range(_MAX_ATTEMPTS):
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    resp = await client.post(
+                        self.url,
+                        json=body,
+                        headers=req_headers,
+                    )
+            except httpx.ConnectError as e:
+                last_error = f"Could not connect to endpoint: {e}"
+            except httpx.TimeoutException:
+                last_error = "Request timed out (30s)"
+            except Exception as e:
+                return {"ok": False, "error": f"Unexpected error during request: {e}"}
+            else:
+                if resp.status_code not in _RETRYABLE_STATUS:
+                    break
+                last_error = (
+                    f"Endpoint returned HTTP {resp.status_code}: {resp.text[:500]}"
                 )
-        except httpx.ConnectError as e:
-            return {"ok": False, "error": f"Could not connect to endpoint: {e}"}
-        except httpx.TimeoutException:
-            return {"ok": False, "error": "Request timed out (30s)"}
-        except Exception as e:
-            return {"ok": False, "error": f"Unexpected error during request: {e}"}
+                resp = None
+
+            if attempt < _MAX_ATTEMPTS - 1:
+                await asyncio.sleep(_BACKOFF_BASE_SECONDS * (2 ** attempt))
+
+        if resp is None:
+            return {
+                "ok": False,
+                "error": f"{last_error} (after {_MAX_ATTEMPTS} attempts)",
+            }
 
         # ── 2. HTTP status ────────────────────────────────────────────────
         if resp.status_code != 200:
@@ -243,7 +271,9 @@ class TextAgentConnection:
 
         Raises:
             RuntimeError: On connection error, timeout, non-200 status, or
-                invalid JSON response.
+                invalid JSON response. Transient failures (connection errors,
+                timeouts, and HTTP 429/502/503/504) are retried with
+                exponential backoff before giving up.
         """
         req_headers = {"Content-Type": "application/json"}
         if self.headers:
@@ -253,38 +283,50 @@ class TextAgentConnection:
         if model is not None:
             body["model"] = model
 
-        try:
-            async with httpx.AsyncClient(timeout=60.0) as client:
-                resp = await client.post(
-                    self.url,
-                    json=body,
-                    headers=req_headers,
+        last_error = None
+        for attempt in range(_MAX_ATTEMPTS):
+            try:
+                async with httpx.AsyncClient(timeout=60.0) as client:
+                    resp = await client.post(
+                        self.url,
+                        json=body,
+                        headers=req_headers,
+                    )
+            except httpx.ConnectError as e:
+                last_error = f"Could not connect to agent at {self.url}: {e}"
+            except httpx.TimeoutException:
+                last_error = f"Agent request timed out (60s): {self.url}"
+            except Exception as e:
+                raise RuntimeError(
+                    f"Unexpected error calling agent at {self.url}: {e}"
+                ) from e
+            else:
+                if resp.status_code == 200:
+                    try:
+                        data = resp.json()
+                    except Exception:
+                        raise RuntimeError(
+                            f"Agent response is not valid JSON: {resp.text[:500]}"
+                        ) from None
+                    return {
+                        "response": data.get("response"),
+                        "tool_calls": data.get("tool_calls", []),
+                    }
+                if resp.status_code not in _RETRYABLE_STATUS:
+                    raise RuntimeError(
+                        f"Agent returned HTTP {resp.status_code}: {resp.text[:500]}"
+                    )
+                last_error = (
+                    f"Agent returned HTTP {resp.status_code}: {resp.text[:500]}"
                 )
-        except httpx.ConnectError as e:
-            raise RuntimeError(f"Could not connect to agent at {self.url}: {e}") from e
-        except httpx.TimeoutException:
-            raise RuntimeError(f"Agent request timed out (60s): {self.url}") from None
-        except Exception as e:
-            raise RuntimeError(
-                f"Unexpected error calling agent at {self.url}: {e}"
-            ) from e
 
-        if resp.status_code != 200:
-            raise RuntimeError(
-                f"Agent returned HTTP {resp.status_code}: {resp.text[:500]}"
-            )
+            if attempt < _MAX_ATTEMPTS - 1:
+                await asyncio.sleep(_BACKOFF_BASE_SECONDS * (2 ** attempt))
 
-        try:
-            data = resp.json()
-        except Exception:
-            raise RuntimeError(
-                f"Agent response is not valid JSON: {resp.text[:500]}"
-            ) from None
-
-        return {
-            "response": data.get("response"),
-            "tool_calls": data.get("tool_calls", []),
-        }
+        raise RuntimeError(
+            f"Agent call to {self.url} failed after {_MAX_ATTEMPTS} attempts. "
+            f"Last error: {last_error}"
+        )
 
 
 __all__ = ["TextAgentConnection"]

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -170,7 +170,7 @@ class TestCallRetry(unittest.IsolatedAsyncioTestCase):
             ({}, 503),
             ({"response": "recovered", "tool_calls": []}, 200),
         ])
-        with ctx, patch("calibrate.connections.asyncio.sleep", AsyncMock()):
+        with ctx, patch("asyncio.sleep", AsyncMock()):
             result = await agent.call([{"role": "user", "content": "Hi"}])
 
         self.assertEqual(result["response"], "recovered")
@@ -185,7 +185,7 @@ class TestCallRetry(unittest.IsolatedAsyncioTestCase):
             httpx.ConnectError("boom"),
             ({"response": "ok", "tool_calls": []}, 200),
         ])
-        with ctx, patch("calibrate.connections.asyncio.sleep", AsyncMock()):
+        with ctx, patch("asyncio.sleep", AsyncMock()):
             result = await agent.call([{"role": "user", "content": "Hi"}])
 
         self.assertEqual(result["response"], "ok")
@@ -197,7 +197,7 @@ class TestCallRetry(unittest.IsolatedAsyncioTestCase):
 
         agent = TextAgentConnection(url="http://fake-agent/chat")
         ctx, mock_client = _patch_httpx_sequence([({}, 502)] * _MAX_ATTEMPTS)
-        with ctx, patch("calibrate.connections.asyncio.sleep", AsyncMock()):
+        with ctx, patch("asyncio.sleep", AsyncMock()):
             with self.assertRaises(RuntimeError) as cm:
                 await agent.call([{"role": "user", "content": "Hi"}])
 
@@ -213,7 +213,7 @@ class TestCallRetry(unittest.IsolatedAsyncioTestCase):
             ({}, 401),
             ({"response": "should not reach", "tool_calls": []}, 200),
         ])
-        with ctx, patch("calibrate.connections.asyncio.sleep", AsyncMock()):
+        with ctx, patch("asyncio.sleep", AsyncMock()):
             with self.assertRaises(RuntimeError) as cm:
                 await agent.call([{"role": "user", "content": "Hi"}])
 
@@ -442,7 +442,7 @@ class TestTextAgentConnectionVerify(unittest.IsolatedAsyncioTestCase):
             ({}, 503),
             ({"response": "up now", "tool_calls": []}, 200),
         ])
-        with ctx, patch("calibrate.connections.asyncio.sleep", AsyncMock()):
+        with ctx, patch("asyncio.sleep", AsyncMock()):
             result = await agent.verify()
 
         self.assertTrue(result["ok"])
@@ -454,7 +454,7 @@ class TestTextAgentConnectionVerify(unittest.IsolatedAsyncioTestCase):
 
         agent = TextAgentConnection(url="http://fake-agent/chat")
         ctx, mock_client = _patch_httpx_sequence([({}, 502)] * _MAX_ATTEMPTS)
-        with ctx, patch("calibrate.connections.asyncio.sleep", AsyncMock()):
+        with ctx, patch("asyncio.sleep", AsyncMock()):
             result = await agent.verify()
 
         self.assertFalse(result["ok"])

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -43,6 +43,28 @@ def _patch_httpx(response_body: dict, status: int = 200):
     return patch("httpx.AsyncClient", return_value=mock_client), mock_client
 
 
+def _patch_httpx_sequence(outcomes):
+    """Patch httpx.AsyncClient.post to yield ``outcomes`` in order.
+
+    Each outcome is either an ``(body, status)`` tuple (a fake response) or an
+    Exception instance (raised on that attempt). Lets tests exercise the retry
+    loop across multiple attempts.
+    """
+    side_effects = []
+    for outcome in outcomes:
+        if isinstance(outcome, BaseException):
+            side_effects.append(outcome)
+        else:
+            body, status = outcome
+            side_effects.append(_make_httpx_response(body, status))
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(side_effect=side_effects)
+    return patch("httpx.AsyncClient", return_value=mock_client), mock_client
+
+
 # ---------------------------------------------------------------------------
 # Tests for TextAgentConnection.call()
 # ---------------------------------------------------------------------------
@@ -131,6 +153,72 @@ class TestCallTextAgent(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(result["response"])
         self.assertEqual(result["tool_calls"], [])
+
+
+# ---------------------------------------------------------------------------
+# Tests for TextAgentConnection.call() — retry on transient failures
+# ---------------------------------------------------------------------------
+
+class TestCallRetry(unittest.IsolatedAsyncioTestCase):
+
+    async def test_retries_then_succeeds_on_502(self):
+        from calibrate.connections import TextAgentConnection
+
+        agent = TextAgentConnection(url="http://fake-agent/chat")
+        ctx, mock_client = _patch_httpx_sequence([
+            ({}, 502),
+            ({}, 503),
+            ({"response": "recovered", "tool_calls": []}, 200),
+        ])
+        with ctx, patch("calibrate.connections.asyncio.sleep", AsyncMock()):
+            result = await agent.call([{"role": "user", "content": "Hi"}])
+
+        self.assertEqual(result["response"], "recovered")
+        self.assertEqual(mock_client.post.await_count, 3)
+
+    async def test_retries_then_succeeds_on_connect_error(self):
+        import httpx
+        from calibrate.connections import TextAgentConnection
+
+        agent = TextAgentConnection(url="http://fake-agent/chat")
+        ctx, mock_client = _patch_httpx_sequence([
+            httpx.ConnectError("boom"),
+            ({"response": "ok", "tool_calls": []}, 200),
+        ])
+        with ctx, patch("calibrate.connections.asyncio.sleep", AsyncMock()):
+            result = await agent.call([{"role": "user", "content": "Hi"}])
+
+        self.assertEqual(result["response"], "ok")
+        self.assertEqual(mock_client.post.await_count, 2)
+
+    async def test_gives_up_after_max_attempts(self):
+        from calibrate.connections import TextAgentConnection
+        from calibrate.connections import _MAX_ATTEMPTS
+
+        agent = TextAgentConnection(url="http://fake-agent/chat")
+        ctx, mock_client = _patch_httpx_sequence([({}, 502)] * _MAX_ATTEMPTS)
+        with ctx, patch("calibrate.connections.asyncio.sleep", AsyncMock()):
+            with self.assertRaises(RuntimeError) as cm:
+                await agent.call([{"role": "user", "content": "Hi"}])
+
+        self.assertEqual(mock_client.post.await_count, _MAX_ATTEMPTS)
+        self.assertIn("502", str(cm.exception))
+        self.assertIn(str(_MAX_ATTEMPTS), str(cm.exception))
+
+    async def test_no_retry_on_4xx(self):
+        from calibrate.connections import TextAgentConnection
+
+        agent = TextAgentConnection(url="http://fake-agent/chat")
+        ctx, mock_client = _patch_httpx_sequence([
+            ({}, 401),
+            ({"response": "should not reach", "tool_calls": []}, 200),
+        ])
+        with ctx, patch("calibrate.connections.asyncio.sleep", AsyncMock()):
+            with self.assertRaises(RuntimeError) as cm:
+                await agent.call([{"role": "user", "content": "Hi"}])
+
+        self.assertEqual(mock_client.post.await_count, 1)
+        self.assertIn("401", str(cm.exception))
 
 
 # ---------------------------------------------------------------------------
@@ -345,6 +433,33 @@ class TestTextAgentConnectionVerify(unittest.IsolatedAsyncioTestCase):
             result = await agent.verify()
 
         self.assertFalse(result["ok"])
+
+    async def test_verify_retries_then_succeeds_on_503(self):
+        from calibrate.connections import TextAgentConnection
+
+        agent = TextAgentConnection(url="http://fake-agent/chat")
+        ctx, mock_client = _patch_httpx_sequence([
+            ({}, 503),
+            ({"response": "up now", "tool_calls": []}, 200),
+        ])
+        with ctx, patch("calibrate.connections.asyncio.sleep", AsyncMock()):
+            result = await agent.verify()
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(mock_client.post.await_count, 2)
+
+    async def test_verify_fails_after_retries_exhausted(self):
+        from calibrate.connections import TextAgentConnection
+        from calibrate.connections import _MAX_ATTEMPTS
+
+        agent = TextAgentConnection(url="http://fake-agent/chat")
+        ctx, mock_client = _patch_httpx_sequence([({}, 502)] * _MAX_ATTEMPTS)
+        with ctx, patch("calibrate.connections.asyncio.sleep", AsyncMock()):
+            result = await agent.verify()
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(mock_client.post.await_count, _MAX_ATTEMPTS)
+        self.assertIn("attempts", result["error"])
 
     async def test_verify_fails_wrong_tool_call_format(self):
         from calibrate.connections import TextAgentConnection


### PR DESCRIPTION
## What

`TextAgentConnection.call()` and `verify()` now retry **transient** failures (connection errors, timeouts, HTTP `429/502/503/504`) with exponential backoff — 4 attempts, 1s → 2s → 4s. Permanent failures (other 4xx, invalid JSON) still fail fast.

## Why

A single transient blip — e.g. a `502` from nginx while the agent restarts — used to kill an entire eval run. Mirrors the `@backoff` retry already used by the STT/TTS routers.

## Tests

6 new cases in `tests/test_connections.py` (retry-then-succeed, give-up-after-max, no-retry-on-4xx), patching `asyncio.sleep` to stay fast. All 25 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)