### PR TITLE
Add general-purpose non-conversational task LLM judge

### DIFF
--- a/calibrate/cli.py
+++ b/calibrate/cli.py
@@ -156,7 +156,7 @@ def main():
 
     parser = argparse.ArgumentParser(
         prog="calibrate",
-        usage="calibrate [-h] [-v] {stt,tts,llm,simulations,status} ...",
+        usage="calibrate [-h] [-v] {stt,tts,llm,simulations,general,status} ...",
         description="Voice agent evaluation and benchmarking toolkit",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
@@ -168,6 +168,7 @@ Examples:
     calibrate llm -c config.json                     # Run LLM tests directly
     calibrate simulations                            # Interactive simulations
     calibrate simulations --type text -c config.json # Run text simulation directly
+    calibrate general --dataset data.json -c config.json  # Score input/output pairs
     calibrate status                                 # Check provider connectivity
         """,
     )
@@ -182,7 +183,7 @@ Examples:
     subparsers = parser.add_subparsers(
         dest="component",
         help="Component to run",
-        metavar="{stt,tts,llm,simulations,status}",
+        metavar="{stt,tts,llm,simulations,general,status}",
     )
     subparsers.required = False  # Allow `calibrate` alone for main menu
 
@@ -421,6 +422,35 @@ Examples:
     sim_lb_parser = sim_subparsers.add_parser("leaderboard")
     sim_lb_parser.add_argument("-o", "--output-dir", type=str, required=True)
     sim_lb_parser.add_argument("-s", "--save-dir", type=str, required=True)
+
+    # ── General task eval ───────────────────────────────────────
+    # `calibrate general --dataset data.json --config config.json` →
+    # score a dataset of {id, input, output} rows with the general
+    # (non-conversational) task judge.
+    general_parser = subparsers.add_parser(
+        "general",
+        help="General task evaluation — judge arbitrary input/output pairs",
+    )
+    general_parser.add_argument(
+        "--dataset",
+        type=str,
+        default=None,
+        help="Path to dataset JSON (list of {id, input, output})",
+    )
+    general_parser.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        default=None,
+        help="Path to JSON config file defining the `evaluators` list",
+    )
+    general_parser.add_argument(
+        "-o",
+        "--output-dir",
+        type=str,
+        default="./out",
+        help="Output directory",
+    )
 
     # ── Status ────────────────────────────────────────────────────
     status_parser = subparsers.add_parser(
@@ -744,6 +774,21 @@ Examples:
                 },
             )
             asyncio.run(agent_main())
+
+    elif args.component == "general":
+        from calibrate.general.eval import main as general_eval_main
+
+        if not args.dataset:
+            print("\033[31mError: --dataset is required\033[0m")
+            sys.exit(1)
+        if not args.config:
+            print("\033[31mError: --config is required\033[0m")
+            sys.exit(1)
+
+        argv = ["calibrate", "--dataset", args.dataset, "-c", args.config]
+        argv.extend(["-o", args.output_dir])
+        sys.argv = argv
+        asyncio.run(general_eval_main())
 
     elif args.component == "status":
         from calibrate.status import run_status_live

--- a/calibrate/general/__init__.py
+++ b/calibrate/general/__init__.py
@@ -1,0 +1,9 @@
+"""General-purpose (non-conversational) task evaluation.
+
+Score arbitrary single-shot LLM tasks — summarization, extraction,
+classification, rewriting, code generation, etc. — by passing a list of
+``(input, output)`` pairs and a list of evaluators. See
+:func:`calibrate.general.metrics.get_general_judge_score` for the core
+scoring function and :func:`calibrate.general.eval.run_general_eval` for the
+file-based runner used by the ``calibrate general`` CLI subcommand.
+"""

--- a/calibrate/general/eval.py
+++ b/calibrate/general/eval.py
@@ -1,0 +1,298 @@
+"""General task evaluation runner + CLI.
+
+File-based pathway for the general (non-conversational) task judge. Reads a
+JSON dataset of ``{id, input, output}`` rows plus a list of evaluators, runs
+the judge over every row, and writes ``results.csv`` + ``metrics.json``.
+
+Invoked via ``calibrate general --dataset data.json --config config.json``.
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from os.path import exists, join
+from typing import List, Optional
+
+import pandas as pd
+
+from calibrate.general.metrics import get_general_judge_score
+from calibrate.judges import (
+    is_rating,
+    require_unique_evaluator_names,
+    write_evaluator_config,
+)
+from calibrate.utils import (
+    provider_log as _log,
+    provider_log_file as _current_log_file,
+)
+
+
+# Required fields for every dataset row.
+GENERAL_DATASET_FIELDS = ("id", "input", "output")
+
+
+def validate_general_eval_dataset(
+    dataset_path: str,
+) -> tuple[bool, str, list[dict]]:
+    """Validate a general eval dataset JSON file.
+
+    Expected format: a JSON list of objects, each with ``id``, ``input`` and
+    ``output`` fields.
+
+    Returns:
+        tuple[bool, str, list[dict]]: (is_valid, error_message, parsed_rows)
+    """
+    if not exists(dataset_path):
+        return False, f"Dataset file does not exist: {dataset_path}", []
+
+    try:
+        with open(dataset_path) as f:
+            data = json.load(f)
+    except Exception as e:
+        return False, f"Failed to parse dataset JSON: {e}", []
+
+    if not isinstance(data, list):
+        return False, "Dataset must be a JSON list of objects", []
+
+    if not data:
+        return False, "Dataset is empty — provide at least one row", []
+
+    required = set(GENERAL_DATASET_FIELDS)
+    seen_ids: set = set()
+    for i, row in enumerate(data):
+        if not isinstance(row, dict):
+            return False, f"Row {i} is not an object", []
+        missing = required - row.keys()
+        if missing:
+            return (
+                False,
+                f"Row {i} missing required fields: {sorted(missing)}. "
+                f"Each row needs 'id', 'input', 'output'.",
+                [],
+            )
+        row_id = row["id"]
+        if row_id in seen_ids:
+            return False, f"Duplicate row id: {row_id!r}", []
+        seen_ids.add(row_id)
+
+    return True, "", data
+
+
+def _resolve_evaluators(config: Optional[dict]) -> List[dict]:
+    """Pull the evaluator list out of a config dict, validating it.
+
+    The general task judge has no implicit default, so the config must define a
+    non-empty ``evaluators`` list. Raises ``ValueError`` otherwise.
+    """
+    evaluators = (config or {}).get("evaluators")
+    if not isinstance(evaluators, list) or len(evaluators) == 0:
+        raise ValueError(
+            "Config must define a non-empty `evaluators` list. Each evaluator "
+            "needs a `name` and `system_prompt` (general task evaluation has no "
+            "implicit default)."
+        )
+    for ev in evaluators:
+        if not isinstance(ev, dict) or "name" not in ev or "system_prompt" not in ev:
+            raise ValueError(
+                "Each evaluator must be a dict with 'name' and 'system_prompt' "
+                "(got: " + repr(ev) + ")"
+            )
+    require_unique_evaluator_names(evaluators)
+    return evaluators
+
+
+async def _score_and_write_results(
+    ids: list,
+    inputs: List[Optional[str]],
+    outputs: List[str],
+    evaluators: List[dict],
+    output_dir: str,
+) -> dict:
+    """Run the general judge over (input, output) pairs and write outputs.
+
+    Writes ``results.csv`` and ``metrics.json`` plus the resolved evaluator
+    ``config.json`` under ``output_dir``. Returns the metrics_data dict.
+    """
+    write_evaluator_config(output_dir, evaluators)
+
+    llm_results = await get_general_judge_score(
+        inputs,
+        outputs,
+        evaluators=evaluators,
+    )
+    for name, score_dict in llm_results["scores"].items():
+        _log(f"  {name}: {score_dict['mean']:.4f}")
+
+    evaluators_by_name = {ev["name"]: ev for ev in evaluators}
+
+    metrics_data: dict = {}
+    for name, score_dict in llm_results["scores"].items():
+        metrics_data[name] = score_dict
+
+    data = []
+    for _id, input_text, output_text, llm_row in zip(
+        ids, inputs, outputs, llm_results["per_row"]
+    ):
+        row = {
+            "id": _id,
+            "input": input_text,
+            "output": output_text,
+        }
+        for name, ev in evaluators_by_name.items():
+            ev_result = llm_row[name]
+            if is_rating(ev):
+                row[name] = ev_result["score"]
+            else:
+                row[name] = bool(ev_result["match"])
+            row[f"{name}_reasoning"] = ev_result["reasoning"]
+        data.append(row)
+
+    with open(join(output_dir, "metrics.json"), "w") as f:
+        json.dump(metrics_data, f, indent=4)
+
+    pd.DataFrame(data).to_csv(join(output_dir, "results.csv"), index=False)
+
+    return metrics_data
+
+
+async def run_general_eval(
+    dataset_path: str,
+    output_dir: str,
+    evaluators: List[dict],
+) -> dict:
+    """Run general task evaluators on a dataset of ``{id, input, output}`` rows.
+
+    Writes ``metrics.json`` and ``results.csv`` under ``output_dir``.
+
+    Args:
+        dataset_path: Path to a JSON file with a list of {"id", "input",
+            "output"} rows.
+        output_dir: Directory to write results and metrics.
+        evaluators: List of evaluator dicts (each with ``name`` and
+            ``system_prompt``).
+
+    Returns:
+        dict with ``status`` and, on success, ``metrics`` and ``output_dir``.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+
+    log_save_path = join(output_dir, "logs")
+    if exists(log_save_path):
+        os.remove(log_save_path)
+
+    token = _current_log_file.set(log_save_path)
+    try:
+        _log("--------------------------------")
+        _log("\033[33mRunning general task evaluation on dataset\033[0m")
+        _log(f"Dataset: {dataset_path}")
+
+        is_valid, error_msg, rows = validate_general_eval_dataset(dataset_path)
+        if not is_valid:
+            _log(f"\033[31mError: {error_msg}\033[0m")
+            return {"status": "error", "error": error_msg}
+
+        ids = [r["id"] for r in rows]
+        inputs = [str(r["input"]) if r["input"] is not None else "" for r in rows]
+        outputs = [str(r["output"]) if r["output"] is not None else "" for r in rows]
+
+        metrics_data = await _score_and_write_results(
+            ids=ids,
+            inputs=inputs,
+            outputs=outputs,
+            evaluators=evaluators,
+            output_dir=output_dir,
+        )
+
+        return {
+            "status": "completed",
+            "metrics": metrics_data,
+            "output_dir": output_dir,
+        }
+    finally:
+        _current_log_file.reset(token)
+
+
+async def main():
+    """CLI entry point for general task evaluation."""
+    parser = argparse.ArgumentParser(
+        description="Run general (non-conversational) task evaluation on a dataset"
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        required=True,
+        help="Path to dataset JSON (list of {id, input, output})",
+    )
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        required=True,
+        help="Path to JSON config file defining the `evaluators` list",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        type=str,
+        default="./out",
+        help="Path to the output directory to save the results",
+    )
+
+    args = parser.parse_args()
+
+    if not exists(args.config):
+        print(f"\033[31mError: config file not found: {args.config}\033[0m")
+        sys.exit(1)
+
+    try:
+        with open(args.config) as f:
+            config = json.load(f)
+    except Exception as e:
+        print(f"\033[31mError: failed to parse config JSON: {e}\033[0m")
+        sys.exit(1)
+
+    try:
+        evaluators = _resolve_evaluators(config)
+    except ValueError as e:
+        print(f"\033[31mError: {e}\033[0m")
+        sys.exit(1)
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    print("\n\033[91mGeneral Task Evaluation\033[0m\n")
+    print(f"Dataset: {args.dataset}")
+    print(f"Config: {args.config}")
+    print(f"Output: {args.output_dir}")
+    print("")
+
+    result = await run_general_eval(
+        dataset_path=args.dataset,
+        output_dir=args.output_dir,
+        evaluators=evaluators,
+    )
+
+    print(f"\n\033[92m{'='*60}\033[0m")
+    print(f"\033[92mSummary\033[0m")
+    print(f"\033[92m{'='*60}\033[0m\n")
+
+    if result.get("status") == "error":
+        print(f"  \033[31mError - {result.get('error')}\033[0m")
+        sys.exit(1)
+
+    metrics = result.get("metrics", {})
+    # Evaluator entries are dicts carrying a ``type`` field; that's the marker
+    # used to pick them out from any other top-level metrics.
+    judge_scores = {
+        k: v["mean"]
+        for k, v in metrics.items()
+        if isinstance(v, dict) and "type" in v
+    }
+    judge_str = ", ".join(f"{k}={v:.4f}" for k, v in judge_scores.items())
+    print(f"  {judge_str}" if judge_str else "  (no scores)")
+    print(f"\n  Results written to {result.get('output_dir')}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/calibrate/general/metrics.py
+++ b/calibrate/general/metrics.py
@@ -1,0 +1,163 @@
+"""General task evaluation metrics.
+
+Thin, non-conversational counterpart to ``calibrate.stt.metrics`` /
+``calibrate.llm.metrics``: judge a list of ``(input, output)`` task pairs
+against a list of evaluators and aggregate per-evaluator scores.
+"""
+
+from typing import List, Optional
+
+import numpy as np
+import backoff
+from tqdm.asyncio import tqdm_asyncio
+
+from calibrate.judges import (
+    general_task_judge,
+    is_rating,
+    evaluator_result_value,
+    require_unique_evaluator_names,
+    DEFAULT_TEXT_JUDGE_MODEL,
+)
+from calibrate.langfuse import observe, langfuse, langfuse_enabled
+
+# Re-export for symmetry with the other metrics modules.
+DEFAULT_GENERAL_JUDGE_MODEL = DEFAULT_TEXT_JUDGE_MODEL
+
+
+def _require_evaluators(evaluators: Optional[List[dict]]) -> List[dict]:
+    """Return ``evaluators`` if it is a non-empty list with unique names.
+
+    The general task judge has no implicit default — there is no universal
+    criteria to grade against — so callers must supply at least one evaluator
+    (each carrying its own ``system_prompt``). Mirrors
+    :func:`calibrate.judges.require_simulation_evaluators`.
+    """
+    if not isinstance(evaluators, list) or len(evaluators) == 0:
+        raise ValueError(
+            "General task evaluation requires a non-empty `evaluators` list "
+            "(there is no implicit default). Each evaluator must define a "
+            "`name` and `system_prompt`."
+        )
+    require_unique_evaluator_names(evaluators)
+    return list(evaluators)
+
+
+@backoff.on_exception(backoff.expo, Exception, max_tries=5, factor=2)
+@observe(
+    name="general_llm_judge",
+    capture_input=False,
+)
+async def general_judge(
+    input_text: Optional[str],
+    output: str,
+    evaluators: List[dict],
+    fallback_model: str = DEFAULT_GENERAL_JUDGE_MODEL,
+) -> dict:
+    """Evaluate a single task output (with optional input) against evaluators.
+
+    Args:
+        input_text: The task input the output was produced for (optional).
+        output: The output text to evaluate.
+        evaluators: List of evaluator dicts (already rendered).
+        fallback_model: Model id used when an evaluator lacks ``judge_model``.
+
+    Returns:
+        Dict keyed by evaluator name — same shape as
+        :func:`calibrate.judges.text_judge`.
+    """
+    result = await general_task_judge(
+        evaluators=evaluators,
+        output=output,
+        input_text=input_text,
+        fallback_model=fallback_model,
+    )
+
+    if langfuse_enabled and langfuse:
+        langfuse.update_current_trace(
+            input={"input": input_text, "output": output},
+            metadata={
+                "input": input_text,
+                "output": output,
+                "result": result,
+            },
+        )
+
+    return result
+
+
+async def get_general_judge_score(
+    inputs: List[Optional[str]],
+    outputs: List[str],
+    evaluators: List[dict],
+    fallback_model: str = DEFAULT_GENERAL_JUDGE_MODEL,
+) -> dict:
+    """Run the general judge across all rows and aggregate per-evaluator scores.
+
+    ``inputs`` and ``outputs`` are positionally paired; ``inputs[i]`` may be
+    ``None`` to judge ``outputs[i]`` on its own.
+
+    Returns:
+        {
+            "scores": {
+                "<evaluator>": {"type": "binary", "mean": 0.83},
+                "<evaluator>": {"type": "rating", "mean": 4.0,
+                                "scale_min": 1, "scale_max": 5},
+                ...
+            },
+            "score": float,        # mean across evaluator means (legacy top-level)
+            "per_row": [
+                {"<evaluator>": {"reasoning": ..., "match": ...}, ...},
+                ...
+            ],
+        }
+
+    Iteration order of ``scores`` and each ``per_row`` entry matches the order
+    of the ``evaluators`` argument.
+    """
+    evaluators = _require_evaluators(evaluators)
+
+    if len(inputs) != len(outputs):
+        raise ValueError(
+            f"inputs and outputs must be the same length "
+            f"(got {len(inputs)} inputs, {len(outputs)} outputs)."
+        )
+
+    coroutines = [
+        general_judge(
+            None if input_text is None else str(input_text),
+            str(output),
+            evaluators=evaluators,
+            fallback_model=fallback_model,
+        )
+        for input_text, output in zip(inputs, outputs)
+    ]
+
+    results = await tqdm_asyncio.gather(
+        *coroutines,
+        desc="Running general evaluators",
+    )
+
+    scores: dict = {}
+    for ev in evaluators:
+        name = ev["name"]
+        per_row_values = [evaluator_result_value(ev, row[name]) for row in results]
+        if is_rating(ev):
+            scores[name] = {
+                "type": "rating",
+                "mean": float(np.mean(per_row_values)),
+                "scale_min": int(ev["scale_min"]),
+                "scale_max": int(ev["scale_max"]),
+            }
+        else:
+            scores[name] = {
+                "type": "binary",
+                "mean": float(np.mean(per_row_values)),  # pass-rate fraction 0.0–1.0
+            }
+
+    overall_score = float(np.mean([s["mean"] for s in scores.values()]))
+
+    return {
+        "scores": scores,
+        "score": overall_score,
+        "per_row": results,
+    }

--- a/calibrate/judges.py
+++ b/calibrate/judges.py
@@ -115,6 +115,21 @@ DEFAULT_TOOL_CALL_PARAM_EVALUATOR = {
     "type": BINARY,
 }
 
+DEFAULT_GENERAL_TASK_EVALUATOR = {
+    "name": "task_quality",
+    "system_prompt": (
+        "You are a highly accurate evaluator assessing the output produced for "
+        "a task.\n\n"
+        "You will be given the task input (when one is provided) and the output "
+        "produced for it. Judge the output on its own merits — do not assume the "
+        "input is a conversation or that the output is a reply to a user.\n\n"
+        "Mark `match` true only if the output satisfies the following criteria, "
+        "and false otherwise:\n\n{{criteria}}"
+    ),
+    "judge_model": DEFAULT_TEXT_JUDGE_MODEL,
+    "type": BINARY,
+}
+
 DEFAULT_STT_EVALUATOR = {
     "name": "semantic_match",
     "system_prompt": (
@@ -670,6 +685,66 @@ def require_simulation_evaluators(evaluators: object) -> None:
             "(simulations have no implicit default)."
         )
     require_unique_evaluator_names(evaluators)
+
+
+# ── General task judge (thin wrapper over text_judge) ───────────────────────
+
+
+def format_task_io(output: str, input_text: Optional[str] = None) -> str:
+    """Build a neutral ``input``/``output`` user prompt for a general task.
+
+    Unlike :func:`format_conversation` this does not assume a chat transcript:
+    the text is framed as a task ``Input`` and ``Output`` pair. ``input_text``
+    is optional — when it is ``None`` or blank only the ``Output`` section is
+    emitted, so a caller can judge an output on its own (e.g. "is this valid
+    JSON", "is this summary faithful") without inventing a fake input.
+    """
+    sections: list[str] = []
+    if input_text is not None and str(input_text).strip():
+        sections.append(f"`Input`:\n\n{input_text}")
+    sections.append(f"`Output`:\n\n{output if output is not None else ''}")
+    return "\n\n".join(sections)
+
+
+@observe(name="general_task_judge", capture_input=False)
+async def general_task_judge(
+    evaluators: list[dict],
+    output: str,
+    input_text: Optional[str] = None,
+    fallback_model: str = DEFAULT_TEXT_JUDGE_MODEL,
+) -> dict:
+    """Evaluate a task output (with optional input) against a list of evaluators.
+
+    A general-purpose, non-conversational counterpart to
+    :func:`simulation_judge`. The ``output`` (and ``input_text`` when given) are
+    framed as a plain task ``Input``/``Output`` pair rather than a chat
+    transcript, so this fits arbitrary single-shot LLM tasks — summarization,
+    extraction, classification, rewriting, code generation, etc.
+
+    There is no implicit default evaluator. If ``evaluators`` is empty the
+    function returns ``{}`` and no judge calls are made.
+
+    Args:
+        evaluators: List of evaluator dicts (already rendered). Use
+            :data:`DEFAULT_GENERAL_TASK_EVALUATOR` for a generic criteria-driven
+            default.
+        output: The text output to evaluate.
+        input_text: Optional task input the output was produced for. Omitted from
+            the prompt when ``None`` or blank.
+        fallback_model: Model id used when an evaluator has no ``judge_model``.
+
+    Returns:
+        Dict keyed by ``evaluator["name"]`` — same shape as :func:`text_judge`.
+    """
+    if not evaluators:
+        return {}
+
+    user_prompt = format_task_io(output, input_text)
+    return await text_judge(
+        evaluators=evaluators,
+        user_prompt=user_prompt,
+        fallback_model=fallback_model,
+    )
 
 
 # ── Simulation judge (thin wrapper over text_judge) ─────────────────────────

--- a/examples/general/config.json
+++ b/examples/general/config.json
@@ -1,0 +1,19 @@
+{
+  "evaluators": [
+    {
+      "id": "faithful-id",
+      "name": "faithful",
+      "system_prompt": "You are a highly accurate evaluator assessing the output produced for a task.\n\nYou will be given the task input and the output produced for it. Judge the output on its own merits — do not assume the input is a conversation or that the output is a reply to a user.\n\nMark `match` true only if the output is faithful to the input: it must not add facts that are absent from the input, contradict the input, or omit information the task clearly required. Otherwise mark it false.",
+      "judge_model": "openai/gpt-5.4-mini"
+    },
+    {
+      "id": "quality-id",
+      "name": "quality",
+      "system_prompt": "You are a highly accurate evaluator that rates the overall quality of an output produced for a task.\n\nYou will be given the task input and the output produced for it. Rate the overall quality on a 1-5 scale: 1 (unusable — wrong, irrelevant, or unreadable), 3 (acceptable — mostly correct but with notable gaps or rough edges), 5 (excellent — accurate, complete, and clearly written).",
+      "judge_model": "openai/gpt-5.4-mini",
+      "type": "rating",
+      "scale_min": 1,
+      "scale_max": 5
+    }
+  ]
+}

--- a/examples/general/sample_dataset.json
+++ b/examples/general/sample_dataset.json
@@ -1,0 +1,22 @@
+[
+    {
+        "id": 1,
+        "input": "Summarize in one sentence: The town council voted 7 to 2 on Tuesday to approve a new bicycle lane along Main Street, with construction set to begin in March.",
+        "output": "The town council approved a new Main Street bicycle lane in a 7-2 vote, with construction starting in March."
+    },
+    {
+        "id": 2,
+        "input": "Extract all email addresses from this text: Contact Asha at asha@example.com or the support desk at help@store.io for returns.",
+        "output": "asha@example.com, help@store.io"
+    },
+    {
+        "id": 3,
+        "input": "Classify the sentiment of this review as positive, negative, or neutral: 'The product arrived late and the box was damaged, but the item itself works fine.'",
+        "output": "positive"
+    },
+    {
+        "id": 4,
+        "input": "Rewrite this sentence to be more concise: 'Due to the fact that the meeting was cancelled, we will be rescheduling it for a later date in the near future.'",
+        "output": "The meeting was cancelled and will be rescheduled soon."
+    }
+]

--- a/tests/general/test_eval.py
+++ b/tests/general/test_eval.py
@@ -7,6 +7,7 @@ metrics.json + results.csv.
 
 import json
 import os
+import sys
 import tempfile
 import unittest
 from unittest.mock import patch, AsyncMock
@@ -17,6 +18,7 @@ from calibrate.general.eval import (
     validate_general_eval_dataset,
     _resolve_evaluators,
     run_general_eval,
+    main as eval_main,
 )
 
 
@@ -124,6 +126,35 @@ class TestRunGeneralEval(unittest.IsolatedAsyncioTestCase):
             )
         self.assertEqual(result["status"], "error")
 
+    async def test_removes_stale_log_file(self):
+        rows = [{"id": "1", "input": "a", "output": "b"}]
+        dataset_path = _write_json(rows)
+        fake_score = {
+            "scores": {"faithful": {"type": "binary", "mean": 1.0}},
+            "score": 1.0,
+            "per_row": [{"faithful": {"reasoning": "ok", "match": True}}],
+        }
+        try:
+            with tempfile.TemporaryDirectory() as out_dir:
+                # Pre-existing logs file should be removed at the start of the run.
+                stale = os.path.join(out_dir, "logs")
+                with open(stale, "w") as f:
+                    f.write("old log\n")
+                with patch(
+                    "calibrate.general.eval.get_general_judge_score",
+                    AsyncMock(return_value=fake_score),
+                ):
+                    result = await run_general_eval(
+                        dataset_path=dataset_path,
+                        output_dir=out_dir,
+                        evaluators=[BINARY_EV],
+                    )
+                self.assertEqual(result["status"], "completed")
+                # The stale content is gone (file recreated fresh by the logger).
+                self.assertNotIn("old log", open(stale).read())
+        finally:
+            os.unlink(dataset_path)
+
     async def test_end_to_end_writes_outputs(self):
         rows = [
             {"id": "row_a", "input": "doc A", "output": "sum A"},
@@ -175,6 +206,149 @@ class TestRunGeneralEval(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(cfg["evaluators"][0]["name"], "faithful")
         finally:
             os.unlink(dataset_path)
+
+
+class TestMain(unittest.IsolatedAsyncioTestCase):
+    """Cover the CLI entry point branches of calibrate.general.eval.main()."""
+
+    def _argv(self, dataset, config, out):
+        return ["calibrate", "--dataset", dataset, "-c", config, "-o", out]
+
+    async def test_config_not_found_exits(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            ds = _write_json([{"id": "1", "input": "a", "output": "b"}])
+            try:
+                with patch.object(
+                    sys, "argv", self._argv(ds, "/no/such/config.json", out_dir)
+                ):
+                    with self.assertRaises(SystemExit) as cm:
+                        await eval_main()
+            finally:
+                os.unlink(ds)
+        self.assertEqual(cm.exception.code, 1)
+
+    async def test_config_bad_json_exits(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            ds = _write_json([{"id": "1", "input": "a", "output": "b"}])
+            bad = tempfile.NamedTemporaryFile(
+                mode="w", delete=False, suffix=".json"
+            )
+            bad.write("{not valid json")
+            bad.close()
+            try:
+                with patch.object(sys, "argv", self._argv(ds, bad.name, out_dir)):
+                    with self.assertRaises(SystemExit) as cm:
+                        await eval_main()
+            finally:
+                os.unlink(ds)
+                os.unlink(bad.name)
+        self.assertEqual(cm.exception.code, 1)
+
+    async def test_config_without_evaluators_exits(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            ds = _write_json([{"id": "1", "input": "a", "output": "b"}])
+            cfg = _write_json({"evaluators": []})
+            try:
+                with patch.object(sys, "argv", self._argv(ds, cfg, out_dir)):
+                    with self.assertRaises(SystemExit) as cm:
+                        await eval_main()
+            finally:
+                os.unlink(ds)
+                os.unlink(cfg)
+        self.assertEqual(cm.exception.code, 1)
+
+    async def test_error_status_exits(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            ds = _write_json([{"id": "1", "input": "a", "output": "b"}])
+            cfg = _write_json({"evaluators": [BINARY_EV]})
+            try:
+                with patch.object(sys, "argv", self._argv(ds, cfg, out_dir)), patch(
+                    "calibrate.general.eval.run_general_eval",
+                    AsyncMock(return_value={"status": "error", "error": "boom"}),
+                ):
+                    with self.assertRaises(SystemExit) as cm:
+                        await eval_main()
+            finally:
+                os.unlink(ds)
+                os.unlink(cfg)
+        self.assertEqual(cm.exception.code, 1)
+
+    async def test_success_prints_summary(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            ds = _write_json([{"id": "1", "input": "a", "output": "b"}])
+            cfg = _write_json({"evaluators": [BINARY_EV]})
+            completed = {
+                "status": "completed",
+                "metrics": {"faithful": {"type": "binary", "mean": 1.0}},
+                "output_dir": out_dir,
+            }
+            run_mock = AsyncMock(return_value=completed)
+            try:
+                with patch.object(sys, "argv", self._argv(ds, cfg, out_dir)), patch(
+                    "calibrate.general.eval.run_general_eval", run_mock
+                ):
+                    # Should not raise SystemExit on success
+                    await eval_main()
+            finally:
+                os.unlink(ds)
+                os.unlink(cfg)
+            # run_general_eval received the resolved evaluators from config
+            self.assertEqual(
+                run_mock.call_args.kwargs["evaluators"][0]["name"], "faithful"
+            )
+
+    async def test_success_with_no_scores_prints_placeholder(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            ds = _write_json([{"id": "1", "input": "a", "output": "b"}])
+            cfg = _write_json({"evaluators": [BINARY_EV]})
+            # metrics with no type-bearing dicts → the "(no scores)" branch
+            completed = {"status": "completed", "metrics": {}, "output_dir": out_dir}
+            try:
+                with patch.object(sys, "argv", self._argv(ds, cfg, out_dir)), patch(
+                    "calibrate.general.eval.run_general_eval",
+                    AsyncMock(return_value=completed),
+                ):
+                    await eval_main()  # should not raise
+            finally:
+                os.unlink(ds)
+                os.unlink(cfg)
+
+
+class TestCliDispatch(unittest.TestCase):
+    """Cover the `general` branch wired into calibrate.cli.main().
+
+    Plain (sync) TestCase because ``cli.main()`` calls ``asyncio.run()`` itself,
+    which cannot nest inside a running event loop.
+    """
+
+    def test_dispatch_invokes_eval_main(self):
+        from calibrate import cli
+
+        eval_main_mock = AsyncMock(return_value=None)
+        argv = ["calibrate", "general", "--dataset", "d.json", "-c", "c.json"]
+        with patch.object(sys, "argv", argv), patch(
+            "calibrate.general.eval.main", eval_main_mock
+        ):
+            cli.main()
+        eval_main_mock.assert_awaited_once()
+
+    def test_dispatch_missing_dataset_exits(self):
+        from calibrate import cli
+
+        argv = ["calibrate", "general", "-c", "c.json"]
+        with patch.object(sys, "argv", argv):
+            with self.assertRaises(SystemExit) as cm:
+                cli.main()
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_dispatch_missing_config_exits(self):
+        from calibrate import cli
+
+        argv = ["calibrate", "general", "--dataset", "d.json"]
+        with patch.object(sys, "argv", argv):
+            with self.assertRaises(SystemExit) as cm:
+                cli.main()
+        self.assertEqual(cm.exception.code, 1)
 
 
 if __name__ == "__main__":

--- a/tests/general/test_eval.py
+++ b/tests/general/test_eval.py
@@ -1,0 +1,181 @@
+"""Unit tests for calibrate/general/eval.py.
+
+Covers dataset validation, evaluator resolution from config, and the
+end-to-end run_general_eval path (with the judge mocked) producing
+metrics.json + results.csv.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch, AsyncMock
+
+import pandas as pd
+
+from calibrate.general.eval import (
+    validate_general_eval_dataset,
+    _resolve_evaluators,
+    run_general_eval,
+)
+
+
+BINARY_EV = {
+    "name": "faithful",
+    "system_prompt": "judge faithfulness",
+    "judge_model": "openai/gpt-4.1",
+}
+
+
+def _write_json(obj) -> str:
+    f = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json")
+    json.dump(obj, f)
+    f.close()
+    return f.name
+
+
+class TestValidateDataset(unittest.TestCase):
+    def test_missing_file(self):
+        ok, err, rows = validate_general_eval_dataset("/no/such/file.json")
+        self.assertFalse(ok)
+        self.assertIn("does not exist", err)
+
+    def test_not_a_list(self):
+        path = _write_json({"id": "1"})
+        try:
+            ok, err, _ = validate_general_eval_dataset(path)
+        finally:
+            os.unlink(path)
+        self.assertFalse(ok)
+        self.assertIn("list", err)
+
+    def test_empty_list(self):
+        path = _write_json([])
+        try:
+            ok, err, _ = validate_general_eval_dataset(path)
+        finally:
+            os.unlink(path)
+        self.assertFalse(ok)
+        self.assertIn("empty", err)
+
+    def test_missing_fields(self):
+        path = _write_json([{"id": "1", "input": "x"}])  # no output
+        try:
+            ok, err, _ = validate_general_eval_dataset(path)
+        finally:
+            os.unlink(path)
+        self.assertFalse(ok)
+        self.assertIn("output", err)
+
+    def test_duplicate_ids(self):
+        path = _write_json(
+            [
+                {"id": "1", "input": "a", "output": "b"},
+                {"id": "1", "input": "c", "output": "d"},
+            ]
+        )
+        try:
+            ok, err, _ = validate_general_eval_dataset(path)
+        finally:
+            os.unlink(path)
+        self.assertFalse(ok)
+        self.assertIn("Duplicate", err)
+
+    def test_valid(self):
+        rows_in = [
+            {"id": "1", "input": "a", "output": "b"},
+            {"id": "2", "input": "c", "output": "d"},
+        ]
+        path = _write_json(rows_in)
+        try:
+            ok, err, rows = validate_general_eval_dataset(path)
+        finally:
+            os.unlink(path)
+        self.assertTrue(ok)
+        self.assertEqual(err, "")
+        self.assertEqual(rows, rows_in)
+
+
+class TestResolveEvaluators(unittest.TestCase):
+    def test_missing_evaluators_raises(self):
+        with self.assertRaises(ValueError):
+            _resolve_evaluators({})
+
+    def test_empty_evaluators_raises(self):
+        with self.assertRaises(ValueError):
+            _resolve_evaluators({"evaluators": []})
+
+    def test_evaluator_without_system_prompt_raises(self):
+        with self.assertRaises(ValueError):
+            _resolve_evaluators({"evaluators": [{"name": "x"}]})
+
+    def test_valid_config(self):
+        out = _resolve_evaluators({"evaluators": [BINARY_EV]})
+        self.assertEqual(out, [BINARY_EV])
+
+
+class TestRunGeneralEval(unittest.IsolatedAsyncioTestCase):
+    async def test_error_status_on_bad_dataset(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            result = await run_general_eval(
+                dataset_path="/no/such/file.json",
+                output_dir=out_dir,
+                evaluators=[BINARY_EV],
+            )
+        self.assertEqual(result["status"], "error")
+
+    async def test_end_to_end_writes_outputs(self):
+        rows = [
+            {"id": "row_a", "input": "doc A", "output": "sum A"},
+            {"id": "row_b", "input": "doc B", "output": "sum B"},
+        ]
+        dataset_path = _write_json(rows)
+
+        fake_score = {
+            "scores": {"faithful": {"type": "binary", "mean": 0.5}},
+            "score": 0.5,
+            "per_row": [
+                {"faithful": {"reasoning": "ok", "match": True}},
+                {"faithful": {"reasoning": "no", "match": False}},
+            ],
+        }
+
+        try:
+            with tempfile.TemporaryDirectory() as out_dir:
+                with patch(
+                    "calibrate.general.eval.get_general_judge_score",
+                    AsyncMock(return_value=fake_score),
+                ):
+                    result = await run_general_eval(
+                        dataset_path=dataset_path,
+                        output_dir=out_dir,
+                        evaluators=[BINARY_EV],
+                    )
+
+                self.assertEqual(result["status"], "completed")
+                self.assertEqual(result["metrics"]["faithful"]["mean"], 0.5)
+
+                # metrics.json
+                with open(os.path.join(out_dir, "metrics.json")) as f:
+                    metrics = json.load(f)
+                self.assertEqual(metrics["faithful"]["mean"], 0.5)
+
+                # results.csv has one row per input row + per-evaluator columns
+                df = pd.read_csv(os.path.join(out_dir, "results.csv"))
+                self.assertEqual(len(df), 2)
+                self.assertIn("faithful", df.columns)
+                self.assertIn("faithful_reasoning", df.columns)
+                self.assertEqual(list(df["id"]), ["row_a", "row_b"])
+                self.assertEqual(bool(df.iloc[0]["faithful"]), True)
+                self.assertEqual(bool(df.iloc[1]["faithful"]), False)
+
+                # config.json captures the evaluators used
+                with open(os.path.join(out_dir, "config.json")) as f:
+                    cfg = json.load(f)
+                self.assertEqual(cfg["evaluators"][0]["name"], "faithful")
+        finally:
+            os.unlink(dataset_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/general/test_metrics.py
+++ b/tests/general/test_metrics.py
@@ -8,7 +8,7 @@ Covers the general (non-conversational) task scoring path:
 """
 
 import unittest
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, MagicMock
 
 from calibrate.general.metrics import (
     general_judge,
@@ -64,6 +64,19 @@ class TestGeneralJudge(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(kwargs["output"], "the summary")
         self.assertEqual(kwargs["input_text"], "the source")
         self.assertEqual(kwargs["evaluators"], [BINARY_EV])
+
+    async def test_updates_langfuse_trace_when_enabled(self):
+        judge = AsyncMock(return_value={"faithful": {"reasoning": "ok", "match": True}})
+        lf = MagicMock()
+        with patch("calibrate.general.metrics.general_task_judge", judge), patch(
+            "calibrate.general.metrics.langfuse_enabled", True
+        ), patch("calibrate.general.metrics.langfuse", lf):
+            await general_judge(
+                input_text="src", output="out", evaluators=[BINARY_EV]
+            )
+        lf.update_current_trace.assert_called_once()
+        call = lf.update_current_trace.call_args.kwargs
+        self.assertEqual(call["input"], {"input": "src", "output": "out"})
 
 
 class TestGetGeneralJudgeScore(unittest.IsolatedAsyncioTestCase):

--- a/tests/general/test_metrics.py
+++ b/tests/general/test_metrics.py
@@ -1,0 +1,136 @@
+"""Unit tests for calibrate/general/metrics.py.
+
+Covers the general (non-conversational) task scoring path:
+- _require_evaluators rejects empty / non-list evaluators
+- general_judge delegates to general_task_judge with input + output
+- get_general_judge_score fans out per row and aggregates binary + rating
+  scores into the {scores, score, per_row} shape
+"""
+
+import unittest
+from unittest.mock import patch, AsyncMock
+
+from calibrate.general.metrics import (
+    general_judge,
+    get_general_judge_score,
+    _require_evaluators,
+)
+
+
+BINARY_EV = {
+    "name": "faithful",
+    "system_prompt": "judge faithfulness",
+    "judge_model": "openai/gpt-4.1",
+}
+RATING_EV = {
+    "name": "quality",
+    "type": "rating",
+    "scale_min": 1,
+    "scale_max": 5,
+    "system_prompt": "rate quality",
+    "judge_model": "openai/gpt-4.1",
+}
+
+
+class TestRequireEvaluators(unittest.TestCase):
+    def test_empty_list_raises(self):
+        with self.assertRaises(ValueError):
+            _require_evaluators([])
+
+    def test_none_raises(self):
+        with self.assertRaises(ValueError):
+            _require_evaluators(None)
+
+    def test_duplicate_names_raise(self):
+        with self.assertRaises(ValueError):
+            _require_evaluators([BINARY_EV, dict(BINARY_EV)])
+
+    def test_valid_list_returned(self):
+        out = _require_evaluators([BINARY_EV])
+        self.assertEqual(out, [BINARY_EV])
+
+
+class TestGeneralJudge(unittest.IsolatedAsyncioTestCase):
+    async def test_delegates_with_input_and_output(self):
+        mock = AsyncMock(return_value={"faithful": {"reasoning": "ok", "match": True}})
+        with patch("calibrate.general.metrics.general_task_judge", mock):
+            result = await general_judge(
+                input_text="the source",
+                output="the summary",
+                evaluators=[BINARY_EV],
+            )
+        self.assertEqual(result, {"faithful": {"reasoning": "ok", "match": True}})
+        kwargs = mock.call_args.kwargs
+        self.assertEqual(kwargs["output"], "the summary")
+        self.assertEqual(kwargs["input_text"], "the source")
+        self.assertEqual(kwargs["evaluators"], [BINARY_EV])
+
+
+class TestGetGeneralJudgeScore(unittest.IsolatedAsyncioTestCase):
+    async def test_requires_evaluators(self):
+        with self.assertRaises(ValueError):
+            await get_general_judge_score(["a"], ["b"], evaluators=[])
+
+    async def test_length_mismatch_raises(self):
+        with self.assertRaises(ValueError):
+            await get_general_judge_score(["a", "b"], ["x"], evaluators=[BINARY_EV])
+
+    async def test_aggregates_binary_scores(self):
+        # Two rows: o1 passes, o2 fails → mean 0.5. The result for each row is
+        # derived from its own ``output`` arg (not a positional side_effect
+        # list) so concurrent completion order cannot scramble the mapping.
+        async def fake(_input, output, **kwargs):
+            return {"faithful": {"reasoning": output, "match": output == "o1"}}
+
+        with patch("calibrate.general.metrics.general_judge", AsyncMock(side_effect=fake)):
+            result = await get_general_judge_score(
+                inputs=["i1", "i2"],
+                outputs=["o1", "o2"],
+                evaluators=[BINARY_EV],
+            )
+        self.assertEqual(result["scores"]["faithful"]["type"], "binary")
+        self.assertAlmostEqual(result["scores"]["faithful"]["mean"], 0.5)
+        self.assertAlmostEqual(result["score"], 0.5)
+        # per_row preserves input order
+        self.assertEqual(
+            result["per_row"],
+            [
+                {"faithful": {"reasoning": "o1", "match": True}},
+                {"faithful": {"reasoning": "o2", "match": False}},
+            ],
+        )
+
+    async def test_aggregates_rating_scores(self):
+        scores_by_output = {"o1": 4, "o2": 2}
+
+        async def fake(_input, output, **kwargs):
+            return {"quality": {"reasoning": output, "score": scores_by_output[output]}}
+
+        with patch("calibrate.general.metrics.general_judge", AsyncMock(side_effect=fake)):
+            result = await get_general_judge_score(
+                inputs=["i1", "i2"],
+                outputs=["o1", "o2"],
+                evaluators=[RATING_EV],
+            )
+        score = result["scores"]["quality"]
+        self.assertEqual(score["type"], "rating")
+        self.assertAlmostEqual(score["mean"], 3.0)
+        self.assertEqual(score["scale_min"], 1)
+        self.assertEqual(score["scale_max"], 5)
+
+    async def test_none_input_passed_through(self):
+        mock = AsyncMock(return_value={"faithful": {"reasoning": "ok", "match": True}})
+        with patch("calibrate.general.metrics.general_judge", mock):
+            await get_general_judge_score(
+                inputs=[None],
+                outputs=["only-output"],
+                evaluators=[BINARY_EV],
+            )
+        # First positional arg to general_judge is the input — stays None
+        args = mock.call_args.args
+        self.assertIsNone(args[0])
+        self.assertEqual(args[1], "only-output")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judges.py
+++ b/tests/test_judges.py
@@ -21,6 +21,8 @@ from pydantic import BaseModel
 from calibrate.judges import (
     text_judge,
     simulation_judge,
+    general_task_judge,
+    format_task_io,
     audio_judge,
     is_rating,
     evaluator_result_value,
@@ -35,6 +37,7 @@ from calibrate.judges import (
     DEFAULT_AUDIO_JUDGE_MODEL,
     DEFAULT_SIMULATION_JUDGE_MODEL,
     DEFAULT_LLM_TEST_EVALUATOR,
+    DEFAULT_GENERAL_TASK_EVALUATOR,
     DEFAULT_STT_EVALUATOR,
     DEFAULT_TTS_EVALUATOR,
 )
@@ -595,6 +598,117 @@ class TestSimulationJudge(unittest.IsolatedAsyncioTestCase):
 
 
 # ---------------------------------------------------------------------------
+# general_task_judge
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTaskIO(unittest.TestCase):
+    def test_input_and_output(self):
+        out = format_task_io("the answer", input_text="the question")
+        self.assertIn("`Input`:\n\nthe question", out)
+        self.assertIn("`Output`:\n\nthe answer", out)
+
+    def test_output_only_when_no_input(self):
+        out = format_task_io("the answer")
+        self.assertNotIn("`Input`", out)
+        self.assertEqual(out, "`Output`:\n\nthe answer")
+
+    def test_blank_input_is_omitted(self):
+        out = format_task_io("the answer", input_text="   ")
+        self.assertNotIn("`Input`", out)
+
+    def test_not_framed_as_conversation(self):
+        out = format_task_io("hello", input_text="hi")
+        self.assertNotIn("Chat history", out)
+        self.assertNotIn("user:", out)
+        self.assertNotIn("assistant:", out)
+
+
+class TestGeneralTaskJudge(unittest.IsolatedAsyncioTestCase):
+    async def test_empty_evaluators_returns_empty_dict(self):
+        result = await general_task_judge(evaluators=[], output="anything")
+        self.assertEqual(result, {})
+
+    async def test_delegates_to_text_judge_with_input_and_output(self):
+        evaluators = [
+            {
+                "name": "task_quality",
+                "system_prompt": "judge it",
+                "judge_model": "openai/gpt-4.1",
+            }
+        ]
+        mock_text_judge = AsyncMock(
+            return_value={"task_quality": {"reasoning": "ok", "match": True}}
+        )
+        with patch("calibrate.judges.text_judge", mock_text_judge):
+            result = await general_task_judge(
+                evaluators=evaluators,
+                output="a faithful summary",
+                input_text="a long document",
+            )
+        self.assertEqual(
+            result, {"task_quality": {"reasoning": "ok", "match": True}}
+        )
+        call_kwargs = mock_text_judge.call_args.kwargs
+        self.assertEqual(call_kwargs["evaluators"], evaluators)
+        prompt = call_kwargs["user_prompt"]
+        self.assertIn("a long document", prompt)
+        self.assertIn("a faithful summary", prompt)
+        # Neutral framing — not a chat transcript
+        self.assertNotIn("Chat history", prompt)
+
+    async def test_output_only_omits_input_section(self):
+        mock_text_judge = AsyncMock(
+            return_value={"x": {"reasoning": "ok", "match": True}}
+        )
+        with patch("calibrate.judges.text_judge", mock_text_judge):
+            await general_task_judge(
+                evaluators=[
+                    {"name": "x", "system_prompt": "y", "judge_model": "m"}
+                ],
+                output="{\"k\": 1}",
+            )
+        prompt = mock_text_judge.call_args.kwargs["user_prompt"]
+        self.assertNotIn("`Input`", prompt)
+        self.assertIn("`Output`", prompt)
+
+    async def test_passes_fallback_model_through(self):
+        mock_text_judge = AsyncMock(return_value={})
+        with patch("calibrate.judges.text_judge", mock_text_judge):
+            await general_task_judge(
+                evaluators=[{"name": "x", "system_prompt": "y"}],
+                output="out",
+                fallback_model="fallback-model",
+            )
+        self.assertEqual(
+            mock_text_judge.call_args.kwargs["fallback_model"], "fallback-model"
+        )
+
+    async def test_end_to_end_with_mocked_client(self):
+        client = _mock_instructor_chat_completions(
+            [{"reasoning": "faithful", "match": True}]
+        )
+        with patch(
+            "calibrate.judges.instructor.apatch", return_value=client
+        ), patch(
+            "calibrate.judges._build_openrouter_client", return_value=MagicMock()
+        ):
+            result = await general_task_judge(
+                evaluators=[
+                    render_evaluator(
+                        DEFAULT_GENERAL_TASK_EVALUATOR,
+                        {"criteria": "the summary is faithful to the input"},
+                    )
+                ],
+                output="a summary",
+                input_text="a document",
+            )
+        self.assertEqual(
+            result, {"task_quality": {"reasoning": "faithful", "match": True}}
+        )
+
+
+# ---------------------------------------------------------------------------
 # audio_judge
 # ---------------------------------------------------------------------------
 
@@ -719,6 +833,16 @@ class TestDefaultEvaluators(unittest.TestCase):
         self.assertIn("{{criteria}}", DEFAULT_LLM_TEST_EVALUATOR["system_prompt"])
         self.assertEqual(
             DEFAULT_LLM_TEST_EVALUATOR["judge_model"], DEFAULT_TEXT_JUDGE_MODEL
+        )
+
+    def test_general_task_default_evaluator_shape(self):
+        self.assertEqual(DEFAULT_GENERAL_TASK_EVALUATOR["name"], "task_quality")
+        self.assertIn(
+            "{{criteria}}", DEFAULT_GENERAL_TASK_EVALUATOR["system_prompt"]
+        )
+        self.assertEqual(DEFAULT_GENERAL_TASK_EVALUATOR["type"], "binary")
+        self.assertEqual(
+            DEFAULT_GENERAL_TASK_EVALUATOR["judge_model"], DEFAULT_TEXT_JUDGE_MODEL
         )
 
     def test_stt_default_evaluator_shape(self):


### PR DESCRIPTION
## What

Adds `general_task_judge` — a general-purpose LLM judge that takes a plain task **input → output** text pair and grades the output, without assuming a conversation.

## Why

The existing judge wrappers (`test_response_llm_judge`, `simulation_judge`) frame the judge prompt as a `Chat history` transcript with `user:`/`assistant:` turns. That biases evaluation toward conversational outputs and makes them awkward for single-shot tasks like summarization, extraction, classification, rewriting, or code generation. This adds a neutral counterpart.

## Changes (`calibrate/judges.py`)

- **`general_task_judge(evaluators, output, input_text=None, fallback_model=...)`** — non-conversational counterpart to `simulation_judge`, built on the existing `text_judge` fan-out, so it inherits binary/rating types, per-evaluator `judge_model`, parallel calls, Langfuse tracing, and the standard result shape keyed by evaluator name.
- **`format_task_io(output, input_text=None)`** — prompt builder framing text as `Input` / `Output`. `input_text` is optional: when `None`/blank only the `Output` section is emitted, so an output can be judged on its own.
- **`DEFAULT_GENERAL_TASK_EVALUATOR`** (`task_quality`) — binary, `{{criteria}}`-driven default whose system prompt explicitly tells the judge to judge the output on its own merits and not assume a conversation.

## Usage

```python
from calibrate.judges import (
    general_task_judge, render_evaluator, DEFAULT_GENERAL_TASK_EVALUATOR,
)

ev = render_evaluator(
    DEFAULT_GENERAL_TASK_EVALUATOR,
    {"criteria": "the summary is faithful to the input and under 50 words"},
)
result = await general_task_judge(
    evaluators=[ev],
    output="<the LLM output>",
    input_text="<the source document>",   # optional
)
# -> {"task_quality": {"reasoning": "...", "match": True}}
```

## Tests

Added `TestFormatTaskIO`, `TestGeneralTaskJudge`, and a default-evaluator sanity check to `tests/test_judges.py` — covering input+output framing, output-only mode, blank-input omission, the non-conversational assertion, delegation/fallback-model wiring, and an end-to-end run with a mocked client. Full file passes (52/52).

## Notes for reviewers

- Param is named `input_text` (not `input`) to avoid shadowing the builtin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)