### PR TITLE
Run LLM test cases in parallel with configurable concurrency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ SARVAM_API_KEY=
 ELEVENLABS_API_KEY=
 OPENROUTER_API_KEY=
 
+# Max test cases to evaluate concurrently per model (defaults to 4 if unset).
+# Overridden by the -n/--parallel CLI flag.
+# CALIBRATE_TEST_PARALLEL=4
+
 # langfuse
 ENVIRONMENT=development # langfuse tracing environment
 ENABLE_TRACING=true

--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,7 @@ Desktop.ini
 
 logs
 out
+out-*/
 data
 
 # MkDocs build output

--- a/calibrate/cli.py
+++ b/calibrate/cli.py
@@ -303,8 +303,7 @@ Examples:
         "--parallel",
         type=int,
         default=None,
-        help="Number of test cases to evaluate in parallel per model "
-        "(overrides CALIBRATE_TEST_PARALLEL; default 4)",
+        help="Number of test cases to evaluate in parallel per model",
     )
     llm_parser.add_argument(
         "--verify",

--- a/calibrate/cli.py
+++ b/calibrate/cli.py
@@ -299,6 +299,14 @@ Examples:
         help="LLM provider",
     )
     llm_parser.add_argument(
+        "-n",
+        "--parallel",
+        type=int,
+        default=None,
+        help="Number of test cases to evaluate in parallel per model "
+        "(overrides CALIBRATE_TEST_PARALLEL; default 4)",
+    )
+    llm_parser.add_argument(
         "--verify",
         action="store_true",
         help="Verify an external agent connection by sending a preset message and checking the response format",
@@ -534,6 +542,8 @@ Examples:
                 "--dataset",
                 args.dataset,
             ]
+            if getattr(args, "parallel", None) is not None:
+                argv.extend(["-n", str(args.parallel)])
             sys.argv = argv
             asyncio.run(llm_run_tests_main())
         elif getattr(args, "verify", False):
@@ -598,6 +608,7 @@ Examples:
                                 output_dir=args.output_dir,
                                 models=[_m],
                                 evaluators=_config.get("evaluators"),
+                                test_parallel=args.parallel,
                             )
                         )
                         _model_results[_m] = _result.get(_m, _result)
@@ -618,6 +629,7 @@ Examples:
                             test_cases=_config["test_cases"],
                             output_dir=args.output_dir,
                             evaluators=_config.get("evaluators"),
+                            test_parallel=args.parallel,
                         )
                     )
             else:
@@ -629,6 +641,8 @@ Examples:
                 argv.extend(["-o", args.output_dir])
                 argv.extend(["-m"] + models)
                 argv.extend(["-p", args.provider])
+                if getattr(args, "parallel", None) is not None:
+                    argv.extend(["-n", str(args.parallel)])
 
                 sys.argv = argv
                 asyncio.run(llm_benchmark_main())

--- a/calibrate/llm/__init__.py
+++ b/calibrate/llm/__init__.py
@@ -262,8 +262,7 @@ class _Tests:
             provider: LLM provider (openai or openrouter)
             run_name: Optional name for this run (used in output folder name)
             max_parallel: Maximum number of models to run in parallel (default: 2)
-            test_parallel: Max test cases to evaluate concurrently per model;
-                resolved via ``_resolve_test_parallel``.
+            test_parallel: Max test cases to evaluate concurrently per model.
             agent: Optional external agent connection. When provided, routes all
                 test cases to the external agent instead of an internal LLM.
             evaluators: Optional list of evaluator dicts (each with ``name``,

--- a/calibrate/llm/__init__.py
+++ b/calibrate/llm/__init__.py
@@ -262,9 +262,8 @@ class _Tests:
             provider: LLM provider (openai or openrouter)
             run_name: Optional name for this run (used in output folder name)
             max_parallel: Maximum number of models to run in parallel (default: 2)
-            test_parallel: Max test cases to evaluate concurrently per model.
-                Falls back to the CALIBRATE_TEST_PARALLEL env var, then a
-                default of 4.
+            test_parallel: Max test cases to evaluate concurrently per model;
+                resolved via ``_resolve_test_parallel``.
             agent: Optional external agent connection. When provided, routes all
                 test cases to the external agent instead of an internal LLM.
             evaluators: Optional list of evaluator dicts (each with ``name``,

--- a/calibrate/llm/__init__.py
+++ b/calibrate/llm/__init__.py
@@ -92,7 +92,7 @@ class _Tests:
             _get_name_to_evaluator_dict,
             _evaluators_for_config_output,
             _resolve_evaluators_for_test_case,
-            _resolve_test_parallel,
+            _run_items_parallel,
         )
         from calibrate.judges import write_evaluator_config
         from calibrate.utils import configure_print_logger, log_and_print
@@ -128,7 +128,6 @@ class _Tests:
 
         configure_print_logger(print_log_save_path)
 
-        results: List[Optional[dict]] = [None] * len(test_cases)
         results_file_path = os.path.join(final_output_dir, "results.json")
 
         # Pass model name to agent for benchmark routing; None for single runs.
@@ -140,64 +139,54 @@ class _Tests:
             output_dir, _evaluators_for_config_output(evaluator_config)
         )
 
