### PR TITLE
Track total token usage for internal and agent-connection LLM tests

### DIFF
--- a/calibrate/llm/__init__.py
+++ b/calibrate/llm/__init__.py
@@ -213,6 +213,7 @@ class _Tests:
             _aggregate_tool_calls,
             _aggregate_cost,
             _aggregate_latency,
+            _aggregate_total_tokens,
         )
         metrics = {
             "total": total_tests,
@@ -226,6 +227,9 @@ class _Tests:
         latency = _aggregate_latency(results)
         if latency is not None:
             metrics["latency_ms"] = latency
+        total_tokens = _aggregate_total_tokens(results)
+        if total_tokens is not None:
+            metrics["total_tokens"] = total_tokens
         with open(os.path.join(final_output_dir, "metrics.json"), "w") as f:
             json.dump(metrics, f, indent=4)
 

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -31,7 +31,9 @@ from pipecat.frames.frames import (
     LLMMessagesAppendFrame,
     TextFrame,
     FunctionCallInProgressFrame,
+    MetricsFrame,
 )
+from pipecat.metrics.metrics import LLMUsageMetricsData
 from pipecat.adapters.schemas.function_schema import FunctionSchema
 from pipecat.services.llm_service import FunctionCallParams
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
@@ -179,6 +181,7 @@ class Processor(FrameProcessor):
         self._tool_calls = []
         self._ready = False
         self._chat_history = chat_history
+        self._total_tokens: Optional[int] = None
 
     def set_task(self, task: "PipelineTask"):
         """Set the task reference after task creation."""
@@ -205,6 +208,16 @@ class Processor(FrameProcessor):
                 self._collecting_response = True
                 self._current_response += text
                 logger.info(f"Received text chunk: {text}")
+
+        # Capture token usage emitted by the LLM service (provider-agnostic:
+        # both OpenAI and OpenRouter services push these when usage metrics are
+        # enabled). A turn may emit more than one usage frame, so accumulate.
+        if isinstance(frame, MetricsFrame):
+            for data in frame.data:
+                if isinstance(data, LLMUsageMetricsData):
+                    total = getattr(data.value, "total_tokens", None)
+                    if total:
+                        self._total_tokens = (self._total_tokens or 0) + int(total)
 
         if isinstance(frame, FunctionCallInProgressFrame):
             log_and_print(f"Function call in progress: {frame.function_name}")
@@ -519,6 +532,7 @@ async def _run_inference_inner(
         "response": processor._current_response,
         "tool_calls": processor._tool_calls,
         "cost": getattr(llm, "last_cost", None),
+        "total_tokens": processor._total_tokens,
     }
 
 
@@ -1503,6 +1517,18 @@ async def run_test_external(
     if agent_cost is not None:
         result_output["cost"] = agent_cost
 
+    # Lift the agent's total token usage into the same canonical field the
+    # internal path populates (output.total_tokens). Fall back to summing the
+    # prompt/completion counts when the agent reports those but no total.
+    agent_total_tokens = _numeric_or_none(metrics_block.get("total_tokens"))
+    if agent_total_tokens is None:
+        prompt_tokens = _numeric_or_none(metrics_block.get("prompt_tokens"))
+        completion_tokens = _numeric_or_none(metrics_block.get("completion_tokens"))
+        if prompt_tokens is not None or completion_tokens is not None:
+            agent_total_tokens = (prompt_tokens or 0) + (completion_tokens or 0)
+    if agent_total_tokens is not None:
+        result_output["total_tokens"] = agent_total_tokens
+
     result: dict = {"output": result_output, "metrics": metrics}
     agent_latency = _numeric_or_none(metrics_block.get("latency_ms"))
     if agent_latency is not None:
@@ -1610,6 +1636,36 @@ def _aggregate_cost(results: List[dict]) -> Optional[dict]:
         "min": min(costs),
         "max": max(costs),
         "count": len(costs),
+    }
+
+
+def _aggregate_total_tokens(results: List[dict]) -> Optional[dict]:
+    """Aggregate per-test-case total token usage across results that report it.
+
+    Token counts live in ``output.total_tokens`` for every path: internal LLM
+    tests capture them from the pipecat usage metrics (both OpenAI and
+    OpenRouter services) and external agents have them lifted there from their
+    self-reported ``metrics`` dict in :func:`run_test_external`. Results without
+    a token count (agents that don't report one, or older results) are ignored.
+    Returns ``None`` when no result carries a count so the metric is absent
+    rather than a misleading ``0``.
+
+    Output shape mirrors :func:`_aggregate_cost`:
+    ``{"mean", "min", "max", "count"}`` with the mean rounded to a whole token.
+    """
+    values = [
+        t
+        for r in results
+        if (t := _numeric_or_none((r.get("output") or {}).get("total_tokens")))
+        is not None
+    ]
+    if not values:
+        return None
+    return {
+        "mean": round(sum(values) / len(values)),
+        "min": min(values),
+        "max": max(values),
+        "count": len(values),
     }
 
 
@@ -1858,6 +1914,9 @@ def _write_test_results_outputs(
     latency = _aggregate_latency(results)
     if latency is not None:
         metrics["latency_ms"] = latency
+    total_tokens = _aggregate_total_tokens(results)
+    if total_tokens is not None:
+        metrics["total_tokens"] = total_tokens
     with open(join(output_dir, "metrics.json"), "w") as f:
         json.dump(metrics, f, indent=4)
 

--- a/calibrate/llm/tests_leaderboard.py
+++ b/calibrate/llm/tests_leaderboard.py
@@ -99,7 +99,8 @@ def _build_leaderboard(
 ) -> pd.DataFrame:
     """Build leaderboard DataFrame.
 
-    Columns: model, passed, total, pass_rate, latency_ms, cost, [criterion_1, ...]
+    Columns: model, passed, total, pass_rate, latency_ms, cost, total_tokens,
+    [criterion_1, ...]
 
     ``latency_ms`` is the mean per-test-case response-generation latency (in
     milliseconds, judge time excluded); ``None`` for runs without it (e.g.
@@ -107,6 +108,10 @@ def _build_leaderboard(
 
     ``cost`` is the mean per-test-case LLM cost in USD (``None`` when the run
     reported no cost, e.g. the OpenAI provider or external agents).
+
+    ``total_tokens`` is the mean per-test-case total token usage (``None`` when
+    the run reported no token counts, e.g. external agents that don't report
+    usage or eval-only).
 
     Per-criterion column values:
     - binary criterion → pass_rate (%)
@@ -119,6 +124,11 @@ def _build_leaderboard(
         total = int(data.get("total", 0))
         latency = data.get("latency_ms") if isinstance(data.get("latency_ms"), dict) else {}
         cost = data.get("cost") if isinstance(data.get("cost"), dict) else {}
+        total_tokens = (
+            data.get("total_tokens")
+            if isinstance(data.get("total_tokens"), dict)
+            else {}
+        )
         row: Dict[str, object] = {
             "model": model_name,
             "passed": passed,
@@ -126,6 +136,7 @@ def _build_leaderboard(
             "pass_rate": _to_percent(passed, total),
             "latency_ms": latency.get("mean"),
             "cost": _numeric_or_none(cost.get("mean")),
+            "total_tokens": _numeric_or_none(total_tokens.get("mean")),
         }
 
         criteria = data.get("criteria") or {}

--- a/tests/llm/test_init_extra.py
+++ b/tests/llm/test_init_extra.py
@@ -92,15 +92,16 @@ class TestLLMTestsRun(unittest.IsolatedAsyncioTestCase):
             )
         self.assertEqual(result["status"], "completed")
 
-    async def test_run_with_agent_aggregates_cost_and_latency(self):
+    async def test_run_with_agent_aggregates_cost_latency_and_tokens(self):
         from calibrate.llm import tests
 
         fake_test_result = {
             "output": {
                 "response": "Hi",
                 "tool_calls": [],
-                "metrics": {"cost": 0.002768, "latency_ms": 1245.8},
+                "metrics": {"cost": 0.002768, "latency_ms": 1245.8, "total_tokens": 4387},
                 "cost": 0.002768,
+                "total_tokens": 4387,
             },
             "metrics": {"passed": True, "judge_results": {}},
             "latency_ms": 1245.8,
@@ -127,8 +128,12 @@ class TestLLMTestsRun(unittest.IsolatedAsyncioTestCase):
         self.assertIn("latency_ms", result["metrics"])
         self.assertEqual(result["metrics"]["latency_ms"]["count"], 1)
         self.assertEqual(result["metrics"]["latency_ms"]["mean"], 1246)
+        self.assertIn("total_tokens", result["metrics"])
+        self.assertEqual(result["metrics"]["total_tokens"]["count"], 1)
+        self.assertEqual(result["metrics"]["total_tokens"]["mean"], 4387)
         self.assertIn("cost", written)
         self.assertIn("latency_ms", written)
+        self.assertIn("total_tokens", written)
 
     async def test_run_agent_benchmark(self):
         from calibrate.llm import tests

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -1586,6 +1586,53 @@ class TestAggregateCost(unittest.TestCase):
         self.assertEqual(agg["count"], 1)
 
 
+class TestAggregateTotalTokens(unittest.TestCase):
+    def test_no_results_returns_none(self):
+        from calibrate.llm.run_tests import _aggregate_total_tokens
+
+        self.assertIsNone(_aggregate_total_tokens([]))
+
+    def test_no_tokens_returns_none(self):
+        from calibrate.llm.run_tests import _aggregate_total_tokens
+
+        results = [
+            {"output": {"response": "hi", "tool_calls": []}},
+            {"output": {"response": "yo", "tool_calls": [], "total_tokens": None}},
+            {"metrics": {"passed": True}},  # no output key at all
+        ]
+        self.assertIsNone(_aggregate_total_tokens(results))
+
+    def test_mean_across_token_counts(self):
+        from calibrate.llm.run_tests import _aggregate_total_tokens
+
+        results = [
+            {"output": {"total_tokens": 100}},
+            {"output": {"total_tokens": 201}},
+            {"output": {"total_tokens": None}},  # ignored
+            {"output": {}},  # ignored
+        ]
+        agg = _aggregate_total_tokens(results)
+        self.assertEqual(agg["mean"], 150)  # round(301 / 2) — banker's rounding
+        self.assertEqual(agg["min"], 100)
+        self.assertEqual(agg["max"], 201)
+        self.assertEqual(agg["count"], 2)
+
+    def test_read_only_from_output_total_tokens(self):
+        """Token usage lives at ``output.total_tokens`` for both paths; a
+        nested-only metrics count is not dug out here (run_test_external lifts
+        it first)."""
+        from calibrate.llm.run_tests import _aggregate_total_tokens
+
+        results = [
+            {"output": {"total_tokens": 50}},                    # counted
+            {"output": {"metrics": {"total_tokens": 999}}},      # not lifted → ignored
+            {"output": {"response": "x", "tool_calls": []}},     # no tokens
+        ]
+        agg = _aggregate_total_tokens(results)
+        self.assertEqual(agg["mean"], 50)
+        self.assertEqual(agg["count"], 1)
+
+
 class TestCostTrackingService(unittest.IsolatedAsyncioTestCase):
     def _service(self):
         from calibrate.llm.run_tests import CostTrackingOpenRouterLLMService
@@ -1634,6 +1681,38 @@ class TestCostTrackingService(unittest.IsolatedAsyncioTestCase):
         usage = MagicMock(cost="not-a-number")
         await self._drain(svc, [MagicMock(usage=usage)])
         self.assertIsNone(svc.last_cost)
+
+
+class TestProcessorTokenCapture(unittest.IsolatedAsyncioTestCase):
+    """The Processor accumulates token usage from LLM usage MetricsFrames."""
+
+    def _usage_frame(self, prompt, completion, total=None):
+        from pipecat.frames.frames import MetricsFrame
+        from pipecat.metrics.metrics import LLMUsageMetricsData, LLMTokenUsage
+
+        usage = LLMTokenUsage(
+            prompt_tokens=prompt, completion_tokens=completion, total_tokens=total
+        )
+        return MetricsFrame(
+            data=[LLMUsageMetricsData(processor="llm", model="m", value=usage)]
+        )
+
+    async def _feed(self, proc, frame):
+        from calibrate.llm import run_tests as RT
+
+        proc._ready = True  # skip the initial queue_frames branch
+        proc._task = None
+        with patch.object(RT.FrameProcessor, "process_frame", AsyncMock()), \
+             patch.object(proc, "push_frame", AsyncMock()):
+            await proc.process_frame(frame, RT.FrameDirection.DOWNSTREAM)
+
+    async def test_accumulates_total_tokens_across_frames(self):
+        from calibrate.llm.run_tests import Processor
+
+        proc = Processor(chat_history=[])
+        await self._feed(proc, self._usage_frame(1000, 200, total=1200))
+        await self._feed(proc, self._usage_frame(300, 50, total=350))
+        self.assertEqual(proc._total_tokens, 1550)
 
 
 class TestRunInferenceWrapping(unittest.IsolatedAsyncioTestCase):
@@ -2411,6 +2490,46 @@ class TestWriteOutputsLatency(unittest.TestCase):
             _write_test_results_outputs(results, tmp, {})
             metrics = json.loads((Path(tmp) / "metrics.json").read_text())
         self.assertNotIn("latency_ms", metrics)
+
+
+class TestWriteOutputsTotalTokens(unittest.TestCase):
+    def test_metrics_includes_total_tokens_when_present(self):
+        from calibrate.llm.run_tests import _write_test_results_outputs
+
+        results = [
+            {
+                "metrics": {"passed": True},
+                "output": {"total_tokens": 100},
+                "test_case": {"evaluation": {"type": "response"}},
+            },
+            {
+                "metrics": {"passed": False},
+                "output": {"total_tokens": 200},
+                "test_case": {"evaluation": {"type": "response"}},
+            },
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_test_results_outputs(results, tmp, {})
+            metrics = json.loads((Path(tmp) / "metrics.json").read_text())
+        self.assertEqual(
+            metrics["total_tokens"],
+            {"mean": 150, "min": 100, "max": 200, "count": 2},
+        )
+
+    def test_metrics_omits_total_tokens_when_absent(self):
+        from calibrate.llm.run_tests import _write_test_results_outputs
+
+        results = [
+            {
+                "metrics": {"passed": True},
+                "output": {"response": "hi", "tool_calls": []},
+                "test_case": {"evaluation": {"type": "response"}},
+            },
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_test_results_outputs(results, tmp, {})
+            metrics = json.loads((Path(tmp) / "metrics.json").read_text())
+        self.assertNotIn("total_tokens", metrics)
 
 
 if __name__ == "__main__":

--- a/tests/llm/test_tests_leaderboard.py
+++ b/tests/llm/test_tests_leaderboard.py
@@ -124,9 +124,11 @@ class TestLeaderboardMultiCriteria(unittest.TestCase):
             self.assertIn("pass_rate", df.columns)
             self.assertIn("passed", df.columns)
             self.assertIn("total", df.columns)
-            # No criterion columns (latency_ms and cost are standard columns, empty here)
+            # No criterion columns (latency_ms, cost and total_tokens are
+            # standard columns, empty here)
             expected_cols = {
                 "model", "passed", "total", "pass_rate", "latency_ms", "cost",
+                "total_tokens",
             }
             self.assertEqual(set(df.columns), expected_cols)
             # Cost is absent in old-style metrics → empty column
@@ -149,6 +151,25 @@ class TestLeaderboardMultiCriteria(unittest.TestCase):
             self.assertIn("cost", df.columns)
             by_model = dict(zip(df["model"], df["cost"]))
             self.assertAlmostEqual(by_model["model-a"], 0.03)
+            self.assertTrue(pd.isna(by_model["model-b"]))
+
+    def test_total_tokens_column_shows_mean(self):
+        """The leaderboard surfaces the per-model mean total tokens, None when absent."""
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            _write_model(base, "model-a", {
+                "total": 2, "passed": 2,
+                "total_tokens": {"mean": 4387, "min": 4000, "max": 4774, "count": 2},
+            })
+            _write_model(base, "model-b", {"total": 2, "passed": 1})
+
+            save_dir = base / "leaderboard"
+            generate_leaderboard(str(base), str(save_dir))
+
+            df = pd.read_csv(save_dir / "llm_leaderboard.csv")
+            self.assertIn("total_tokens", df.columns)
+            by_model = dict(zip(df["model"], df["total_tokens"]))
+            self.assertEqual(by_model["model-a"], 4387)
             self.assertTrue(pd.isna(by_model["model-b"]))
 
     def test_skip_leaderboard_folder(self):

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -457,6 +457,38 @@ class TestRunTestExternalMetrics(unittest.IsolatedAsyncioTestCase):
         agg = _aggregate_latency([result])
         self.assertEqual(agg["mean"], 200)
 
+    async def test_agent_reported_total_tokens_lifted_to_output(self):
+        result = await self._run(
+            {"response": "hi", "tool_calls": [], "metrics": {"total_tokens": 4387}}
+        )
+        self.assertEqual(result["output"]["total_tokens"], 4387)
+
+    async def test_total_tokens_derived_from_prompt_and_completion(self):
+        result = await self._run(
+            {"response": "hi", "tool_calls": [],
+             "metrics": {"prompt_tokens": 1200, "completion_tokens": 340}}
+        )
+        self.assertEqual(result["output"]["total_tokens"], 1540)
+
+    async def test_no_total_tokens_when_agent_does_not_report(self):
+        result = await self._run({"response": "hi", "tool_calls": []})
+        self.assertNotIn("total_tokens", result["output"])
+
+    async def test_malformed_total_tokens_ignored(self):
+        result = await self._run(
+            {"response": "hi", "tool_calls": [], "metrics": {"total_tokens": "lots"}}
+        )
+        self.assertNotIn("total_tokens", result["output"])
+
+    async def test_agent_total_tokens_feeds_aggregate(self):
+        from calibrate.llm.run_tests import _aggregate_total_tokens
+
+        result = await self._run(
+            {"response": "hi", "tool_calls": [], "metrics": {"total_tokens": 4387}}
+        )
+        agg = _aggregate_total_tokens([result])
+        self.assertEqual(agg["mean"], 4387)
+
 
 # ---------------------------------------------------------------------------
 # Tests for TextAgentConnection.verify()


### PR DESCRIPTION
## Summary
- Adds per-test-case **total token usage** to LLM tests/benchmark for both paths:
  - **Internal agent**: captured from pipecat usage metrics in the `Processor` (provider-agnostic — OpenAI and OpenRouter).
  - **Agent connection**: lifted from the agent's self-reported `metrics` into `output.total_tokens` (falls back to `prompt_tokens + completion_tokens` when no `total_tokens` is reported).
- Aggregated into `metrics.json` as `total_tokens: {mean, min, max, count}` alongside `cost` and `latency_ms` (absent rather than a misleading `0` when no run reports tokens).
- Surfaced as a `total_tokens` column in the LLM tests leaderboard.

## Test plan
- [x] `_aggregate_total_tokens` aggregation (empty, none, mean, output-only source).
- [x] `run_test_external` lifts agent tokens (direct, prompt+completion fallback, malformed ignored, feeds aggregate).
- [x] `_write_test_results_outputs` includes/omits `total_tokens` in `metrics.json`.
- [x] Leaderboard `total_tokens` column (mean shown; absent → None).
- [x] `uv run pytest tests/llm/test_run_tests_extra.py tests/llm/test_tests_leaderboard.py tests/test_connections.py tests/llm/test_init_extra.py` — 239 passed.

Made with [Cursor](https://cursor.com)