### PR TITLE
Add row-level parallelism to STT/TTS evaluations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,12 @@ CALIBRATE_TEST_PARALLEL=4
 # Overridden by the -n/--parallel CLI flag.
 CALIBRATE_SIMULATION_PARALLEL=2
 
+# Max rows (audio files / texts) a single STT/TTS provider processes
+# concurrently within one evaluation (defaults to 4 if unset).
+# Overridden by the -n/--parallel CLI flag.
+# CALIBRATE_STT_PARALLEL=4
+# CALIBRATE_TTS_PARALLEL=4
+
 # langfuse
 ENVIRONMENT=development # langfuse tracing environment
 ENABLE_TRACING=true

--- a/calibrate/cli.py
+++ b/calibrate/cli.py
@@ -206,6 +206,13 @@ Examples:
     stt_parser.add_argument("-f", "--input-file-name", type=str, default="stt.csv")
     stt_parser.add_argument("-d", "--debug", action="store_true")
     stt_parser.add_argument("-dc", "--debug_count", type=int, default=5)
+    stt_parser.add_argument(
+        "-n",
+        "--parallel",
+        type=int,
+        default=None,
+        help="Number of audio files to transcribe in parallel per provider",
+    )
     stt_parser.add_argument("--ignore_retry", action="store_true")
     stt_parser.add_argument("--overwrite", action="store_true")
     stt_parser.add_argument(
@@ -253,6 +260,13 @@ Examples:
     tts_parser.add_argument("-o", "--output-dir", type=str, default="./out")
     tts_parser.add_argument("-d", "--debug", action="store_true")
     tts_parser.add_argument("-dc", "--debug_count", type=int, default=5)
+    tts_parser.add_argument(
+        "-n",
+        "--parallel",
+        type=int,
+        default=None,
+        help="Number of texts to synthesize in parallel per provider",
+    )
     tts_parser.add_argument("--overwrite", action="store_true")
     tts_parser.add_argument(
         "--leaderboard",
@@ -487,6 +501,8 @@ Examples:
                 argv.append("--ignore_retry")
             if args.overwrite:
                 argv.append("--overwrite")
+            if args.parallel is not None:
+                argv.extend(["-n", str(args.parallel)])
             if args.save_dir:
                 argv.extend(["-s", args.save_dir])
             if args.config:
@@ -512,6 +528,8 @@ Examples:
             argv.extend(["-dc", str(args.debug_count)])
             if args.overwrite:
                 argv.append("--overwrite")
+            if args.parallel is not None:
+                argv.extend(["-n", str(args.parallel)])
             if args.config:
                 argv.extend(["--config", args.config])
 

--- a/calibrate/stt/benchmark.py
+++ b/calibrate/stt/benchmark.py
@@ -75,6 +75,7 @@ async def run(
     ignore_retry: bool = False,
     overwrite: bool = False,
     max_parallel: int = MAX_PARALLEL_PROVIDERS,
+    row_parallel: int = None,
     judge_evaluators: list[dict] = None,
 ) -> dict:
     """
@@ -93,6 +94,9 @@ async def run(
         ignore_retry: Skip retry if not all audios are processed
         overwrite: Overwrite existing results instead of resuming from checkpoint (default: False)
         max_parallel: Maximum number of providers to run in parallel (default: 2)
+        row_parallel: Maximum number of audio files to transcribe in parallel
+            per provider. Resolves CLI flag / SDK arg > ``CALIBRATE_STT_PARALLEL``
+            env var > default 4.
         judge_evaluators: Optional list of evaluator dicts (each with ``name``,
             ``system_prompt``, ``judge_model``, ``type``, ...). When omitted
             the implicit default STT evaluator runs.
@@ -126,6 +130,7 @@ async def run(
                 debug_count=debug_count,
                 ignore_retry=ignore_retry,
                 overwrite=overwrite,
+                row_parallel=row_parallel,
                 judge_evaluators=judge_evaluators,
             )
             return (provider, result)
@@ -239,6 +244,13 @@ async def main():
         default=None,
         help="Path to optional JSON config file with an `evaluators` list",
     )
+    parser.add_argument(
+        "-n",
+        "--parallel",
+        type=int,
+        default=None,
+        help="Number of audio files to transcribe in parallel per provider",
+    )
 
     args = parser.parse_args()
 
@@ -350,6 +362,7 @@ async def main():
             debug_count=args.debug_count,
             ignore_retry=args.ignore_retry,
             overwrite=args.overwrite,
+            row_parallel=args.parallel,
             judge_evaluators=judge_evaluators,
         )
 

--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -30,6 +30,7 @@ from calibrate.utils import (
     validate_stt_language,
     provider_log as _log,
     provider_log_file as _current_log_file,
+    resolve_row_parallel,
 )
 from calibrate.stt.metrics import (
     get_wer_score,
@@ -636,8 +637,17 @@ async def run_stt_eval(
     provider: str,
     language: str,
     results_csv_path: Path,
+    row_parallel: int = None,
 ) -> int:
-    """Process audio files and save results immediately to CSV.
+    """Process audio files concurrently and save results to CSV.
+
+    Audio files are transcribed with bounded concurrency (capped by
+    ``resolve_row_parallel("stt", row_parallel)``). Files whose ``id`` already
+    appears in an existing ``results.csv`` are skipped, so a re-run resumes
+    where a previous run left off. New results are written in input
+    (``gt_data``) order regardless of completion order — existing rows first,
+    then the freshly processed rows by their original index — and the partial
+    CSV is rewritten after each row completes for crash recovery.
 
     Args:
         gt_data: List of {"id": ..., "gt": ...} for each file to process
@@ -645,6 +655,8 @@ async def run_stt_eval(
         provider: STT provider name
         language: Language code
         results_csv_path: Path to save results CSV
+        row_parallel: Max audio files to transcribe concurrently. Resolves
+            CLI/SDK arg > ``CALIBRATE_STT_PARALLEL`` env var > default.
 
     Returns:
         Number of files successfully transcribed (non-empty) in this run.
@@ -652,46 +664,59 @@ async def run_stt_eval(
     # Load existing results to skip already processed files
     if exists(results_csv_path):
         existing_df = pd.read_csv(results_csv_path)
-        results = existing_df.to_dict("records")
+        existing_results = existing_df.to_dict("records")
         processed_ids = set(existing_df["id"].tolist())
     else:
-        results = []
+        existing_results = []
         processed_ids = set()
 
     success_count = 0
 
     unique_id = str(uuid.uuid4())
 
-    for i, gt_info in enumerate(gt_data):
-        # Skip if already processed
-        if gt_info["id"] in processed_ids:
-            continue
+    pending = [
+        (i, gt_info)
+        for i, gt_info in enumerate(gt_data)
+        if gt_info["id"] not in processed_ids
+    ]
+
+    semaphore = asyncio.Semaphore(resolve_row_parallel("stt", row_parallel))
+    write_lock = asyncio.Lock()
+    new_results: dict[int, dict] = {}
+
+    async def process_one(index: int, gt_info: Dict) -> None:
+        nonlocal success_count
 
         audio_path = audio_dir / f"{gt_info['id']}.wav"
 
-        _log(f"--------------------------------")
-        _log(f"Processing audio [{i + 1}/{len(gt_data)}]: {audio_path.name}")
-
-        try:
-            transcript = await transcribe_audio(
-                audio_path, gt_info["gt"], provider, language, unique_id
+        async with semaphore:
+            _log(f"--------------------------------")
+            _log(
+                f"Processing audio [{index + 1}/{len(gt_data)}]: {audio_path.name}"
             )
-            _log(f"\033[33mTranscript: {transcript}\033[0m")
-            if transcript:
-                success_count += 1
-        except Exception as e:
-            _log(f"\033[91mFailed to transcribe {audio_path}: {e}\033[0m")
-            raise
 
-        # Save immediately after each file
-        results.append(
-            {
+            try:
+                transcript = await transcribe_audio(
+                    audio_path, gt_info["gt"], provider, language, unique_id
+                )
+                _log(f"\033[33mTranscript: {transcript}\033[0m")
+            except Exception as e:
+                _log(f"\033[91mFailed to transcribe {audio_path}: {e}\033[0m")
+                raise
+
+        async with write_lock:
+            new_results[index] = {
                 "id": gt_info["id"],
                 "gt": gt_info["gt"],
                 "pred": transcript,
             }
-        )
-        pd.DataFrame(results).to_csv(results_csv_path, index=False)
+            if transcript:
+                success_count += 1
+            pd.DataFrame(
+                existing_results + [new_results[k] for k in sorted(new_results)]
+            ).to_csv(results_csv_path, index=False)
+
+    await asyncio.gather(*[process_one(i, g) for i, g in pending])
 
     return success_count
 
@@ -851,6 +876,7 @@ async def run_single_provider_eval(
     debug_count: int,
     ignore_retry: bool,
     overwrite: bool,
+    row_parallel: int = None,
     judge_evaluators: list[dict] = None,
 ) -> dict:
     """Run STT evaluation for a single provider."""
@@ -955,6 +981,7 @@ async def run_single_provider_eval(
                 provider=provider,
                 language=language,
                 results_csv_path=results_csv_path,
+                row_parallel=row_parallel,
             )
 
             if ignore_retry:
@@ -1217,6 +1244,13 @@ async def main():
         action="store_true",
         help="Overwrite existing results instead of resuming from last checkpoint",
     )
+    parser.add_argument(
+        "-n",
+        "--parallel",
+        type=int,
+        default=None,
+        help="Number of audio files to transcribe in parallel",
+    )
 
     args = parser.parse_args()
 
@@ -1258,6 +1292,7 @@ async def main():
         debug_count=args.debug_count,
         ignore_retry=args.ignore_retry,
         overwrite=args.overwrite,
+        row_parallel=args.parallel,
     )
 
     # Print summary

--- a/calibrate/tts/benchmark.py
+++ b/calibrate/tts/benchmark.py
@@ -59,6 +59,7 @@ async def run(
     debug_count: int = 5,
     overwrite: bool = False,
     max_parallel: int = MAX_PARALLEL_PROVIDERS,
+    row_parallel: int = None,
     judge_evaluators: list[dict] = None,
 ) -> dict:
     """
@@ -75,6 +76,9 @@ async def run(
         debug_count: Number of texts to run in debug mode (default: 5)
         overwrite: Overwrite existing results instead of resuming from checkpoint (default: False)
         max_parallel: Maximum number of providers to run in parallel (default: 2)
+        row_parallel: Max texts to synthesize concurrently within each provider.
+            Resolved via CLI flag / SDK arg > ``CALIBRATE_TTS_PARALLEL`` env var >
+            default. Orthogonal to ``max_parallel`` (which bounds providers).
         judge_evaluators: Optional list of evaluator dicts (each with ``name``,
             ``system_prompt``, ``judge_model``, ``type``, ...). When omitted
             the implicit default TTS evaluator runs.
@@ -106,6 +110,7 @@ async def run(
                 debug=debug,
                 debug_count=debug_count,
                 overwrite=overwrite,
+                row_parallel=row_parallel,
                 judge_evaluators=judge_evaluators,
             )
             return (provider, result)
@@ -192,6 +197,13 @@ async def main():
         default=None,
         help="Path to optional JSON config file with an `evaluators` list",
     )
+    parser.add_argument(
+        "-n",
+        "--parallel",
+        type=int,
+        default=None,
+        help="Number of texts to synthesize in parallel per provider",
+    )
 
     args = parser.parse_args()
 
@@ -251,6 +263,7 @@ async def main():
             debug=args.debug,
             debug_count=args.debug_count,
             overwrite=args.overwrite,
+            row_parallel=args.parallel,
             judge_evaluators=judge_evaluators,
         )
 

--- a/calibrate/tts/eval.py
+++ b/calibrate/tts/eval.py
@@ -29,6 +29,7 @@ from calibrate.utils import (
     validate_tts_language,
     provider_log as _log,
     provider_log_file as _current_log_file,
+    resolve_row_parallel,
 )
 from calibrate.tts.metrics import get_tts_llm_judge_score
 from calibrate.judges import (
@@ -479,8 +480,17 @@ async def run_tts_eval(
     output_dir: str,
     results_csv_path: Path,
     overwrite: bool = False,
-) -> int:
-    """Process texts and synthesize speech, saving results immediately to CSV.
+    row_parallel: int = None,
+) -> dict:
+    """Process texts and synthesize speech concurrently, saving results to CSV.
+
+    Rows are processed concurrently with bounded parallelism (capped by
+    ``resolve_row_parallel("tts", row_parallel)``). Despite out-of-order
+    completion, output rows are written in input order: existing (resumed)
+    rows first, then newly synthesized rows ordered by their position in
+    ``gt_data``. The full CSV is rewritten under a write-lock after each row
+    completes so concurrent writes are safe and the partial file stays
+    crash-recoverable.
 
     Args:
         gt_data: List of {"id": ..., "text": ...} for each text to process
@@ -489,69 +499,81 @@ async def run_tts_eval(
         output_dir: Directory to save audio files
         results_csv_path: Path to save results CSV
         overwrite: If True, overwrite existing results instead of resuming
+        row_parallel: Max texts to synthesize concurrently. Resolved via
+            CLI/SDK arg > ``CALIBRATE_TTS_PARALLEL`` env var > default.
 
     Returns:
-        Number of texts successfully synthesized in this run.
+        dict with ``success_count`` (texts synthesized this run) and
+        ``ttfb_values`` (TTFBs reported by the provider this run).
     """
     # Load existing results to skip already processed texts (unless overwrite is True)
     if overwrite:
         processed_ids = set()
+        existing_records = []
         # Remove existing results file if overwriting
         if exists(results_csv_path):
             os.remove(results_csv_path)
     elif exists(results_csv_path):
         existing_df = pd.read_csv(results_csv_path)
+        existing_records = existing_df.to_dict("records")
         processed_ids = set(existing_df["id"].tolist())
     else:
         processed_ids = set()
+        existing_records = []
 
     audio_output_dir = join(output_dir, "audios")
     os.makedirs(audio_output_dir, exist_ok=True)
 
     success_count = 0
     ttfb_values = []
+    new_rows: dict[int, dict] = {}
 
-    for i, item in enumerate(gt_data):
+    pending = [
+        (i, item) for i, item in enumerate(gt_data) if item["id"] not in processed_ids
+    ]
+
+    semaphore = asyncio.Semaphore(resolve_row_parallel("tts", row_parallel))
+    write_lock = asyncio.Lock()
+
+    async def process_one(index: int, item: Dict) -> None:
+        nonlocal success_count
         _id = item["id"]
         text = item["text"]
 
-        # Skip if already processed
-        if _id in processed_ids:
-            _log(f"Skipping already processed: {_id}")
-            continue
-
-        _log(f"Processing [{i+1}/{len(gt_data)}]: {_id}")
-
         audio_path = join(audio_output_dir, f"{_id}.wav")
-        try:
-            result = await synthesize_speech(text, provider, language, audio_path)
-        except Exception as e:
-            _log(f"\033[91mFailed to synthesize {_id}: {e}\033[0m")
-            raise
+        async with semaphore:
+            _log(f"Processing [{index + 1}/{len(gt_data)}]: {_id}")
+            try:
+                result = await synthesize_speech(text, provider, language, audio_path)
+            except Exception as e:
+                _log(f"\033[91mFailed to synthesize {_id}: {e}\033[0m")
+                raise
 
         # Handle optional ttfb (some providers may not return it)
         ttfb = result.get("ttfb")
-        if ttfb is not None:
-            ttfb_values.append(ttfb)
 
-        # Prepare row data
-        row_data = {
-            "id": _id,
-            "text": text,
-            "audio_path": audio_path,
-            "ttfb": ttfb,
-        }
+        async with write_lock:
+            new_rows[index] = {
+                "id": _id,
+                "text": text,
+                "audio_path": audio_path,
+                "ttfb": ttfb,
+            }
+            if ttfb is not None:
+                ttfb_values.append(ttfb)
+            success_count += 1
 
-        # Append to CSV immediately for crash recovery
-        row_df = pd.DataFrame([row_data])
-        if exists(results_csv_path):
-            row_df.to_csv(results_csv_path, mode="a", header=False, index=False)
-        else:
-            row_df.to_csv(results_csv_path, index=False)
+            # Rewrite the full CSV (existing rows first, then new rows in input
+            # order) so concurrent writes stay deterministic and crash-safe.
+            ordered_new = [new_rows[k] for k in sorted(new_rows)]
+            pd.DataFrame(existing_records + ordered_new).to_csv(
+                results_csv_path, index=False
+            )
 
-        success_count += 1
-        if ttfb is not None:
-            _log(f"\n\033[93m  TTFB: {ttfb:.3f}s\033[0m")
+            if ttfb is not None:
+                _log(f"\n\033[93m  TTFB: {ttfb:.3f}s\033[0m")
+
+    await asyncio.gather(*[process_one(i, it) for i, it in pending])
 
     return {
         "success_count": success_count,
@@ -694,6 +716,7 @@ async def run_single_provider_eval(
     debug: bool,
     debug_count: int,
     overwrite: bool,
+    row_parallel: int = None,
     judge_evaluators: list[dict] = None,
 ) -> dict:
     """Run TTS evaluation for a single provider."""
@@ -748,6 +771,7 @@ async def run_single_provider_eval(
             output_dir=provider_output_dir,
             results_csv_path=results_csv_path,
             overwrite=overwrite,
+            row_parallel=row_parallel,
         )
 
         _log("--------------------------------")
@@ -906,6 +930,13 @@ async def main():
         action="store_true",
         help="Overwrite existing results instead of resuming from last checkpoint",
     )
+    parser.add_argument(
+        "-n",
+        "--parallel",
+        type=int,
+        default=None,
+        help="Number of texts to synthesize in parallel",
+    )
     args = parser.parse_args()
 
     provider = args.provider
@@ -944,6 +975,7 @@ async def main():
         debug=args.debug,
         debug_count=args.debug_count,
         overwrite=args.overwrite,
+        row_parallel=args.parallel,
     )
 
     # Print summary

--- a/calibrate/utils.py
+++ b/calibrate/utils.py
@@ -23,6 +23,40 @@ from pipecat.transcriptions.language import Language
 current_context: ContextVar[str] = ContextVar("current_context", default="UNKNOWN")
 
 
+# Default number of rows (audio files / texts) a single STT/TTS provider
+# processes concurrently within one evaluation.
+DEFAULT_ROW_PARALLEL = 4
+
+
+def resolve_row_parallel(
+    component: Literal["stt", "tts", "llm"], cli_value: Optional[int] = None
+) -> int:
+    """Resolve how many rows a single provider/model processes concurrently.
+
+    "Rows" are the per-item units of an evaluation — audio files for STT,
+    texts for TTS. This bounds the in-provider concurrency, orthogonal to
+    :func:`resolve_benchmark_parallel` which bounds how many providers/models
+    run at once.
+
+    Precedence: explicit ``cli_value`` (CLI flag / SDK arg) >
+    ``CALIBRATE_{STT,TTS,LLM}_PARALLEL`` env var > default (4).
+
+    Non-positive or unparseable values are ignored so callers always get a
+    sane positive concurrency.
+    """
+    if cli_value is not None and cli_value > 0:
+        return cli_value
+    env_value = os.getenv(f"CALIBRATE_{component.upper()}_PARALLEL")
+    if env_value:
+        try:
+            parsed = int(env_value)
+            if parsed > 0:
+                return parsed
+        except ValueError:
+            pass
+    return DEFAULT_ROW_PARALLEL
+
+
 def patch_langfuse_trace(trace_name: str):
     from pipecat.utils.tracing import service_decorators
 

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -5,6 +5,7 @@ Run with:
     python -m unittest tests.stt.test_eval -v
 """
 
+import asyncio
 import json
 import os
 import tempfile
@@ -367,6 +368,436 @@ class TestSTTRunEvalOnly(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(result["status"], "error")
         self.assertIn("does not exist", result["error"])
+
+
+class TestSTTRunSTTEvalParallel(unittest.IsolatedAsyncioTestCase):
+    @staticmethod
+    def _gt_data(ids):
+        return [{"id": i, "gt": f"gt {i}"} for i in ids]
+
+    async def test_concurrency_overlaps(self):
+        """With row_parallel=3 at least 3 rows are transcribed simultaneously."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c", "row_d", "row_e"]
+        release = asyncio.Event()
+        in_flight = 0
+        max_in_flight = 0
+        reached = asyncio.Event()
+        lock = asyncio.Lock()
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            nonlocal in_flight, max_in_flight
+            async with lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+                if in_flight >= 3:
+                    reached.set()
+            await release.wait()
+            async with lock:
+                in_flight -= 1
+            return f"pred {reference}"
+
+        async def releaser():
+            await reached.wait()
+            release.set()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "results.csv"
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                await asyncio.gather(
+                    stt_eval.run_stt_eval(
+                        gt_data=self._gt_data(ids),
+                        audio_dir=Path(tmp),
+                        provider="deepgram",
+                        language="english",
+                        results_csv_path=out,
+                        row_parallel=3,
+                    ),
+                    releaser(),
+                )
+
+        self.assertGreaterEqual(max_in_flight, 3)
+
+    async def test_output_order_matches_input(self):
+        """CSV rows preserve input order even when later rows finish first."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c", "row_d"]
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            # Later ids (lexicographically larger) return faster.
+            stem = audio_path.stem
+            delay = 0.05 * (len(ids) - ids.index(stem))
+            await asyncio.sleep(delay)
+            return f"pred-{stem}"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "results.csv"
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                count = await stt_eval.run_stt_eval(
+                    gt_data=self._gt_data(ids),
+                    audio_dir=Path(tmp),
+                    provider="deepgram",
+                    language="english",
+                    results_csv_path=out,
+                    row_parallel=4,
+                )
+
+            self.assertEqual(count, 4)
+            df = pd.read_csv(out)
+            self.assertEqual(df["id"].tolist(), ids)
+            self.assertEqual(df["pred"].tolist(), [f"pred-{i}" for i in ids])
+
+    async def test_resume_skips_processed_ids(self):
+        """Pre-seeded rows are kept, not re-transcribed, and new rows appended."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c"]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "results.csv"
+            # Pre-seed first two ids as already processed.
+            pd.DataFrame(
+                [
+                    {"id": "row_a", "gt": "gt row_a", "pred": "old_a"},
+                    {"id": "row_b", "gt": "gt row_b", "pred": "old_b"},
+                ]
+            ).to_csv(out, index=False)
+
+            seen = []
+
+            async def fake_transcribe(audio_path, reference, provider, language, uid):
+                seen.append(audio_path.stem)
+                return "new_c"
+
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                count = await stt_eval.run_stt_eval(
+                    gt_data=self._gt_data(ids),
+                    audio_dir=Path(tmp),
+                    provider="deepgram",
+                    language="english",
+                    results_csv_path=out,
+                    row_parallel=4,
+                )
+
+            self.assertEqual(seen, ["row_c"])  # only the unprocessed id
+            self.assertEqual(count, 1)
+            df = pd.read_csv(out)
+            self.assertEqual(df["id"].tolist(), ids)
+            self.assertEqual(
+                df["pred"].tolist(), ["old_a", "old_b", "new_c"]
+            )
+
+    async def test_row_parallel_limit_serializes(self):
+        """row_parallel=1 forces strictly serial transcription (no overlap)."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c"]
+        in_flight = 0
+        max_in_flight = 0
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            await asyncio.sleep(0.01)
+            in_flight -= 1
+            return "x"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "results.csv"
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                await stt_eval.run_stt_eval(
+                    gt_data=self._gt_data(ids),
+                    audio_dir=Path(tmp),
+                    provider="deepgram",
+                    language="english",
+                    results_csv_path=out,
+                    row_parallel=1,
+                )
+
+        self.assertEqual(max_in_flight, 1)
+
+    async def test_env_var_caps_concurrency(self):
+        """CALIBRATE_STT_PARALLEL caps concurrency when no row_parallel passed."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c", "row_d"]
+        in_flight = 0
+        max_in_flight = 0
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            await asyncio.sleep(0.01)
+            in_flight -= 1
+            return "x"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "results.csv"
+            with patch.dict(
+                "os.environ", {"CALIBRATE_STT_PARALLEL": "2"}
+            ), patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                await stt_eval.run_stt_eval(
+                    gt_data=self._gt_data(ids),
+                    audio_dir=Path(tmp),
+                    provider="deepgram",
+                    language="english",
+                    results_csv_path=out,
+                )
+
+        self.assertLessEqual(max_in_flight, 2)
+
+    async def test_failure_propagates(self):
+        """An exception from transcribe_audio bubbles out of run_stt_eval."""
+        from calibrate.stt import eval as stt_eval
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            raise RuntimeError("boom")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "results.csv"
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                with self.assertRaises(RuntimeError):
+                    await stt_eval.run_stt_eval(
+                        gt_data=self._gt_data(["row_a"]),
+                        audio_dir=Path(tmp),
+                        provider="deepgram",
+                        language="english",
+                        results_csv_path=out,
+                        row_parallel=2,
+                    )
+
+
+class TestRunSTTEvalRowParallel(unittest.IsolatedAsyncioTestCase):
+    """Row-level concurrency behaviour of ``run_stt_eval``."""
+
+    @staticmethod
+    def _gt_data(ids):
+        # Non-numeric ids on purpose: pandas coerces numeric-looking ids to
+        # int on CSV round-trip, which breaks the resume id comparison.
+        return [{"id": i, "gt": f"gt {i}"} for i in ids]
+
+    @staticmethod
+    def _make_audio(audio_dir: Path, ids):
+        for i in ids:
+            (audio_dir / f"{i}.wav").write_bytes(b"RIFF0000WAVE")
+
+    async def test_concurrency_actually_overlaps(self):
+        """row_parallel=3 over 5 rows reaches a peak in-flight of >= 3."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c", "row_d", "row_e"]
+        row_parallel = 3
+        in_flight = 0
+        max_in_flight = 0
+        counter_lock = asyncio.Lock()
+        release = asyncio.Event()
+        reached = asyncio.Event()
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            nonlocal in_flight, max_in_flight
+            async with counter_lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+                if in_flight >= min(row_parallel, len(ids)):
+                    reached.set()
+            await release.wait()
+            async with counter_lock:
+                in_flight -= 1
+            return f"pred {reference}"
+
+        async def releaser():
+            await reached.wait()
+            release.set()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audio_dir = Path(tmp)
+            self._make_audio(audio_dir, ids)
+            out = audio_dir / "results.csv"
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                await asyncio.gather(
+                    stt_eval.run_stt_eval(
+                        gt_data=self._gt_data(ids),
+                        audio_dir=audio_dir,
+                        provider="deepgram",
+                        language="english",
+                        results_csv_path=out,
+                        row_parallel=row_parallel,
+                    ),
+                    releaser(),
+                )
+
+        self.assertGreaterEqual(max_in_flight, min(row_parallel, len(ids)))
+
+    async def test_concurrency_is_capped_at_one(self):
+        """row_parallel=1 serializes transcription (peak in-flight never > 1)."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c", "row_d"]
+        in_flight = 0
+        max_in_flight = 0
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            await asyncio.sleep(0.01)
+            in_flight -= 1
+            return "x"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audio_dir = Path(tmp)
+            self._make_audio(audio_dir, ids)
+            out = audio_dir / "results.csv"
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                await stt_eval.run_stt_eval(
+                    gt_data=self._gt_data(ids),
+                    audio_dir=audio_dir,
+                    provider="deepgram",
+                    language="english",
+                    results_csv_path=out,
+                    row_parallel=1,
+                )
+
+        self.assertEqual(max_in_flight, 1)
+
+    async def test_output_order_preserved_when_later_rows_finish_first(self):
+        """Reversed completion order still writes CSV in input order."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c", "row_d"]
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            # Earlier ids sleep longer so later ids complete first.
+            stem = audio_path.stem
+            delay = 0.05 * (len(ids) - ids.index(stem))
+            await asyncio.sleep(delay)
+            return f"pred-{stem}"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audio_dir = Path(tmp)
+            self._make_audio(audio_dir, ids)
+            out = audio_dir / "results.csv"
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                count = await stt_eval.run_stt_eval(
+                    gt_data=self._gt_data(ids),
+                    audio_dir=audio_dir,
+                    provider="deepgram",
+                    language="english",
+                    results_csv_path=out,
+                    row_parallel=4,
+                )
+
+            self.assertEqual(count, len(ids))
+            df = pd.read_csv(out)
+            self.assertEqual(df["id"].tolist(), ids)
+            self.assertEqual(df["pred"].tolist(), [f"pred-{i}" for i in ids])
+
+    async def test_resume_skips_already_processed_id(self):
+        """A pre-seeded id is kept and never re-transcribed."""
+        from calibrate.stt import eval as stt_eval
+
+        ids = ["row_a", "row_b", "row_c"]
+        seen = []
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            seen.append(audio_path.stem)
+            return f"new-{audio_path.stem}"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audio_dir = Path(tmp)
+            self._make_audio(audio_dir, ids)
+            out = audio_dir / "results.csv"
+            # Pre-seed the first id as already processed.
+            pd.DataFrame(
+                [{"id": "row_a", "gt": "gt row_a", "pred": "old_a"}]
+            ).to_csv(out, index=False)
+
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_transcribe)
+            ):
+                await stt_eval.run_stt_eval(
+                    gt_data=self._gt_data(ids),
+                    audio_dir=audio_dir,
+                    provider="deepgram",
+                    language="english",
+                    results_csv_path=out,
+                    row_parallel=4,
+                )
+
+            self.assertNotIn("row_a", seen)
+            self.assertEqual(sorted(seen), ["row_b", "row_c"])
+            df = pd.read_csv(out)
+            self.assertIn("row_a", df["id"].tolist())
+            self.assertEqual(
+                df.loc[df["id"] == "row_a", "pred"].iloc[0], "old_a"
+            )
+
+
+class TestResolveRowParallelPrecedence(unittest.TestCase):
+    """Precedence rules of ``resolve_row_parallel`` for the STT component."""
+
+    def test_cli_value_takes_precedence_over_env(self):
+        from calibrate.utils import resolve_row_parallel
+
+        with patch.dict("os.environ", {"CALIBRATE_STT_PARALLEL": "7"}):
+            self.assertEqual(resolve_row_parallel("stt", 3), 3)
+
+    def test_env_used_when_no_cli_value(self):
+        from calibrate.utils import resolve_row_parallel
+
+        with patch.dict("os.environ", {"CALIBRATE_STT_PARALLEL": "6"}):
+            self.assertEqual(resolve_row_parallel("stt", None), 6)
+
+    def test_default_when_no_cli_or_env(self):
+        from calibrate.utils import resolve_row_parallel, DEFAULT_ROW_PARALLEL
+
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("CALIBRATE_STT_PARALLEL", None)
+            self.assertEqual(
+                resolve_row_parallel("stt", None), DEFAULT_ROW_PARALLEL
+            )
+
+    def test_non_positive_and_garbage_fall_back_to_default(self):
+        from calibrate.utils import resolve_row_parallel, DEFAULT_ROW_PARALLEL
+
+        # Non-positive CLI values are ignored -> fall through to env/default.
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("CALIBRATE_STT_PARALLEL", None)
+            self.assertEqual(
+                resolve_row_parallel("stt", 0), DEFAULT_ROW_PARALLEL
+            )
+            self.assertEqual(
+                resolve_row_parallel("stt", -5), DEFAULT_ROW_PARALLEL
+            )
+
+        # Garbage / non-positive env values are ignored too.
+        for bad in ("abc", "0", "-1"):
+            with patch.dict("os.environ", {"CALIBRATE_STT_PARALLEL": bad}):
+                self.assertEqual(
+                    resolve_row_parallel("stt", None), DEFAULT_ROW_PARALLEL
+                )
 
 
 if __name__ == "__main__":

