### PR TITLE
Make STT/TTS benchmark-level parallelism configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,12 @@ CALIBRATE_TEST_PARALLEL=4
 # Overridden by the -n/--parallel CLI flag.
 CALIBRATE_SIMULATION_PARALLEL=2
 
+# Max providers/models a benchmark runs concurrently (defaults to 2 if unset).
+# Overridden by the --benchmark-parallel CLI flag.
+# CALIBRATE_STT_BENCHMARK_PARALLEL=2
+# CALIBRATE_TTS_BENCHMARK_PARALLEL=2
+# CALIBRATE_LLM_BENCHMARK_PARALLEL=2
+
 # langfuse
 ENVIRONMENT=development # langfuse tracing environment
 ENABLE_TRACING=true

--- a/calibrate/cli.py
+++ b/calibrate/cli.py
@@ -209,6 +209,12 @@ Examples:
     stt_parser.add_argument("--ignore_retry", action="store_true")
     stt_parser.add_argument("--overwrite", action="store_true")
     stt_parser.add_argument(
+        "--benchmark-parallel",
+        type=int,
+        default=None,
+        help="Number of providers to evaluate in parallel (overrides CALIBRATE_STT_BENCHMARK_PARALLEL; default 2)",
+    )
+    stt_parser.add_argument(
         "--leaderboard",
         action="store_true",
         help="Generate leaderboard after evaluation (for single provider)",
@@ -254,6 +260,12 @@ Examples:
     tts_parser.add_argument("-d", "--debug", action="store_true")
     tts_parser.add_argument("-dc", "--debug_count", type=int, default=5)
     tts_parser.add_argument("--overwrite", action="store_true")
+    tts_parser.add_argument(
+        "--benchmark-parallel",
+        type=int,
+        default=None,
+        help="Number of providers to evaluate in parallel (overrides CALIBRATE_TTS_BENCHMARK_PARALLEL; default 2)",
+    )
     tts_parser.add_argument(
         "--leaderboard",
         action="store_true",
@@ -491,6 +503,8 @@ Examples:
                 argv.extend(["-s", args.save_dir])
             if args.config:
                 argv.extend(["--config", args.config])
+            if args.benchmark_parallel is not None:
+                argv.extend(["--benchmark-parallel", str(args.benchmark_parallel)])
 
             sys.argv = argv
             asyncio.run(stt_benchmark_main())
@@ -514,6 +528,8 @@ Examples:
                 argv.append("--overwrite")
             if args.config:
                 argv.extend(["--config", args.config])
+            if args.benchmark_parallel is not None:
+                argv.extend(["--benchmark-parallel", str(args.benchmark_parallel)])
 
             sys.argv = argv
             asyncio.run(tts_benchmark_main())

--- a/calibrate/stt/benchmark.py
+++ b/calibrate/stt/benchmark.py
@@ -32,11 +32,7 @@ from calibrate.stt.eval import (
     STT_LANGUAGES,
 )
 from calibrate.stt.leaderboard import generate_leaderboard
-from calibrate.utils import StreamTee
-
-
-# Maximum number of providers to run in parallel
-MAX_PARALLEL_PROVIDERS = 2
+from calibrate.utils import StreamTee, resolve_benchmark_parallel
 
 
 async def run(
@@ -74,7 +70,7 @@ async def run(
     debug_count: int = 5,
     ignore_retry: bool = False,
     overwrite: bool = False,
-    max_parallel: int = MAX_PARALLEL_PROVIDERS,
+    max_parallel: int | None = None,
     judge_evaluators: list[dict] = None,
 ) -> dict:
     """
@@ -92,7 +88,9 @@ async def run(
         debug_count: Number of audio files to run in debug mode (default: 5)
         ignore_retry: Skip retry if not all audios are processed
         overwrite: Overwrite existing results instead of resuming from checkpoint (default: False)
-        max_parallel: Maximum number of providers to run in parallel (default: 2)
+        max_parallel: Maximum number of providers to run in parallel. Resolves
+            CLI flag / SDK arg > ``CALIBRATE_STT_BENCHMARK_PARALLEL`` env var >
+            default 2.
         judge_evaluators: Optional list of evaluator dicts (each with ``name``,
             ``system_prompt``, ``judge_model``, ``type``, ...). When omitted
             the implicit default STT evaluator runs.
@@ -111,6 +109,7 @@ async def run(
         ... ))
     """
     results = {}
+    max_parallel = resolve_benchmark_parallel("stt", max_parallel)
     semaphore = asyncio.Semaphore(max_parallel)
 
     async def run_provider(provider: str) -> tuple[str, dict]:
@@ -239,6 +238,12 @@ async def main():
         default=None,
         help="Path to optional JSON config file with an `evaluators` list",
     )
+    parser.add_argument(
+        "--benchmark-parallel",
+        type=int,
+        default=None,
+        help="Number of providers to evaluate in parallel (overrides CALIBRATE_STT_BENCHMARK_PARALLEL)",
+    )
 
     args = parser.parse_args()
 
@@ -350,6 +355,7 @@ async def main():
             debug_count=args.debug_count,
             ignore_retry=args.ignore_retry,
             overwrite=args.overwrite,
+            max_parallel=args.benchmark_parallel,
             judge_evaluators=judge_evaluators,
         )
 

--- a/calibrate/tts/benchmark.py
+++ b/calibrate/tts/benchmark.py
@@ -27,10 +27,7 @@ from calibrate.tts.eval import (
     validate_tts_input_file,
 )
 from calibrate.tts.leaderboard import generate_leaderboard
-from calibrate.utils import StreamTee
-
-# Maximum number of providers to run in parallel
-MAX_PARALLEL_PROVIDERS = 2
+from calibrate.utils import StreamTee, resolve_benchmark_parallel
 
 
 async def run(
@@ -58,7 +55,7 @@ async def run(
     debug: bool = False,
     debug_count: int = 5,
     overwrite: bool = False,
-    max_parallel: int = MAX_PARALLEL_PROVIDERS,
+    max_parallel: int | None = None,
     judge_evaluators: list[dict] = None,
 ) -> dict:
     """
@@ -74,7 +71,8 @@ async def run(
         debug: Run evaluation on first N texts only
         debug_count: Number of texts to run in debug mode (default: 5)
         overwrite: Overwrite existing results instead of resuming from checkpoint (default: False)
-        max_parallel: Maximum number of providers to run in parallel (default: 2)
+        max_parallel: Maximum number of providers to run in parallel. Resolved via
+            CLI flag / SDK arg > ``CALIBRATE_TTS_BENCHMARK_PARALLEL`` env var > default 2.
         judge_evaluators: Optional list of evaluator dicts (each with ``name``,
             ``system_prompt``, ``judge_model``, ``type``, ...). When omitted
             the implicit default TTS evaluator runs.
@@ -93,6 +91,7 @@ async def run(
         ... ))
     """
     results = {}
+    max_parallel = resolve_benchmark_parallel("tts", max_parallel)
     semaphore = asyncio.Semaphore(max_parallel)
 
     async def run_provider(provider: str) -> tuple[str, dict]:
@@ -192,6 +191,12 @@ async def main():
         default=None,
         help="Path to optional JSON config file with an `evaluators` list",
     )
+    parser.add_argument(
+        "--benchmark-parallel",
+        type=int,
+        default=None,
+        help="Number of providers to evaluate in parallel (overrides CALIBRATE_TTS_BENCHMARK_PARALLEL)",
+    )
 
     args = parser.parse_args()
 
@@ -251,6 +256,7 @@ async def main():
             debug=args.debug,
             debug_count=args.debug_count,
             overwrite=args.overwrite,
+            max_parallel=args.benchmark_parallel,
             judge_evaluators=judge_evaluators,
         )
 