-        semaphore = asyncio.Semaphore(_resolve_test_parallel(test_parallel))
-        write_lock = asyncio.Lock()
-
-        async def run_one(test_case_index: int, test_case: dict) -> None:
-            async with semaphore:
-                evaluation = test_case["evaluation"]
-                resolved_evaluators = (
-                    _resolve_evaluators_for_test_case(
-                        evaluation,
-                        _get_name_to_evaluator_dict(
-                            evaluator_config,
-                            include_default=(evaluation.get("type") == "response"),
-                        ),
-                    )
-                    if evaluation.get("type") in ("response", "conversation")
-                    else None
+        async def process(test_case_index: int, test_case: dict) -> dict:
+            evaluation = test_case["evaluation"]
+            resolved_evaluators = (
+                _resolve_evaluators_for_test_case(
+                    evaluation,
+                    _get_name_to_evaluator_dict(
+                        evaluator_config,
+                        include_default=(evaluation.get("type") == "response"),
+                    ),
                 )
-                if agent is not None:
-                    result = await _run_test_external(
-                        chat_history=test_case["history"],
-                        evaluation=evaluation,
-                        agent=agent,
-                        model=agent_model_hint,
-                        evaluators=resolved_evaluators,
-                    )
-                else:
-                    result = await _run_test(
-                        chat_history=test_case["history"],
-                        evaluation=evaluation,
-                        system_prompt=system_prompt,
-                        model=model,
-                        provider=provider,
-                        tools=tools,
-                        unique_id=run_name or "",
-                        evaluators=resolved_evaluators,
-                    )
+                if evaluation.get("type") in ("response", "conversation")
+                else None
+            )
+            if agent is not None:
+                result = await _run_test_external(
+                    chat_history=test_case["history"],
+                    evaluation=evaluation,
+                    agent=agent,
+                    model=agent_model_hint,
+                    evaluators=resolved_evaluators,
+                )
+            else:
+                result = await _run_test(
+                    chat_history=test_case["history"],
+                    evaluation=evaluation,
+                    system_prompt=system_prompt,
+                    model=model,
+                    provider=provider,
+                    tools=tools,
+                    unique_id=run_name or "",
+                    evaluators=resolved_evaluators,
+                )
 
-                if result["metrics"]["passed"]:
-                    log_and_print(f"✅ Test case {test_case_index + 1} passed")
-                else:
-                    log_and_print(f"❌ Test case {test_case_index + 1} failed")
-                if "reasoning" in result["metrics"]:
-                    log_and_print(result["metrics"]["reasoning"])
+            if result["metrics"]["passed"]:
+                log_and_print(f"✅ Test case {test_case_index + 1} passed")
+            else:
+                log_and_print(f"❌ Test case {test_case_index + 1} failed")
+            if "reasoning" in result["metrics"]:
+                log_and_print(result["metrics"]["reasoning"])
 
-                if "id" in test_case:
-                    result["test_case_id"] = test_case["id"]
-                result["test_case"] = test_case
-                results[test_case_index] = result
+            if "id" in test_case:
+                result["test_case_id"] = test_case["id"]
+            result["test_case"] = test_case
+            log_and_print("-" * 40)
+            return result
 
-                # Save intermediate results as each test case completes (in order).
-                async with write_lock:
-                    with open(results_file_path, "w") as f:
-                        json.dump([r for r in results if r is not None], f, indent=4)
-
-                log_and_print("-" * 40)
-
-        await asyncio.gather(
-            *[run_one(i, test_case) for i, test_case in enumerate(test_cases)]
+        results = await _run_items_parallel(
+            test_cases, process, results_file_path, test_parallel
         )
 
         total_passed = sum(1 for r in results if r["metrics"]["passed"])

--- a/calibrate/llm/__init__.py
+++ b/calibrate/llm/__init__.py
@@ -83,6 +83,7 @@ class _Tests:
         run_name: Optional[str] = None,
         agent: Optional["TextAgentConnection"] = None,
         evaluators: Optional[List[dict]] = None,
+        test_parallel: Optional[int] = None,
     ) -> dict:
         """Run tests for a single model (or external agent)."""
         from calibrate.llm.run_tests import (
@@ -91,6 +92,7 @@ class _Tests:
             _get_name_to_evaluator_dict,
             _evaluators_for_config_output,
             _resolve_evaluators_for_test_case,
+            _resolve_test_parallel,
         )
         from calibrate.judges import write_evaluator_config
         from calibrate.utils import configure_print_logger, log_and_print
@@ -126,7 +128,7 @@ class _Tests:
 
         configure_print_logger(print_log_save_path)
 
-        results = []
+        results: List[Optional[dict]] = [None] * len(test_cases)
         results_file_path = os.path.join(final_output_dir, "results.json")
 
         # Pass model name to agent for benchmark routing; None for single runs.
@@ -138,56 +140,65 @@ class _Tests:
             output_dir, _evaluators_for_config_output(evaluator_config)
         )
 