--- a/tests/tts/test_eval.py
+++ b/tests/tts/test_eval.py
@@ -5,6 +5,7 @@ Run with:
     python -m unittest tests.tts.test_eval -v
 """
 
+import asyncio
 import os
 import tempfile
 import unittest
@@ -287,6 +288,440 @@ class TestRunTTSEval(unittest.IsolatedAsyncioTestCase):
             df = pd.read_csv(results_csv)
             self.assertEqual(df.iloc[0]["text"], "new")
             self.assertEqual(df.iloc[0]["ttfb"], 0.5)
+
+
+class TestRunTTSEvalParallel(unittest.IsolatedAsyncioTestCase):
+    async def test_concurrency_overlaps(self):
+        from calibrate.tts import eval as tts_eval
+
+        row_parallel = 3
+        in_flight = 0
+        max_in_flight = 0
+        lock = asyncio.Lock()
+        release = asyncio.Event()
+        reached = asyncio.Event()
+
+        async def fake_synth(text, provider, language, audio_path):
+            nonlocal in_flight, max_in_flight
+            async with lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+                if in_flight >= row_parallel:
+                    reached.set()
+            # Hold the row open until enough rows are concurrently in-flight.
+            await release.wait()
+            async with lock:
+                in_flight -= 1
+            Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(audio_path).write_bytes(b"RIFF")
+            return {"ttfb": 0.1}
+
+        async def releaser():
+            # Once row_parallel rows are simultaneously in-flight, let them go.
+            await reached.wait()
+            release.set()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            gt_data = [{"id": f"row_{i}", "text": f"t{i}"} for i in range(6)]
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                await asyncio.gather(
+                    tts_eval.run_tts_eval(
+                        gt_data=gt_data,
+                        provider="openai",
+                        language="english",
+                        output_dir=str(out),
+                        results_csv_path=results_csv,
+                        row_parallel=row_parallel,
+                    ),
+                    releaser(),
+                )
+
+            self.assertGreaterEqual(max_in_flight, row_parallel)
+
+    async def test_output_order_matches_input(self):
+        from calibrate.tts import eval as tts_eval
+
+        # Make later ids finish first to force out-of-order completion.
+        delays = {"row_a": 0.06, "row_b": 0.02, "row_c": 0.04}
+
+        async def fake_synth(text, provider, language, audio_path):
+            _id = Path(audio_path).stem
+            await asyncio.sleep(delays[_id])
+            Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(audio_path).write_bytes(b"RIFF")
+            return {"ttfb": delays[_id]}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            gt_data = [
+                {"id": "row_a", "text": "a"},
+                {"id": "row_b", "text": "b"},
+                {"id": "row_c", "text": "c"},
+            ]
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                await tts_eval.run_tts_eval(
+                    gt_data=gt_data,
+                    provider="openai",
+                    language="english",
+                    output_dir=str(out),
+                    results_csv_path=results_csv,
+                    row_parallel=3,
+                )
+
+            df = pd.read_csv(results_csv)
+            self.assertEqual(
+                df["id"].astype(str).tolist(), ["row_a", "row_b", "row_c"]
+            )
+
+    async def test_resume_skips_processed_ids_parallel(self):
+        from calibrate.tts import eval as tts_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            pd.DataFrame(
+                [{"id": "row_a", "text": "hello", "audio_path": "/x.wav", "ttfb": 0.1}]
+            ).to_csv(results_csv, index=False)
+
+            processed = []
+
+            async def fake_synth(text, provider, language, audio_path):
+                processed.append(Path(audio_path).stem)
+                Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+                Path(audio_path).write_bytes(b"RIFF")
+                return {"ttfb": 0.2}
+
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                result = await tts_eval.run_tts_eval(
+                    gt_data=[
+                        {"id": "row_a", "text": "hello"},
+                        {"id": "row_b", "text": "world"},
+                        {"id": "row_c", "text": "again"},
+                    ],
+                    provider="openai",
+                    language="english",
+                    output_dir=str(out),
+                    results_csv_path=results_csv,
+                    row_parallel=3,
+                )
+
+            self.assertNotIn("row_a", processed)
+            self.assertEqual(result["success_count"], 2)
+            df = pd.read_csv(results_csv)
+            self.assertEqual(
+                df["id"].astype(str).tolist(), ["row_a", "row_b", "row_c"]
+            )
+
+    async def test_overwrite_wipes_and_reprocesses_parallel(self):
+        from calibrate.tts import eval as tts_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            pd.DataFrame(
+                [
+                    {"id": "row_a", "text": "old", "audio_path": "/x.wav", "ttfb": 0.1},
+                    {"id": "row_b", "text": "old", "audio_path": "/y.wav", "ttfb": 0.1},
+                ]
+            ).to_csv(results_csv, index=False)
+
+            async def fake_synth(text, provider, language, audio_path):
+                Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+                Path(audio_path).write_bytes(b"RIFF")
+                return {"ttfb": 0.5}
+
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                result = await tts_eval.run_tts_eval(
+                    gt_data=[
+                        {"id": "row_a", "text": "new"},
+                        {"id": "row_b", "text": "new"},
+                    ],
+                    provider="openai",
+                    language="english",
+                    output_dir=str(out),
+                    results_csv_path=results_csv,
+                    overwrite=True,
+                    row_parallel=2,
+                )
+
+            self.assertEqual(result["success_count"], 2)
+            df = pd.read_csv(results_csv)
+            self.assertEqual(df["id"].astype(str).tolist(), ["row_a", "row_b"])
+            self.assertTrue((df["text"] == "new").all())
+            self.assertTrue((df["ttfb"] == 0.5).all())
+
+
+class TestRunTTSEvalRowParallel(unittest.IsolatedAsyncioTestCase):
+    """Row-level parallelism in run_tts_eval: bounded concurrency, output
+    ordering, resume, and overwrite semantics."""
+
+    async def test_concurrency_actually_overlaps(self):
+        from calibrate.tts import eval as tts_eval
+
+        row_parallel = 3
+        n_rows = 5
+        in_flight = 0
+        max_in_flight = 0
+        lock = asyncio.Lock()
+        release = asyncio.Event()
+        reached = asyncio.Event()
+
+        async def fake_synth(text, provider, language, audio_path):
+            nonlocal in_flight, max_in_flight
+            async with lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+                if in_flight >= min(row_parallel, n_rows):
+                    reached.set()
+            # Keep the row open until enough rows are concurrently in-flight.
+            await release.wait()
+            async with lock:
+                in_flight -= 1
+            Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(audio_path).write_bytes(b"RIFF")
+            return {"ttfb": 0.1}
+
+        async def releaser():
+            await reached.wait()
+            release.set()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            gt_data = [{"id": f"row_{i}", "text": f"t{i}"} for i in range(n_rows)]
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                await asyncio.gather(
+                    tts_eval.run_tts_eval(
+                        gt_data=gt_data,
+                        provider="openai",
+                        language="english",
+                        output_dir=str(out),
+                        results_csv_path=results_csv,
+                        row_parallel=row_parallel,
+                    ),
+                    releaser(),
+                )
+
+            self.assertGreaterEqual(max_in_flight, min(row_parallel, n_rows))
+
+    async def test_concurrency_capped_serialized(self):
+        from calibrate.tts import eval as tts_eval
+
+        in_flight = 0
+        max_in_flight = 0
+        lock = asyncio.Lock()
+
+        async def fake_synth(text, provider, language, audio_path):
+            nonlocal in_flight, max_in_flight
+            async with lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+            # Yield control so a second concurrent row could interleave if the
+            # semaphore weren't capping concurrency at 1.
+            await asyncio.sleep(0.01)
+            async with lock:
+                in_flight -= 1
+            Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(audio_path).write_bytes(b"RIFF")
+            return {"ttfb": 0.1}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            gt_data = [{"id": f"row_{i}", "text": f"t{i}"} for i in range(5)]
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                await tts_eval.run_tts_eval(
+                    gt_data=gt_data,
+                    provider="openai",
+                    language="english",
+                    output_dir=str(out),
+                    results_csv_path=results_csv,
+                    row_parallel=1,
+                )
+
+            self.assertEqual(max_in_flight, 1)
+
+    async def test_output_order_preserved_when_later_rows_finish_first(self):
+        from calibrate.tts import eval as tts_eval
+
+        # Later rows return first so completion order is the reverse of input.
+        delays = {"row_a": 0.06, "row_b": 0.04, "row_c": 0.02}
+
+        async def fake_synth(text, provider, language, audio_path):
+            _id = Path(audio_path).stem
+            await asyncio.sleep(delays[_id])
+            Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(audio_path).write_bytes(b"RIFF")
+            return {"ttfb": delays[_id]}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            gt_data = [
+                {"id": "row_a", "text": "a"},
+                {"id": "row_b", "text": "b"},
+                {"id": "row_c", "text": "c"},
+            ]
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                await tts_eval.run_tts_eval(
+                    gt_data=gt_data,
+                    provider="openai",
+                    language="english",
+                    output_dir=str(out),
+                    results_csv_path=results_csv,
+                    row_parallel=3,
+                )
+
+            df = pd.read_csv(results_csv)
+            self.assertEqual(
+                df["id"].astype(str).tolist(), ["row_a", "row_b", "row_c"]
+            )
+
+    async def test_resume_does_not_recall_processed_id(self):
+        from calibrate.tts import eval as tts_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            pd.DataFrame(
+                [{"id": "row_a", "text": "hello", "audio_path": "/x.wav", "ttfb": 0.1}]
+            ).to_csv(results_csv, index=False)
+
+            processed = []
+
+            async def fake_synth(text, provider, language, audio_path):
+                processed.append(Path(audio_path).stem)
+                Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+                Path(audio_path).write_bytes(b"RIFF")
+                return {"ttfb": 0.2}
+
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                result = await tts_eval.run_tts_eval(
+                    gt_data=[
+                        {"id": "row_a", "text": "hello"},
+                        {"id": "row_b", "text": "world"},
+                        {"id": "row_c", "text": "again"},
+                    ],
+                    provider="openai",
+                    language="english",
+                    output_dir=str(out),
+                    results_csv_path=results_csv,
+                    row_parallel=3,
+                )
+
+            self.assertNotIn("row_a", processed)
+            self.assertEqual(result["success_count"], 2)
+            df = pd.read_csv(results_csv)
+            self.assertIn("row_a", df["id"].astype(str).tolist())
+            self.assertEqual(
+                df["id"].astype(str).tolist(), ["row_a", "row_b", "row_c"]
+            )
+
+    async def test_overwrite_reprocesses_all_rows(self):
+        from calibrate.tts import eval as tts_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_csv = out / "results.csv"
+            pd.DataFrame(
+                [
+                    {"id": "row_a", "text": "old", "audio_path": "/x.wav", "ttfb": 0.1},
+                    {"id": "row_b", "text": "old", "audio_path": "/y.wav", "ttfb": 0.1},
+                ]
+            ).to_csv(results_csv, index=False)
+
+            processed = []
+
+            async def fake_synth(text, provider, language, audio_path):
+                processed.append(Path(audio_path).stem)
+                Path(audio_path).parent.mkdir(parents=True, exist_ok=True)
+                Path(audio_path).write_bytes(b"RIFF")
+                return {"ttfb": 0.5}
+
+            with patch.object(
+                tts_eval, "synthesize_speech", AsyncMock(side_effect=fake_synth)
+            ):
+                result = await tts_eval.run_tts_eval(
+                    gt_data=[
+                        {"id": "row_a", "text": "new"},
+                        {"id": "row_b", "text": "new"},
+                    ],
+                    provider="openai",
+                    language="english",
+                    output_dir=str(out),
+                    results_csv_path=results_csv,
+                    overwrite=True,
+                    row_parallel=2,
+                )
+
+            self.assertEqual(sorted(processed), ["row_a", "row_b"])
+            self.assertEqual(result["success_count"], 2)
+            df = pd.read_csv(results_csv)
+            self.assertEqual(df["id"].astype(str).tolist(), ["row_a", "row_b"])
+            self.assertTrue((df["text"] == "new").all())
+            self.assertTrue((df["ttfb"] == 0.5).all())
+
+
+class TestResolveRowParallelTTS(unittest.TestCase):
+    """Precedence for resolve_row_parallel('tts', ...): CLI > env > default."""
+
+    def test_cli_value_takes_precedence(self):
+        from calibrate.utils import resolve_row_parallel
+
+        with patch.dict(os.environ, {"CALIBRATE_TTS_PARALLEL": "7"}, clear=False):
+            self.assertEqual(resolve_row_parallel("tts", 3), 3)
+
+    def test_env_used_when_no_cli(self):
+        from calibrate.utils import resolve_row_parallel
+
+        with patch.dict(os.environ, {"CALIBRATE_TTS_PARALLEL": "6"}, clear=False):
+            self.assertEqual(resolve_row_parallel("tts", None), 6)
+
+    def test_default_when_nothing_set(self):
+        from calibrate.utils import resolve_row_parallel, DEFAULT_ROW_PARALLEL
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CALIBRATE_TTS_PARALLEL", None)
+            self.assertEqual(
+                resolve_row_parallel("tts", None), DEFAULT_ROW_PARALLEL
+            )
+
+    def test_non_positive_and_garbage_fall_back_to_default(self):
+        from calibrate.utils import resolve_row_parallel, DEFAULT_ROW_PARALLEL
+
+        # Non-positive CLI values are ignored; with no usable env, fall back.
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CALIBRATE_TTS_PARALLEL", None)
+            self.assertEqual(resolve_row_parallel("tts", 0), DEFAULT_ROW_PARALLEL)
+            self.assertEqual(resolve_row_parallel("tts", -5), DEFAULT_ROW_PARALLEL)
+
+        # Garbage / non-positive env values are ignored too.
+        for bad in ("abc", "0", "-3"):
+            with patch.dict(
+                os.environ, {"CALIBRATE_TTS_PARALLEL": bad}, clear=False
+            ):
+                self.assertEqual(
+                    resolve_row_parallel("tts", None), DEFAULT_ROW_PARALLEL
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Process multiple rows (audio files for STT, texts for TTS) concurrently within a single provider, bounded by a semaphore with locked, order-preserving CSV writes and resume support.
- Configurable via `-n/--parallel` and `CALIBRATE_{STT,TTS}_PARALLEL`, resolved via `resolve_row_parallel` (flag > env > default 4). Orthogonal to provider-level benchmark parallelism.

## Changes
- `calibrate/stt/eval.py`, `calibrate/tts/eval.py`: bounded concurrent row processing.
- `calibrate/utils.py`: `resolve_row_parallel` + `DEFAULT_ROW_PARALLEL`.
- `calibrate/stt/benchmark.py`, `calibrate/tts/benchmark.py`: thread `row_parallel`; `-n/--parallel` CLI arg.
- `calibrate/cli.py`: forward `-n/--parallel` for the `stt`/`tts` subcommands.
- `.env.example`: document the row env vars.
- Tests: `tests/stt/test_eval.py`, `tests/tts/test_eval.py`.

## Test plan
- [ ] `uv run pytest tests/stt/test_eval.py tests/tts/test_eval.py`

Note: touches the same benchmark modules / cli.py / .env.example as the STT/TTS benchmark-level parallelism PR (different hunks); whichever merges second needs a trivial rebase.

Made with [Cursor](https://cursor.com)