--- a/calibrate/utils.py
+++ b/calibrate/utils.py
@@ -23,6 +23,34 @@ from pipecat.transcriptions.language import Language
 current_context: ContextVar[str] = ContextVar("current_context", default="UNKNOWN")
 
 
+# Default number of providers/models a benchmark runs concurrently.
+DEFAULT_BENCHMARK_PARALLEL = 2
+
+
+def resolve_benchmark_parallel(
+    component: Literal["stt", "tts", "llm"], cli_value: Optional[int] = None
+) -> int:
+    """Resolve how many providers/models a benchmark runs concurrently.
+
+    Precedence: explicit ``cli_value`` (CLI flag / SDK arg) >
+    ``CALIBRATE_{STT,TTS,LLM}_BENCHMARK_PARALLEL`` env var > default (2).
+
+    Non-positive or unparseable values are ignored so callers always get a
+    sane positive concurrency.
+    """
+    if cli_value is not None and cli_value > 0:
+        return cli_value
+    env_value = os.getenv(f"CALIBRATE_{component.upper()}_BENCHMARK_PARALLEL")
+    if env_value:
+        try:
+            parsed = int(env_value)
+            if parsed > 0:
+                return parsed
+        except ValueError:
+            pass
+    return DEFAULT_BENCHMARK_PARALLEL
+
+
 def patch_langfuse_trace(trace_name: str):
     from pipecat.utils.tracing import service_decorators
 