-        for test_case_index, test_case in enumerate(test_cases):
-            evaluation = test_case["evaluation"]
-            resolved_evaluators = (
-                _resolve_evaluators_for_test_case(
-                    evaluation,
-                    _get_name_to_evaluator_dict(
-                        evaluator_config,
-                        include_default=(evaluation.get("type") == "response"),
-                    ),
+        semaphore = asyncio.Semaphore(_resolve_test_parallel(test_parallel))
+        write_lock = asyncio.Lock()
+
+        async def run_one(test_case_index: int, test_case: dict) -> None:
+            async with semaphore:
+                evaluation = test_case["evaluation"]
+                resolved_evaluators = (
+                    _resolve_evaluators_for_test_case(
+                        evaluation,
+                        _get_name_to_evaluator_dict(
+                            evaluator_config,
+                            include_default=(evaluation.get("type") == "response"),
+                        ),
+                    )
+                    if evaluation.get("type") in ("response", "conversation")
+                    else None
                 )
-                if evaluation.get("type") in ("response", "conversation")
-                else None
-            )
-            if agent is not None:
-                result = await _run_test_external(
-                    chat_history=test_case["history"],
-                    evaluation=evaluation,
-                    agent=agent,
-                    model=agent_model_hint,
-                    evaluators=resolved_evaluators,
-                )
-            else:
-                result = await _run_test(
-                    chat_history=test_case["history"],
-                    evaluation=evaluation,
-                    system_prompt=system_prompt,
-                    model=model,
-                    provider=provider,
-                    tools=tools,
-                    unique_id=run_name or "",
-                    evaluators=resolved_evaluators,
-                )
+                if agent is not None:
+                    result = await _run_test_external(
+                        chat_history=test_case["history"],
+                        evaluation=evaluation,
+                        agent=agent,
+                        model=agent_model_hint,
+                        evaluators=resolved_evaluators,
+                    )
+                else:
+                    result = await _run_test(
+                        chat_history=test_case["history"],
+                        evaluation=evaluation,
+                        system_prompt=system_prompt,
+                        model=model,
+                        provider=provider,
+                        tools=tools,
+                        unique_id=run_name or "",
+                        evaluators=resolved_evaluators,
+                    )
 
-            if result["metrics"]["passed"]:
-                log_and_print(f"✅ Test case {test_case_index + 1} passed")
-            else:
-                log_and_print(f"❌ Test case {test_case_index + 1} failed")
-            if "reasoning" in result["metrics"]:
-                log_and_print(result["metrics"]["reasoning"])
+                if result["metrics"]["passed"]:
+                    log_and_print(f"✅ Test case {test_case_index + 1} passed")
+                else:
+                    log_and_print(f"❌ Test case {test_case_index + 1} failed")
+                if "reasoning" in result["metrics"]:
+                    log_and_print(result["metrics"]["reasoning"])
 
-            if "id" in test_case:
-                result["test_case_id"] = test_case["id"]
-            result["test_case"] = test_case
-            results.append(result)
+                if "id" in test_case:
+                    result["test_case_id"] = test_case["id"]
+                result["test_case"] = test_case
+                results[test_case_index] = result
 
-            # Save intermediate results
-            with open(results_file_path, "w") as f:
-                json.dump(results, f, indent=4)
+                # Save intermediate results as each test case completes (in order).
+                async with write_lock:
+                    with open(results_file_path, "w") as f:
+                        json.dump([r for r in results if r is not None], f, indent=4)
 
-            log_and_print("-" * 40)
+                log_and_print("-" * 40)
+
+        await asyncio.gather(
+            *[run_one(i, test_case) for i, test_case in enumerate(test_cases)]
+        )
 
         total_passed = sum(1 for r in results if r["metrics"]["passed"])
         total_tests = len(results)
@@ -240,6 +251,7 @@ class _Tests:
         max_parallel: int = 2,
         agent: Optional["TextAgentConnection"] = None,
         evaluators: Optional[List[dict]] = None,
+        test_parallel: Optional[int] = None,
     ) -> dict:
         """
         Run LLM tests with the given configuration.
@@ -261,6 +273,9 @@ class _Tests:
             provider: LLM provider (openai or openrouter)
             run_name: Optional name for this run (used in output folder name)
             max_parallel: Maximum number of models to run in parallel (default: 2)
+            test_parallel: Max test cases to evaluate concurrently per model.
+                Falls back to the CALIBRATE_TEST_PARALLEL env var, then a
+                default of 4.
             agent: Optional external agent connection. When provided, routes all
                 test cases to the external agent instead of an internal LLM.
             evaluators: Optional list of evaluator dicts (each with ``name``,
@@ -306,6 +321,7 @@ class _Tests:
                         run_name=run_name,
                         agent=agent,
                         evaluators=evaluators,
+                        test_parallel=test_parallel,
                     )
 
             results = await asyncio.gather(*[run_agent_model(m) for m in models])
@@ -324,6 +340,7 @@ class _Tests:
                 run_name=run_name,
                 agent=agent,
                 evaluators=evaluators,
+                test_parallel=test_parallel,
             )
 
         # If models list is provided, run in parallel
@@ -341,6 +358,7 @@ class _Tests:
                         provider=provider,
                         run_name=run_name,
                         evaluators=evaluators,
+                        test_parallel=test_parallel,
                     )
 
             tasks = [run_with_semaphore(m) for m in models]
@@ -373,6 +391,7 @@ class _Tests:
             provider=provider,
             run_name=run_name,
             evaluators=evaluators,
+            test_parallel=test_parallel,
         )
 
     @staticmethod

--- a/calibrate/llm/benchmark.py
+++ b/calibrate/llm/benchmark.py
@@ -150,8 +150,7 @@ async def main():
         "--parallel",
         type=int,
         default=None,
-        help="Number of test cases to evaluate in parallel per model "
-        "(overrides CALIBRATE_TEST_PARALLEL; default 4)",
+        help="Number of test cases to evaluate in parallel per model",
     )
 
     args = parser.parse_args()

--- a/calibrate/llm/benchmark.py
+++ b/calibrate/llm/benchmark.py
@@ -55,8 +55,8 @@ async def run(
         output_dir: Path to output directory for results (default: ./out)
             Results saved to output_dir/model_name/ for each model
         max_parallel: Maximum number of models to run in parallel (default: 2)
-        test_parallel: Max test cases to evaluate concurrently per model. Falls
-            back to the CALIBRATE_TEST_PARALLEL env var, then a default of 4.
+        test_parallel: Max test cases to evaluate concurrently per model;
+            resolved via ``_resolve_test_parallel``.
 
     Returns:
         dict: Results summary with status and output paths

--- a/calibrate/llm/benchmark.py
+++ b/calibrate/llm/benchmark.py
@@ -55,8 +55,7 @@ async def run(
         output_dir: Path to output directory for results (default: ./out)
             Results saved to output_dir/model_name/ for each model
         max_parallel: Maximum number of models to run in parallel (default: 2)
-        test_parallel: Max test cases to evaluate concurrently per model;
-            resolved via ``_resolve_test_parallel``.
+        test_parallel: Max test cases to evaluate concurrently per model.
 
     Returns:
         dict: Results summary with status and output paths

--- a/calibrate/llm/benchmark.py
+++ b/calibrate/llm/benchmark.py
@@ -41,6 +41,7 @@ async def run(
     provider: str,
     output_dir: str = "./out",
     max_parallel: int = MAX_PARALLEL_MODELS,
+    test_parallel: int | None = None,
 ) -> dict:
     """
     Run LLM tests for multiple models in parallel and generate a leaderboard.
