### PR TITLE
Run LLM benchmark models in parallel (+ configurable --benchmark-parallel)

### DIFF
--- a/calibrate/cli.py
+++ b/calibrate/cli.py
@@ -306,6 +306,12 @@ Examples:
         help="Number of test cases to evaluate in parallel per model",
     )
     llm_parser.add_argument(
+        "--benchmark-parallel",
+        type=int,
+        default=None,
+        help="Number of models to evaluate in parallel (overrides CALIBRATE_LLM_BENCHMARK_PARALLEL; default 2)",
+    )
+    llm_parser.add_argument(
         "--verify",
         action="store_true",
         help="Verify an external agent connection by sending a preset message and checking the response format",
@@ -590,37 +596,30 @@ Examples:
                         _print_sample_output(_verify_result)
                         print()
 
-                from calibrate.llm.tests_leaderboard import generate_leaderboard
-                from calibrate.llm._output import print_benchmark_summary
-
-                # Run — one model at a time so output is clearly separated
+                # Benchmark across models, reusing the same scaffolding as the
+                # non-agent benchmark (parallel run, per-run ``logs`` file,
+                # leaderboard, consolidated summary). Models run in parallel —
+                # the shared helper tees output to a logfile so concurrent
+                # per-model output doesn't interleave on the terminal.
                 if _models:
-                    _model_results = {}
-                    for _m in _models:
-                        print(f"\n\033[92m{'='*60}\033[0m")
-                        print(f"\033[92m  Model: {_m}\033[0m")
-                        print(f"\033[92m{'='*60}\033[0m\n")
-                        _result = asyncio.run(
-                            _tests.run(
+                    from calibrate.llm._output import run_benchmark_cli
+
+                    asyncio.run(
+                        run_benchmark_cli(
+                            output_dir=args.output_dir,
+                            models=_models,
+                            runner=lambda: _tests.run(
                                 agent=_agent,
                                 test_cases=_config["test_cases"],
                                 output_dir=args.output_dir,
-                                models=[_m],
+                                models=_models,
                                 evaluators=_config.get("evaluators"),
                                 test_parallel=args.parallel,
-                            )
+                                max_parallel=args.benchmark_parallel,
+                            ),
+                            config_path=args.config,
                         )
-                        _model_results[_m] = _result.get(_m, _result)
-
-                    _lb_dir = os.path.join(args.output_dir, "leaderboard")
-                    generate_leaderboard(output_dir=args.output_dir, save_dir=_lb_dir)
-                    _has_errors = print_benchmark_summary(
-                        models=_models,
-                        model_results=_model_results,
-                        leaderboard_dir=_lb_dir,
                     )
-                    if _has_errors:
-                        sys.exit(1)
                 else:
                     asyncio.run(
                         _tests.run(
@@ -642,6 +641,8 @@ Examples:
                 argv.extend(["-p", args.provider])
                 if getattr(args, "parallel", None) is not None:
                     argv.extend(["-n", str(args.parallel)])
+                if getattr(args, "benchmark_parallel", None) is not None:
+                    argv.extend(["--benchmark-parallel", str(args.benchmark_parallel)])
 
                 sys.argv = argv
                 asyncio.run(llm_benchmark_main())

--- a/calibrate/llm/__init__.py
+++ b/calibrate/llm/__init__.py
@@ -128,6 +128,17 @@ class _Tests:
 
         configure_print_logger(print_log_save_path)
 
+        # Print a per-model header (mirrors the non-agent benchmark output) so
+        # interleaved parallel runs are attributable. Skipped for single
+        # agent-connection runs, where ``model`` is empty.
+        if model:
+            from calibrate.llm.run_tests import display_label
+
+            _label = display_label(provider, model)
+            log_and_print(f"\n\033[94m{'='*60}\033[0m")
+            log_and_print(f"\033[94mModel: {_label}\033[0m")
+            log_and_print(f"\033[94m{'='*60}\033[0m\n")
+
         results_file_path = os.path.join(final_output_dir, "results.json")
 
         # Pass model name to agent for benchmark routing; None for single runs.
@@ -237,7 +248,7 @@ class _Tests:
         model: str = "gpt-4.1",
         provider: Literal["openai", "openrouter"] = "openrouter",
         run_name: Optional[str] = None,
-        max_parallel: int = 2,
+        max_parallel: Optional[int] = None,
         agent: Optional["TextAgentConnection"] = None,
         evaluators: Optional[List[dict]] = None,
         test_parallel: Optional[int] = None,
@@ -261,7 +272,9 @@ class _Tests:
             model: Single model name to use (used if models is not provided)
             provider: LLM provider (openai or openrouter)
             run_name: Optional name for this run (used in output folder name)
-            max_parallel: Maximum number of models to run in parallel (default: 2)
+            max_parallel: Maximum number of models to run in parallel. Resolves
+                via SDK arg > ``CALIBRATE_LLM_BENCHMARK_PARALLEL`` env var >
+                default 2.
             test_parallel: Max test cases to evaluate concurrently per model.
             agent: Optional external agent connection. When provided, routes all
                 test cases to the external agent instead of an internal LLM.
@@ -290,7 +303,13 @@ class _Tests:
             ...     test_cases=[...],
             ... ))
         """
+        from calibrate.utils import resolve_benchmark_parallel
+
         tools = tools or []
+
+        # Model-level concurrency: SDK arg > CALIBRATE_LLM_BENCHMARK_PARALLEL > 2.
+        # Resolved once here so both the agent and internal-model branches share it.
+        max_parallel = resolve_benchmark_parallel("llm", max_parallel)
 
         # External agent benchmark: run once per model, passing model hint in each request
         if agent is not None and models and len(models) > 0:
@@ -540,9 +559,9 @@ class _Simulations:
         output_dir: str,
         model: str,
         provider: str,
-        parallel: int,
-        agent_speaks_first: bool,
-        max_turns: int,
+        parallel: Optional[int] = None,
+        agent_speaks_first: bool = True,
+        max_turns: int = 50,
         agent: Optional["TextAgentConnection"] = None,
         _flat_output: bool = False,
     ) -> dict:
@@ -554,7 +573,10 @@ class _Simulations:
                 for backward compatibility.
         """
         from calibrate.judges import require_simulation_evaluators, write_evaluator_config
-        from calibrate.llm.run_simulation import run_single_simulation_task
+        from calibrate.llm.run_simulation import (
+            run_single_simulation_task,
+            _resolve_simulation_parallel,
+        )
 
         require_simulation_evaluators(evaluators or [])
 
@@ -591,7 +613,7 @@ class _Simulations:
         args.provider = provider
 
         # Create semaphore for parallel execution
-        semaphore = asyncio.Semaphore(parallel)
+        semaphore = asyncio.Semaphore(_resolve_simulation_parallel(parallel))
 
         # Create all simulation tasks
         tasks = []
@@ -692,7 +714,7 @@ class _Simulations:
         models: Optional[List[str]] = None,
         model: str = "gpt-4.1",
         provider: Literal["openai", "openrouter"] = "openrouter",
-        parallel: int = 1,
+        parallel: Optional[int] = None,
         agent_speaks_first: bool = True,
         max_turns: int = 50,
         max_parallel_models: int = 2,
@@ -717,7 +739,7 @@ class _Simulations:
             models: List of model names to evaluate (if provided, runs in parallel)
             model: Single model name to use (used if models is not provided)
             provider: LLM provider (openai or openrouter)
-            parallel: Number of simulations to run in parallel per model (default: 1)
+            parallel: Number of simulations to run in parallel per model (default: CALIBRATE_SIMULATION_PARALLEL env var or 1)
             agent_speaks_first: Whether the agent initiates the conversation (default: True)
             max_turns: Maximum number of assistant turns (default: 50)
             max_parallel_models: Maximum number of models to run in parallel (default: 2)
@@ -833,7 +855,7 @@ class _Simulations:
         output_dir: str = "./out",
         model: str = "gpt-4.1",
         provider: Literal["openai", "openrouter"] = "openrouter",
-        parallel: int = 1,
+        parallel: Optional[int] = None,
         agent_speaks_first: bool = True,
         max_turns: int = 50,
         agent: Optional["TextAgentConnection"] = None,

--- a/calibrate/llm/_output.py
+++ b/calibrate/llm/_output.py
@@ -1,6 +1,87 @@
 """Shared output helpers for LLM benchmark results."""
 
+import os
 import sys
+from os.path import exists, join
+from typing import Awaitable, Callable, Optional
+
+
+async def run_benchmark_cli(
+    *,
+    output_dir: str,
+    models: list,
+    runner: "Callable[[], Awaitable[dict]]",
+    config_path: Optional[str] = None,
+    provider: Optional[str] = None,
+    model_label=None,
+) -> None:
+    """Run a multi-model LLM benchmark with consolidated logging + summary.
+
+    Shared scaffolding for both the direct-provider benchmark
+    (``llm/benchmark.py``) and the agent-connection benchmark (the ``llm`` CLI
+    path). Mirrors stdout/stderr into a per-run ``logs`` file — so concurrent
+    per-model output doesn't interleave on the terminal — prints the banner,
+    awaits ``runner`` (which returns a ``{model: result}`` dict), writes the
+    leaderboard, and prints the consolidated summary. Exits non-zero if any
+    model errored.
+
+    Args:
+        output_dir: Base output directory (per-model subfolders live here).
+        models: Ordered list of model names.
+        runner: Zero-arg coroutine factory returning ``{model: result}``.
+        config_path: Optional config path shown in the banner.
+        provider: Optional provider shown in the banner (omitted for agents).
+        model_label: Optional callable to format display labels.
+    """
+    from calibrate.utils import StreamTee
+    from calibrate.llm.tests_leaderboard import generate_leaderboard
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    # When the interactive UI runs each model in its own subprocess, several
+    # processes target the same ``logs`` path; ``CALIBRATE_LLM_LOG_APPEND=1``
+    # makes them append instead of racing to truncate each other's output.
+    log_path = join(output_dir, "logs")
+    append_mode = os.environ.get("CALIBRATE_LLM_LOG_APPEND") == "1"
+    if not append_mode and exists(log_path):
+        os.remove(log_path)
+    log_file = open(log_path, "a" if append_mode else "w")
+    original_stdout, original_stderr = sys.stdout, sys.stderr
+    sys.stdout = StreamTee(original_stdout, log_file)
+    sys.stderr = StreamTee(original_stderr, log_file)
+
+    label_fn = model_label or (lambda m: m)
+    try:
+        print("\n\033[91mLLM Tests Benchmark\033[0m\n")
+        if config_path:
+            print(f"Config: {config_path}")
+        print(f"Model(s): {', '.join(label_fn(m) for m in models)}")
+        if provider:
+            print(f"Provider: {provider}")
+        print(f"Output: {output_dir}")
+        print("")
+
+        model_results = await runner()
+
+        leaderboard_dir = join(output_dir, "leaderboard")
+        try:
+            generate_leaderboard(output_dir=output_dir, save_dir=leaderboard_dir)
+        except Exception as e:
+            print(f"\033[31mLeaderboard generation failed: {e}\033[0m")
+
+        has_errors = print_benchmark_summary(
+            models=models,
+            model_results=model_results,
+            leaderboard_dir=leaderboard_dir,
+            model_label=model_label,
+        )
+    finally:
+        sys.stdout = original_stdout
+        sys.stderr = original_stderr
+        log_file.close()
+
+    if has_errors:
+        sys.exit(1)
 
 
 def print_benchmark_summary(

--- a/calibrate/llm/benchmark.py
+++ b/calibrate/llm/benchmark.py
@@ -22,17 +22,49 @@ Python SDK:
 import argparse
 import asyncio
 import json
-import os
-import sys
-from os.path import exists, join
+from os.path import join
 
 from calibrate.llm.run_tests import display_label, run_model_tests
 from calibrate.llm.tests_leaderboard import generate_leaderboard
-from calibrate.llm._output import print_benchmark_summary
-from calibrate.utils import StreamTee
+from calibrate.llm._output import run_benchmark_cli
+from calibrate.utils import resolve_benchmark_parallel
 
-# Maximum number of models to run in parallel
-MAX_PARALLEL_MODELS = 2
+
+async def _run_models(
+    config: dict,
+    models: list[str],
+    provider: str,
+    output_dir: str,
+    max_parallel: int | None = None,
+    test_parallel: int | None = None,
+) -> dict:
+    """Run tests for each model with bounded parallelism.
+
+    ``max_parallel`` resolves via CLI flag > ``CALIBRATE_LLM_BENCHMARK_PARALLEL``
+    env var > default 2 (see :func:`calibrate.utils.resolve_benchmark_parallel`).
+
+    Returns a ``{model: result}`` dict (no leaderboard side effect), so it can
+    be reused as the ``runner`` for :func:`run_benchmark_cli`.
+    """
+    results: dict = {}
+    max_parallel = resolve_benchmark_parallel("llm", max_parallel)
+    semaphore = asyncio.Semaphore(max_parallel)
+
+    async def run_model(model: str) -> tuple[str, dict]:
+        async with semaphore:
+            result = await run_model_tests(
+                model=model,
+                provider=provider,
+                config=config,
+                output_dir=output_dir,
+                test_parallel=test_parallel,
+            )
+            return (model, result)
+
+    tasks = [run_model(model) for model in models]
+    for model, result in await asyncio.gather(*tasks):
+        results[model] = result
+    return results
 
 
 async def run(
@@ -40,7 +72,7 @@ async def run(
     models: list[str],
     provider: str,
     output_dir: str = "./out",
-    max_parallel: int = MAX_PARALLEL_MODELS,
+    max_parallel: int | None = None,
     test_parallel: int | None = None,
 ) -> dict:
     """
@@ -54,7 +86,8 @@ async def run(
         provider: LLM provider (openai or openrouter)
         output_dir: Path to output directory for results (default: ./out)
             Results saved to output_dir/model_name/ for each model
-        max_parallel: Maximum number of models to run in parallel (default: 2)
+        max_parallel: Maximum number of models to run in parallel. Resolves via
+            CLI flag > ``CALIBRATE_LLM_BENCHMARK_PARALLEL`` env var > default 2.
         test_parallel: Max test cases to evaluate concurrently per model.
 
     Returns:
@@ -72,27 +105,14 @@ async def run(
         ...     output_dir="./out"
         ... ))
     """
-    results = {}
-    semaphore = asyncio.Semaphore(max_parallel)
-
-    async def run_model(model: str) -> tuple[str, dict]:
-        """Run tests for a single model with semaphore control."""
-        async with semaphore:
-            result = await run_model_tests(
-                model=model,
-                provider=provider,
-                config=config,
-                output_dir=output_dir,
-                test_parallel=test_parallel,
-            )
-            return (model, result)
-
-    # Run all models with limited parallelism
-    tasks = [run_model(model) for model in models]
-    model_results = await asyncio.gather(*tasks)
-
-    for model, result in model_results:
-        results[model] = result
+    results = await _run_models(
+        config=config,
+        models=models,
+        provider=provider,
+        output_dir=output_dir,
+        max_parallel=max_parallel,
+        test_parallel=test_parallel,
+    )
 
     # Generate leaderboard from output_dir (which contains model folders)
     leaderboard_dir = join(output_dir, "leaderboard")
@@ -151,6 +171,13 @@ async def main():
         default=None,
         help="Number of test cases to evaluate in parallel per model",
     )
+    parser.add_argument(
+        "--benchmark-parallel",
+        type=int,
+        default=None,
+        help="Number of models to run in parallel "
+        "(overrides CALIBRATE_LLM_BENCHMARK_PARALLEL env var)",
+    )
 
     args = parser.parse_args()
 
@@ -158,60 +185,21 @@ async def main():
 
     config = json.load(open(args.config))
 
-    # ``exist_ok=True`` makes this safe when several ``calibrate llm``
-    # subprocesses (e.g. one per model spawned by the interactive UI) race to
-    # create the output dir — the previous ``if not exists: makedirs(...)``
-    # pattern was non-atomic and the loser raised ``FileExistsError``.
-    os.makedirs(args.output_dir, exist_ok=True)
-
-    # Mirror everything written to stdout/stderr into a single output-dir-level
-    # `logs` file so the full terminal session (banner, per-model output,
-    # leaderboard prints, summary) is captured in one place — same pattern as
-    # the STT/TTS benchmark CLIs.
-    #
-    # When the interactive UI runs each model in its own ``calibrate llm``
-    # subprocess, multiple processes target the same ``logs`` path concurrently;
-    # the UI sets ``CALIBRATE_LLM_LOG_APPEND=1`` so subprocesses append instead
-    # of racing to truncate each other's output. The UI itself clears the file
-    # once before kicking off the run.
-    log_path = join(args.output_dir, "logs")
-    append_mode = os.environ.get("CALIBRATE_LLM_LOG_APPEND") == "1"
-    if not append_mode and exists(log_path):
-        os.remove(log_path)
-    log_file = open(log_path, "a" if append_mode else "w")
-    original_stdout, original_stderr = sys.stdout, sys.stderr
-    sys.stdout = StreamTee(original_stdout, log_file)
-    sys.stderr = StreamTee(original_stderr, log_file)
-
-    try:
-        print("\n\033[91mLLM Tests Benchmark\033[0m\n")
-        print(f"Config: {args.config}")
-        print(f"Model(s): {', '.join(display_label(args.provider, m) for m in models)}")
-        print(f"Provider: {args.provider}")
-        print(f"Output: {args.output_dir}")
-        print("")
-
-        result = await run(
+    await run_benchmark_cli(
+        output_dir=args.output_dir,
+        models=models,
+        runner=lambda: _run_models(
             config=config,
             models=models,
             provider=args.provider,
             output_dir=args.output_dir,
+            max_parallel=args.benchmark_parallel,
             test_parallel=args.parallel,
-        )
-
-        has_errors = print_benchmark_summary(
-            models=models,
-            model_results=result["models"],
-            leaderboard_dir=result["leaderboard_dir"],
-            model_label=lambda m: display_label(args.provider, m),
-        )
-
-        if has_errors:
-            sys.exit(1)
-    finally:
-        sys.stdout = original_stdout
-        sys.stderr = original_stderr
-        log_file.close()
+        ),
+        config_path=args.config,
+        provider=args.provider,
+        model_label=lambda m: display_label(args.provider, m),
+    )
 
 
 if __name__ == "__main__":

--- a/calibrate/utils.py
+++ b/calibrate/utils.py
@@ -23,6 +23,34 @@ from pipecat.transcriptions.language import Language
 current_context: ContextVar[str] = ContextVar("current_context", default="UNKNOWN")
 
 
+# Default number of providers/models a benchmark runs concurrently.
+DEFAULT_BENCHMARK_PARALLEL = 2
+
+
+def resolve_benchmark_parallel(
+    component: Literal["stt", "tts", "llm"], cli_value: Optional[int] = None
+) -> int:
+    """Resolve how many providers/models a benchmark runs concurrently.
+
+    Precedence: explicit ``cli_value`` (CLI flag / SDK arg) >
+    ``CALIBRATE_{STT,TTS,LLM}_BENCHMARK_PARALLEL`` env var > default (2).
+
+    Non-positive or unparseable values are ignored so callers always get a
+    sane positive concurrency.
+    """
+    if cli_value is not None and cli_value > 0:
+        return cli_value
+    env_value = os.getenv(f"CALIBRATE_{component.upper()}_BENCHMARK_PARALLEL")
+    if env_value:
+        try:
+            parsed = int(env_value)
+            if parsed > 0:
+                return parsed
+        except ValueError:
+            pass
+    return DEFAULT_BENCHMARK_PARALLEL
+
+
 def patch_langfuse_trace(trace_name: str):
     from pipecat.utils.tracing import service_decorators
 

--- a/tests/llm/test_benchmark.py
+++ b/tests/llm/test_benchmark.py
@@ -11,6 +11,8 @@ Run with:
     python -m pytest tests/test_agent_benchmarking.py -v
 """
 
+import asyncio
+import os
 import unittest
 from unittest.mock import patch, AsyncMock, MagicMock
 
@@ -294,6 +296,152 @@ class TestFolderNaming(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(subfolders, [])
             # results.json written directly to output_dir
             self.assertTrue(os.path.exists(os.path.join(tmpdir, "results.json")))
+
+
+# ---------------------------------------------------------------------------
+# Tests for model-level benchmark parallelism (CALIBRATE_LLM_BENCHMARK_PARALLEL)
+#
+# This is the MODEL-level concurrency (how many models run at once), distinct
+# from the test-case-level CALIBRATE_TEST_PARALLEL handled in run_tests.py.
+# ---------------------------------------------------------------------------
+
+class TestResolveBenchmarkParallelLLM(unittest.TestCase):
+    def test_cli_value_takes_precedence(self):
+        from calibrate.utils import resolve_benchmark_parallel
+
+        with patch.dict("os.environ", {"CALIBRATE_LLM_BENCHMARK_PARALLEL": "7"}):
+            self.assertEqual(resolve_benchmark_parallel("llm", 3), 3)
+
+    def test_env_var_used_when_no_cli(self):
+        from calibrate.utils import resolve_benchmark_parallel
+
+        with patch.dict("os.environ", {"CALIBRATE_LLM_BENCHMARK_PARALLEL": "7"}):
+            self.assertEqual(resolve_benchmark_parallel("llm", None), 7)
+
+    def test_default_when_neither_set(self):
+        from calibrate.utils import (
+            resolve_benchmark_parallel,
+            DEFAULT_BENCHMARK_PARALLEL,
+        )
+
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("CALIBRATE_LLM_BENCHMARK_PARALLEL", None)
+            self.assertEqual(
+                resolve_benchmark_parallel("llm", None), DEFAULT_BENCHMARK_PARALLEL
+            )
+            self.assertEqual(DEFAULT_BENCHMARK_PARALLEL, 2)
+
+    def test_invalid_env_falls_back_to_default(self):
+        from calibrate.utils import (
+            resolve_benchmark_parallel,
+            DEFAULT_BENCHMARK_PARALLEL,
+        )
+
+        with patch.dict("os.environ", {"CALIBRATE_LLM_BENCHMARK_PARALLEL": "abc"}):
+            self.assertEqual(
+                resolve_benchmark_parallel("llm", None), DEFAULT_BENCHMARK_PARALLEL
+            )
+
+    def test_zero_values_ignored(self):
+        from calibrate.utils import (
+            resolve_benchmark_parallel,
+            DEFAULT_BENCHMARK_PARALLEL,
+        )
+
+        with patch.dict("os.environ", {"CALIBRATE_LLM_BENCHMARK_PARALLEL": "0"}):
+            # CLI 0 ignored, env 0 ignored -> default
+            self.assertEqual(
+                resolve_benchmark_parallel("llm", 0), DEFAULT_BENCHMARK_PARALLEL
+            )
+
+    def test_does_not_read_test_parallel_env(self):
+        """Model-level resolver ignores the test-case-level env var."""
+        from calibrate.utils import (
+            resolve_benchmark_parallel,
+            DEFAULT_BENCHMARK_PARALLEL,
+        )
+
+        with patch.dict(
+            "os.environ", {"CALIBRATE_TEST_PARALLEL": "9"}, clear=False
+        ):
+            os.environ.pop("CALIBRATE_LLM_BENCHMARK_PARALLEL", None)
+            self.assertEqual(
+                resolve_benchmark_parallel("llm", None), DEFAULT_BENCHMARK_PARALLEL
+            )
+
+
+class TestRunModelsBenchmarkParallel(unittest.IsolatedAsyncioTestCase):
+    async def _capture_semaphore(self, *, max_parallel=None, env=None):
+        """Run ``_run_models`` and capture the int passed to ``asyncio.Semaphore``."""
+        from calibrate.llm import benchmark as BM
+
+        captured = {}
+        real_semaphore = asyncio.Semaphore
+
+        def fake_semaphore(value):
+            captured["value"] = value
+            return real_semaphore(value)
+
+        config = {"system_prompt": "sp", "tools": [], "evaluators": [], "test_cases": []}
+        env = env or {}
+        with patch.dict("os.environ", env, clear=False):
+            if "CALIBRATE_LLM_BENCHMARK_PARALLEL" not in env:
+                os.environ.pop("CALIBRATE_LLM_BENCHMARK_PARALLEL", None)
+            with patch.object(
+                BM, "run_model_tests", AsyncMock(return_value={"metrics": {}})
+            ), patch.object(BM.asyncio, "Semaphore", side_effect=fake_semaphore):
+                await BM._run_models(
+                    config=config,
+                    models=["m1", "m2", "m3"],
+                    provider="openrouter",
+                    output_dir="./out",
+                    max_parallel=max_parallel,
+                )
+        return captured["value"]
+
+    async def test_env_var_sets_model_parallelism(self):
+        value = await self._capture_semaphore(
+            env={"CALIBRATE_LLM_BENCHMARK_PARALLEL": "5"}
+        )
+        self.assertEqual(value, 5)
+
+    async def test_explicit_arg_overrides_env(self):
+        value = await self._capture_semaphore(
+            max_parallel=8, env={"CALIBRATE_LLM_BENCHMARK_PARALLEL": "5"}
+        )
+        self.assertEqual(value, 8)
+
+    async def test_zero_env_falls_back_to_default(self):
+        value = await self._capture_semaphore(
+            env={"CALIBRATE_LLM_BENCHMARK_PARALLEL": "0"}
+        )
+        self.assertEqual(value, 2)
+
+    async def test_default_when_unset(self):
+        value = await self._capture_semaphore()
+        self.assertEqual(value, 2)
+
+    async def test_benchmark_parallel_does_not_touch_test_parallel(self):
+        """The benchmark env var must not be forwarded as ``test_parallel``."""
+        from calibrate.llm import benchmark as BM
+
+        mock_run = AsyncMock(return_value={"metrics": {}})
+        config = {"system_prompt": "sp", "tools": [], "evaluators": [], "test_cases": []}
+        with patch.dict(
+            "os.environ",
+            {"CALIBRATE_LLM_BENCHMARK_PARALLEL": "5", "CALIBRATE_TEST_PARALLEL": "9"},
+            clear=False,
+        ):
+            with patch.object(BM, "run_model_tests", mock_run):
+                await BM._run_models(
+                    config=config,
+                    models=["m1"],
+                    provider="openrouter",
+                    output_dir="./out",
+                )
+        # test_parallel was not passed by the benchmark, so it stays None and the
+        # per-model run resolves CALIBRATE_TEST_PARALLEL itself downstream.
+        self.assertIsNone(mock_run.await_args.kwargs["test_parallel"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/llm/test_init_extra.py
+++ b/tests/llm/test_init_extra.py
@@ -56,6 +56,71 @@ class TestLLMTestsRun(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["status"], "completed")
         self.assertEqual(set(result["models"].keys()), {"m1", "m2"})
 
+    async def _capture_run_semaphore(self, *, max_parallel=None, env=None, agent=False):
+        """Run ``tests.run`` (multi-model) and capture the model-level Semaphore size."""
+        import asyncio
+        import calibrate.llm as llm_pkg
+        from calibrate.llm import tests
+
+        # The model-level semaphore is created first in tests.run, before any
+        # per-model test-case-level semaphore, so values[0] is the model-level size.
+        values = []
+        real_semaphore = asyncio.Semaphore
+
+        def fake_semaphore(value):
+            values.append(value)
+            return real_semaphore(value)
+
+        fake_test_result = {
+            "output": {"response": "Hi", "tool_calls": []},
+            "metrics": {"passed": True, "judge_results": {}},
+        }
+        env = env or {}
+        fake_agent = MagicMock() if agent else None
+        target = "run_test_external" if agent else "run_test"
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch.dict("os.environ", env, clear=False), \
+             patch(f"calibrate.llm.run_tests.{target}",
+                   AsyncMock(return_value=fake_test_result)), \
+             patch.object(llm_pkg.asyncio, "Semaphore", side_effect=fake_semaphore):
+            if "CALIBRATE_LLM_BENCHMARK_PARALLEL" not in env:
+                os.environ.pop("CALIBRATE_LLM_BENCHMARK_PARALLEL", None)
+            await tests.run(
+                test_cases=[{
+                    "history": [{"role": "user", "content": "hi"}],
+                    "evaluation": {"type": "response", "criteria": "x"},
+                }],
+                output_dir=tmp,
+                models=["m1", "m2"],
+                max_parallel=max_parallel,
+                agent=fake_agent,
+            )
+        return values[0]
+
+    async def test_run_model_parallel_env_var(self):
+        value = await self._capture_run_semaphore(
+            env={"CALIBRATE_LLM_BENCHMARK_PARALLEL": "5"}
+        )
+        self.assertEqual(value, 5)
+
+    async def test_run_model_parallel_arg_overrides_env(self):
+        value = await self._capture_run_semaphore(
+            max_parallel=8, env={"CALIBRATE_LLM_BENCHMARK_PARALLEL": "5"}
+        )
+        self.assertEqual(value, 8)
+
+    async def test_run_model_parallel_zero_env_default(self):
+        value = await self._capture_run_semaphore(
+            env={"CALIBRATE_LLM_BENCHMARK_PARALLEL": "0"}
+        )
+        self.assertEqual(value, 2)
+
+    async def test_run_model_parallel_agent_path_uses_resolver(self):
+        value = await self._capture_run_semaphore(
+            env={"CALIBRATE_LLM_BENCHMARK_PARALLEL": "6"}, agent=True
+        )
+        self.assertEqual(value, 6)
+
     async def test_run_multi_model_with_exception(self):
         from calibrate.llm import tests
 

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -67,7 +67,8 @@ class TestLLMBenchmarkMain(unittest.IsolatedAsyncioTestCase):
                             "leaderboard_dir": tmp,
                             "models": {"m1": {"metrics": {"passed": 1, "total": 1}}}}
             with patch.object(sys, "argv", argv), \
-                 patch.object(B, "run", AsyncMock(return_value=fake_results)):
+                 patch.object(B, "_run_models",
+                              AsyncMock(return_value=fake_results["models"])):
                 await B.main()
 
     async def test_main_error_path_exits(self):
@@ -84,7 +85,8 @@ class TestLLMBenchmarkMain(unittest.IsolatedAsyncioTestCase):
                             "leaderboard_dir": tmp,
                             "models": {"m1": {"status": "error", "error": "boom"}}}
             with patch.object(sys, "argv", argv), \
-                 patch.object(B, "run", AsyncMock(return_value=fake_results)):
+                 patch.object(B, "_run_models",
+                              AsyncMock(return_value=fake_results["models"])):
                 with self.assertRaises(SystemExit):
                     await B.main()
 
@@ -106,7 +108,8 @@ class TestLLMBenchmarkMain(unittest.IsolatedAsyncioTestCase):
                             "models": {"m1": {"metrics": {"passed": 1, "total": 1}}}}
             with patch.object(sys, "argv", argv), \
                  patch.dict(os.environ, {"CALIBRATE_LLM_LOG_APPEND": "1"}), \
-                 patch.object(B, "run", AsyncMock(return_value=fake_results)):
+                 patch.object(B, "_run_models",
+                              AsyncMock(return_value=fake_results["models"])):
                 await B.main()
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -258,17 +258,12 @@ class TestAgentBenchmark:
             f"'Overall Summary' not in stdout.\nstdout: {result.stdout}"
         )
 
-    def test_models_run_in_order(self, agent_config):
-        """gpt-4.1 output appears before gpt-5.1 output in stdout."""
+    def test_both_models_present_in_output(self, agent_config):
+        """Both models appear in stdout (order-agnostic — models run in parallel)."""
         result, _, _ = self._run_benchmark(agent_config)
         stdout = result.stdout
-        pos_41 = stdout.find("gpt-4.1")
-        pos_51 = stdout.find("gpt-5.1")
-        assert pos_41 != -1, "gpt-4.1 not found in stdout"
-        assert pos_51 != -1, "gpt-5.1 not found in stdout"
-        assert pos_41 < pos_51, (
-            "Expected gpt-4.1 to appear before gpt-5.1 in stdout"
-        )
+        assert "gpt-4.1" in stdout, "gpt-4.1 not found in stdout"
+        assert "gpt-5.1" in stdout, "gpt-5.1 not found in stdout"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Refactor the agent-connection LLM benchmark path to reuse `run_benchmark_cli` so models run in parallel with a shared logfile, leaderboard, and consolidated summary (previously one model at a time).
- Add configurable benchmark-level parallelism for LLM: `--benchmark-parallel` flag and `CALIBRATE_LLM_BENCHMARK_PARALLEL` env var, resolved via `resolve_benchmark_parallel` (flag > env > default 2).

## Changes
- `calibrate/llm/_output.py`, `calibrate/llm/__init__.py`, `calibrate/llm/benchmark.py`: parallel model runner + `run_benchmark_cli` scaffolding.
- `calibrate/utils.py`: `resolve_benchmark_parallel` + `DEFAULT_BENCHMARK_PARALLEL`.
- `calibrate/cli.py`: agent-path refactor + LLM `--benchmark-parallel` wiring.
- Tests: `tests/llm/test_benchmark.py`, `tests/llm/test_init_extra.py`, `tests/test_cli.py`.

## Test plan
- [ ] `uv run pytest tests/llm/test_benchmark.py tests/llm/test_init_extra.py tests/test_cli.py`

Note: shares the `resolve_benchmark_parallel` addition in `utils.py` with the STT/TTS benchmark-parallel PR; whichever merges second needs a trivial rebase.

Made with [Cursor](https://cursor.com)