### PR TITLE
Track LLM-test cost and surface it on the leaderboard

### DIFF
--- a/calibrate/connections.py
+++ b/calibrate/connections.py
@@ -77,6 +77,21 @@ class TextAgentConnection:
             {"tool": "get_weather", "arguments": {"city": "NYC"},
              "output": {"temp": 72, "condition": "sunny"}}
 
+        The response may also include an optional ``metrics`` dict reporting what
+        the call cost the agent. Every field is optional; ``cost`` (USD for this
+        call) is the one Calibrate aggregates into the per-model mean cost — the
+        rest are stored as-is for review::
+
+            {
+                "response": "...",
+                "tool_calls": [],
+                "metrics": {"cost": 0.0021, "prompt_tokens": 1200,
+                            "completion_tokens": 340, "latency_ms": 850}
+            }
+
+        Omit ``metrics`` entirely and the agent behaves exactly as before;
+        malformed metrics are ignored rather than rejected.
+
     Use :meth:`verify` to confirm the endpoint is reachable and returns the
     expected format before running a full evaluation.
 
@@ -242,6 +257,8 @@ class TextAgentConnection:
             dict with ``response`` (str | None) and ``tool_calls`` (list) keys.
             Each tool call dict is passed through verbatim, so an optional
             ``output`` field (the tool's own result) is preserved for review.
+            An optional ``metrics`` dict (e.g. ``{"cost": ...}``) is passed
+            through when the agent reports one and it is a dict.
 
         Raises:
             RuntimeError: On connection error, timeout, non-200 status, or
@@ -274,10 +291,14 @@ class TextAgentConnection:
                 f"Agent response is not valid JSON: {resp.text[:500]}"
             ) from None
 