@@ -54,6 +55,8 @@ async def run(
         output_dir: Path to output directory for results (default: ./out)
             Results saved to output_dir/model_name/ for each model
         max_parallel: Maximum number of models to run in parallel (default: 2)
+        test_parallel: Max test cases to evaluate concurrently per model. Falls
+            back to the CALIBRATE_TEST_PARALLEL env var, then a default of 4.
 
     Returns:
         dict: Results summary with status and output paths
@@ -81,6 +84,7 @@ async def run(
                 provider=provider,
                 config=config,
                 output_dir=output_dir,
+                test_parallel=test_parallel,
             )
             return (model, result)
 
@@ -141,6 +145,14 @@ async def main():
         default="openrouter",
         help="LLM provider to use (openai or openrouter)",
     )
+    parser.add_argument(
+        "-n",
+        "--parallel",
+        type=int,
+        default=None,
+        help="Number of test cases to evaluate in parallel per model "
+        "(overrides CALIBRATE_TEST_PARALLEL; default 4)",
+    )
 
     args = parser.parse_args()
 
@@ -186,6 +198,7 @@ async def main():
             models=models,
             provider=args.provider,
             output_dir=args.output_dir,
+            test_parallel=args.parallel,
         )
 
         has_errors = print_benchmark_summary(

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -233,6 +233,24 @@ import threading
 
 _logger_lock = threading.Lock()
 
+# Default number of test cases to evaluate concurrently within a single model.
+DEFAULT_TEST_PARALLEL = 4
+
+
+def _resolve_test_parallel(cli_value: Optional[int] = None) -> int:
+    """Resolve max test-case concurrency: CLI flag > CALIBRATE_TEST_PARALLEL > default."""
+    if cli_value is not None and cli_value > 0:
+        return cli_value
+    env_value = os.getenv("CALIBRATE_TEST_PARALLEL")
+    if env_value:
+        try:
+            parsed = int(env_value)
+            if parsed > 0:
+                return parsed
+        except ValueError:
+            pass
+    return DEFAULT_TEST_PARALLEL
+
 
 # Strip ANSI color codes when mirroring terminal output to results.log
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
@@ -1517,6 +1535,7 @@ async def run_model_tests(
     provider: str,
     config: dict,
     output_dir: str,
+    test_parallel: Optional[int] = None,
 ) -> dict:
     """Run tests for a single model and return results.
 
@@ -1525,6 +1544,8 @@ async def run_model_tests(
         provider: LLM provider (openai or openrouter)
         config: Test configuration dict
         output_dir: Base output directory - results saved to output_dir/model_name/
+        test_parallel: Max test cases to evaluate concurrently. Falls back to the
+            CALIBRATE_TEST_PARALLEL env var, then DEFAULT_TEST_PARALLEL.
     """
     # Build model folder name: for openai provider, prefix with provider name
     save_folder_name = f"{provider}/{model}" if provider == "openai" else f"{model}"
@@ -1556,7 +1577,8 @@ async def run_model_tests(
     _print_and_log(f"\033[94mModel: {label}\033[0m", print_log_save_path)
     _print_and_log(f"\033[94m{'='*60}\033[0m\n", print_log_save_path)
 
-    results = []
+    test_cases = config["test_cases"]
+    results: List[Optional[dict]] = [None] * len(test_cases)
     results_file_path = join(model_output_dir, "results.json")
 
     unique_id = str(uuid.uuid4())
@@ -1567,58 +1589,67 @@ async def run_model_tests(
     tools = config.get("tools") or []
     system_prompt = config.get("system_prompt", "")
 
-    for test_case_index, test_case in enumerate(config["test_cases"]):
-        evaluation = test_case["evaluation"]
-        preprocessed_history = preprocess_conversation_history(
-            test_case["history"], tools
-        )
-        resolved_evaluators = (
-            _resolve_evaluators_for_test_case(
-                evaluation,
-                _get_name_to_evaluator_dict(
-                    config,
-                    include_default=(evaluation.get("type") == "response"),
-                ),
-            )
-            if evaluation.get("type") in ("response", "conversation")
-            else None
-        )
+    semaphore = asyncio.Semaphore(_resolve_test_parallel(test_parallel))
+    write_lock = asyncio.Lock()
 
-        result = await run_test(
-            chat_history=preprocessed_history,
-            evaluation=evaluation,
-            system_prompt=system_prompt,
-            model=model,
-            provider=provider,
-            tools=tools,
-            unique_id=unique_id,
-            evaluators=resolved_evaluators,
-        )
-
-        if result["metrics"]["passed"]:
-            _print_and_log(
-                f"[{label}] ✅ Test case {test_case_index + 1} passed",
-                print_log_save_path,
+    async def run_one(test_case_index: int, test_case: dict) -> None:
+        async with semaphore:
+            evaluation = test_case["evaluation"]
+            preprocessed_history = preprocess_conversation_history(
+                test_case["history"], tools
             )
-        else:
-            _print_and_log(
-                f"[{label}] ❌ Test case {test_case_index + 1} failed",
-                print_log_save_path,
-            )
-        if "reasoning" in result["metrics"]:
-            _print_and_log(
-                f"  Reason: {result['metrics']['reasoning']}",
-                print_log_save_path,
+            resolved_evaluators = (
+                _resolve_evaluators_for_test_case(
+                    evaluation,
+                    _get_name_to_evaluator_dict(
+                        config,
+                        include_default=(evaluation.get("type") == "response"),
+                    ),
+                )
+                if evaluation.get("type") in ("response", "conversation")
+                else None
             )
 
-        if "id" in test_case:
-            result["test_case_id"] = test_case["id"]
-        result["test_case"] = test_case
-        results.append(result)
+            result = await run_test(
+                chat_history=preprocessed_history,
+                evaluation=evaluation,
+                system_prompt=system_prompt,
+                model=model,
+                provider=provider,
+                tools=tools,
+                unique_id=unique_id,
+                evaluators=resolved_evaluators,
+            )
 
-        # Save intermediate results after each test case
-        with open(results_file_path, "w") as f:
-            json.dump(results, f, indent=4)
+            if result["metrics"]["passed"]:
+                _print_and_log(
+                    f"[{label}] ✅ Test case {test_case_index + 1} passed",
+                    print_log_save_path,
+                )
+            else:
+                _print_and_log(
+                    f"[{label}] ❌ Test case {test_case_index + 1} failed",
+                    print_log_save_path,
+                )
+            if "reasoning" in result["metrics"]:
+                _print_and_log(
+                    f"  Reason: {result['metrics']['reasoning']}",
+                    print_log_save_path,
+                )
+
+            if "id" in test_case:
+                result["test_case_id"] = test_case["id"]
+            result["test_case"] = test_case
+            results[test_case_index] = result
+
+            # Save intermediate results as each test case completes (in order).
+            async with write_lock:
+                with open(results_file_path, "w") as f:
+                    json.dump([r for r in results if r is not None], f, indent=4)
+
+    await asyncio.gather(
+        *[run_one(i, test_case) for i, test_case in enumerate(test_cases)]
+    )
 
     total_passed = sum(1 for result in results if result["metrics"]["passed"])
     total_tests = len(results)
@@ -1740,6 +1771,7 @@ async def run_eval_only_tests(
     config: dict,
     dataset: list[dict],
     output_dir: str,
+    test_parallel: Optional[int] = None,
 ) -> dict:
     """Run evaluators on a pre-existing dataset of (test_case, output) pairs.
 
@@ -1766,55 +1798,64 @@ async def run_eval_only_tests(
 
     _print_and_log("\n\033[94mEval-only\033[0m\n", print_log_save_path)
 
-    results: list[dict] = []
+    results: List[Optional[dict]] = [None] * len(dataset)
     results_file_path = join(output_dir, "results.json")
 
     tools = config.get("tools", []) or []
 
-    for i, item in enumerate(dataset):
-        test_case = item["test_case"]
-        evaluation = test_case["evaluation"]
-        resolved_evaluators = (
-            _resolve_evaluators_for_test_case(
-                evaluation,
-                _get_name_to_evaluator_dict(
-                    config,
-                    include_default=(evaluation.get("type") == "response"),
-                ),
+    semaphore = asyncio.Semaphore(_resolve_test_parallel(test_parallel))
+    write_lock = asyncio.Lock()
+
+    async def run_one(i: int, item: dict) -> None:
+        async with semaphore:
+            test_case = item["test_case"]
+            evaluation = test_case["evaluation"]
+            resolved_evaluators = (
+                _resolve_evaluators_for_test_case(
+                    evaluation,
+                    _get_name_to_evaluator_dict(
+                        config,
+                        include_default=(evaluation.get("type") == "response"),
+                    ),
+                )
+                if evaluation.get("type") in ("response", "conversation")
+                else None
             )
-            if evaluation.get("type") in ("response", "conversation")
-            else None
-        )
 
-        preprocessed_history = preprocess_conversation_history(
-            test_case["history"], tools
-        )
-        output = item["output"]
-        metrics = await evaluate_test_case_output(
-            chat_history=preprocessed_history,
-            evaluation=evaluation,
-            output=output,
-            evaluators=resolved_evaluators,
-            no_response_reasoning_with_tool_calls=(
-                f"Tool calls present: {output.get('tool_calls')}, but no reply provided"
-            ),
-            no_response_reasoning_no_tool_calls="No reply provided",
-        )
+            preprocessed_history = preprocess_conversation_history(
+                test_case["history"], tools
+            )
+            output = item["output"]
+            metrics = await evaluate_test_case_output(
+                chat_history=preprocessed_history,
+                evaluation=evaluation,
+                output=output,
+                evaluators=resolved_evaluators,
+                no_response_reasoning_with_tool_calls=(
+                    f"Tool calls present: {output.get('tool_calls')}, but no reply provided"
+                ),
+                no_response_reasoning_no_tool_calls="No reply provided",
+            )
 
-        if metrics["passed"]:
-            _print_and_log(f"✅ Test case {i + 1} passed", print_log_save_path)
-        else:
-            _print_and_log(f"❌ Test case {i + 1} failed", print_log_save_path)
-        if "reasoning" in metrics:
-            _print_and_log(f"  Reason: {metrics['reasoning']}", print_log_save_path)
+            if metrics["passed"]:
+                _print_and_log(f"✅ Test case {i + 1} passed", print_log_save_path)
+            else:
+                _print_and_log(f"❌ Test case {i + 1} failed", print_log_save_path)
+            if "reasoning" in metrics:
+                _print_and_log(
+                    f"  Reason: {metrics['reasoning']}", print_log_save_path
+                )
 
-        result = {"output": output, "metrics": metrics, "test_case": test_case}
-        if "id" in test_case:
-            result["test_case_id"] = test_case["id"]
-        results.append(result)
+            result = {"output": output, "metrics": metrics, "test_case": test_case}
+            if "id" in test_case:
+                result["test_case_id"] = test_case["id"]
+            results[i] = result
 
-        with open(results_file_path, "w") as f:
-            json.dump(results, f, indent=4)
+            async with write_lock:
+                with open(results_file_path, "w") as f:
+                    json.dump([r for r in results if r is not None], f, indent=4)
+
+    await asyncio.gather(*[run_one(i, item) for i, item in enumerate(dataset)])
 
     passed, total = _write_test_results_outputs(results, output_dir, name_to_evaluator)
     pct = (passed / total * 100) if total else 0.0
@@ -1865,6 +1906,14 @@ async def main():
         help="LLM provider to use (openai or openrouter)",
     )
     parser.add_argument(
+        "-n",
+        "--parallel",
+        type=int,
+        default=None,
+        help="Number of test cases to evaluate in parallel "
+        "(overrides CALIBRATE_TEST_PARALLEL; default 4)",
+    )
+    parser.add_argument(
         "--eval-only",
         action="store_true",
         help="Skip LLM inference and run evaluators on a dataset of (test_case, output) pairs",
@@ -1907,6 +1956,7 @@ async def main():
             config=config,
             dataset=dataset,
             output_dir=args.output_dir,
+            test_parallel=args.parallel,
         )
         passed = result["passed"]
         total = result["total"]
@@ -1935,6 +1985,7 @@ async def main():
         provider=args.provider,
         config=config,
         output_dir=args.output_dir,
+        test_parallel=args.parallel,
     )
 
     # Print summary

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -1573,8 +1573,7 @@ async def run_model_tests(
         provider: LLM provider (openai or openrouter)
         config: Test configuration dict
         output_dir: Base output directory - results saved to output_dir/model_name/
-        test_parallel: Max test cases to evaluate concurrently; resolved via
-            ``_resolve_test_parallel``.
+        test_parallel: Max test cases to evaluate concurrently.
     """
     # Build model folder name: for openai provider, prefix with provider name
     save_folder_name = f"{provider}/{model}" if provider == "openai" else f"{model}"

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -1919,8 +1919,7 @@ async def main():
         "--parallel",
         type=int,
         default=None,
-        help="Number of test cases to evaluate in parallel "
-        "(overrides CALIBRATE_TEST_PARALLEL; default 4)",
+        help="Number of test cases to evaluate in parallel",
     )
     parser.add_argument(
         "--eval-only",

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -1573,8 +1573,8 @@ async def run_model_tests(
         provider: LLM provider (openai or openrouter)
         config: Test configuration dict
         output_dir: Base output directory - results saved to output_dir/model_name/
-        test_parallel: Max test cases to evaluate concurrently. Falls back to the
-            CALIBRATE_TEST_PARALLEL env var, then DEFAULT_TEST_PARALLEL.
+        test_parallel: Max test cases to evaluate concurrently; resolved via
+            ``_resolve_test_parallel``.
     """
     # Build model folder name: for openai provider, prefix with provider name
     save_folder_name = f"{provider}/{model}" if provider == "openai" else f"{model}"

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -4,7 +4,7 @@ import re
 import sys
 import uuid
 from collections import defaultdict
-from typing import Any, List, Optional, TYPE_CHECKING
+from typing import Any, Awaitable, Callable, List, Optional, TYPE_CHECKING
 from loguru import logger
 
 if TYPE_CHECKING:
@@ -250,6 +250,35 @@ def _resolve_test_parallel(cli_value: Optional[int] = None) -> int:
         except ValueError:
             pass
     return DEFAULT_TEST_PARALLEL
+
+
+async def _run_items_parallel(
+    items: List[Any],
+    process: "Callable[[int, Any], Awaitable[dict]]",
+    results_file_path: str,
+    test_parallel: Optional[int] = None,
+) -> List[dict]:
+    """Run ``process(index, item)`` over ``items`` with bounded concurrency.
+
+    Concurrency is capped by ``_resolve_test_parallel(test_parallel)``. Results
+    are collected in input order regardless of completion order, and the
+    partial (in-order) ``results.json`` is rewritten after each item completes.
+    Returns the ordered list of results.
+    """
+    results: List[Optional[dict]] = [None] * len(items)
+    semaphore = asyncio.Semaphore(_resolve_test_parallel(test_parallel))
+    write_lock = asyncio.Lock()
+
+    async def run_one(index: int, item: Any) -> None:
+        async with semaphore:
+            results[index] = await process(index, item)
+            # Save intermediate results as each item completes (in order).
+            async with write_lock:
+                with open(results_file_path, "w") as f:
+                    json.dump([r for r in results if r is not None], f, indent=4)
+
+    await asyncio.gather(*[run_one(i, item) for i, item in enumerate(items)])
+    return results
 
 
 # Strip ANSI color codes when mirroring terminal output to results.log
@@ -1577,8 +1606,6 @@ async def run_model_tests(
     _print_and_log(f"\033[94mModel: {label}\033[0m", print_log_save_path)
     _print_and_log(f"\033[94m{'='*60}\033[0m\n", print_log_save_path)
 
-    test_cases = config["test_cases"]
-    results: List[Optional[dict]] = [None] * len(test_cases)
     results_file_path = join(model_output_dir, "results.json")
 
     unique_id = str(uuid.uuid4())
@@ -1589,66 +1616,57 @@ async def run_model_tests(
     tools = config.get("tools") or []
     system_prompt = config.get("system_prompt", "")
 
-    semaphore = asyncio.Semaphore(_resolve_test_parallel(test_parallel))
-    write_lock = asyncio.Lock()
-
-    async def run_one(test_case_index: int, test_case: dict) -> None:
-        async with semaphore:
-            evaluation = test_case["evaluation"]
-            preprocessed_history = preprocess_conversation_history(
-                test_case["history"], tools
+    async def process(test_case_index: int, test_case: dict) -> dict:
+        evaluation = test_case["evaluation"]
+        preprocessed_history = preprocess_conversation_history(
+            test_case["history"], tools
+        )
+        resolved_evaluators = (
+            _resolve_evaluators_for_test_case(
+                evaluation,
+                _get_name_to_evaluator_dict(
+                    config,
+                    include_default=(evaluation.get("type") == "response"),
+                ),
             )
-            resolved_evaluators = (
-                _resolve_evaluators_for_test_case(
-                    evaluation,
-                    _get_name_to_evaluator_dict(
-                        config,
-                        include_default=(evaluation.get("type") == "response"),
-                    ),
-                )
-                if evaluation.get("type") in ("response", "conversation")
-                else None
+            if evaluation.get("type") in ("response", "conversation")
+            else None
+        )
+
+        result = await run_test(
+            chat_history=preprocessed_history,
+            evaluation=evaluation,
+            system_prompt=system_prompt,
+            model=model,
+            provider=provider,
+            tools=tools,
+            unique_id=unique_id,
+            evaluators=resolved_evaluators,
+        )
+
+        if result["metrics"]["passed"]:
+            _print_and_log(
+                f"[{label}] ✅ Test case {test_case_index + 1} passed",
+                print_log_save_path,
+            )
+        else:
+            _print_and_log(
+                f"[{label}] ❌ Test case {test_case_index + 1} failed",
+                print_log_save_path,
+            )
+        if "reasoning" in result["metrics"]:
+            _print_and_log(
+                f"  Reason: {result['metrics']['reasoning']}",
+                print_log_save_path,
             )
 
-            result = await run_test(
-                chat_history=preprocessed_history,
-                evaluation=evaluation,
-                system_prompt=system_prompt,
-                model=model,
-                provider=provider,
-                tools=tools,
-                unique_id=unique_id,
-                evaluators=resolved_evaluators,
-            )
+        if "id" in test_case:
+            result["test_case_id"] = test_case["id"]
+        result["test_case"] = test_case
+        return result
 
-            if result["metrics"]["passed"]:
-                _print_and_log(
-                    f"[{label}] ✅ Test case {test_case_index + 1} passed",
-                    print_log_save_path,
-                )
-            else:
-                _print_and_log(
-                    f"[{label}] ❌ Test case {test_case_index + 1} failed",
-                    print_log_save_path,
-                )
-            if "reasoning" in result["metrics"]:
-                _print_and_log(
-                    f"  Reason: {result['metrics']['reasoning']}",
-                    print_log_save_path,
-                )
-
-            if "id" in test_case:
-                result["test_case_id"] = test_case["id"]
-            result["test_case"] = test_case
-            results[test_case_index] = result
-
-            # Save intermediate results as each test case completes (in order).
-            async with write_lock:
-                with open(results_file_path, "w") as f:
-                    json.dump([r for r in results if r is not None], f, indent=4)
-
-    await asyncio.gather(
-        *[run_one(i, test_case) for i, test_case in enumerate(test_cases)]
+    results = await _run_items_parallel(
+        config["test_cases"], process, results_file_path, test_parallel
     )
 
     total_passed = sum(1 for result in results if result["metrics"]["passed"])
@@ -1798,64 +1816,55 @@ async def run_eval_only_tests(
 
     _print_and_log("\n\033[94mEval-only\033[0m\n", print_log_save_path)
 
-    results: List[Optional[dict]] = [None] * len(dataset)
     results_file_path = join(output_dir, "results.json")
 
     tools = config.get("tools", []) or []
 
-    semaphore = asyncio.Semaphore(_resolve_test_parallel(test_parallel))
-    write_lock = asyncio.Lock()
-
-    async def run_one(i: int, item: dict) -> None:
-        async with semaphore:
-            test_case = item["test_case"]
-            evaluation = test_case["evaluation"]
-            resolved_evaluators = (
-                _resolve_evaluators_for_test_case(
-                    evaluation,
-                    _get_name_to_evaluator_dict(
-                        config,
-                        include_default=(evaluation.get("type") == "response"),
-                    ),
-                )
-                if evaluation.get("type") in ("response", "conversation")
-                else None
-            )
-
-            preprocessed_history = preprocess_conversation_history(
-                test_case["history"], tools
-            )
-            output = item["output"]
-            metrics = await evaluate_test_case_output(
-                chat_history=preprocessed_history,
-                evaluation=evaluation,
-                output=output,
-                evaluators=resolved_evaluators,
-                no_response_reasoning_with_tool_calls=(
-                    f"Tool calls present: {output.get('tool_calls')}, but no reply provided"
+    async def process(i: int, item: dict) -> dict:
+        test_case = item["test_case"]
+        evaluation = test_case["evaluation"]
+        resolved_evaluators = (
+            _resolve_evaluators_for_test_case(
+                evaluation,
+                _get_name_to_evaluator_dict(
+                    config,
+                    include_default=(evaluation.get("type") == "response"),
                 ),
-                no_response_reasoning_no_tool_calls="No reply provided",
             )
+            if evaluation.get("type") in ("response", "conversation")
+            else None
+        )
 
-            if metrics["passed"]:
-                _print_and_log(f"✅ Test case {i + 1} passed", print_log_save_path)
-            else:
-                _print_and_log(f"❌ Test case {i + 1} failed", print_log_save_path)
-            if "reasoning" in metrics:
-                _print_and_log(
-                    f"  Reason: {metrics['reasoning']}", print_log_save_path
-                )
+        preprocessed_history = preprocess_conversation_history(
+            test_case["history"], tools
+        )
+        output = item["output"]
+        metrics = await evaluate_test_case_output(
+            chat_history=preprocessed_history,
+            evaluation=evaluation,
+            output=output,
+            evaluators=resolved_evaluators,
+            no_response_reasoning_with_tool_calls=(
+                f"Tool calls present: {output.get('tool_calls')}, but no reply provided"
+            ),
+            no_response_reasoning_no_tool_calls="No reply provided",
+        )
 
-            result = {"output": output, "metrics": metrics, "test_case": test_case}
-            if "id" in test_case:
-                result["test_case_id"] = test_case["id"]
-            results[i] = result
+        if metrics["passed"]:
+            _print_and_log(f"✅ Test case {i + 1} passed", print_log_save_path)
+        else:
+            _print_and_log(f"❌ Test case {i + 1} failed", print_log_save_path)
+        if "reasoning" in metrics:
+            _print_and_log(f"  Reason: {metrics['reasoning']}", print_log_save_path)
 
-            async with write_lock:
-                with open(results_file_path, "w") as f:
-                    json.dump([r for r in results if r is not None], f, indent=4)
+        result = {"output": output, "metrics": metrics, "test_case": test_case}
+        if "id" in test_case:
+            result["test_case_id"] = test_case["id"]
+        return result
 
-    await asyncio.gather(*[run_one(i, item) for i, item in enumerate(dataset)])
+    results = await _run_items_parallel(
+        dataset, process, results_file_path, test_parallel
+    )
 
     passed, total = _write_test_results_outputs(results, output_dir, name_to_evaluator)
     pct = (passed / total * 100) if total else 0.0

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -1586,6 +1586,131 @@ class TestRunModelTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["metrics"]["passed"], 1)
 
 
+class TestResolveTestParallel(unittest.TestCase):
+    def test_cli_value_takes_precedence(self):
+        from calibrate.llm.run_tests import _resolve_test_parallel
+
+        with patch.dict("os.environ", {"CALIBRATE_TEST_PARALLEL": "7"}):
+            self.assertEqual(_resolve_test_parallel(3), 3)
+
+    def test_env_var_used_when_no_cli(self):
+        from calibrate.llm.run_tests import _resolve_test_parallel
+
+        with patch.dict("os.environ", {"CALIBRATE_TEST_PARALLEL": "7"}):
+            self.assertEqual(_resolve_test_parallel(None), 7)
+
+    def test_default_when_neither_set(self):
+        from calibrate.llm.run_tests import _resolve_test_parallel, DEFAULT_TEST_PARALLEL
+
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+            os.environ.pop("CALIBRATE_TEST_PARALLEL", None)
+            self.assertEqual(_resolve_test_parallel(None), DEFAULT_TEST_PARALLEL)
+
+    def test_invalid_env_falls_back_to_default(self):
+        from calibrate.llm.run_tests import _resolve_test_parallel, DEFAULT_TEST_PARALLEL
+
+        with patch.dict("os.environ", {"CALIBRATE_TEST_PARALLEL": "abc"}):
+            self.assertEqual(_resolve_test_parallel(None), DEFAULT_TEST_PARALLEL)
+
+    def test_non_positive_values_ignored(self):
+        from calibrate.llm.run_tests import _resolve_test_parallel, DEFAULT_TEST_PARALLEL
+
+        with patch.dict("os.environ", {"CALIBRATE_TEST_PARALLEL": "0"}):
+            # CLI 0 ignored, env 0 ignored -> default
+            self.assertEqual(_resolve_test_parallel(0), DEFAULT_TEST_PARALLEL)
+
+
+class TestRunModelTestsParallel(unittest.IsolatedAsyncioTestCase):
+    async def test_test_cases_run_concurrently(self):
+        from calibrate.llm import run_tests as RT
+
+        concurrency = {"current": 0, "peak": 0}
+        gate = asyncio.Event()
+        started = 0
+        n_cases = 4
+
+        async def fake_run_test(**kwargs):
+            nonlocal started
+            concurrency["current"] += 1
+            concurrency["peak"] = max(concurrency["peak"], concurrency["current"])
+            started += 1
+            if started >= n_cases:
+                gate.set()
+            await gate.wait()  # block until all have started -> proves overlap
+            concurrency["current"] -= 1
+            return {
+                "output": {"response": "Hi", "tool_calls": []},
+                "metrics": {"passed": True, "judge_results": {}, "reasoning": "ok"},
+            }
+
+        config = {
+            "system_prompt": "sp",
+            "tools": [],
+            "evaluators": [],
+            "test_cases": [
+                {
+                    "id": f"tc{i}",
+                    "history": [{"role": "user", "content": "hi"}],
+                    "evaluation": {"type": "response", "criteria": "be polite"},
+                }
+                for i in range(n_cases)
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch.object(RT, "run_test", side_effect=fake_run_test):
+            result = await asyncio.wait_for(
+                RT.run_model_tests(
+                    model="m", provider="openrouter", config=config,
+                    output_dir=tmp, test_parallel=n_cases,
+                ),
+                timeout=5,
+            )
+
+        self.assertEqual(concurrency["peak"], n_cases)
+        self.assertEqual(result["metrics"]["passed"], n_cases)
+
+    async def test_results_preserve_test_case_order(self):
+        from calibrate.llm import run_tests as RT
+
+        async def fake_run_test(**kwargs):
+            # Later test cases finish first to scramble completion order.
+            content = kwargs["chat_history"][0]["content"]
+            await asyncio.sleep(0.01 * (5 - int(content)))
+            return {
+                "output": {"response": content, "tool_calls": []},
+                "metrics": {"passed": True, "judge_results": {}, "reasoning": "ok"},
+            }
+
+        config = {
+            "system_prompt": "sp",
+            "tools": [],
+            "evaluators": [],
+            "test_cases": [
+                {
+                    "id": f"tc{i}",
+                    "history": [{"role": "user", "content": str(i)}],
+                    "evaluation": {"type": "response", "criteria": "x"},
+                }
+                for i in range(5)
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch.object(RT, "run_test", side_effect=fake_run_test):
+            result = await RT.run_model_tests(
+                model="m", provider="openrouter", config=config,
+                output_dir=tmp, test_parallel=5,
+            )
+            with open(Path(tmp) / "m" / "results.json") as f:
+                saved = json.load(f)
+
+        self.assertEqual(
+            [r["test_case_id"] for r in result["results"]],
+            [f"tc{i}" for i in range(5)],
+        )
+        self.assertEqual([r["test_case_id"] for r in saved], [f"tc{i}" for i in range(5)])
+
+
 class TestMainCLI(unittest.IsolatedAsyncioTestCase):
     async def test_main_eval_only(self):
         from calibrate.llm import run_tests as RT


### PR DESCRIPTION
## What
- LLM test cases within a model now run concurrently instead of sequentially (semaphore-bounded `asyncio.gather`); results stay ordered and intermediate `results.json` writes are preserved.
- Concurrency is set by a new `-n/--parallel` CLI flag and `CALIBRATE_TEST_PARALLEL` env var, precedence flag > env > default 4. Threaded through the CLI, `benchmark.run`, the SDK `tests.run`, and the eval-only path.

## Notes
- Default of 4 means existing runs hit the provider ~4× harder by default; set `-n 1` or `CALIBRATE_TEST_PARALLEL=1` to restore old behavior on tight rate limits.
- Text simulations were already parallel; unchanged.
- Docs (`docs/`) not updated.