### PR TITLE
Aggregate cost and latency for external-agent LLM tests

### DIFF
--- a/calibrate/llm/__init__.py
+++ b/calibrate/llm/__init__.py
@@ -208,13 +208,24 @@ class _Tests:
         with open(os.path.join(final_output_dir, "results.json"), "w") as f:
             json.dump(results, f, indent=4)
 
-        from calibrate.llm.run_tests import _aggregate_criteria, _aggregate_tool_calls
+        from calibrate.llm.run_tests import (
+            _aggregate_criteria,
+            _aggregate_tool_calls,
+            _aggregate_cost,
+            _aggregate_latency,
+        )
         metrics = {
             "total": total_tests,
             "passed": total_passed,
             "criteria": _aggregate_criteria(results, name_to_evaluator),
             "tool_calls": _aggregate_tool_calls(results),
         }
+        cost = _aggregate_cost(results)
+        if cost is not None:
+            metrics["cost"] = cost
+        latency = _aggregate_latency(results)
+        if latency is not None:
+            metrics["latency_ms"] = latency
         with open(os.path.join(final_output_dir, "metrics.json"), "w") as f:
             json.dump(metrics, f, indent=4)
 

--- a/tests/llm/test_init_extra.py
+++ b/tests/llm/test_init_extra.py
@@ -92,6 +92,44 @@ class TestLLMTestsRun(unittest.IsolatedAsyncioTestCase):
             )
         self.assertEqual(result["status"], "completed")
 
+    async def test_run_with_agent_aggregates_cost_and_latency(self):
+        from calibrate.llm import tests
+
+        fake_test_result = {
+            "output": {
+                "response": "Hi",
+                "tool_calls": [],
+                "metrics": {"cost": 0.002768, "latency_ms": 1245.8},
+                "cost": 0.002768,
+            },
+            "metrics": {"passed": True, "judge_results": {}},
+            "latency_ms": 1245.8,
+        }
+        fake_agent = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch("calibrate.llm.run_tests.run_test_external", AsyncMock(return_value=fake_test_result)):
+            result = await tests.run(
+                test_cases=[{
+                    "history": [{"role": "user", "content": "hi"}],
+                    "evaluation": {"type": "response", "criteria": "respond"},
+                }],
+                output_dir=tmp,
+                agent=fake_agent,
+            )
+            with open(os.path.join(result["output_dir"], "metrics.json")) as f:
+                written = json.load(f)
+
+        self.assertEqual(result["status"], "completed")
+        self.assertIn("cost", result["metrics"])
+        self.assertEqual(result["metrics"]["cost"]["count"], 1)
+        self.assertAlmostEqual(result["metrics"]["cost"]["mean"], 0.002768)
+        self.assertIn("latency_ms", result["metrics"])
+        self.assertEqual(result["metrics"]["latency_ms"]["count"], 1)
+        self.assertEqual(result["metrics"]["latency_ms"]["mean"], 1246)
+        self.assertIn("cost", written)
+        self.assertIn("latency_ms", written)
+
     async def test_run_agent_benchmark(self):
         from calibrate.llm import tests
 


### PR DESCRIPTION
## Summary
- The external-agent LLM test path (`_run_single_model` in `calibrate/llm/__init__.py`) built `metrics.json` inline and only included `total`, `passed`, `criteria`, and `tool_calls` — dropping the `cost` and `latency_ms` aggregates.
- The per-run values were already captured (`output.cost` and top-level `latency_ms` in `results.json`), and the **internal** LLM test path (`_write_test_results_outputs`) already aggregates them.
- This reuses the same `_aggregate_cost` / `_aggregate_latency` helpers so the external-agent summary matches internal LLM tests (still absent rather than a misleading `0.0` when no result reports them).

## Test plan
- [x] Added `test_run_with_agent_aggregates_cost_and_latency` asserting both `cost` and `latency_ms` appear in the returned metrics and in the written `metrics.json`.
- [x] `uv run pytest tests/llm/test_init_extra.py` — 17 passed.

Made with [Cursor](https://cursor.com)