-        return {
+        result = {
             "response": data.get("response"),
             "tool_calls": data.get("tool_calls", []),
         }
+        metrics = data.get("metrics")
+        if isinstance(metrics, dict):
+            result["metrics"] = metrics
+        return result
 
     @backoff.on_exception(
         backoff.expo,

--- a/calibrate/llm/_metrics_utils.py
+++ b/calibrate/llm/_metrics_utils.py
@@ -1,0 +1,19 @@
+"""Small, dependency-free helpers shared by LLM metric aggregation and the
+leaderboard. Kept separate from ``run_tests`` (heavy: pipecat) and
+``tests_leaderboard`` (pandas) so both can import it without a cross-module
+dependency in the wrong direction.
+"""
+
+from typing import Optional
+
+
+def _numeric_or_none(value: object) -> Optional[float]:
+    """Return ``value`` if it is a real number, else ``None``.
+
+    Booleans are excluded even though ``bool`` is a subclass of ``int`` — a cost
+    or latency is never a true/false value, so ``True`` must not be read as
+    ``1.0``.
+    """
+    if isinstance(value, bool):
+        return None
+    return value if isinstance(value, (int, float)) else None

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -47,6 +47,7 @@ from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.services.openrouter.llm import OpenRouterLLMService
 from pipecat.observers.loggers.llm_log_observer import LLMLogObserver
 from calibrate.llm.metrics import test_response_llm_judge, evaluate_simuation
+from calibrate.llm._metrics_utils import _numeric_or_none
 from calibrate.judges import (
     DEFAULT_LLM_TEST_EVALUATOR,
     attach_evaluator_id,
@@ -223,6 +224,45 @@ class Processor(FrameProcessor):
         await self.push_frame(frame, direction)
 
 
+class CostTrackingOpenRouterLLMService(OpenRouterLLMService):
+    """OpenRouter LLM service that records the authoritative per-request USD cost.
+
+    OpenRouter returns the actual charged cost inline in the final usage chunk of
+    every streaming response (``usage.cost`` — already net of cache discounts,
+    fallback routing, and BYOK upstream pricing). The base pipecat service reads
+    only token counts from that chunk and discards the cost, so we wrap the
+    completion stream to capture it without reimplementing the chunk-processing
+    loop. This keeps cost tracking robust to new models — the price comes from
+    OpenRouter itself, not a local price table that can go stale.
+
+    After a run, ``last_cost`` holds the most recent request's cost (USD) or
+    ``None`` if OpenRouter did not report one.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.last_cost: Optional[float] = None
+
+    async def get_chat_completions(self, params_from_context):
+        stream = await super().get_chat_completions(params_from_context)
+        return self._capture_cost(stream)
+
+    async def _capture_cost(self, stream):
+        async for chunk in stream:
+            usage = getattr(chunk, "usage", None)
+            if usage is not None:
+                cost = getattr(usage, "cost", None)
+                if cost is None:
+                    extra = getattr(usage, "model_extra", None) or {}
+                    cost = extra.get("cost")
+                if cost is not None:
+                    try:
+                        self.last_cost = float(cost)
+                    except (TypeError, ValueError):
+                        pass
+            yield chunk
+
+
 class LLMInferenceError(Exception):
     """Raised when LLM inference fails due to system error (API error, invalid model, etc.)"""
 
@@ -370,7 +410,7 @@ async def _run_inference_inner(
     """Inner implementation of run_inference."""
     # Create LLM service
     if provider == "openrouter":
-        llm = OpenRouterLLMService(
+        llm = CostTrackingOpenRouterLLMService(
             api_key=os.getenv("OPENROUTER_API_KEY"),
             model=model,
             base_url="https://openrouter.ai/api/v1",
@@ -478,6 +518,7 @@ async def _run_inference_inner(
     return {
         "response": processor._current_response,
         "tool_calls": processor._tool_calls,
+        "cost": getattr(llm, "last_cost", None),
     }
 
 
@@ -1410,7 +1451,18 @@ async def run_test_external(
     same logic as the internal :func:`run_test`.
 
     The agent must return ``{"response": ..., "tool_calls": [...]}`` — see
-    :meth:`~calibrate.connections.TextAgentConnection.call` for details.
+    :meth:`~calibrate.connections.TextAgentConnection.call` for details. It may
+    optionally include a ``metrics`` dict (e.g. ``{"cost": 0.0021,
+    "latency_ms": 850}``); when present and well-formed it is preserved on the
+    output and its ``cost`` / ``latency_ms`` feed the same per-model aggregates
+    as internal LLM tests. Anything malformed is ignored so the agent contract
+    stays backwards-compatible.
+
+    Unlike the internal path, latency is **not** measured here: a wall-clock
+    timer around the HTTP call would fold in network, proxy, and queueing
+    overhead rather than the agent's true inference time. We rely solely on the
+    agent's self-reported ``metrics.latency_ms``; if it doesn't report one, the
+    run simply has no latency.
 
     Args:
         chat_history: Conversation history (role/content dicts, no system message).
@@ -1421,13 +1473,10 @@ async def run_test_external(
     Returns:
         dict with ``output`` and ``metrics`` keys.
     """
-    # Time only the agent's response; the LLM-judge evaluation that follows is
-    # excluded so the latency reflects the external agent, not the judge.
-    call_start = time.time()
     output = await agent.call(chat_history, model=model)
-    latency_ms = round((time.time() - call_start) * 1000)
     response = output.get("response")
     tool_calls = output.get("tool_calls", [])
+    agent_metrics = output.get("metrics")
     metrics = await evaluate_test_case_output(
         chat_history=chat_history,
         evaluation=evaluation,
@@ -1439,11 +1488,26 @@ async def run_test_external(
         no_response_reasoning_no_tool_calls="No reply was returned by the external agent",
     )
 
-    return {
-        "output": {"response": response, "tool_calls": tool_calls},
-        "metrics": metrics,
-        "latency_ms": latency_ms,
-    }
+    result_output: dict = {"response": response, "tool_calls": tool_calls}
+    if isinstance(agent_metrics, dict):
+        result_output["metrics"] = agent_metrics
+
+    # Lift the agent's self-reported cost and latency out of its metrics block
+    # into the same canonical fields the internal path populates, so both are
+    # extracted the same way (cost → output.cost, latency → result.latency_ms)
+    # instead of one being dug back out of the nested metrics during aggregation.
+    # Latency uses only the agent's number (clean inference time), never a
+    # network-contaminated round-trip measured from here.
+    metrics_block = agent_metrics if isinstance(agent_metrics, dict) else {}
+    agent_cost = _numeric_or_none(metrics_block.get("cost"))
+    if agent_cost is not None:
+        result_output["cost"] = agent_cost
+
+    result: dict = {"output": result_output, "metrics": metrics}
+    agent_latency = _numeric_or_none(metrics_block.get("latency_ms"))
+    if agent_latency is not None:
+        result["latency_ms"] = agent_latency
+    return result
 
 
 def _aggregate_criteria(results: List[dict], name_to_evaluator: dict) -> dict:
@@ -1518,6 +1582,35 @@ def _aggregate_criteria(results: List[dict], name_to_evaluator: dict) -> dict:
         if ev and "id" in ev:
             aggregated[name]["evaluator_id"] = ev["id"]
     return aggregated
+
+
+def _aggregate_cost(results: List[dict]) -> Optional[dict]:
+    """Aggregate per-test-case LLM cost (USD) across results that report one.
+
+    Cost lives in ``output.cost`` for every path: internal LLM tests get it from
+    OpenRouter (see :class:`CostTrackingOpenRouterLLMService`) and external
+    agents have it lifted there from their self-reported ``metrics`` dict in
+    :func:`run_test_external`. Test cases without a cost (the OpenAI provider,
+    agents that don't report one, or older results) are ignored. Returns
+    ``None`` when no result carries a cost so the metric is absent rather than a
+    misleading ``0.0``.
+
+    Output shape mirrors :func:`_aggregate_latency`:
+    ``{"mean", "min", "max", "count"}`` with USD floats.
+    """
+    costs = [
+        c
+        for r in results
+        if (c := _numeric_or_none((r.get("output") or {}).get("cost"))) is not None
+    ]
+    if not costs:
+        return None
+    return {
+        "mean": sum(costs) / len(costs),
+        "min": min(costs),
+        "max": max(costs),
+        "count": len(costs),
+    }
 
 
 def _aggregate_tool_calls(results: List[dict]) -> dict:
@@ -1759,6 +1852,9 @@ def _write_test_results_outputs(
         "criteria": _aggregate_criteria(results, name_to_evaluator),
         "tool_calls": _aggregate_tool_calls(results),
     }
+    cost = _aggregate_cost(results)
+    if cost is not None:
+        metrics["cost"] = cost
     latency = _aggregate_latency(results)
     if latency is not None:
         metrics["latency_ms"] = latency

--- a/calibrate/llm/tests_leaderboard.py
+++ b/calibrate/llm/tests_leaderboard.py
@@ -5,6 +5,8 @@ from typing import Dict, List, Optional
 
 import pandas as pd
 
+from calibrate.llm._metrics_utils import _numeric_or_none
+
 
 def generate_leaderboard(output_dir: str, save_dir: str) -> None:
     """
@@ -97,11 +99,14 @@ def _build_leaderboard(
 ) -> pd.DataFrame:
     """Build leaderboard DataFrame.
 
-    Columns: model, passed, total, pass_rate, latency_ms, [criterion_1, ...]
+    Columns: model, passed, total, pass_rate, latency_ms, cost, [criterion_1, ...]
 
     ``latency_ms`` is the mean per-test-case response-generation latency (in
     milliseconds, judge time excluded); ``None`` for runs without it (e.g.
     eval-only).
+
+    ``cost`` is the mean per-test-case LLM cost in USD (``None`` when the run
+    reported no cost, e.g. the OpenAI provider or external agents).
 
     Per-criterion column values:
     - binary criterion → pass_rate (%)
@@ -113,12 +118,14 @@ def _build_leaderboard(
         passed = int(data.get("passed", 0))
         total = int(data.get("total", 0))
         latency = data.get("latency_ms") if isinstance(data.get("latency_ms"), dict) else {}
+        cost = data.get("cost") if isinstance(data.get("cost"), dict) else {}
         row: Dict[str, object] = {
             "model": model_name,
             "passed": passed,
             "total": total,
             "pass_rate": _to_percent(passed, total),
             "latency_ms": latency.get("mean"),
+            "cost": _numeric_or_none(cost.get("mean")),
         }
 
         criteria = data.get("criteria") or {}

--- a/tests/llm/test_run_tests.py
+++ b/tests/llm/test_run_tests.py
@@ -83,16 +83,17 @@ class TestRunTestExternalMultiCriteria(unittest.IsolatedAsyncioTestCase):
                 evaluators=evaluators,
             )
 
-    async def test_returns_latency_ms(self):
+    async def test_no_latency_without_agent_reported_metrics(self):
+        # Calibrate no longer times external agents itself (a round-trip timer
+        # would fold in network/proxy overhead, not true inference time). With no
+        # agent-reported metrics, the result simply has no latency. The
+        # agent-reported latency path is covered in tests/test_connections.py.
         result = await self._run(
             agent_response="Hello, how can I help?",
             evaluators=[_binary_ev("greeting")],
             judge_result={"greeting": {"match": True, "reasoning": "greeted"}},
         )
-        # Latency reflects the external agent call, captured before the judge runs.
-        self.assertIn("latency_ms", result)
-        self.assertIsInstance(result["latency_ms"], int)
-        self.assertGreaterEqual(result["latency_ms"], 0)
+        self.assertNotIn("latency_ms", result)
 
     async def test_all_evaluators_match_passes(self):
         result = await self._run(

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -1492,6 +1492,149 @@ class TestWriteTestResults(unittest.TestCase):
             self.assertTrue((Path(tmp) / "results.json").exists())
             self.assertTrue((Path(tmp) / "metrics.json").exists())
 
+    def test_metrics_includes_mean_cost(self):
+        from calibrate.llm.run_tests import _write_test_results_outputs
+
+        with tempfile.TemporaryDirectory() as tmp:
+            results = [
+                {
+                    "metrics": {"passed": True, "judge_results": {}},
+                    "test_case": {"evaluation": {"type": "tool_call", "tool_calls": []}},
+                    "output": {"response": "", "tool_calls": [], "cost": 0.02},
+                },
+                {
+                    "metrics": {"passed": True, "judge_results": {}},
+                    "test_case": {"evaluation": {"type": "tool_call", "tool_calls": []}},
+                    "output": {"response": "", "tool_calls": [], "cost": 0.04},
+                },
+            ]
+            _write_test_results_outputs(results, tmp, {})
+            metrics = json.loads((Path(tmp) / "metrics.json").read_text())
+            self.assertAlmostEqual(metrics["cost"]["mean"], 0.03)
+            self.assertAlmostEqual(metrics["cost"]["min"], 0.02)
+            self.assertAlmostEqual(metrics["cost"]["max"], 0.04)
+            self.assertEqual(metrics["cost"]["count"], 2)
+
+    def test_metrics_cost_omitted_without_costs(self):
+        from calibrate.llm.run_tests import _write_test_results_outputs
+
+        with tempfile.TemporaryDirectory() as tmp:
+            results = [
+                {
+                    "metrics": {"passed": True, "judge_results": {}},
+                    "test_case": {"evaluation": {"type": "tool_call", "tool_calls": []}},
+                    "output": {"response": "", "tool_calls": []},
+                },
+            ]
+            _write_test_results_outputs(results, tmp, {})
+            metrics = json.loads((Path(tmp) / "metrics.json").read_text())
+            self.assertNotIn("cost", metrics)
+
+
+class TestAggregateCost(unittest.TestCase):
+    def test_no_results_returns_none(self):
+        from calibrate.llm.run_tests import _aggregate_cost
+
+        self.assertIsNone(_aggregate_cost([]))
+
+    def test_no_costs_returns_none(self):
+        from calibrate.llm.run_tests import _aggregate_cost
+
+        results = [
+            {"output": {"response": "hi", "tool_calls": []}},
+            {"output": {"response": "yo", "tool_calls": [], "cost": None}},
+            {"metrics": {"passed": True}},  # no output key at all
+        ]
+        self.assertIsNone(_aggregate_cost(results))
+
+    def test_mean_across_costs(self):
+        from calibrate.llm.run_tests import _aggregate_cost
+
+        results = [
+            {"output": {"cost": 0.01}},
+            {"output": {"cost": 0.03}},
+            {"output": {"cost": None}},  # ignored
+            {"output": {}},  # ignored
+        ]
+        agg = _aggregate_cost(results)
+        self.assertAlmostEqual(agg["mean"], 0.02)
+        self.assertAlmostEqual(agg["min"], 0.01)
+        self.assertAlmostEqual(agg["max"], 0.03)
+        self.assertEqual(agg["count"], 2)
+
+    def test_zero_cost_counted(self):
+        from calibrate.llm.run_tests import _aggregate_cost
+
+        results = [{"output": {"cost": 0.0}}, {"output": {"cost": 0.02}}]
+        agg = _aggregate_cost(results)
+        self.assertAlmostEqual(agg["mean"], 0.01)
+        self.assertEqual(agg["count"], 2)
+
+
+    def test_cost_read_only_from_output_cost(self):
+        """Cost lives at ``output.cost`` for both paths; a nested-only metrics
+        cost is not dug out here (run_test_external lifts it first)."""
+        from calibrate.llm.run_tests import _aggregate_cost
+
+        results = [
+            {"output": {"cost": 0.02}},                       # counted
+            {"output": {"metrics": {"cost": 0.04}}},          # not lifted → ignored
+            {"output": {"response": "x", "tool_calls": []}},  # no cost
+        ]
+        agg = _aggregate_cost(results)
+        self.assertAlmostEqual(agg["mean"], 0.02)
+        self.assertEqual(agg["count"], 1)
+
+
+class TestCostTrackingService(unittest.IsolatedAsyncioTestCase):
+    def _service(self):
+        from calibrate.llm.run_tests import CostTrackingOpenRouterLLMService
+
+        return CostTrackingOpenRouterLLMService.__new__(
+            CostTrackingOpenRouterLLMService
+        )
+
+    async def _drain(self, svc, chunks):
+        async def fake_stream():
+            for c in chunks:
+                yield c
+
+        out = [c async for c in svc._capture_cost(fake_stream())]
+        return out
+
+    async def test_captures_cost_from_usage_attr(self):
+        svc = self._service()
+        svc.last_cost = None
+        usage = MagicMock(cost=0.00231)
+        chunks = [MagicMock(usage=None), MagicMock(usage=usage)]
+        out = await self._drain(svc, chunks)
+        self.assertEqual(len(out), 2)  # stream passes through unchanged
+        self.assertAlmostEqual(svc.last_cost, 0.00231)
+
+    async def test_captures_cost_from_model_extra(self):
+        svc = self._service()
+        svc.last_cost = None
+        usage = MagicMock(spec=["model_extra"])
+        usage.model_extra = {"cost": 0.005}
+        out = await self._drain(svc, [MagicMock(usage=usage)])
+        self.assertEqual(len(out), 1)
+        self.assertAlmostEqual(svc.last_cost, 0.005)
+
+    async def test_no_cost_leaves_none(self):
+        svc = self._service()
+        svc.last_cost = None
+        usage = MagicMock(spec=["model_extra"])
+        usage.model_extra = {}
+        await self._drain(svc, [MagicMock(usage=usage), MagicMock(usage=None)])
+        self.assertIsNone(svc.last_cost)
+
+    async def test_non_numeric_cost_ignored(self):
+        svc = self._service()
+        svc.last_cost = None
+        usage = MagicMock(cost="not-a-number")
+        await self._drain(svc, [MagicMock(usage=usage)])
+        self.assertIsNone(svc.last_cost)
+
 
 class TestRunInferenceWrapping(unittest.IsolatedAsyncioTestCase):
     async def test_run_inference_wraps(self):

--- a/tests/llm/test_tests_leaderboard.py
+++ b/tests/llm/test_tests_leaderboard.py
@@ -27,6 +27,21 @@ def _write_model(base: Path, model_name: str, metrics: dict) -> None:
     (model_dir / "metrics.json").write_text(json.dumps(metrics))
 
 
+class TestNumericOrNone(unittest.TestCase):
+    def test_numbers_pass_through(self):
+        from calibrate.llm._metrics_utils import _numeric_or_none
+
+        self.assertEqual(_numeric_or_none(0.0), 0.0)
+        self.assertEqual(_numeric_or_none(3), 3)
+
+    def test_non_numbers_and_bools_become_none(self):
+        from calibrate.llm._metrics_utils import _numeric_or_none
+
+        self.assertIsNone(_numeric_or_none(None))
+        self.assertIsNone(_numeric_or_none("0.02"))
+        self.assertIsNone(_numeric_or_none(True))
+
+
 class TestLeaderboardMultiCriteria(unittest.TestCase):
 
     def test_per_criterion_columns_present(self):
@@ -109,11 +124,32 @@ class TestLeaderboardMultiCriteria(unittest.TestCase):
             self.assertIn("pass_rate", df.columns)
             self.assertIn("passed", df.columns)
             self.assertIn("total", df.columns)
-            # No criterion columns (latency_ms is a standard column, empty here)
+            # No criterion columns (latency_ms and cost are standard columns, empty here)
             expected_cols = {
-                "model", "passed", "total", "pass_rate", "latency_ms",
+                "model", "passed", "total", "pass_rate", "latency_ms", "cost",
             }
             self.assertEqual(set(df.columns), expected_cols)
+            # Cost is absent in old-style metrics → empty column
+            self.assertTrue(df["cost"].isna().all())
+
+    def test_cost_column_shows_mean_cost(self):
+        """The leaderboard surfaces the per-model mean cost, None when absent."""
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            _write_model(base, "model-a", {
+                "total": 2, "passed": 2,
+                "cost": {"mean": 0.03, "min": 0.02, "max": 0.04, "count": 2},
+            })
+            _write_model(base, "model-b", {"total": 2, "passed": 1})
+
+            save_dir = base / "leaderboard"
+            generate_leaderboard(str(base), str(save_dir))
+
+            df = pd.read_csv(save_dir / "llm_leaderboard.csv")
+            self.assertIn("cost", df.columns)
+            by_model = dict(zip(df["model"], df["cost"]))
+            self.assertAlmostEqual(by_model["model-a"], 0.03)
+            self.assertTrue(pd.isna(by_model["model-b"]))
 
     def test_skip_leaderboard_folder(self):
         """The existing 'leaderboard' subdirectory inside output_dir should be ignored."""

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -372,6 +372,93 @@ class TestRunTestExternalResponse(unittest.IsolatedAsyncioTestCase):
 
 
 # ---------------------------------------------------------------------------
+# Tests for run_test_external — optional agent-reported metrics
+# ---------------------------------------------------------------------------
+
+class TestRunTestExternalMetrics(unittest.IsolatedAsyncioTestCase):
+
+    async def _run(self, fake_body):
+        from calibrate.connections import TextAgentConnection
+        from calibrate.llm.run_tests import run_test_external
+
+        agent = TextAgentConnection(url="http://fake-agent/chat")
+        evaluation = {"type": "tool_call", "tool_calls": []}
+        ctx, _ = _patch_httpx(fake_body)
+        with ctx:
+            return await run_test_external(
+                chat_history=[{"role": "user", "content": "hi"}],
+                evaluation=evaluation,
+                agent=agent,
+            )
+
+    async def test_metrics_dict_passed_through_to_output(self):
+        result = await self._run(
+            {"response": "hi", "tool_calls": [],
+             "metrics": {"cost": 0.0021, "prompt_tokens": 1200}}
+        )
+        self.assertEqual(result["output"]["metrics"]["cost"], 0.0021)
+
+    async def test_no_metrics_key_omitted(self):
+        result = await self._run({"response": "hi", "tool_calls": []})
+        self.assertNotIn("metrics", result["output"])
+
+    async def test_malformed_metrics_ignored(self):
+        result = await self._run(
+            {"response": "hi", "tool_calls": [], "metrics": "cheap"}
+        )
+        self.assertNotIn("metrics", result["output"])
+
+    async def test_agent_reported_cost_lifted_to_output(self):
+        result = await self._run(
+            {"response": "hi", "tool_calls": [], "metrics": {"cost": 0.05}}
+        )
+        self.assertEqual(result["output"]["cost"], 0.05)
+
+    async def test_no_cost_when_agent_does_not_report(self):
+        result = await self._run({"response": "hi", "tool_calls": []})
+        self.assertNotIn("cost", result["output"])
+
+    async def test_malformed_cost_ignored(self):
+        result = await self._run(
+            {"response": "hi", "tool_calls": [], "metrics": {"cost": "free"}}
+        )
+        self.assertNotIn("cost", result["output"])
+
+    async def test_agent_cost_feeds_aggregate_mean(self):
+        from calibrate.llm.run_tests import _aggregate_cost
+
+        result = await self._run(
+            {"response": "hi", "tool_calls": [], "metrics": {"cost": 0.05}}
+        )
+        self.assertAlmostEqual(_aggregate_cost([result])["mean"], 0.05)
+
+    async def test_agent_reported_latency_used(self):
+        result = await self._run(
+            {"response": "hi", "tool_calls": [], "metrics": {"latency_ms": 850}}
+        )
+        self.assertEqual(result["latency_ms"], 850)
+
+    async def test_no_latency_when_agent_does_not_report(self):
+        result = await self._run({"response": "hi", "tool_calls": []})
+        self.assertNotIn("latency_ms", result)
+
+    async def test_malformed_latency_ignored(self):
+        result = await self._run(
+            {"response": "hi", "tool_calls": [], "metrics": {"latency_ms": "slow"}}
+        )
+        self.assertNotIn("latency_ms", result)
+
+    async def test_agent_latency_feeds_aggregate(self):
+        from calibrate.llm.run_tests import _aggregate_latency
+
+        result = await self._run(
+            {"response": "hi", "tool_calls": [], "metrics": {"latency_ms": 200}}
+        )
+        agg = _aggregate_latency([result])
+        self.assertEqual(agg["mean"], 200)
+
+
+# ---------------------------------------------------------------------------
 # Tests for TextAgentConnection.verify()
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What
- Capture OpenRouter's authoritative per-request USD cost (`usage.cost`) during LLM-test inference via a `CostTrackingOpenRouterLLMService` wrapper, so cost stays correct for new models without a local price table.
- Store the mean per-test-case cost as a top-level `cost` in each model's `metrics.json`.
- Add a `cost` column to the LLM tests leaderboard.

## Notes
- Cost is only reported for the OpenRouter provider; OpenAI provider and external agents yield `null` (excluded from the mean / shown empty).
- Langfuse wiring untouched.