--- a/tests/stt/test_benchmark.py
+++ b/tests/stt/test_benchmark.py
@@ -1,0 +1,84 @@
+import os
+import unittest
+from unittest.mock import patch, AsyncMock
+
+from calibrate.utils import resolve_benchmark_parallel, DEFAULT_BENCHMARK_PARALLEL
+
+
+class TestResolveBenchmarkParallelStt(unittest.TestCase):
+    def test_cli_value_takes_precedence(self):
+        with patch.dict("os.environ", {"CALIBRATE_STT_BENCHMARK_PARALLEL": "7"}):
+            self.assertEqual(resolve_benchmark_parallel("stt", 3), 3)
+
+    def test_env_var_used_when_no_cli(self):
+        with patch.dict("os.environ", {"CALIBRATE_STT_BENCHMARK_PARALLEL": "7"}):
+            self.assertEqual(resolve_benchmark_parallel("stt", None), 7)
+
+    def test_default_when_neither_set(self):
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("CALIBRATE_STT_BENCHMARK_PARALLEL", None)
+            self.assertEqual(
+                resolve_benchmark_parallel("stt", None), DEFAULT_BENCHMARK_PARALLEL
+            )
+
+    def test_invalid_env_falls_back_to_default(self):
+        with patch.dict("os.environ", {"CALIBRATE_STT_BENCHMARK_PARALLEL": "abc"}):
+            self.assertEqual(
+                resolve_benchmark_parallel("stt", None), DEFAULT_BENCHMARK_PARALLEL
+            )
+
+    def test_non_positive_values_ignored(self):
+        with patch.dict("os.environ", {"CALIBRATE_STT_BENCHMARK_PARALLEL": "0"}):
+            # CLI 0 ignored, env 0 ignored -> default
+            self.assertEqual(
+                resolve_benchmark_parallel("stt", 0), DEFAULT_BENCHMARK_PARALLEL
+            )
+
+
+class TestRunBuildsSemaphoreFromResolvedParallel(unittest.IsolatedAsyncioTestCase):
+    """``run`` must size its provider semaphore via ``resolve_benchmark_parallel``."""
+
+    async def _run_and_capture_semaphore_value(self, *, max_parallel):
+        captured = {}
+        real_semaphore = __import__("asyncio").Semaphore
+
+        def _spy_semaphore(value, *args, **kwargs):
+            captured["value"] = value
+            return real_semaphore(value, *args, **kwargs)
+
+        with patch(
+            "calibrate.stt.benchmark.run_single_provider_eval",
+            new=AsyncMock(return_value={"status": "completed", "metrics": {}}),
+        ), patch(
+            "calibrate.stt.benchmark.generate_leaderboard"
+        ), patch(
+            "calibrate.stt.benchmark.asyncio.Semaphore", side_effect=_spy_semaphore
+        ):
+            from calibrate.stt.benchmark import run
+
+            await run(
+                providers=["deepgram"],
+                input_dir="/tmp/does-not-matter",
+                output_dir="/tmp/out",
+                max_parallel=max_parallel,
+            )
+        return captured["value"]
+
+    async def test_env_var_sets_parallelism(self):
+        with patch.dict("os.environ", {"CALIBRATE_STT_BENCHMARK_PARALLEL": "5"}):
+            value = await self._run_and_capture_semaphore_value(max_parallel=None)
+        self.assertEqual(value, 5)
+
+    async def test_explicit_arg_overrides_env(self):
+        with patch.dict("os.environ", {"CALIBRATE_STT_BENCHMARK_PARALLEL": "5"}):
+            value = await self._run_and_capture_semaphore_value(max_parallel=3)
+        self.assertEqual(value, 3)
+
+    async def test_invalid_env_falls_back_to_default(self):
+        with patch.dict("os.environ", {"CALIBRATE_STT_BENCHMARK_PARALLEL": "0"}):
+            value = await self._run_and_capture_semaphore_value(max_parallel=None)
+        self.assertEqual(value, DEFAULT_BENCHMARK_PARALLEL)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tts/test_benchmark.py
+++ b/tests/tts/test_benchmark.py
@@ -1,0 +1,99 @@
+"""Coverage for tts/benchmark.py — benchmark-parallel resolution."""
+
+import asyncio
+import unittest
+from unittest.mock import patch, AsyncMock
+
+
+class TestResolveBenchmarkParallel(unittest.TestCase):
+    def test_env_var_sets_parallelism(self):
+        from calibrate.utils import resolve_benchmark_parallel
+
+        with patch.dict("os.environ", {"CALIBRATE_TTS_BENCHMARK_PARALLEL": "5"}):
+            self.assertEqual(resolve_benchmark_parallel("tts", None), 5)
+
+    def test_explicit_value_overrides_env(self):
+        from calibrate.utils import resolve_benchmark_parallel
+
+        with patch.dict("os.environ", {"CALIBRATE_TTS_BENCHMARK_PARALLEL": "5"}):
+            self.assertEqual(resolve_benchmark_parallel("tts", 3), 3)
+
+    def test_invalid_env_falls_back_to_default(self):
+        from calibrate.utils import resolve_benchmark_parallel, DEFAULT_BENCHMARK_PARALLEL
+
+        with patch.dict("os.environ", {"CALIBRATE_TTS_BENCHMARK_PARALLEL": "abc"}):
+            self.assertEqual(
+                resolve_benchmark_parallel("tts", None), DEFAULT_BENCHMARK_PARALLEL
+            )
+        self.assertEqual(DEFAULT_BENCHMARK_PARALLEL, 2)
+
+    def test_zero_env_falls_back_to_default(self):
+        from calibrate.utils import resolve_benchmark_parallel, DEFAULT_BENCHMARK_PARALLEL
+
+        with patch.dict("os.environ", {"CALIBRATE_TTS_BENCHMARK_PARALLEL": "0"}):
+            self.assertEqual(
+                resolve_benchmark_parallel("tts", None), DEFAULT_BENCHMARK_PARALLEL
+            )
+
+
+class TestRunBenchmarkParallel(unittest.IsolatedAsyncioTestCase):
+    async def _run_and_measure_peak(self, env, max_parallel):
+        """Run the benchmark with a fake provider eval and return peak concurrency."""
+        from calibrate.tts import benchmark as B
+
+        concurrency = {"current": 0, "peak": 0}
+        gate = asyncio.Event()
+        n_providers = 6
+        started = {"count": 0}
+
+        async def fake_eval(**kwargs):
+            concurrency["current"] += 1
+            concurrency["peak"] = max(concurrency["peak"], concurrency["current"])
+            started["count"] += 1
+            # Once all providers that *can* run concurrently have started, release.
+            if started["count"] >= n_providers:
+                gate.set()
+            try:
+                await asyncio.wait_for(gate.wait(), timeout=1.0)
+            except asyncio.TimeoutError:
+                pass
+            concurrency["current"] -= 1
+            return {"status": "ok", "metrics": {}}
+
+        providers = [f"p{i}" for i in range(n_providers)]
+        with patch.dict("os.environ", env, clear=False):
+            import os
+
+            if not env:
+                os.environ.pop("CALIBRATE_TTS_BENCHMARK_PARALLEL", None)
+            with patch.object(
+                B, "run_single_provider_eval", AsyncMock(side_effect=fake_eval)
+            ), patch.object(B, "generate_leaderboard", lambda **k: None):
+                await B.run(
+                    input="x.csv",
+                    providers=providers,
+                    language="english",
+                    output_dir="./out",
+                    max_parallel=max_parallel,
+                )
+        return concurrency["peak"]
+
+    async def test_env_var_bounds_concurrency(self):
+        peak = await self._run_and_measure_peak(
+            {"CALIBRATE_TTS_BENCHMARK_PARALLEL": "3"}, None
+        )
+        self.assertEqual(peak, 3)
+
+    async def test_explicit_max_parallel_overrides_env(self):
+        peak = await self._run_and_measure_peak(
+            {"CALIBRATE_TTS_BENCHMARK_PARALLEL": "3"}, 2
+        )
+        self.assertEqual(peak, 2)
+
+    async def test_default_when_env_unset(self):
+        peak = await self._run_and_measure_peak({}, None)
+        self.assertEqual(peak, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add configurable benchmark-level (provider) parallelism for STT and TTS: `--benchmark-parallel` flag and `CALIBRATE_{STT,TTS}_BENCHMARK_PARALLEL` env vars, resolved via `resolve_benchmark_parallel` (flag > env > default 2), replacing the hardcoded `MAX_PARALLEL_PROVIDERS`.

## Changes
- `calibrate/utils.py`: `resolve_benchmark_parallel` + `DEFAULT_BENCHMARK_PARALLEL`.
- `calibrate/stt/benchmark.py`, `calibrate/tts/benchmark.py`: resolve provider concurrency from flag/env; `--benchmark-parallel` CLI arg.
- `calibrate/cli.py`: forward `--benchmark-parallel` for the `stt`/`tts` subcommands.
- `.env.example`: document the benchmark env vars.
- Tests: `tests/stt/test_benchmark.py`, `tests/tts/test_benchmark.py`.

## Test plan
- [ ] `uv run pytest tests/stt/test_benchmark.py tests/tts/test_benchmark.py`

Note: shares the `resolve_benchmark_parallel` addition in `utils.py` with the LLM benchmark PR, and touches the same benchmark modules / cli.py / .env.example as the STT/TTS row-level parallelism PR (different hunks); whichever merges second needs a trivial rebase.

Made with [Cursor](https://cursor.com)