### PR TITLE
Add configurable parallelism across STT, TTS, LLM benchmarks and simulations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,22 @@ CALIBRATE_TEST_PARALLEL=4
 # Overridden by the -n/--parallel CLI flag.
 CALIBRATE_SIMULATION_PARALLEL=2
 
+# Max rows (audio files / texts) a single STT/TTS provider processes
+# concurrently within one evaluation (defaults to 4 if unset).
+# Overridden by the -n/--parallel CLI flag.
+# CALIBRATE_STT_PARALLEL=4
+# CALIBRATE_TTS_PARALLEL=4
+
+# Number of text simulations to run in parallel (defaults to 1 if unset).
+# Overridden by the -n/--parallel CLI flag.
+# CALIBRATE_SIMULATION_PARALLEL=1
+
+# Max providers/models a benchmark runs concurrently (defaults to 2 if unset).
+# Overridden by the --benchmark-parallel CLI flag.
+# CALIBRATE_STT_BENCHMARK_PARALLEL=2
+# CALIBRATE_TTS_BENCHMARK_PARALLEL=2
+# CALIBRATE_LLM_BENCHMARK_PARALLEL=2
+
 # langfuse
 ENVIRONMENT=development # langfuse tracing environment
 ENABLE_TRACING=true

--- a/.env.example
+++ b/.env.example
@@ -24,10 +24,6 @@ CALIBRATE_SIMULATION_PARALLEL=2
 # CALIBRATE_STT_PARALLEL=4
 # CALIBRATE_TTS_PARALLEL=4
 
-# Number of text simulations to run in parallel (defaults to 1 if unset).
-# Overridden by the -n/--parallel CLI flag.
-# CALIBRATE_SIMULATION_PARALLEL=1
-
 # Max providers/models a benchmark runs concurrently (defaults to 2 if unset).
 # Overridden by the --benchmark-parallel CLI flag.
 # CALIBRATE_STT_BENCHMARK_PARALLEL=2

--- a/calibrate/cli.py
+++ b/calibrate/cli.py
@@ -590,37 +590,29 @@ Examples:
                         _print_sample_output(_verify_result)
                         print()
 
-                from calibrate.llm.tests_leaderboard import generate_leaderboard
-                from calibrate.llm._output import print_benchmark_summary
-
-                # Run — one model at a time so output is clearly separated
+                # Benchmark across models, reusing the same scaffolding as the
+                # non-agent benchmark (parallel run, per-run ``logs`` file,
+                # leaderboard, consolidated summary). Models run in parallel —
+                # the shared helper tees output to a logfile so concurrent
+                # per-model output doesn't interleave on the terminal.
                 if _models:
-                    _model_results = {}
-                    for _m in _models:
-                        print(f"\n\033[92m{'='*60}\033[0m")
-                        print(f"\033[92m  Model: {_m}\033[0m")
-                        print(f"\033[92m{'='*60}\033[0m\n")
-                        _result = asyncio.run(
-                            _tests.run(
+                    from calibrate.llm._output import run_benchmark_cli
+
+                    asyncio.run(
+                        run_benchmark_cli(
+                            output_dir=args.output_dir,
+                            models=_models,
+                            runner=lambda: _tests.run(
                                 agent=_agent,
                                 test_cases=_config["test_cases"],
                                 output_dir=args.output_dir,
-                                models=[_m],
+                                models=_models,
                                 evaluators=_config.get("evaluators"),
                                 test_parallel=args.parallel,
-                            )
+                            ),
+                            config_path=args.config,
                         )
-                        _model_results[_m] = _result.get(_m, _result)
-
-                    _lb_dir = os.path.join(args.output_dir, "leaderboard")
-                    generate_leaderboard(output_dir=args.output_dir, save_dir=_lb_dir)
-                    _has_errors = print_benchmark_summary(
-                        models=_models,
-                        model_results=_model_results,
-                        leaderboard_dir=_lb_dir,
                     )
-                    if _has_errors:
-                        sys.exit(1)
                 else:
                     asyncio.run(
                         _tests.run(

--- a/calibrate/cli.py
+++ b/calibrate/cli.py
@@ -206,8 +206,21 @@ Examples:
     stt_parser.add_argument("-f", "--input-file-name", type=str, default="stt.csv")
     stt_parser.add_argument("-d", "--debug", action="store_true")
     stt_parser.add_argument("-dc", "--debug_count", type=int, default=5)
+    stt_parser.add_argument(
+        "-n",
+        "--parallel",
+        type=int,
+        default=None,
+        help="Number of audio files to transcribe in parallel per provider",
+    )
     stt_parser.add_argument("--ignore_retry", action="store_true")
     stt_parser.add_argument("--overwrite", action="store_true")
+    stt_parser.add_argument(
+        "--benchmark-parallel",
+        type=int,
+        default=None,
+        help="Number of providers to evaluate in parallel (overrides CALIBRATE_STT_BENCHMARK_PARALLEL; default 2)",
+    )
     stt_parser.add_argument(
         "--leaderboard",
         action="store_true",
@@ -253,7 +266,20 @@ Examples:
     tts_parser.add_argument("-o", "--output-dir", type=str, default="./out")
     tts_parser.add_argument("-d", "--debug", action="store_true")
     tts_parser.add_argument("-dc", "--debug_count", type=int, default=5)
+    tts_parser.add_argument(
+        "-n",
+        "--parallel",
+        type=int,
+        default=None,
+        help="Number of texts to synthesize in parallel per provider",
+    )
     tts_parser.add_argument("--overwrite", action="store_true")
+    tts_parser.add_argument(
+        "--benchmark-parallel",
+        type=int,
+        default=None,
+        help="Number of providers to evaluate in parallel (overrides CALIBRATE_TTS_BENCHMARK_PARALLEL; default 2)",
+    )
     tts_parser.add_argument(
         "--leaderboard",
         action="store_true",
@@ -304,6 +330,12 @@ Examples:
         type=int,
         default=None,
         help="Number of test cases to evaluate in parallel per model",
+    )
+    llm_parser.add_argument(
+        "--benchmark-parallel",
+        type=int,
+        default=None,
+        help="Number of models to evaluate in parallel (overrides CALIBRATE_LLM_BENCHMARK_PARALLEL; default 2)",
     )
     llm_parser.add_argument(
         "--verify",
@@ -379,8 +411,8 @@ Examples:
         "-n",
         "--parallel",
         type=int,
-        default=1,
-        help="Number of simulations to run in parallel",
+        default=None,
+        help="Number of simulations to run in parallel (overrides CALIBRATE_SIMULATION_PARALLEL)",
     )
     sim_parser.add_argument(
         "--verify",
@@ -487,10 +519,14 @@ Examples:
                 argv.append("--ignore_retry")
             if args.overwrite:
                 argv.append("--overwrite")
+            if args.parallel is not None:
+                argv.extend(["-n", str(args.parallel)])
             if args.save_dir:
                 argv.extend(["-s", args.save_dir])
             if args.config:
                 argv.extend(["--config", args.config])
+            if args.benchmark_parallel is not None:
+                argv.extend(["--benchmark-parallel", str(args.benchmark_parallel)])
 
             sys.argv = argv
             asyncio.run(stt_benchmark_main())
@@ -512,8 +548,12 @@ Examples:
             argv.extend(["-dc", str(args.debug_count)])
             if args.overwrite:
                 argv.append("--overwrite")
+            if args.parallel is not None:
+                argv.extend(["-n", str(args.parallel)])
             if args.config:
                 argv.extend(["--config", args.config])
+            if args.benchmark_parallel is not None:
+                argv.extend(["--benchmark-parallel", str(args.benchmark_parallel)])
 
             sys.argv = argv
             asyncio.run(tts_benchmark_main())
@@ -609,6 +649,7 @@ Examples:
                                 models=_models,
                                 evaluators=_config.get("evaluators"),
                                 test_parallel=args.parallel,
+                                max_parallel=args.benchmark_parallel,
                             ),
                             config_path=args.config,
                         )
@@ -634,6 +675,8 @@ Examples:
                 argv.extend(["-p", args.provider])
                 if getattr(args, "parallel", None) is not None:
                     argv.extend(["-n", str(args.parallel)])
+                if getattr(args, "benchmark_parallel", None) is not None:
+                    argv.extend(["--benchmark-parallel", str(args.benchmark_parallel)])
 
                 sys.argv = argv
                 asyncio.run(llm_benchmark_main())

--- a/calibrate/llm/__init__.py
+++ b/calibrate/llm/__init__.py
@@ -248,7 +248,7 @@ class _Tests:
         model: str = "gpt-4.1",
         provider: Literal["openai", "openrouter"] = "openrouter",
         run_name: Optional[str] = None,
-        max_parallel: int = 2,
+        max_parallel: Optional[int] = None,
         agent: Optional["TextAgentConnection"] = None,
         evaluators: Optional[List[dict]] = None,
         test_parallel: Optional[int] = None,
@@ -272,7 +272,9 @@ class _Tests:
             model: Single model name to use (used if models is not provided)
             provider: LLM provider (openai or openrouter)
             run_name: Optional name for this run (used in output folder name)
-            max_parallel: Maximum number of models to run in parallel (default: 2)
+            max_parallel: Maximum number of models to run in parallel. Resolves
+                via SDK arg > ``CALIBRATE_LLM_BENCHMARK_PARALLEL`` env var >
+                default 2.
             test_parallel: Max test cases to evaluate concurrently per model.
             agent: Optional external agent connection. When provided, routes all
                 test cases to the external agent instead of an internal LLM.
@@ -301,7 +303,13 @@ class _Tests:
             ...     test_cases=[...],
             ... ))
         """
+        from calibrate.utils import resolve_benchmark_parallel
+
         tools = tools or []
+
+        # Model-level concurrency: SDK arg > CALIBRATE_LLM_BENCHMARK_PARALLEL > 2.
+        # Resolved once here so both the agent and internal-model branches share it.
+        max_parallel = resolve_benchmark_parallel("llm", max_parallel)
 
         # External agent benchmark: run once per model, passing model hint in each request
         if agent is not None and models and len(models) > 0:
@@ -551,9 +559,9 @@ class _Simulations:
         output_dir: str,
         model: str,
         provider: str,
-        parallel: int,
-        agent_speaks_first: bool,
-        max_turns: int,
+        parallel: Optional[int] = None,
+        agent_speaks_first: bool = True,
+        max_turns: int = 50,
         agent: Optional["TextAgentConnection"] = None,
         _flat_output: bool = False,
     ) -> dict:
@@ -565,7 +573,10 @@ class _Simulations:
                 for backward compatibility.
         """
         from calibrate.judges import require_simulation_evaluators, write_evaluator_config
-        from calibrate.llm.run_simulation import run_single_simulation_task
+        from calibrate.llm.run_simulation import (
+            run_single_simulation_task,
+            _resolve_simulation_parallel,
+        )
 
         require_simulation_evaluators(evaluators or [])
 
@@ -602,7 +613,7 @@ class _Simulations:
         args.provider = provider
 
         # Create semaphore for parallel execution
-        semaphore = asyncio.Semaphore(parallel)
+        semaphore = asyncio.Semaphore(_resolve_simulation_parallel(parallel))
 
         # Create all simulation tasks
         tasks = []
@@ -703,7 +714,7 @@ class _Simulations:
         models: Optional[List[str]] = None,
         model: str = "gpt-4.1",
         provider: Literal["openai", "openrouter"] = "openrouter",
-        parallel: int = 1,
+        parallel: Optional[int] = None,
         agent_speaks_first: bool = True,
         max_turns: int = 50,
         max_parallel_models: int = 2,
@@ -728,7 +739,7 @@ class _Simulations:
             models: List of model names to evaluate (if provided, runs in parallel)
             model: Single model name to use (used if models is not provided)
             provider: LLM provider (openai or openrouter)
-            parallel: Number of simulations to run in parallel per model (default: 1)
+            parallel: Number of simulations to run in parallel per model (default: CALIBRATE_SIMULATION_PARALLEL env var or 1)
             agent_speaks_first: Whether the agent initiates the conversation (default: True)
             max_turns: Maximum number of assistant turns (default: 50)
             max_parallel_models: Maximum number of models to run in parallel (default: 2)
@@ -844,7 +855,7 @@ class _Simulations:
         output_dir: str = "./out",
         model: str = "gpt-4.1",
         provider: Literal["openai", "openrouter"] = "openrouter",
-        parallel: int = 1,
+        parallel: Optional[int] = None,
         agent_speaks_first: bool = True,
         max_turns: int = 50,
         agent: Optional["TextAgentConnection"] = None,

--- a/calibrate/llm/__init__.py
+++ b/calibrate/llm/__init__.py
@@ -128,6 +128,17 @@ class _Tests:
 
         configure_print_logger(print_log_save_path)
 
+        # Print a per-model header (mirrors the non-agent benchmark output) so
+        # interleaved parallel runs are attributable. Skipped for single
+        # agent-connection runs, where ``model`` is empty.
+        if model:
+            from calibrate.llm.run_tests import display_label
+
+            _label = display_label(provider, model)
+            log_and_print(f"\n\033[94m{'='*60}\033[0m")
+            log_and_print(f"\033[94mModel: {_label}\033[0m")
+            log_and_print(f"\033[94m{'='*60}\033[0m\n")
+
         results_file_path = os.path.join(final_output_dir, "results.json")
 
         # Pass model name to agent for benchmark routing; None for single runs.

--- a/calibrate/llm/_output.py
+++ b/calibrate/llm/_output.py
@@ -1,6 +1,87 @@
 """Shared output helpers for LLM benchmark results."""
 
+import os
 import sys
+from os.path import exists, join
+from typing import Awaitable, Callable, Optional
+
+
+async def run_benchmark_cli(
+    *,
+    output_dir: str,
+    models: list,
+    runner: "Callable[[], Awaitable[dict]]",
+    config_path: Optional[str] = None,
+    provider: Optional[str] = None,
+    model_label=None,
+) -> None:
+    """Run a multi-model LLM benchmark with consolidated logging + summary.
+
+    Shared scaffolding for both the direct-provider benchmark
+    (``llm/benchmark.py``) and the agent-connection benchmark (the ``llm`` CLI
+    path). Mirrors stdout/stderr into a per-run ``logs`` file — so concurrent
+    per-model output doesn't interleave on the terminal — prints the banner,
+    awaits ``runner`` (which returns a ``{model: result}`` dict), writes the
+    leaderboard, and prints the consolidated summary. Exits non-zero if any
+    model errored.
+
+    Args:
+        output_dir: Base output directory (per-model subfolders live here).
+        models: Ordered list of model names.
+        runner: Zero-arg coroutine factory returning ``{model: result}``.
+        config_path: Optional config path shown in the banner.
+        provider: Optional provider shown in the banner (omitted for agents).
+        model_label: Optional callable to format display labels.
+    """
+    from calibrate.utils import StreamTee
+    from calibrate.llm.tests_leaderboard import generate_leaderboard
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    # When the interactive UI runs each model in its own subprocess, several
+    # processes target the same ``logs`` path; ``CALIBRATE_LLM_LOG_APPEND=1``
+    # makes them append instead of racing to truncate each other's output.
+    log_path = join(output_dir, "logs")
+    append_mode = os.environ.get("CALIBRATE_LLM_LOG_APPEND") == "1"
+    if not append_mode and exists(log_path):
+        os.remove(log_path)
+    log_file = open(log_path, "a" if append_mode else "w")
+    original_stdout, original_stderr = sys.stdout, sys.stderr
+    sys.stdout = StreamTee(original_stdout, log_file)
+    sys.stderr = StreamTee(original_stderr, log_file)
+
+    label_fn = model_label or (lambda m: m)
+    try:
+        print("\n\033[91mLLM Tests Benchmark\033[0m\n")
+        if config_path:
+            print(f"Config: {config_path}")
+        print(f"Model(s): {', '.join(label_fn(m) for m in models)}")
+        if provider:
+            print(f"Provider: {provider}")
+        print(f"Output: {output_dir}")
+        print("")
+
+        model_results = await runner()
+
+        leaderboard_dir = join(output_dir, "leaderboard")
+        try:
+            generate_leaderboard(output_dir=output_dir, save_dir=leaderboard_dir)
+        except Exception as e:
+            print(f"\033[31mLeaderboard generation failed: {e}\033[0m")
+
+        has_errors = print_benchmark_summary(
+            models=models,
+            model_results=model_results,
+            leaderboard_dir=leaderboard_dir,
+            model_label=model_label,
+        )
+    finally:
+        sys.stdout = original_stdout
+        sys.stderr = original_stderr
+        log_file.close()
+
+    if has_errors:
+        sys.exit(1)
 
 
 def print_benchmark_summary(

--- a/calibrate/llm/benchmark.py
+++ b/calibrate/llm/benchmark.py
@@ -22,17 +22,47 @@ Python SDK:
 import argparse
 import asyncio
 import json
-import os
-import sys
-from os.path import exists, join
+from os.path import join
 
 from calibrate.llm.run_tests import display_label, run_model_tests
 from calibrate.llm.tests_leaderboard import generate_leaderboard
-from calibrate.llm._output import print_benchmark_summary
-from calibrate.utils import StreamTee
+from calibrate.llm._output import run_benchmark_cli
 
 # Maximum number of models to run in parallel
 MAX_PARALLEL_MODELS = 2
+
+
+async def _run_models(
+    config: dict,
+    models: list[str],
+    provider: str,
+    output_dir: str,
+    max_parallel: int = MAX_PARALLEL_MODELS,
+    test_parallel: int | None = None,
+) -> dict:
+    """Run tests for each model with bounded parallelism.
+
+    Returns a ``{model: result}`` dict (no leaderboard side effect), so it can
+    be reused as the ``runner`` for :func:`run_benchmark_cli`.
+    """
+    results: dict = {}
+    semaphore = asyncio.Semaphore(max_parallel)
+
+    async def run_model(model: str) -> tuple[str, dict]:
+        async with semaphore:
+            result = await run_model_tests(
+                model=model,
+                provider=provider,
+                config=config,
+                output_dir=output_dir,
+                test_parallel=test_parallel,
+            )
+            return (model, result)
+
+    tasks = [run_model(model) for model in models]
+    for model, result in await asyncio.gather(*tasks):
+        results[model] = result
+    return results
 
 
 async def run(
@@ -72,27 +102,14 @@ async def run(
         ...     output_dir="./out"
         ... ))
     """
-    results = {}
-    semaphore = asyncio.Semaphore(max_parallel)
-
-    async def run_model(model: str) -> tuple[str, dict]:
-        """Run tests for a single model with semaphore control."""
-        async with semaphore:
-            result = await run_model_tests(
-                model=model,
-                provider=provider,
-                config=config,
-                output_dir=output_dir,
-                test_parallel=test_parallel,
-            )
-            return (model, result)
-
-    # Run all models with limited parallelism
-    tasks = [run_model(model) for model in models]
-    model_results = await asyncio.gather(*tasks)
-
-    for model, result in model_results:
-        results[model] = result
+    results = await _run_models(
+        config=config,
+        models=models,
+        provider=provider,
+        output_dir=output_dir,
+        max_parallel=max_parallel,
+        test_parallel=test_parallel,
+    )
 
     # Generate leaderboard from output_dir (which contains model folders)
     leaderboard_dir = join(output_dir, "leaderboard")
@@ -158,60 +175,20 @@ async def main():
 
     config = json.load(open(args.config))
 
-    # ``exist_ok=True`` makes this safe when several ``calibrate llm``
-    # subprocesses (e.g. one per model spawned by the interactive UI) race to
-    # create the output dir — the previous ``if not exists: makedirs(...)``
-    # pattern was non-atomic and the loser raised ``FileExistsError``.
-    os.makedirs(args.output_dir, exist_ok=True)
-
-    # Mirror everything written to stdout/stderr into a single output-dir-level
-    # `logs` file so the full terminal session (banner, per-model output,
-    # leaderboard prints, summary) is captured in one place — same pattern as
-    # the STT/TTS benchmark CLIs.
-    #
-    # When the interactive UI runs each model in its own ``calibrate llm``
-    # subprocess, multiple processes target the same ``logs`` path concurrently;
-    # the UI sets ``CALIBRATE_LLM_LOG_APPEND=1`` so subprocesses append instead
-    # of racing to truncate each other's output. The UI itself clears the file
-    # once before kicking off the run.
-    log_path = join(args.output_dir, "logs")
-    append_mode = os.environ.get("CALIBRATE_LLM_LOG_APPEND") == "1"
-    if not append_mode and exists(log_path):
-        os.remove(log_path)
-    log_file = open(log_path, "a" if append_mode else "w")
-    original_stdout, original_stderr = sys.stdout, sys.stderr
-    sys.stdout = StreamTee(original_stdout, log_file)
-    sys.stderr = StreamTee(original_stderr, log_file)
-
-    try:
-        print("\n\033[91mLLM Tests Benchmark\033[0m\n")
-        print(f"Config: {args.config}")
-        print(f"Model(s): {', '.join(display_label(args.provider, m) for m in models)}")
-        print(f"Provider: {args.provider}")
-        print(f"Output: {args.output_dir}")
-        print("")
-
-        result = await run(
+    await run_benchmark_cli(
+        output_dir=args.output_dir,
+        models=models,
+        runner=lambda: _run_models(
             config=config,
             models=models,
             provider=args.provider,
             output_dir=args.output_dir,
             test_parallel=args.parallel,
-        )
-
-        has_errors = print_benchmark_summary(
-            models=models,
-            model_results=result["models"],
-            leaderboard_dir=result["leaderboard_dir"],
-            model_label=lambda m: display_label(args.provider, m),
-        )
-
-        if has_errors:
-            sys.exit(1)
-    finally:
-        sys.stdout = original_stdout
-        sys.stderr = original_stderr
-        log_file.close()
+        ),
+        config_path=args.config,
+        provider=args.provider,
+        model_label=lambda m: display_label(args.provider, m),
+    )
 
 
 if __name__ == "__main__":

--- a/calibrate/llm/benchmark.py
+++ b/calibrate/llm/benchmark.py
@@ -27,9 +27,7 @@ from os.path import join
 from calibrate.llm.run_tests import display_label, run_model_tests
 from calibrate.llm.tests_leaderboard import generate_leaderboard
 from calibrate.llm._output import run_benchmark_cli
-
-# Maximum number of models to run in parallel
-MAX_PARALLEL_MODELS = 2
+from calibrate.utils import resolve_benchmark_parallel
 
 
 async def _run_models(
@@ -37,15 +35,19 @@ async def _run_models(
     models: list[str],
     provider: str,
     output_dir: str,
-    max_parallel: int = MAX_PARALLEL_MODELS,
+    max_parallel: int | None = None,
     test_parallel: int | None = None,
 ) -> dict:
     """Run tests for each model with bounded parallelism.
+
+    ``max_parallel`` resolves via CLI flag > ``CALIBRATE_LLM_BENCHMARK_PARALLEL``
+    env var > default 2 (see :func:`calibrate.utils.resolve_benchmark_parallel`).
 
     Returns a ``{model: result}`` dict (no leaderboard side effect), so it can
     be reused as the ``runner`` for :func:`run_benchmark_cli`.
     """
     results: dict = {}
+    max_parallel = resolve_benchmark_parallel("llm", max_parallel)
     semaphore = asyncio.Semaphore(max_parallel)
 
     async def run_model(model: str) -> tuple[str, dict]:
@@ -70,7 +72,7 @@ async def run(
     models: list[str],
     provider: str,
     output_dir: str = "./out",
-    max_parallel: int = MAX_PARALLEL_MODELS,
+    max_parallel: int | None = None,
     test_parallel: int | None = None,
 ) -> dict:
     """
@@ -84,7 +86,8 @@ async def run(
         provider: LLM provider (openai or openrouter)
         output_dir: Path to output directory for results (default: ./out)
             Results saved to output_dir/model_name/ for each model
-        max_parallel: Maximum number of models to run in parallel (default: 2)
+        max_parallel: Maximum number of models to run in parallel. Resolves via
+            CLI flag > ``CALIBRATE_LLM_BENCHMARK_PARALLEL`` env var > default 2.
         test_parallel: Max test cases to evaluate concurrently per model.
 
     Returns:
@@ -168,6 +171,13 @@ async def main():
         default=None,
         help="Number of test cases to evaluate in parallel per model",
     )
+    parser.add_argument(
+        "--benchmark-parallel",
+        type=int,
+        default=None,
+        help="Number of models to run in parallel "
+        "(overrides CALIBRATE_LLM_BENCHMARK_PARALLEL env var)",
+    )
 
     args = parser.parse_args()
 
@@ -183,6 +193,7 @@ async def main():
             models=models,
             provider=args.provider,
             output_dir=args.output_dir,
+            max_parallel=args.benchmark_parallel,
             test_parallel=args.parallel,
         ),
         config_path=args.config,

--- a/calibrate/stt/benchmark.py
+++ b/calibrate/stt/benchmark.py
@@ -32,11 +32,7 @@ from calibrate.stt.eval import (
     STT_LANGUAGES,
 )
 from calibrate.stt.leaderboard import generate_leaderboard
-from calibrate.utils import StreamTee
-
-
-# Maximum number of providers to run in parallel
-MAX_PARALLEL_PROVIDERS = 2
+from calibrate.utils import StreamTee, resolve_benchmark_parallel
 
 
 async def run(
@@ -74,7 +70,8 @@ async def run(
     debug_count: int = 5,
     ignore_retry: bool = False,
     overwrite: bool = False,
-    max_parallel: int = MAX_PARALLEL_PROVIDERS,
+    max_parallel: int | None = None,
+    row_parallel: int = None,
     judge_evaluators: list[dict] = None,
 ) -> dict:
     """
@@ -92,7 +89,12 @@ async def run(
         debug_count: Number of audio files to run in debug mode (default: 5)
         ignore_retry: Skip retry if not all audios are processed
         overwrite: Overwrite existing results instead of resuming from checkpoint (default: False)
-        max_parallel: Maximum number of providers to run in parallel (default: 2)
+        max_parallel: Maximum number of providers to run in parallel. Resolves
+            CLI flag / SDK arg > ``CALIBRATE_STT_BENCHMARK_PARALLEL`` env var >
+            default 2.
+        row_parallel: Maximum number of audio files to transcribe in parallel
+            per provider. Resolves CLI flag / SDK arg > ``CALIBRATE_STT_PARALLEL``
+            env var > default 4.
         judge_evaluators: Optional list of evaluator dicts (each with ``name``,
             ``system_prompt``, ``judge_model``, ``type``, ...). When omitted
             the implicit default STT evaluator runs.
@@ -111,6 +113,7 @@ async def run(
         ... ))
     """
     results = {}
+    max_parallel = resolve_benchmark_parallel("stt", max_parallel)
     semaphore = asyncio.Semaphore(max_parallel)
 
     async def run_provider(provider: str) -> tuple[str, dict]:
@@ -126,6 +129,7 @@ async def run(
                 debug_count=debug_count,
                 ignore_retry=ignore_retry,
                 overwrite=overwrite,
+                row_parallel=row_parallel,
                 judge_evaluators=judge_evaluators,
             )
             return (provider, result)
@@ -239,6 +243,19 @@ async def main():
         default=None,
         help="Path to optional JSON config file with an `evaluators` list",
     )
+    parser.add_argument(
+        "--benchmark-parallel",
+        type=int,
+        default=None,
+        help="Number of providers to evaluate in parallel (overrides CALIBRATE_STT_BENCHMARK_PARALLEL)",
+    )
+    parser.add_argument(
+        "-n",
+        "--parallel",
+        type=int,
+        default=None,
+        help="Number of audio files to transcribe in parallel per provider",
+    )
 
     args = parser.parse_args()
 
@@ -350,6 +367,8 @@ async def main():
             debug_count=args.debug_count,
             ignore_retry=args.ignore_retry,
             overwrite=args.overwrite,
+            max_parallel=args.benchmark_parallel,
+            row_parallel=args.parallel,
             judge_evaluators=judge_evaluators,
         )
 

--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -30,6 +30,7 @@ from calibrate.utils import (
     validate_stt_language,
     provider_log as _log,
     provider_log_file as _current_log_file,
+    resolve_row_parallel,
 )
 from calibrate.stt.metrics import (
     get_wer_score,
@@ -636,8 +637,17 @@ async def run_stt_eval(
     provider: str,
     language: str,
     results_csv_path: Path,
+    row_parallel: int = None,
 ) -> int:
-    """Process audio files and save results immediately to CSV.
+    """Process audio files concurrently and save results to CSV.
+
+    Audio files are transcribed with bounded concurrency (capped by
+    ``resolve_row_parallel("stt", row_parallel)``). Files whose ``id`` already
+    appears in an existing ``results.csv`` are skipped, so a re-run resumes
+    where a previous run left off. New results are written in input
+    (``gt_data``) order regardless of completion order — existing rows first,
+    then the freshly processed rows by their original index — and the partial
+    CSV is rewritten after each row completes for crash recovery.
 
     Args:
         gt_data: List of {"id": ..., "gt": ...} for each file to process
@@ -645,6 +655,8 @@ async def run_stt_eval(
         provider: STT provider name
         language: Language code
         results_csv_path: Path to save results CSV
+        row_parallel: Max audio files to transcribe concurrently. Resolves
+            CLI/SDK arg > ``CALIBRATE_STT_PARALLEL`` env var > default.
 
     Returns:
         Number of files successfully transcribed (non-empty) in this run.
@@ -652,46 +664,59 @@ async def run_stt_eval(
     # Load existing results to skip already processed files
     if exists(results_csv_path):
         existing_df = pd.read_csv(results_csv_path)
-        results = existing_df.to_dict("records")
+        existing_results = existing_df.to_dict("records")
         processed_ids = set(existing_df["id"].tolist())
     else:
-        results = []
+        existing_results = []
         processed_ids = set()
 
     success_count = 0
 
     unique_id = str(uuid.uuid4())
 
-    for i, gt_info in enumerate(gt_data):
-        # Skip if already processed
-        if gt_info["id"] in processed_ids:
-            continue
+    pending = [
+        (i, gt_info)
+        for i, gt_info in enumerate(gt_data)
+        if gt_info["id"] not in processed_ids
+    ]
+
+    semaphore = asyncio.Semaphore(resolve_row_parallel("stt", row_parallel))
+    write_lock = asyncio.Lock()
+    new_results: dict[int, dict] = {}
+
+    async def process_one(index: int, gt_info: Dict) -> None:
+        nonlocal success_count
 
         audio_path = audio_dir / f"{gt_info['id']}.wav"
 
-        _log(f"--------------------------------")
-        _log(f"Processing audio [{i + 1}/{len(gt_data)}]: {audio_path.name}")
-
-        try:
-            transcript = await transcribe_audio(
-                audio_path, gt_info["gt"], provider, language, unique_id
+        async with semaphore:
+            _log(f"--------------------------------")
+            _log(
+                f"Processing audio [{index + 1}/{len(gt_data)}]: {audio_path.name}"
             )
-            _log(f"\033[33mTranscript: {transcript}\033[0m")
-            if transcript:
-                success_count += 1
-        except Exception as e:
-            _log(f"\033[91mFailed to transcribe {audio_path}: {e}\033[0m")
-            raise
 
-        # Save immediately after each file
-        results.append(
-            {
+            try:
+                transcript = await transcribe_audio(
+                    audio_path, gt_info["gt"], provider, language, unique_id
+                )
+                _log(f"\033[33mTranscript: {transcript}\033[0m")
+            except Exception as e:
+                _log(f"\033[91mFailed to transcribe {audio_path}: {e}\033[0m")
+                raise
+
+        async with write_lock:
+            new_results[index] = {
                 "id": gt_info["id"],
                 "gt": gt_info["gt"],
                 "pred": transcript,
             }
-        )
-        pd.DataFrame(results).to_csv(results_csv_path, index=False)
+            if transcript:
+                success_count += 1
+            pd.DataFrame(
+                existing_results + [new_results[k] for k in sorted(new_results)]
+            ).to_csv(results_csv_path, index=False)
+
+    await asyncio.gather(*[process_one(i, g) for i, g in pending])
 
     return success_count
 
@@ -851,6 +876,7 @@ async def run_single_provider_eval(
     debug_count: int,
     ignore_retry: bool,
     overwrite: bool,
+    row_parallel: int = None,
     judge_evaluators: list[dict] = None,
 ) -> dict:
     """Run STT evaluation for a single provider."""
@@ -955,6 +981,7 @@ async def run_single_provider_eval(
                 provider=provider,
                 language=language,
                 results_csv_path=results_csv_path,
+                row_parallel=row_parallel,
             )
 
             if ignore_retry:
@@ -1217,6 +1244,13 @@ async def main():
         action="store_true",
         help="Overwrite existing results instead of resuming from last checkpoint",
     )
+    parser.add_argument(
+        "-n",
+        "--parallel",
+        type=int,
+        default=None,
+        help="Number of audio files to transcribe in parallel",
+    )
 
     args = parser.parse_args()
 
@@ -1258,6 +1292,7 @@ async def main():
         debug_count=args.debug_count,
         ignore_retry=args.ignore_retry,
         overwrite=args.overwrite,
+        row_parallel=args.parallel,
     )
 
     # Print summary

--- a/calibrate/tts/benchmark.py
+++ b/calibrate/tts/benchmark.py
@@ -27,10 +27,7 @@ from calibrate.tts.eval import (
     validate_tts_input_file,
 )
 from calibrate.tts.leaderboard import generate_leaderboard
-from calibrate.utils import StreamTee
-
-# Maximum number of providers to run in parallel
-MAX_PARALLEL_PROVIDERS = 2
+from calibrate.utils import StreamTee, resolve_benchmark_parallel
 
 
 async def run(
@@ -58,7 +55,8 @@ async def run(
     debug: bool = False,
     debug_count: int = 5,
     overwrite: bool = False,
-    max_parallel: int = MAX_PARALLEL_PROVIDERS,
+    max_parallel: int | None = None,
+    row_parallel: int = None,
     judge_evaluators: list[dict] = None,
 ) -> dict:
     """
@@ -74,7 +72,11 @@ async def run(
         debug: Run evaluation on first N texts only
         debug_count: Number of texts to run in debug mode (default: 5)
         overwrite: Overwrite existing results instead of resuming from checkpoint (default: False)
-        max_parallel: Maximum number of providers to run in parallel (default: 2)
+        max_parallel: Maximum number of providers to run in parallel. Resolved via
+            CLI flag / SDK arg > ``CALIBRATE_TTS_BENCHMARK_PARALLEL`` env var > default 2.
+        row_parallel: Max texts to synthesize concurrently within each provider.
+            Resolved via CLI flag / SDK arg > ``CALIBRATE_TTS_PARALLEL`` env var >
+            default. Orthogonal to ``max_parallel`` (which bounds providers).
         judge_evaluators: Optional list of evaluator dicts (each with ``name``,
             ``system_prompt``, ``judge_model``, ``type``, ...). When omitted
             the implicit default TTS evaluator runs.
@@ -93,6 +95,7 @@ async def run(
         ... ))
     """
     results = {}
+    max_parallel = resolve_benchmark_parallel("tts", max_parallel)
     semaphore = asyncio.Semaphore(max_parallel)
 
     async def run_provider(provider: str) -> tuple[str, dict]:
@@ -106,6 +109,7 @@ async def run(
                 debug=debug,
                 debug_count=debug_count,
                 overwrite=overwrite,
+                row_parallel=row_parallel,
                 judge_evaluators=judge_evaluators,
             )
             return (provider, result)
@@ -192,6 +196,19 @@ async def main():
         default=None,
         help="Path to optional JSON config file with an `evaluators` list",
     )
+    parser.add_argument(
+        "--benchmark-parallel",
+        type=int,
+        default=None,
+        help="Number of providers to evaluate in parallel (overrides CALIBRATE_TTS_BENCHMARK_PARALLEL)",
+    )
+    parser.add_argument(
+        "-n",
+        "--parallel",
+        type=int,
+        default=None,
+        help="Number of texts to synthesize in parallel per provider",
+    )
 
     args = parser.parse_args()
 
@@ -251,6 +268,8 @@ async def main():
             debug=args.debug,
             debug_count=args.debug_count,
             overwrite=args.overwrite,
+            max_parallel=args.benchmark_parallel,
+            row_parallel=args.parallel,
             judge_evaluators=judge_evaluators,
         )
 

--- a/calibrate/tts/eval.py
+++ b/calibrate/tts/eval.py
@@ -29,6 +29,7 @@ from calibrate.utils import (
     validate_tts_language,
     provider_log as _log,
     provider_log_file as _current_log_file,
+    resolve_row_parallel,
 )
 from calibrate.tts.metrics import get_tts_llm_judge_score
 from calibrate.judges import (
@@ -479,8 +480,17 @@ async def run_tts_eval(
     output_dir: str,
     results_csv_path: Path,
     overwrite: bool = False,
-) -> int:
-    """Process texts and synthesize speech, saving results immediately to CSV.
+    row_parallel: int = None,
+) -> dict:
+    """Process texts and synthesize speech concurrently, saving results to CSV.
+
+    Rows are processed concurrently with bounded parallelism (capped by
+    ``resolve_row_parallel("tts", row_parallel)``). Despite out-of-order
+    completion, output rows are written in input order: existing (resumed)
+    rows first, then newly synthesized rows ordered by their position in
+    ``gt_data``. The full CSV is rewritten under a write-lock after each row
+    completes so concurrent writes are safe and the partial file stays
+    crash-recoverable.
 
     Args:
         gt_data: List of {"id": ..., "text": ...} for each text to process
@@ -489,69 +499,81 @@ async def run_tts_eval(
         output_dir: Directory to save audio files
         results_csv_path: Path to save results CSV
         overwrite: If True, overwrite existing results instead of resuming
+        row_parallel: Max texts to synthesize concurrently. Resolved via
+            CLI/SDK arg > ``CALIBRATE_TTS_PARALLEL`` env var > default.
 
     Returns:
-        Number of texts successfully synthesized in this run.
+        dict with ``success_count`` (texts synthesized this run) and
+        ``ttfb_values`` (TTFBs reported by the provider this run).
     """
     # Load existing results to skip already processed texts (unless overwrite is True)
     if overwrite:
         processed_ids = set()
+        existing_records = []
         # Remove existing results file if overwriting
         if exists(results_csv_path):
             os.remove(results_csv_path)
     elif exists(results_csv_path):
         existing_df = pd.read_csv(results_csv_path)
+        existing_records = existing_df.to_dict("records")
         processed_ids = set(existing_df["id"].tolist())
     else:
         processed_ids = set()
+        existing_records = []
 
     audio_output_dir = join(output_dir, "audios")
     os.makedirs(audio_output_dir, exist_ok=True)
 
     success_count = 0
     ttfb_values = []
+    new_rows: dict[int, dict] = {}
 
-    for i, item in enumerate(gt_data):
+    pending = [
+        (i, item) for i, item in enumerate(gt_data) if item["id"] not in processed_ids
+    ]
+
+    semaphore = asyncio.Semaphore(resolve_row_parallel("tts", row_parallel))
+    write_lock = asyncio.Lock()
+
+    async def process_one(index: int, item: Dict) -> None:
+        nonlocal success_count
         _id = item["id"]
         text = item["text"]
 
-        # Skip if already processed
-        if _id in processed_ids:
-            _log(f"Skipping already processed: {_id}")
-            continue
-
-        _log(f"Processing [{i+1}/{len(gt_data)}]: {_id}")
-
         audio_path = join(audio_output_dir, f"{_id}.wav")
-        try:
-            result = await synthesize_speech(text, provider, language, audio_path)
-        except Exception as e:
-            _log(f"\033[91mFailed to synthesize {_id}: {e}\033[0m")
-            raise
+        async with semaphore:
+            _log(f"Processing [{index + 1}/{len(gt_data)}]: {_id}")
+            try:
+                result = await synthesize_speech(text, provider, language, audio_path)
+            except Exception as e:
+                _log(f"\033[91mFailed to synthesize {_id}: {e}\033[0m")
+                raise
 
         # Handle optional ttfb (some providers may not return it)
         ttfb = result.get("ttfb")
-        if ttfb is not None:
-            ttfb_values.append(ttfb)
 
-        # Prepare row data
-        row_data = {
-            "id": _id,
-            "text": text,
-            "audio_path": audio_path,
-            "ttfb": ttfb,
-        }
+        async with write_lock:
+            new_rows[index] = {
+                "id": _id,
+                "text": text,
+                "audio_path": audio_path,
+                "ttfb": ttfb,
+            }
+            if ttfb is not None:
+                ttfb_values.append(ttfb)
+            success_count += 1
 
-        # Append to CSV immediately for crash recovery
-        row_df = pd.DataFrame([row_data])
-        if exists(results_csv_path):
-            row_df.to_csv(results_csv_path, mode="a", header=False, index=False)
-        else:
-            row_df.to_csv(results_csv_path, index=False)
+            # Rewrite the full CSV (existing rows first, then new rows in input
+            # order) so concurrent writes stay deterministic and crash-safe.
+            ordered_new = [new_rows[k] for k in sorted(new_rows)]
+            pd.DataFrame(existing_records + ordered_new).to_csv(
+                results_csv_path, index=False
+            )
 
-        success_count += 1
-        if ttfb is not None:
-            _log(f"\n\033[93m  TTFB: {ttfb:.3f}s\033[0m")
+            if ttfb is not None:
+                _log(f"\n\033[93m  TTFB: {ttfb:.3f}s\033[0m")
+
+    await asyncio.gather(*[process_one(i, it) for i, it in pending])
 
     return {
         "success_count": success_count,
@@ -694,6 +716,7 @@ async def run_single_provider_eval(
     debug: bool,
     debug_count: int,
     overwrite: bool,
+    row_parallel: int = None,
     judge_evaluators: list[dict] = None,
 ) -> dict:
     """Run TTS evaluation for a single provider."""
@@ -748,6 +771,7 @@ async def run_single_provider_eval(
             output_dir=provider_output_dir,
             results_csv_path=results_csv_path,
             overwrite=overwrite,
+            row_parallel=row_parallel,
         )
 
         _log("--------------------------------")
@@ -906,6 +930,13 @@ async def main():
         action="store_true",
         help="Overwrite existing results instead of resuming from last checkpoint",
     )
+    parser.add_argument(
+        "-n",
+        "--parallel",
+        type=int,
+        default=None,
+        help="Number of texts to synthesize in parallel",
+    )
     args = parser.parse_args()
 
     provider = args.provider
@@ -944,6 +975,7 @@ async def main():
         debug=args.debug,
         debug_count=args.debug_count,
         overwrite=args.overwrite,
+        row_parallel=args.parallel,
     )
 
     # Print summary

--- a/calibrate/utils.py
+++ b/calibrate/utils.py
@@ -23,6 +23,68 @@ from pipecat.transcriptions.language import Language
 current_context: ContextVar[str] = ContextVar("current_context", default="UNKNOWN")
 
 
+# Default number of providers/models a benchmark runs concurrently.
+DEFAULT_BENCHMARK_PARALLEL = 2
+
+
+def resolve_benchmark_parallel(
+    component: Literal["stt", "tts", "llm"], cli_value: Optional[int] = None
+) -> int:
+    """Resolve how many providers/models a benchmark runs concurrently.
+
+    Precedence: explicit ``cli_value`` (CLI flag / SDK arg) >
+    ``CALIBRATE_{STT,TTS,LLM}_BENCHMARK_PARALLEL`` env var > default (2).
+
+    Non-positive or unparseable values are ignored so callers always get a
+    sane positive concurrency.
+    """
+    if cli_value is not None and cli_value > 0:
+        return cli_value
+    env_value = os.getenv(f"CALIBRATE_{component.upper()}_BENCHMARK_PARALLEL")
+    if env_value:
+        try:
+            parsed = int(env_value)
+            if parsed > 0:
+                return parsed
+        except ValueError:
+            pass
+    return DEFAULT_BENCHMARK_PARALLEL
+
+
+# Default number of rows (audio files / texts) a single STT/TTS provider
+# processes concurrently within one evaluation.
+DEFAULT_ROW_PARALLEL = 4
+
+
+def resolve_row_parallel(
+    component: Literal["stt", "tts", "llm"], cli_value: Optional[int] = None
+) -> int:
+    """Resolve how many rows a single provider/model processes concurrently.
+
+    "Rows" are the per-item units of an evaluation — audio files for STT,
+    texts for TTS. This bounds the in-provider concurrency, orthogonal to
+    :func:`resolve_benchmark_parallel` which bounds how many providers/models
+    run at once.
+
+    Precedence: explicit ``cli_value`` (CLI flag / SDK arg) >
+    ``CALIBRATE_{STT,TTS,LLM}_PARALLEL`` env var > default (4).
+
+    Non-positive or unparseable values are ignored so callers always get a
+    sane positive concurrency.
+    """
+    if cli_value is not None and cli_value > 0:
+        return cli_value
+    env_value = os.getenv(f"CALIBRATE_{component.upper()}_PARALLEL")
+    if env_value:
+        try:
+            parsed = int(env_value)
+            if parsed > 0:
+                return parsed
+        except ValueError:
+            pass
+    return DEFAULT_ROW_PARALLEL
+
+
 def patch_langfuse_trace(trace_name: str):
     from pipecat.utils.tracing import service_decorators
 

--- a/tests/llm/test_benchmark.py
+++ b/tests/llm/test_benchmark.py
@@ -11,6 +11,8 @@ Run with:
     python -m pytest tests/test_agent_benchmarking.py -v
 """
 
+import asyncio
+import os
 import unittest
 from unittest.mock import patch, AsyncMock, MagicMock
 
@@ -294,6 +296,152 @@ class TestFolderNaming(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(subfolders, [])
             # results.json written directly to output_dir
             self.assertTrue(os.path.exists(os.path.join(tmpdir, "results.json")))
+
+
+# ---------------------------------------------------------------------------
+# Tests for model-level benchmark parallelism (CALIBRATE_LLM_BENCHMARK_PARALLEL)
+#
+# This is the MODEL-level concurrency (how many models run at once), distinct
+# from the test-case-level CALIBRATE_TEST_PARALLEL handled in run_tests.py.
+# ---------------------------------------------------------------------------
+
+class TestResolveBenchmarkParallelLLM(unittest.TestCase):
+    def test_cli_value_takes_precedence(self):
+        from calibrate.utils import resolve_benchmark_parallel
+
+        with patch.dict("os.environ", {"CALIBRATE_LLM_BENCHMARK_PARALLEL": "7"}):
+            self.assertEqual(resolve_benchmark_parallel("llm", 3), 3)
+
+    def test_env_var_used_when_no_cli(self):
+        from calibrate.utils import resolve_benchmark_parallel
+
+        with patch.dict("os.environ", {"CALIBRATE_LLM_BENCHMARK_PARALLEL": "7"}):
+            self.assertEqual(resolve_benchmark_parallel("llm", None), 7)
+
+    def test_default_when_neither_set(self):
+        from calibrate.utils import (
+            resolve_benchmark_parallel,
+            DEFAULT_BENCHMARK_PARALLEL,
+        )
+
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("CALIBRATE_LLM_BENCHMARK_PARALLEL", None)
+            self.assertEqual(
+                resolve_benchmark_parallel("llm", None), DEFAULT_BENCHMARK_PARALLEL
+            )
+            self.assertEqual(DEFAULT_BENCHMARK_PARALLEL, 2)
+
+    def test_invalid_env_falls_back_to_default(self):
+        from calibrate.utils import (
+            resolve_benchmark_parallel,
+            DEFAULT_BENCHMARK_PARALLEL,
+        )
+
+        with patch.dict("os.environ", {"CALIBRATE_LLM_BENCHMARK_PARALLEL": "abc"}):
+            self.assertEqual(
+                resolve_benchmark_parallel("llm", None), DEFAULT_BENCHMARK_PARALLEL
+            )
+
+    def test_zero_values_ignored(self):
+        from calibrate.utils import (
+            resolve_benchmark_parallel,
+            DEFAULT_BENCHMARK_PARALLEL,
+        )
+
+        with patch.dict("os.environ", {"CALIBRATE_LLM_BENCHMARK_PARALLEL": "0"}):
+            # CLI 0 ignored, env 0 ignored -> default
+            self.assertEqual(
+                resolve_benchmark_parallel("llm", 0), DEFAULT_BENCHMARK_PARALLEL
+            )
+
+    def test_does_not_read_test_parallel_env(self):
+        """Model-level resolver ignores the test-case-level env var."""
+        from calibrate.utils import (
+            resolve_benchmark_parallel,
+            DEFAULT_BENCHMARK_PARALLEL,
+        )
+
+        with patch.dict(
+            "os.environ", {"CALIBRATE_TEST_PARALLEL": "9"}, clear=False
+        ):
+            os.environ.pop("CALIBRATE_LLM_BENCHMARK_PARALLEL", None)
+            self.assertEqual(
+                resolve_benchmark_parallel("llm", None), DEFAULT_BENCHMARK_PARALLEL
+            )
+
+
+class TestRunModelsBenchmarkParallel(unittest.IsolatedAsyncioTestCase):
+    async def _capture_semaphore(self, *, max_parallel=None, env=None):
+        """Run ``_run_models`` and capture the int passed to ``asyncio.Semaphore``."""
+        from calibrate.llm import benchmark as BM
+
+        captured = {}
+        real_semaphore = asyncio.Semaphore
+
+        def fake_semaphore(value):
+            captured["value"] = value
+            return real_semaphore(value)
+
+        config = {"system_prompt": "sp", "tools": [], "evaluators": [], "test_cases": []}
+        env = env or {}
+        with patch.dict("os.environ", env, clear=False):
+            if "CALIBRATE_LLM_BENCHMARK_PARALLEL" not in env:
+                os.environ.pop("CALIBRATE_LLM_BENCHMARK_PARALLEL", None)
+            with patch.object(
+                BM, "run_model_tests", AsyncMock(return_value={"metrics": {}})
+            ), patch.object(BM.asyncio, "Semaphore", side_effect=fake_semaphore):
+                await BM._run_models(
+                    config=config,
+                    models=["m1", "m2", "m3"],
+                    provider="openrouter",
+                    output_dir="./out",
+                    max_parallel=max_parallel,
+                )
+        return captured["value"]
+
+    async def test_env_var_sets_model_parallelism(self):
+        value = await self._capture_semaphore(
+            env={"CALIBRATE_LLM_BENCHMARK_PARALLEL": "5"}
+        )
+        self.assertEqual(value, 5)
+
+    async def test_explicit_arg_overrides_env(self):
+        value = await self._capture_semaphore(
+            max_parallel=8, env={"CALIBRATE_LLM_BENCHMARK_PARALLEL": "5"}
+        )
+        self.assertEqual(value, 8)
+
+    async def test_zero_env_falls_back_to_default(self):
+        value = await self._capture_semaphore(
+            env={"CALIBRATE_LLM_BENCHMARK_PARALLEL": "0"}
+        )
+        self.assertEqual(value, 2)
+
+    async def test_default_when_unset(self):
+        value = await self._capture_semaphore()
+        self.assertEqual(value, 2)
+
+    async def test_benchmark_parallel_does_not_touch_test_parallel(self):
+        """The benchmark env var must not be forwarded as ``test_parallel``."""
+        from calibrate.llm import benchmark as BM
+
+        mock_run = AsyncMock(return_value={"metrics": {}})
+        config = {"system_prompt": "sp", "tools": [], "evaluators": [], "test_cases": []}
+        with patch.dict(
+            "os.environ",
+            {"CALIBRATE_LLM_BENCHMARK_PARALLEL": "5", "CALIBRATE_TEST_PARALLEL": "9"},
+            clear=False,
+        ):
+            with patch.object(BM, "run_model_tests", mock_run):
+                await BM._run_models(
+                    config=config,
+                    models=["m1"],
+                    provider="openrouter",
+                    output_dir="./out",
+                )
+        # test_parallel was not passed by the benchmark, so it stays None and the
+        # per-model run resolves CALIBRATE_TEST_PARALLEL itself downstream.
+        self.assertIsNone(mock_run.await_args.kwargs["test_parallel"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/llm/test_init_extra.py
+++ b/tests/llm/test_init_extra.py
@@ -56,6 +56,71 @@ class TestLLMTestsRun(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["status"], "completed")
         self.assertEqual(set(result["models"].keys()), {"m1", "m2"})
 
+    async def _capture_run_semaphore(self, *, max_parallel=None, env=None, agent=False):
+        """Run ``tests.run`` (multi-model) and capture the model-level Semaphore size."""
+        import asyncio
+        import calibrate.llm as llm_pkg
+        from calibrate.llm import tests
+
+        # The model-level semaphore is created first in tests.run, before any
+        # per-model test-case-level semaphore, so values[0] is the model-level size.
+        values = []
+        real_semaphore = asyncio.Semaphore
+
+        def fake_semaphore(value):
+            values.append(value)
+            return real_semaphore(value)
+
+        fake_test_result = {
+            "output": {"response": "Hi", "tool_calls": []},
+            "metrics": {"passed": True, "judge_results": {}},
+        }
+        env = env or {}
+        fake_agent = MagicMock() if agent else None
+        target = "run_test_external" if agent else "run_test"
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch.dict("os.environ", env, clear=False), \
+             patch(f"calibrate.llm.run_tests.{target}",
+                   AsyncMock(return_value=fake_test_result)), \
+             patch.object(llm_pkg.asyncio, "Semaphore", side_effect=fake_semaphore):
+            if "CALIBRATE_LLM_BENCHMARK_PARALLEL" not in env:
+                os.environ.pop("CALIBRATE_LLM_BENCHMARK_PARALLEL", None)
+            await tests.run(
+                test_cases=[{
+                    "history": [{"role": "user", "content": "hi"}],
+                    "evaluation": {"type": "response", "criteria": "x"},
+                }],
+                output_dir=tmp,
+                models=["m1", "m2"],
+                max_parallel=max_parallel,
+                agent=fake_agent,
+            )
+        return values[0]
+
+    async def test_run_model_parallel_env_var(self):
+        value = await self._capture_run_semaphore(
+            env={"CALIBRATE_LLM_BENCHMARK_PARALLEL": "5"}
+        )
+        self.assertEqual(value, 5)
+
+    async def test_run_model_parallel_arg_overrides_env(self):
+        value = await self._capture_run_semaphore(
+            max_parallel=8, env={"CALIBRATE_LLM_BENCHMARK_PARALLEL": "5"}
+        )
+        self.assertEqual(value, 8)
+
+    async def test_run_model_parallel_zero_env_default(self):
+        value = await self._capture_run_semaphore(
+            env={"CALIBRATE_LLM_BENCHMARK_PARALLEL": "0"}
+        )
+        self.assertEqual(value, 2)
+
+    async def test_run_model_parallel_agent_path_uses_resolver(self):
+        value = await self._capture_run_semaphore(
+            env={"CALIBRATE_LLM_BENCHMARK_PARALLEL": "6"}, agent=True
+        )
+        self.assertEqual(value, 6)
+
     async def test_run_multi_model_with_exception(self):
         from calibrate.llm import tests
 

--- a/tests/stt/test_benchmark.py
+++ b/tests/stt/test_benchmark.py
@@ -1,0 +1,84 @@
+import os
+import unittest
+from unittest.mock import patch, AsyncMock
+
+from calibrate.utils import resolve_benchmark_parallel, DEFAULT_BENCHMARK_PARALLEL
+
+
+class TestResolveBenchmarkParallelStt(unittest.TestCase):
+    def test_cli_value_takes_precedence(self):
+        with patch.dict("os.environ", {"CALIBRATE_STT_BENCHMARK_PARALLEL": "7"}):
+            self.assertEqual(resolve_benchmark_parallel("stt", 3), 3)
+
+    def test_env_var_used_when_no_cli(self):
+        with patch.dict("os.environ", {"CALIBRATE_STT_BENCHMARK_PARALLEL": "7"}):
+            self.assertEqual(resolve_benchmark_parallel("stt", None), 7)
+
+    def test_default_when_neither_set(self):
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("CALIBRATE_STT_BENCHMARK_PARALLEL", None)
+            self.assertEqual(
+                resolve_benchmark_parallel("stt", None), DEFAULT_BENCHMARK_PARALLEL
+            )
+
+    def test_invalid_env_falls_back_to_default(self):
+        with patch.dict("os.environ", {"CALIBRATE_STT_BENCHMARK_PARALLEL": "abc"}):
+            self.assertEqual(
+                resolve_benchmark_parallel("stt", None), DEFAULT_BENCHMARK_PARALLEL
+            )
+
+    def test_non_positive_values_ignored(self):
+        with patch.dict("os.environ", {"CALIBRATE_STT_BENCHMARK_PARALLEL": "0"}):
+            # CLI 0 ignored, env 0 ignored -> default
+            self.assertEqual(
+                resolve_benchmark_parallel("stt", 0), DEFAULT_BENCHMARK_PARALLEL
+            )
+
+
+class TestRunBuildsSemaphoreFromResolvedParallel(unittest.IsolatedAsyncioTestCase):
+    """``run`` must size its provider semaphore via ``resolve_benchmark_parallel``."""
+
+    async def _run_and_capture_semaphore_value(self, *, max_parallel):
+        captured = {}
+        real_semaphore = __import__("asyncio").Semaphore
+
+        def _spy_semaphore(value, *args, **kwargs):
+            captured["value"] = value
+            return real_semaphore(value, *args, **kwargs)
+
+        with patch(
+            "calibrate.stt.benchmark.run_single_provider_eval",
+            new=AsyncMock(return_value={"status": "completed", "metrics": {}}),
+        ), patch(
+            "calibrate.stt.benchmark.generate_leaderboard"
+        ), patch(
+            "calibrate.stt.benchmark.asyncio.Semaphore", side_effect=_spy_semaphore
+        ):
+            from calibrate.stt.benchmark import run
+
+            await run(
+                providers=["deepgram"],
+                input_dir="/tmp/does-not-matter",
+                output_dir="/tmp/out",
+                max_parallel=max_parallel,
+            )
+        return captured["value"]
+
+    async def test_env_var_sets_parallelism(self):
+        with patch.dict("os.environ", {"CALIBRATE_STT_BENCHMARK_PARALLEL": "5"}):
+            value = await self._run_and_capture_semaphore_value(max_parallel=None)
+        self.assertEqual(value, 5)
+
+    async def test_explicit_arg_overrides_env(self):
+        with patch.dict("os.environ", {"CALIBRATE_STT_BENCHMARK_PARALLEL": "5"}):
+            value = await self._run_and_capture_semaphore_value(max_parallel=3)
+        self.assertEqual(value, 3)
+
+    async def test_invalid_env_falls_back_to_default(self):
+        with patch.dict("os.environ", {"CALIBRATE_STT_BENCHMARK_PARALLEL": "0"}):
+            value = await self._run_and_capture_semaphore_value(max_parallel=None)
+        self.assertEqual(value, DEFAULT_BENCHMARK_PARALLEL)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -5,6 +5,7 @@ Run with:
     python -m unittest tests.stt.test_eval -v
 """
 
+import asyncio
 import json
 import os
 import tempfile
@@ -367,6 +368,219 @@ class TestSTTRunEvalOnly(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(result["status"], "error")
         self.assertIn("does not exist", result["error"])
+
+
+class TestSTTRunSTTEvalParallel(unittest.IsolatedAsyncioTestCase):
+    @staticmethod
+    def _gt_data(ids):
+        return [{"id": i, "gt": f"gt {i}"} for i in ids]
+
+    async def test_concurrency_overlaps(self):
+        """With row_parallel=3 at least 3 rows are transcribed simultaneously."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c", "row_d", "row_e"]
+        release = asyncio.Event()
+        in_flight = 0
+        max_in_flight = 0
+        reached = asyncio.Event()
+        lock = asyncio.Lock()
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            nonlocal in_flight, max_in_flight
+            async with lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+                if in_flight >= 3:
+                    reached.set()
+            await release.wait()
+            async with lock:
+                in_flight -= 1
+            return f"pred {reference}"
+
+        async def releaser():
+            await reached.wait()
+            release.set()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "results.csv"
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                await asyncio.gather(
+                    stt_eval.run_stt_eval(
+                        gt_data=self._gt_data(ids),
+                        audio_dir=Path(tmp),
+                        provider="deepgram",
+                        language="english",
+                        results_csv_path=out,
+                        row_parallel=3,
+                    ),
+                    releaser(),
+                )
+
+        self.assertGreaterEqual(max_in_flight, 3)
+
+    async def test_output_order_matches_input(self):
+        """CSV rows preserve input order even when later rows finish first."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c", "row_d"]
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            # Later ids (lexicographically larger) return faster.
+            stem = audio_path.stem
+            delay = 0.05 * (len(ids) - ids.index(stem))
+            await asyncio.sleep(delay)
+            return f"pred-{stem}"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "results.csv"
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                count = await stt_eval.run_stt_eval(
+                    gt_data=self._gt_data(ids),
+                    audio_dir=Path(tmp),
+                    provider="deepgram",
+                    language="english",
+                    results_csv_path=out,
+                    row_parallel=4,
+                )
+
+            self.assertEqual(count, 4)
+            df = pd.read_csv(out)
+            self.assertEqual(df["id"].tolist(), ids)
+            self.assertEqual(df["pred"].tolist(), [f"pred-{i}" for i in ids])
+
+    async def test_resume_skips_processed_ids(self):
+        """Pre-seeded rows are kept, not re-transcribed, and new rows appended."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c"]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "results.csv"
+            # Pre-seed first two ids as already processed.
+            pd.DataFrame(
+                [
+                    {"id": "row_a", "gt": "gt row_a", "pred": "old_a"},
+                    {"id": "row_b", "gt": "gt row_b", "pred": "old_b"},
+                ]
+            ).to_csv(out, index=False)
+
+            seen = []
+
+            async def fake_transcribe(audio_path, reference, provider, language, uid):
+                seen.append(audio_path.stem)
+                return "new_c"
+
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                count = await stt_eval.run_stt_eval(
+                    gt_data=self._gt_data(ids),
+                    audio_dir=Path(tmp),
+                    provider="deepgram",
+                    language="english",
+                    results_csv_path=out,
+                    row_parallel=4,
+                )
+
+            self.assertEqual(seen, ["row_c"])  # only the unprocessed id
+            self.assertEqual(count, 1)
+            df = pd.read_csv(out)
+            self.assertEqual(df["id"].tolist(), ids)
+            self.assertEqual(
+                df["pred"].tolist(), ["old_a", "old_b", "new_c"]
+            )
+
+    async def test_row_parallel_limit_serializes(self):
+        """row_parallel=1 forces strictly serial transcription (no overlap)."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c"]
+        in_flight = 0
+        max_in_flight = 0
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            await asyncio.sleep(0.01)
+            in_flight -= 1
+            return "x"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "results.csv"
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                await stt_eval.run_stt_eval(
+                    gt_data=self._gt_data(ids),
+                    audio_dir=Path(tmp),
+                    provider="deepgram",
+                    language="english",
+                    results_csv_path=out,
+                    row_parallel=1,
+                )
+
+        self.assertEqual(max_in_flight, 1)
+
+    async def test_env_var_caps_concurrency(self):
+        """CALIBRATE_STT_PARALLEL caps concurrency when no row_parallel passed."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c", "row_d"]
+        in_flight = 0
+        max_in_flight = 0
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            await asyncio.sleep(0.01)
+            in_flight -= 1
+            return "x"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "results.csv"
+            with patch.dict(
+                "os.environ", {"CALIBRATE_STT_PARALLEL": "2"}
+            ), patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                await stt_eval.run_stt_eval(
+                    gt_data=self._gt_data(ids),
+                    audio_dir=Path(tmp),
+                    provider="deepgram",
+                    language="english",
+                    results_csv_path=out,
+                )
+
+        self.assertLessEqual(max_in_flight, 2)
+
+    async def test_failure_propagates(self):
+        """An exception from transcribe_audio bubbles out of run_stt_eval."""
+        from calibrate.stt import eval as stt_eval
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            raise RuntimeError("boom")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "results.csv"
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                with self.assertRaises(RuntimeError):
+                    await stt_eval.run_stt_eval(
+                        gt_data=self._gt_data(["row_a"]),
+                        audio_dir=Path(tmp),
+                        provider="deepgram",
+                        language="english",
+                        results_csv_path=out,
+                        row_parallel=2,
+                    )
 
 
 if __name__ == "__main__":

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -583,5 +583,222 @@ class TestSTTRunSTTEvalParallel(unittest.IsolatedAsyncioTestCase):
                     )
 
 
+class TestRunSTTEvalRowParallel(unittest.IsolatedAsyncioTestCase):
+    """Row-level concurrency behaviour of ``run_stt_eval``."""
+
+    @staticmethod
+    def _gt_data(ids):
+        # Non-numeric ids on purpose: pandas coerces numeric-looking ids to
+        # int on CSV round-trip, which breaks the resume id comparison.
+        return [{"id": i, "gt": f"gt {i}"} for i in ids]
+
+    @staticmethod
+    def _make_audio(audio_dir: Path, ids):
+        for i in ids:
+            (audio_dir / f"{i}.wav").write_bytes(b"RIFF0000WAVE")
+
+    async def test_concurrency_actually_overlaps(self):
+        """row_parallel=3 over 5 rows reaches a peak in-flight of >= 3."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c", "row_d", "row_e"]
+        row_parallel = 3
+        in_flight = 0
+        max_in_flight = 0
+        counter_lock = asyncio.Lock()
+        release = asyncio.Event()
+        reached = asyncio.Event()
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            nonlocal in_flight, max_in_flight
+            async with counter_lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+                if in_flight >= min(row_parallel, len(ids)):
+                    reached.set()
+            await release.wait()
+            async with counter_lock:
+                in_flight -= 1
+            return f"pred {reference}"
+
+        async def releaser():
+            await reached.wait()
+            release.set()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audio_dir = Path(tmp)
+            self._make_audio(audio_dir, ids)
+            out = audio_dir / "results.csv"
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                await asyncio.gather(
+                    stt_eval.run_stt_eval(
+                        gt_data=self._gt_data(ids),
+                        audio_dir=audio_dir,
+                        provider="deepgram",
+                        language="english",
+                        results_csv_path=out,
+                        row_parallel=row_parallel,
+                    ),
+                    releaser(),
+                )
+
+        self.assertGreaterEqual(max_in_flight, min(row_parallel, len(ids)))
+
+    async def test_concurrency_is_capped_at_one(self):
+        """row_parallel=1 serializes transcription (peak in-flight never > 1)."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c", "row_d"]
+        in_flight = 0
+        max_in_flight = 0
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            await asyncio.sleep(0.01)
+            in_flight -= 1
+            return "x"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audio_dir = Path(tmp)
+            self._make_audio(audio_dir, ids)
+            out = audio_dir / "results.csv"
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                await stt_eval.run_stt_eval(
+                    gt_data=self._gt_data(ids),
+                    audio_dir=audio_dir,
+                    provider="deepgram",
+                    language="english",
+                    results_csv_path=out,
+                    row_parallel=1,
+                )
+
+        self.assertEqual(max_in_flight, 1)
+
+    async def test_output_order_preserved_when_later_rows_finish_first(self):
+        """Reversed completion order still writes CSV in input order."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c", "row_d"]
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            # Earlier ids sleep longer so later ids complete first.
+            stem = audio_path.stem
+            delay = 0.05 * (len(ids) - ids.index(stem))
+            await asyncio.sleep(delay)
+            return f"pred-{stem}"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audio_dir = Path(tmp)
+            self._make_audio(audio_dir, ids)
+            out = audio_dir / "results.csv"
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                count = await stt_eval.run_stt_eval(
+                    gt_data=self._gt_data(ids),
+                    audio_dir=audio_dir,
+                    provider="deepgram",
+                    language="english",
+                    results_csv_path=out,
+                    row_parallel=4,
+                )
+
+            self.assertEqual(count, len(ids))
+            df = pd.read_csv(out)
+            self.assertEqual(df["id"].tolist(), ids)
+            self.assertEqual(df["pred"].tolist(), [f"pred-{i}" for i in ids])
+
+    async def test_resume_skips_already_processed_id(self):
+        """A pre-seeded id is kept and never re-transcribed."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c"]
+        seen = []
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            seen.append(audio_path.stem)
+            return f"new-{audio_path.stem}"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audio_dir = Path(tmp)
+            self._make_audio(audio_dir, ids)
+            out = audio_dir / "results.csv"
+            # Pre-seed the first id as already processed.
+            pd.DataFrame(
+                [{"id": "row_a", "gt": "gt row_a", "pred": "old_a"}]
+            ).to_csv(out, index=False)
+
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                await stt_eval.run_stt_eval(
+                    gt_data=self._gt_data(ids),
+                    audio_dir=audio_dir,
+                    provider="deepgram",
+                    language="english",
+                    results_csv_path=out,
+                    row_parallel=4,
+                )
+
+            self.assertNotIn("row_a", seen)
+            self.assertEqual(sorted(seen), ["row_b", "row_c"])
+            df = pd.read_csv(out)
+            self.assertIn("row_a", df["id"].tolist())
+            self.assertEqual(
+                df.loc[df["id"] == "row_a", "pred"].iloc[0], "old_a"
+            )
+
+
+class TestResolveRowParallelPrecedence(unittest.TestCase):
+    """Precedence rules of ``resolve_row_parallel`` for the STT component."""
+
+    def test_cli_value_takes_precedence_over_env(self):
+        from calibrate.utils import resolve_row_parallel
+
+        with patch.dict("os.environ", {"CALIBRATE_STT_PARALLEL": "7"}):
+            self.assertEqual(resolve_row_parallel("stt", 3), 3)
+
+    def test_env_used_when_no_cli_value(self):
+        from calibrate.utils import resolve_row_parallel
+
+        with patch.dict("os.environ", {"CALIBRATE_STT_PARALLEL": "6"}):
+            self.assertEqual(resolve_row_parallel("stt", None), 6)
+
+    def test_default_when_no_cli_or_env(self):
+        from calibrate.utils import resolve_row_parallel, DEFAULT_ROW_PARALLEL
+
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("CALIBRATE_STT_PARALLEL", None)
+            self.assertEqual(
+                resolve_row_parallel("stt", None), DEFAULT_ROW_PARALLEL
+            )
+
+    def test_non_positive_and_garbage_fall_back_to_default(self):
+        from calibrate.utils import resolve_row_parallel, DEFAULT_ROW_PARALLEL
+
+        # Non-positive CLI values are ignored -> fall through to env/default.
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("CALIBRATE_STT_PARALLEL", None)
+            self.assertEqual(
+                resolve_row_parallel("stt", 0), DEFAULT_ROW_PARALLEL
+            )
+            self.assertEqual(
+                resolve_row_parallel("stt", -5), DEFAULT_ROW_PARALLEL
+            )
+
+        # Garbage / non-positive env values are ignored too.
+        for bad in ("abc", "0", "-1"):
+            with patch.dict("os.environ", {"CALIBRATE_STT_PARALLEL": bad}):
+                self.assertEqual(
+                    resolve_row_parallel("stt", None), DEFAULT_ROW_PARALLEL
+                )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -258,17 +258,12 @@ class TestAgentBenchmark:
             f"'Overall Summary' not in stdout.\nstdout: {result.stdout}"
         )
 
-    def test_models_run_in_order(self, agent_config):
-        """gpt-4.1 output appears before gpt-5.1 output in stdout."""
+    def test_both_models_present_in_output(self, agent_config):
+        """Both models appear in stdout (order-agnostic — models run in parallel)."""
         result, _, _ = self._run_benchmark(agent_config)
         stdout = result.stdout
-        pos_41 = stdout.find("gpt-4.1")
-        pos_51 = stdout.find("gpt-5.1")
-        assert pos_41 != -1, "gpt-4.1 not found in stdout"
-        assert pos_51 != -1, "gpt-5.1 not found in stdout"
-        assert pos_41 < pos_51, (
-            "Expected gpt-4.1 to appear before gpt-5.1 in stdout"
-        )
+        assert "gpt-4.1" in stdout, "gpt-4.1 not found in stdout"
+        assert "gpt-5.1" in stdout, "gpt-5.1 not found in stdout"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tts/test_benchmark.py
+++ b/tests/tts/test_benchmark.py
@@ -1,0 +1,99 @@
+"""Coverage for tts/benchmark.py — benchmark-parallel resolution."""
+
+import asyncio
+import unittest
+from unittest.mock import patch, AsyncMock
+
+
+class TestResolveBenchmarkParallel(unittest.TestCase):
+    def test_env_var_sets_parallelism(self):
+        from calibrate.utils import resolve_benchmark_parallel
+
+        with patch.dict("os.environ", {"CALIBRATE_TTS_BENCHMARK_PARALLEL": "5"}):
+            self.assertEqual(resolve_benchmark_parallel("tts", None), 5)
+
+    def test_explicit_value_overrides_env(self):
+        from calibrate.utils import resolve_benchmark_parallel
+
+        with patch.dict("os.environ", {"CALIBRATE_TTS_BENCHMARK_PARALLEL": "5"}):
+            self.assertEqual(resolve_benchmark_parallel("tts", 3), 3)
+
+    def test_invalid_env_falls_back_to_default(self):
+        from calibrate.utils import resolve_benchmark_parallel, DEFAULT_BENCHMARK_PARALLEL
+
+        with patch.dict("os.environ", {"CALIBRATE_TTS_BENCHMARK_PARALLEL": "abc"}):
+            self.assertEqual(
+                resolve_benchmark_parallel("tts", None), DEFAULT_BENCHMARK_PARALLEL
+            )
+        self.assertEqual(DEFAULT_BENCHMARK_PARALLEL, 2)
+
+    def test_zero_env_falls_back_to_default(self):
+        from calibrate.utils import resolve_benchmark_parallel, DEFAULT_BENCHMARK_PARALLEL
+
+        with patch.dict("os.environ", {"CALIBRATE_TTS_BENCHMARK_PARALLEL": "0"}):
+            self.assertEqual(
+                resolve_benchmark_parallel("tts", None), DEFAULT_BENCHMARK_PARALLEL
+            )
+
+
+class TestRunBenchmarkParallel(unittest.IsolatedAsyncioTestCase):
+    async def _run_and_measure_peak(self, env, max_parallel):
+        """Run the benchmark with a fake provider eval and return peak concurrency."""
+        from calibrate.tts import benchmark as B
+
+        concurrency = {"current": 0, "peak": 0}
+        gate = asyncio.Event()
+        n_providers = 6
+        started = {"count": 0}
+
+        async def fake_eval(**kwargs):
+            concurrency["current"] += 1
+            concurrency["peak"] = max(concurrency["peak"], concurrency["current"])
+            started["count"] += 1
+            # Once all providers that *can* run concurrently have started, release.
+            if started["count"] >= n_providers:
+                gate.set()
+            try:
+                await asyncio.wait_for(gate.wait(), timeout=1.0)
+            except asyncio.TimeoutError:
+                pass
+            concurrency["current"] -= 1
+            return {"status": "ok", "metrics": {}}
+
+        providers = [f"p{i}" for i in range(n_providers)]
+        with patch.dict("os.environ", env, clear=False):
+            import os
+
+            if not env:
+                os.environ.pop("CALIBRATE_TTS_BENCHMARK_PARALLEL", None)
+            with patch.object(
+                B, "run_single_provider_eval", AsyncMock(side_effect=fake_eval)
+            ), patch.object(B, "generate_leaderboard", lambda **k: None):
+                await B.run(
+                    input="x.csv",
+                    providers=providers,
+                    language="english",
+                    output_dir="./out",
+                    max_parallel=max_parallel,
+                )
+        return concurrency["peak"]
+
+    async def test_env_var_bounds_concurrency(self):
+        peak = await self._run_and_measure_peak(
+            {"CALIBRATE_TTS_BENCHMARK_PARALLEL": "3"}, None
+        )
+        self.assertEqual(peak, 3)
+
+    async def test_explicit_max_parallel_overrides_env(self):
+        peak = await self._run_and_measure_peak(
+            {"CALIBRATE_TTS_BENCHMARK_PARALLEL": "3"}, 2
+        )
+        self.assertEqual(peak, 2)
+
+    async def test_default_when_env_unset(self):
+        peak = await self._run_and_measure_peak({}, None)
+        self.assertEqual(peak, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tts/test_eval.py
+++ b/tests/tts/test_eval.py
@@ -462,5 +462,267 @@ class TestRunTTSEvalParallel(unittest.IsolatedAsyncioTestCase):
             self.assertTrue((df["ttfb"] == 0.5).all())
 
 
+class TestRunTTSEvalRowParallel(unittest.IsolatedAsyncioTestCase):
+    """Row-level parallelism in run_tts_eval: bounded concurrency, output
+    ordering, resume, and overwrite semantics."""
+
+    async def test_concurrency_actually_overlaps(self):
+        from calibrate.tts import eval as tts_eval
+
+        row_parallel = 3
+        n_rows = 5
+        in_flight = 0
+        max_in_flight = 0
+        lock = asyncio.Lock()
+        release = asyncio.Event()
+        reached = asyncio.Event()
+
+        async def fake_synth(text, provider, language, audio_path):
+            nonlocal in_flight, max_in_flight
+            async with lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+                if in_flight >= min(row_parallel, n_rows):
+                    reached.set()
+            # Keep the row open until enough rows are concurrently in-flight.
+            await release.wait()
+            async with lock:
+                in_flight -= 1
+            Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(audio_path).write_bytes(b"RIFF")
+            return {"ttfb": 0.1}
+
+        async def releaser():
+            await reached.wait()
+            release.set()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            gt_data = [{"id": f"row_{i}", "text": f"t{i}"} for i in range(n_rows)]
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                await asyncio.gather(
+                    tts_eval.run_tts_eval(
+                        gt_data=gt_data,
+                        provider="openai",
+                        language="english",
+                        output_dir=str(out),
+                        results_csv_path=results_csv,
+                        row_parallel=row_parallel,
+                    ),
+                    releaser(),
+                )
+
+            self.assertGreaterEqual(max_in_flight, min(row_parallel, n_rows))
+
+    async def test_concurrency_capped_serialized(self):
+        from calibrate.tts import eval as tts_eval
+
+        in_flight = 0
+        max_in_flight = 0
+        lock = asyncio.Lock()
+
+        async def fake_synth(text, provider, language, audio_path):
+            nonlocal in_flight, max_in_flight
+            async with lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+            # Yield control so a second concurrent row could interleave if the
+            # semaphore weren't capping concurrency at 1.
+            await asyncio.sleep(0.01)
+            async with lock:
+                in_flight -= 1
+            Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(audio_path).write_bytes(b"RIFF")
+            return {"ttfb": 0.1}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            gt_data = [{"id": f"row_{i}", "text": f"t{i}"} for i in range(5)]
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                await tts_eval.run_tts_eval(
+                    gt_data=gt_data,
+                    provider="openai",
+                    language="english",
+                    output_dir=str(out),
+                    results_csv_path=results_csv,
+                    row_parallel=1,
+                )
+
+            self.assertEqual(max_in_flight, 1)
+
+    async def test_output_order_preserved_when_later_rows_finish_first(self):
+        from calibrate.tts import eval as tts_eval
+
+        # Later rows return first so completion order is the reverse of input.
+        delays = {"row_a": 0.06, "row_b": 0.04, "row_c": 0.02}
+
+        async def fake_synth(text, provider, language, audio_path):
+            _id = Path(audio_path).stem
+            await asyncio.sleep(delays[_id])
+            Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(audio_path).write_bytes(b"RIFF")
+            return {"ttfb": delays[_id]}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            gt_data = [
+                {"id": "row_a", "text": "a"},
+                {"id": "row_b", "text": "b"},
+                {"id": "row_c", "text": "c"},
+            ]
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                await tts_eval.run_tts_eval(
+                    gt_data=gt_data,
+                    provider="openai",
+                    language="english",
+                    output_dir=str(out),
+                    results_csv_path=results_csv,
+                    row_parallel=3,
+                )
+
+            df = pd.read_csv(results_csv)
+            self.assertEqual(
+                df["id"].astype(str).tolist(), ["row_a", "row_b", "row_c"]
+            )
+
+    async def test_resume_does_not_recall_processed_id(self):
+        from calibrate.tts import eval as tts_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            pd.DataFrame(
+                [{"id": "row_a", "text": "hello", "audio_path": "/x.wav", "ttfb": 0.1}]
+            ).to_csv(results_csv, index=False)
+
+            processed = []
+
+            async def fake_synth(text, provider, language, audio_path):
+                processed.append(Path(audio_path).stem)
+                Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+                Path(audio_path).write_bytes(b"RIFF")
+                return {"ttfb": 0.2}
+
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                result = await tts_eval.run_tts_eval(
+                    gt_data=[
+                        {"id": "row_a", "text": "hello"},
+                        {"id": "row_b", "text": "world"},
+                        {"id": "row_c", "text": "again"},
+                    ],
+                    provider="openai",
+                    language="english",
+                    output_dir=str(out),
+                    results_csv_path=results_csv,
+                    row_parallel=3,
+                )
+
+            self.assertNotIn("row_a", processed)
+            self.assertEqual(result["success_count"], 2)
+            df = pd.read_csv(results_csv)
+            self.assertIn("row_a", df["id"].astype(str).tolist())
+            self.assertEqual(
+                df["id"].astype(str).tolist(), ["row_a", "row_b", "row_c"]
+            )
+
+    async def test_overwrite_reprocesses_all_rows(self):
+        from calibrate.tts import eval as tts_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            pd.DataFrame(
+                [
+                    {"id": "row_a", "text": "old", "audio_path": "/x.wav", "ttfb": 0.1},
+                    {"id": "row_b", "text": "old", "audio_path": "/y.wav", "ttfb": 0.1},
+                ]
+            ).to_csv(results_csv, index=False)
+
+            processed = []
+
+            async def fake_synth(text, provider, language, audio_path):
+                processed.append(Path(audio_path).stem)
+                Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+                Path(audio_path).write_bytes(b"RIFF")
+                return {"ttfb": 0.5}
+
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                result = await tts_eval.run_tts_eval(
+                    gt_data=[
+                        {"id": "row_a", "text": "new"},
+                        {"id": "row_b", "text": "new"},
+                    ],
+                    provider="openai",
+                    language="english",
+                    output_dir=str(out),
+                    results_csv_path=results_csv,
+                    overwrite=True,
+                    row_parallel=2,
+                )
+
+            self.assertEqual(sorted(processed), ["row_a", "row_b"])
+            self.assertEqual(result["success_count"], 2)
+            df = pd.read_csv(results_csv)
+            self.assertEqual(df["id"].astype(str).tolist(), ["row_a", "row_b"])
+            self.assertTrue((df["text"] == "new").all())
+            self.assertTrue((df["ttfb"] == 0.5).all())
+
+
+class TestResolveRowParallelTTS(unittest.TestCase):
+    """Precedence for resolve_row_parallel('tts', ...): CLI > env > default."""
+
+    def test_cli_value_takes_precedence(self):
+        from calibrate.utils import resolve_row_parallel
+
+        with patch.dict(os.environ, {"CALIBRATE_TTS_PARALLEL": "7"}, clear=False):
+            self.assertEqual(resolve_row_parallel("tts", 3), 3)
+
+    def test_env_used_when_no_cli(self):
+        from calibrate.utils import resolve_row_parallel
+
+        with patch.dict(os.environ, {"CALIBRATE_TTS_PARALLEL": "6"}, clear=False):
+            self.assertEqual(resolve_row_parallel("tts", None), 6)
+
+    def test_default_when_nothing_set(self):
+        from calibrate.utils import resolve_row_parallel, DEFAULT_ROW_PARALLEL
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CALIBRATE_TTS_PARALLEL", None)
+            self.assertEqual(
+                resolve_row_parallel("tts", None), DEFAULT_ROW_PARALLEL
+            )
+
+    def test_non_positive_and_garbage_fall_back_to_default(self):
+        from calibrate.utils import resolve_row_parallel, DEFAULT_ROW_PARALLEL
+
+        # Non-positive CLI values are ignored; with no usable env, fall back.
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CALIBRATE_TTS_PARALLEL", None)
+            self.assertEqual(resolve_row_parallel("tts", 0), DEFAULT_ROW_PARALLEL)
+            self.assertEqual(resolve_row_parallel("tts", -5), DEFAULT_ROW_PARALLEL)
+
+        # Garbage / non-positive env values are ignored too.
+        for bad in ("abc", "0", "-3"):
+            with patch.dict(
+                os.environ, {"CALIBRATE_TTS_PARALLEL": bad}, clear=False
+            ):
+                self.assertEqual(
+                    resolve_row_parallel("tts", None), DEFAULT_ROW_PARALLEL
+                )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tts/test_eval.py
+++ b/tests/tts/test_eval.py
@@ -5,6 +5,7 @@ Run with:
     python -m unittest tests.tts.test_eval -v
 """
 
+import asyncio
 import os
 import tempfile
 import unittest
@@ -287,6 +288,178 @@ class TestRunTTSEval(unittest.IsolatedAsyncioTestCase):
             df = pd.read_csv(results_csv)
             self.assertEqual(df.iloc[0]["text"], "new")
             self.assertEqual(df.iloc[0]["ttfb"], 0.5)
+
+
+class TestRunTTSEvalParallel(unittest.IsolatedAsyncioTestCase):
+    async def test_concurrency_overlaps(self):
+        from calibrate.tts import eval as tts_eval
+
+        row_parallel = 3
+        in_flight = 0
+        max_in_flight = 0
+        lock = asyncio.Lock()
+        release = asyncio.Event()
+        reached = asyncio.Event()
+
+        async def fake_synth(text, provider, language, audio_path):
+            nonlocal in_flight, max_in_flight
+            async with lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+                if in_flight >= row_parallel:
+                    reached.set()
+            # Hold the row open until enough rows are concurrently in-flight.
+            await release.wait()
+            async with lock:
+                in_flight -= 1
+            Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(audio_path).write_bytes(b"RIFF")
+            return {"ttfb": 0.1}
+
+        async def releaser():
+            # Once row_parallel rows are simultaneously in-flight, let them go.
+            await reached.wait()
+            release.set()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            gt_data = [{"id": f"row_{i}", "text": f"t{i}"} for i in range(6)]
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                await asyncio.gather(
+                    tts_eval.run_tts_eval(
+                        gt_data=gt_data,
+                        provider="openai",
+                        language="english",
+                        output_dir=str(out),
+                        results_csv_path=results_csv,
+                        row_parallel=row_parallel,
+                    ),
+                    releaser(),
+                )
+
+            self.assertGreaterEqual(max_in_flight, row_parallel)
+
+    async def test_output_order_matches_input(self):
+        from calibrate.tts import eval as tts_eval
+
+        # Make later ids finish first to force out-of-order completion.
+        delays = {"row_a": 0.06, "row_b": 0.02, "row_c": 0.04}
+
+        async def fake_synth(text, provider, language, audio_path):
+            _id = Path(audio_path).stem
+            await asyncio.sleep(delays[_id])
+            Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(audio_path).write_bytes(b"RIFF")
+            return {"ttfb": delays[_id]}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            gt_data = [
+                {"id": "row_a", "text": "a"},
+                {"id": "row_b", "text": "b"},
+                {"id": "row_c", "text": "c"},
+            ]
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                await tts_eval.run_tts_eval(
+                    gt_data=gt_data,
+                    provider="openai",
+                    language="english",
+                    output_dir=str(out),
+                    results_csv_path=results_csv,
+                    row_parallel=3,
+                )
+
+            df = pd.read_csv(results_csv)
+            self.assertEqual(
+                df["id"].astype(str).tolist(), ["row_a", "row_b", "row_c"]
+            )
+
+    async def test_resume_skips_processed_ids_parallel(self):
+        from calibrate.tts import eval as tts_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            pd.DataFrame(
+                [{"id": "row_a", "text": "hello", "audio_path": "/x.wav", "ttfb": 0.1}]
+            ).to_csv(results_csv, index=False)
+
+            processed = []
+
+            async def fake_synth(text, provider, language, audio_path):
+                processed.append(Path(audio_path).stem)
+                Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+                Path(audio_path).write_bytes(b"RIFF")
+                return {"ttfb": 0.2}
+
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                result = await tts_eval.run_tts_eval(
+                    gt_data=[
+                        {"id": "row_a", "text": "hello"},
+                        {"id": "row_b", "text": "world"},
+                        {"id": "row_c", "text": "again"},
+                    ],
+                    provider="openai",
+                    language="english",
+                    output_dir=str(out),
+                    results_csv_path=results_csv,
+                    row_parallel=3,
+                )
+
+            self.assertNotIn("row_a", processed)
+            self.assertEqual(result["success_count"], 2)
+            df = pd.read_csv(results_csv)
+            self.assertEqual(
+                df["id"].astype(str).tolist(), ["row_a", "row_b", "row_c"]
+            )
+
+    async def test_overwrite_wipes_and_reprocesses_parallel(self):
+        from calibrate.tts import eval as tts_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            pd.DataFrame(
+                [
+                    {"id": "row_a", "text": "old", "audio_path": "/x.wav", "ttfb": 0.1},
+                    {"id": "row_b", "text": "old", "audio_path": "/y.wav", "ttfb": 0.1},
+                ]
+            ).to_csv(results_csv, index=False)
+
+            async def fake_synth(text, provider, language, audio_path):
+                Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+                Path(audio_path).write_bytes(b"RIFF")
+                return {"ttfb": 0.5}
+
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                result = await tts_eval.run_tts_eval(
+                    gt_data=[
+                        {"id": "row_a", "text": "new"},
+                        {"id": "row_b", "text": "new"},
+                    ],
+                    provider="openai",
+                    language="english",
+                    output_dir=str(out),
+                    results_csv_path=results_csv,
+                    overwrite=True,
+                    row_parallel=2,
+                )
+
+            self.assertEqual(result["success_count"], 2)
+            df = pd.read_csv(results_csv)
+            self.assertEqual(df["id"].astype(str).tolist(), ["row_a", "row_b"])
+            self.assertTrue((df["text"] == "new").all())
+            self.assertTrue((df["ttfb"] == 0.5).all())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Makes concurrency configurable and consistent across every evaluation surface, and parallelises two paths that were previously sequential. Two orthogonal layers of parallelism are introduced, each resolved the same way: explicit CLI flag / SDK arg > environment variable > default.

1. Benchmark-level parallelism — how many providers/models a benchmark runs at once.
2. Row-level parallelism — how many rows (audio files for STT, texts for TTS, test cases for LLM, simulations) a single provider/model processes at once.

## What changed

### Shared resolvers (`calibrate/utils.py`)
- `resolve_benchmark_parallel(component, cli_value)` — CLI/SDK arg > `CALIBRATE_{STT,TTS,LLM}_BENCHMARK_PARALLEL` > default 2.
- `resolve_row_parallel(component, cli_value)` — CLI/SDK arg > `CALIBRATE_{STT,TTS}_PARALLEL` > default 4.
- Non-positive / unparseable values are ignored so callers always get a sane positive concurrency.

### Agent-connection LLM benchmark now runs models in parallel
- Extracted the shared benchmark scaffolding (StreamTee logfile, banner, leaderboard, consolidated summary, non-zero exit) into `run_benchmark_cli` in `calibrate/llm/_output.py`.
- Routed both the direct-provider benchmark (`llm/benchmark.py`, via a new `_run_models` helper) and the agent-connection benchmark (`cli.py`) through it, removing duplicated logging/summary boilerplate. The agent path previously ran models sequentially purely to keep terminal output legible; output is now teed to a per-run `logs` file so concurrent per-model output stays separated, with a per-model `Model:` header for attributability.

### STT/TTS row-level parallelism (previously sequential)
- `run_stt_eval` / `run_tts_eval` now transcribe / synthesize rows concurrently with a bounded `asyncio.Semaphore(resolve_row_parallel(...))` and an `asyncio.Lock` guarding writes.
- Output preserves input order regardless of completion order, and the partial `results.csv` is rewritten after each row for crash recovery / resume (already-processed ids are skipped). TTS switched from per-row append to an ordered full rewrite so concurrent writes stay safe and deterministic. `raise`-on-failure is preserved (completed rows are flushed before the exception propagates).
- Threaded `row_parallel` through `run_single_provider_eval`, each `main()`, and `benchmark.run()/main()`.

### CLI flags
- `--benchmark-parallel` added to the `stt`, `tts`, and `llm` benchmark paths (benchmark-level).
- `-n` / `--parallel` added to the `stt` and `tts` subparsers (row-level), matching the existing LLM-tests flag; forwarded into the benchmark argv.

### Simulations
- `-n/--parallel` now defaults to env-aware resolution: `CALIBRATE_SIMULATION_PARALLEL` > default 1 (via `_resolve_simulation_parallel`), for both live and eval-only simulation runs.

### Docs
- `.env.example`: documented `CALIBRATE_STT_PARALLEL`, `CALIBRATE_TTS_PARALLEL`, `CALIBRATE_SIMULATION_PARALLEL`, and the `CALIBRATE_{STT,TTS,LLM}_BENCHMARK_PARALLEL` group.
- `docs/cli/simulations.mdx`: noted `CALIBRATE_SIMULATION_PARALLEL`.

## Test plan

- [x] `tests/stt/test_eval.py` — row concurrency overlap, serialization cap, output-order preservation, resume, and `resolve_row_parallel` precedence (34 passed)
- [x] `tests/tts/test_eval.py` — same coverage plus `overwrite` reprocessing (29 passed)
- [x] `tests/stt/test_eval.py tests/tts/test_eval.py` combined — 63 passed
- [x] `tests/stt/test_benchmark.py`, `tests/tts/test_benchmark.py` — benchmark-level parallel paths + resolver wiring
- [x] `tests/llm/test_benchmark.py`, `tests/test_cli.py` — `run_benchmark_cli` refactor; `test_models_run_in_order` updated to be order-agnostic (models now run in parallel)
- [x] `tests/llm/test_init_extra.py`, `tests/llm/test_run_simulation_extra.py` — simulation concurrency resolver
- [ ] CI runs the full suite as the backstop

Made with [Cursor](https://cursor.com)