### PR TITLE
Add "any" wildcard for tool-call argument matching

### DIFF
--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -704,7 +704,7 @@ def _tool_call_pair_mismatch(
     return _tool_call_arguments_mismatch_message(exp_args, out_args)
 
 
-# ── Per-parameter criteria specs (exact match vs. LLM judge) ─────────────────
+# ── Per-parameter criteria specs (exact match, LLM judge, or "any" wildcard) ─
 
 
 def _is_any_spec(value) -> bool:
@@ -727,7 +727,9 @@ def _param_criteria_spec(value, key: str) -> Optional[dict]:
 
         {"match_type": "llm_judge", "criteria": "...", "judge_model": "..."}
         {"match_type": "exact", "value": <literal>}
-        {"match_type": "any"}
+
+    The ``{"match_type": "any"}`` wildcard is recognized and skipped by
+    :func:`_is_any_spec` before this point, so it never reaches here.
 
     Returns the normalized spec, or ``None`` when ``value`` is an ordinary
     literal (the default, exact-match behavior). Raises ``ValueError`` for a
@@ -736,11 +738,6 @@ def _param_criteria_spec(value, key: str) -> Optional[dict]:
     if not isinstance(value, dict) or "match_type" not in value:
         return None
     match_type = value["match_type"]
-    if match_type == "any":
-        # Wildcard — the parameter is ignored entirely. The caller skips it via
-        # ``_is_any_spec`` before spec interpretation; recognized here too so all
-        # valid match_types live in one place.
-        return {"match_type": "any"}
     if match_type == "llm_judge":
         criteria = value.get("criteria")
         if not isinstance(criteria, str) or not criteria.strip():
@@ -833,7 +830,10 @@ def _collect_arg_diffs(
 ) -> None:
     """Recursively diff expected vs. actual argument dicts.
 
-    The single walk behind both exact and criteria-aware matching:
+    The single walk behind both exact and criteria-aware matching. In either
+    mode a ``{"match_type": "any"}`` value is a wildcard: the parameter is
+    skipped entirely (no line, no record) regardless of whether it appears in
+    ``actual``.
 
     - ``criteria_aware=True`` (default): a value may be a criteria spec — an
       ``llm_judge`` field is queued in ``judge_jobs`` (judged after the walk; a

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -656,8 +656,14 @@ def _tool_call_arguments_diff_lines(
     return lines
 
 
-def _tool_call_arguments_mismatch_message(expected, actual) -> str:
-    """Build a multi-line tool-call arguments mismatch reason."""
+def _tool_call_arguments_mismatch_message(expected, actual) -> Optional[str]:
+    """Build a multi-line tool-call arguments mismatch reason, or ``None``.
+
+    Returns ``None`` when two argument dicts have no differences under our
+    matching rules — i.e. the only divergences are wildcard ("any") parameters,
+    which produce no diff lines. This mirrors the async eval path so the
+    leaderboard's per-slot pass calculation agrees with it.
+    """
     header = "Tool call arguments mismatch:"
     if not isinstance(expected, dict):
         return (
@@ -673,11 +679,7 @@ def _tool_call_arguments_mismatch_message(expected, actual) -> str:
         )
     detail_lines = _tool_call_arguments_diff_lines(expected, actual)
     if not detail_lines:
-        return (
-            f"{header}\n"
-            f"  expected arguments: {expected!r}\n"
-            f"  actual arguments: {actual!r}"
-        )
+        return None
     return header + "\n" + "\n".join(detail_lines)
 
 
@@ -698,15 +700,7 @@ def _tool_call_pair_mismatch(
     out_args = output_tool_call.get("arguments")
     if out_args == exp_args:
         return None
-    # When the only differences are wildcard ("any") parameters the diff is
-    # empty and the arguments match under our rules — mirror the async eval path
-    # so the leaderboard's per-slot pass calculation agrees with it.
-    if (
-        isinstance(exp_args, dict)
-        and isinstance(out_args, dict)
-        and not _tool_call_arguments_diff_lines(exp_args, out_args)
-    ):
-        return None
+    # Returns None when the only differences are wildcard ("any") parameters.
     return _tool_call_arguments_mismatch_message(exp_args, out_args)
 
 

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -698,10 +698,32 @@ def _tool_call_pair_mismatch(
     out_args = output_tool_call.get("arguments")
     if out_args == exp_args:
         return None
+    # When the only differences are wildcard ("any") parameters the diff is
+    # empty and the arguments match under our rules — mirror the async eval path
+    # so the leaderboard's per-slot pass calculation agrees with it.
+    if (
+        isinstance(exp_args, dict)
+        and isinstance(out_args, dict)
+        and not _tool_call_arguments_diff_lines(exp_args, out_args)
+    ):
+        return None
     return _tool_call_arguments_mismatch_message(exp_args, out_args)
 
 
 # ── Per-parameter criteria specs (exact match vs. LLM judge) ─────────────────
+
+
+def _is_any_sentinel(value) -> bool:
+    """True when an expected argument value is the ``"any"`` wildcard.
+
+    A parameter whose expected value is the literal string ``"any"`` is ignored
+    entirely: it need not appear in the produced tool call, and whatever value it
+    carries is accepted. This lets a test pin down the arguments that matter while
+    leaving free-form or non-deterministic ones unconstrained. To match the
+    literal string ``"any"`` verbatim instead, wrap it in an exact spec
+    (``{"match_type": "exact", "value": "any"}``).
+    """
+    return value == "any"
 
 
 def _param_criteria_spec(value, key: str) -> Optional[dict]:
@@ -845,6 +867,13 @@ def _collect_arg_diffs(
                 lines,
                 records,
             )
+            continue
+
+        # An ``"any"`` expected value is a wildcard: skip the parameter entirely
+        # so neither its presence nor its value is checked. Honored in both exact
+        # and criteria-aware walks so the live evaluation and the leaderboard's
+        # per-slot pass calculation agree.
+        if _is_any_sentinel(expected[key]):
             continue
 
         spec = _param_criteria_spec(expected[key], path) if criteria_aware else None

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -707,17 +707,16 @@ def _tool_call_pair_mismatch(
 # ── Per-parameter criteria specs (exact match vs. LLM judge) ─────────────────
 
 
-def _is_any_sentinel(value) -> bool:
-    """True when an expected argument value is the ``"any"`` wildcard.
+def _is_any_spec(value) -> bool:
+    """True when an expected argument value is the ``any`` wildcard spec.
 
-    A parameter whose expected value is the literal string ``"any"`` is ignored
+    A parameter whose expected value is ``{"match_type": "any"}`` is ignored
     entirely: it need not appear in the produced tool call, and whatever value it
     carries is accepted. This lets a test pin down the arguments that matter while
-    leaving free-form or non-deterministic ones unconstrained. To match the
-    literal string ``"any"`` verbatim instead, wrap it in an exact spec
-    (``{"match_type": "exact", "value": "any"}``).
+    leaving free-form or non-deterministic ones unconstrained. A plain ``"any"``
+    string is *not* special — it is an ordinary literal, matched exactly.
     """
-    return value == "any"
+    return isinstance(value, dict) and value.get("match_type") == "any"
 
 
 def _param_criteria_spec(value, key: str) -> Optional[dict]:
@@ -728,6 +727,7 @@ def _param_criteria_spec(value, key: str) -> Optional[dict]:
 
         {"match_type": "llm_judge", "criteria": "...", "judge_model": "..."}
         {"match_type": "exact", "value": <literal>}
+        {"match_type": "any"}
 
     Returns the normalized spec, or ``None`` when ``value`` is an ordinary
     literal (the default, exact-match behavior). Raises ``ValueError`` for a
@@ -736,6 +736,11 @@ def _param_criteria_spec(value, key: str) -> Optional[dict]:
     if not isinstance(value, dict) or "match_type" not in value:
         return None
     match_type = value["match_type"]
+    if match_type == "any":
+        # Wildcard — the parameter is ignored entirely. The caller skips it via
+        # ``_is_any_spec`` before spec interpretation; recognized here too so all
+        # valid match_types live in one place.
+        return {"match_type": "any"}
     if match_type == "llm_judge":
         criteria = value.get("criteria")
         if not isinstance(criteria, str) or not criteria.strip():
@@ -755,8 +760,8 @@ def _param_criteria_spec(value, key: str) -> Optional[dict]:
             )
         return {"match_type": "exact", "value": value["value"]}
     raise ValueError(
-        f"Tool-call parameter '{key}': match_type must be 'exact' or "
-        f"'llm_judge' (got {match_type!r})."
+        f"Tool-call parameter '{key}': match_type must be 'exact', "
+        f"'llm_judge', or 'any' (got {match_type!r})."
     )
 
 
@@ -863,11 +868,11 @@ def _collect_arg_diffs(
             )
             continue
 
-        # An ``"any"`` expected value is a wildcard: skip the parameter entirely
-        # so neither its presence nor its value is checked. Honored in both exact
-        # and criteria-aware walks so the live evaluation and the leaderboard's
-        # per-slot pass calculation agree.
-        if _is_any_sentinel(expected[key]):
+        # A ``{"match_type": "any"}`` expected value is a wildcard: skip the
+        # parameter entirely so neither its presence nor its value is checked.
+        # Honored in both exact and criteria-aware walks so the live evaluation
+        # and the leaderboard's per-slot pass calculation agree.
+        if _is_any_spec(expected[key]):
             continue
 
         spec = _param_criteria_spec(expected[key], path) if criteria_aware else None

--- a/docs/cli/text-to-text.mdx
+++ b/docs/cli/text-to-text.mdx
@@ -196,20 +196,19 @@ A plain literal value (e.g. `"555-123-4567"`) is matched exactly, as usual. To o
 | ------------- | ------------------------------------------------ | ------------------------------------------------------------- |
 | `"exact"`     | `{"match_type": "exact", "value": <literal>}`    | Check if the produced value is equal to the `<literal>` value |
 | `"llm_judge"` | `{"match_type": "llm_judge", "criteria": "..."}` | An LLM judge checks the produced value against `criteria`     |
+| `"any"`       | `{"match_type": "any"}`                          | Wildcard — the argument is ignored entirely (see below)       |
 
-To leave an argument completely unconstrained, give it the literal lowercase value `"any"`. This is a wildcard: the parameter is ignored entirely — it need not appear in the produced tool call, and whatever value it has is accepted. Use it to pin down only the arguments that matter and leave free-form or non-deterministic ones unchecked:
+To leave an argument completely unconstrained, give it an `"any"` spec. This is a wildcard: the parameter is ignored entirely — it need not appear in the produced tool call, and whatever value it has is accepted. Use it to pin down only the arguments that matter and leave free-form or non-deterministic ones unchecked. (A plain `"any"` string is not special — it is matched exactly like any other literal.)
 
 ```jsonc
 {
   "tool": "send_sms",
   "arguments": {
     "phone_number": "555-123-4567", // exact match
-    "message": "any", // ignored — not checked
+    "message": { "match_type": "any" }, // ignored — not checked
   },
 }
 ```
-
-To match the literal string `"any"` verbatim instead of treating it as a wildcard, wrap it in an exact spec: `{"match_type": "exact", "value": "any"}`.
 
 Works for nested arguments as well where each sub-parameter is graded independently:
 

--- a/docs/cli/text-to-text.mdx
+++ b/docs/cli/text-to-text.mdx
@@ -197,6 +197,20 @@ A plain literal value (e.g. `"555-123-4567"`) is matched exactly, as usual. To o
 | `"exact"`     | `{"match_type": "exact", "value": <literal>}`    | Check if the produced value is equal to the `<literal>` value |
 | `"llm_judge"` | `{"match_type": "llm_judge", "criteria": "..."}` | An LLM judge checks the produced value against `criteria`     |
 
+To leave an argument completely unconstrained, give it the literal lowercase value `"any"`. This is a wildcard: the parameter is ignored entirely — it need not appear in the produced tool call, and whatever value it has is accepted. Use it to pin down only the arguments that matter and leave free-form or non-deterministic ones unchecked:
+
+```jsonc
+{
+  "tool": "send_sms",
+  "arguments": {
+    "phone_number": "555-123-4567", // exact match
+    "message": "any", // ignored — not checked
+  },
+}
+```
+
+To match the literal string `"any"` verbatim instead of treating it as a wildcard, wrap it in an exact spec: `{"match_type": "exact", "value": "any"}`.
+
 Works for nested arguments as well where each sub-parameter is graded independently:
 
 ```jsonc

--- a/docs/cli/text-to-text.mdx
+++ b/docs/cli/text-to-text.mdx
@@ -198,7 +198,7 @@ A plain literal value (e.g. `"555-123-4567"`) is matched exactly, as usual. To o
 | `"llm_judge"` | `{"match_type": "llm_judge", "criteria": "..."}` | An LLM judge checks the produced value against `criteria`     |
 | `"any"`       | `{"match_type": "any"}`                          | Wildcard — the argument is ignored entirely (see below)       |
 
-To leave an argument completely unconstrained, give it an `"any"` spec. This is a wildcard: the parameter is ignored entirely — it need not appear in the produced tool call, and whatever value it has is accepted. Use it to pin down only the arguments that matter and leave free-form or non-deterministic ones unchecked. (A plain `"any"` string is not special — it is matched exactly like any other literal.)
+To leave an argument completely unconstrained, give it an `"any"` spec. This is a wildcard: the parameter is ignored entirely — it need not appear in the produced tool call, and whatever value it has is accepted. Use it to pin down only the arguments that matter and leave free-form or non-deterministic ones unchecked.
 
 ```jsonc
 {

--- a/examples/llm/tool_call_scenarios/README.md
+++ b/examples/llm/tool_call_scenarios/README.md
@@ -6,7 +6,7 @@ Test fixtures that exercise per-parameter tool-call matching.
 
 - **`config.json`** — clinic-assistant system prompt + tools, plus a few
   `tool_call` test cases for a live run against a real model.
-- **`eval_only_dataset.json`** — 12 `(test_case, output)` pairs that pin the
+- **`eval_only_dataset.json`** — 13 `(test_case, output)` pairs that pin the
   agent's output, so you see the exact pass/fail + reasoning each scenario
   produces. The `_scenario` field on each item just labels what it demonstrates.
 
@@ -56,3 +56,4 @@ python -m calibrate.llm.run_tests \
 | `nested-object`        | exact + judged sub-fields (dotted paths) | pass                               |
 | `wrong-tool`           | agent called a different tool            | fail                               |
 | `multi-call`           | two tool calls, each judged              | pass (tool-prefixed lines)         |
+| `any-wildcard`         | arg value `"any"` ignored, other pinned  | pass (wildcard arg differs)        |

--- a/examples/llm/tool_call_scenarios/README.md
+++ b/examples/llm/tool_call_scenarios/README.md
@@ -56,4 +56,4 @@ python -m calibrate.llm.run_tests \
 | `nested-object`        | exact + judged sub-fields (dotted paths) | pass                               |
 | `wrong-tool`           | agent called a different tool            | fail                               |
 | `multi-call`           | two tool calls, each judged              | pass (tool-prefixed lines)         |
-| `any-wildcard`         | arg value `"any"` ignored, other pinned  | pass (wildcard arg differs)        |
+| `any-wildcard`         | `match_type: any` arg ignored, other pinned | pass (wildcard arg differs)     |

--- a/examples/llm/tool_call_scenarios/eval_only_dataset.json
+++ b/examples/llm/tool_call_scenarios/eval_only_dataset.json
@@ -228,5 +228,24 @@
         { "tool": "send_sms", "arguments": { "to": "+15551234567", "message": "Your appointment is confirmed!" } }
       ]
     }
+  },
+  {
+    "_scenario": "13. ANY WILDCARD — arg value \"any\" is ignored; another arg pinned exact (pass). The wildcard arg differs from any literal, proving it's skipped.",
+    "test_case": {
+      "id": "any-wildcard",
+      "history": [{ "role": "user", "content": "Book John Doe for whatever the earliest slot is — the reason is a fever." }],
+      "evaluation": {
+        "type": "tool_call",
+        "tool_calls": [
+          { "tool": "book_appointment", "arguments": { "patient_name": "John Doe", "date": "any", "reason": "fever" } }
+        ]
+      }
+    },
+    "output": {
+      "response": "",
+      "tool_calls": [
+        { "tool": "book_appointment", "arguments": { "patient_name": "John Doe", "date": "2026-06-12", "reason": "fever" } }
+      ]
+    }
   }
 ]

--- a/examples/llm/tool_call_scenarios/eval_only_dataset.json
+++ b/examples/llm/tool_call_scenarios/eval_only_dataset.json
@@ -230,14 +230,14 @@
     }
   },
   {
-    "_scenario": "13. ANY WILDCARD — arg value \"any\" is ignored; another arg pinned exact (pass). The wildcard arg differs from any literal, proving it's skipped.",
+    "_scenario": "13. ANY WILDCARD — arg with {match_type: any} is ignored; another arg pinned exact (pass). The wildcard arg differs from any literal, proving it's skipped.",
     "test_case": {
       "id": "any-wildcard",
       "history": [{ "role": "user", "content": "Book John Doe for whatever the earliest slot is — the reason is a fever." }],
       "evaluation": {
         "type": "tool_call",
         "tool_calls": [
-          { "tool": "book_appointment", "arguments": { "patient_name": "John Doe", "date": "any", "reason": "fever" } }
+          { "tool": "book_appointment", "arguments": { "patient_name": "John Doe", "date": { "match_type": "any" }, "reason": "fever" } }
         ]
       }
     },

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -634,6 +634,144 @@ class TestEvaluateToolCallsCriteria(unittest.TestCase):
         self.assertIn("reads as friendly", result["reasoning"])
 
 
+class TestAnyWildcardParam(unittest.TestCase):
+    """The ``"any"`` expected value is a wildcard — the parameter is ignored."""
+
+    def test_is_any_sentinel(self):
+        from calibrate.llm.run_tests import _is_any_sentinel
+
+        self.assertTrue(_is_any_sentinel("any"))
+        self.assertFalse(_is_any_sentinel("Any"))
+        self.assertFalse(_is_any_sentinel("anything"))
+        self.assertFalse(_is_any_sentinel(""))
+        self.assertFalse(_is_any_sentinel(None))
+        self.assertFalse(_is_any_sentinel({"match_type": "exact", "value": "any"}))
+
+    def test_wildcard_absent_from_output_passes(self):
+        from calibrate.llm.run_tests import evaluate_tool_calls
+
+        with patch("calibrate.llm.run_tests.text_judge") as mock_judge:
+            result = asyncio.run(evaluate_tool_calls(
+                [{"tool": "lookup", "arguments": {"city": "London"}}],
+                [{"tool": "lookup", "arguments": {"city": "London", "token": "any"}}],
+            ))
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["tool_call_results"], [{"tool": "lookup", "passed": True}])
+        mock_judge.assert_not_called()
+
+    def test_wildcard_present_with_arbitrary_value_passes(self):
+        from calibrate.llm.run_tests import evaluate_tool_calls
+
+        with patch("calibrate.llm.run_tests.text_judge") as mock_judge:
+            result = asyncio.run(evaluate_tool_calls(
+                [{"tool": "lookup",
+                  "arguments": {"city": "London", "token": "xyz-123"}}],
+                [{"tool": "lookup", "arguments": {"city": "London", "token": "any"}}],
+            ))
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["tool_call_results"], [{"tool": "lookup", "passed": True}])
+        mock_judge.assert_not_called()
+
+    def test_wildcard_does_not_mask_sibling_failure(self):
+        from calibrate.llm.run_tests import evaluate_tool_calls
+
+        with patch("calibrate.llm.run_tests.text_judge") as mock_judge:
+            result = asyncio.run(evaluate_tool_calls(
+                [{"tool": "lookup",
+                  "arguments": {"city": "Paris", "token": "whatever"}}],
+                [{"tool": "lookup", "arguments": {"city": "London", "token": "any"}}],
+            ))
+        self.assertFalse(result["passed"])
+        self.assertIn("city", result["reasoning"])
+        # The wildcard sibling must not appear in the failure reasoning.
+        self.assertNotIn("token", result["reasoning"])
+        mock_judge.assert_not_called()
+
+    def test_nested_wildcard_passes(self):
+        from calibrate.llm.run_tests import evaluate_tool_calls
+
+        with patch("calibrate.llm.run_tests.text_judge") as mock_judge:
+            result = asyncio.run(evaluate_tool_calls(
+                [{"tool": "book",
+                  "arguments": {"patient": {"name": "John Doe", "session": "s-999"}}}],
+                [{"tool": "book",
+                  "arguments": {"patient": {"name": "John Doe", "session": "any"}}}],
+            ))
+        self.assertTrue(result["passed"])
+        # Also passes when the wildcard sub-key is absent entirely.
+        with patch("calibrate.llm.run_tests.text_judge"):
+            result_absent = asyncio.run(evaluate_tool_calls(
+                [{"tool": "book", "arguments": {"patient": {"name": "John Doe"}}}],
+                [{"tool": "book",
+                  "arguments": {"patient": {"name": "John Doe", "session": "any"}}}],
+            ))
+        self.assertTrue(result_absent["passed"])
+        mock_judge.assert_not_called()
+
+    def test_exact_spec_escape_hatch_matches_literal_any(self):
+        from calibrate.llm.run_tests import evaluate_tool_calls
+
+        with patch("calibrate.llm.run_tests.text_judge") as mock_judge:
+            passing = asyncio.run(evaluate_tool_calls(
+                [{"tool": "a", "arguments": {"x": "any"}}],
+                [{"tool": "a",
+                  "arguments": {"x": {"match_type": "exact", "value": "any"}}}],
+            ))
+            failing = asyncio.run(evaluate_tool_calls(
+                [{"tool": "a", "arguments": {"x": "other"}}],
+                [{"tool": "a",
+                  "arguments": {"x": {"match_type": "exact", "value": "any"}}}],
+            ))
+        self.assertTrue(passing["passed"])
+        self.assertFalse(failing["passed"])
+        self.assertIn("x", failing["reasoning"])
+        mock_judge.assert_not_called()
+
+    def test_wildcard_contributes_no_param_record(self):
+        from calibrate.llm.run_tests import evaluate_tool_calls
+
+        # Pair a wildcard param with an llm_judge param so the slot carries a
+        # param_judgments breakdown; the wildcard must be absent from it.
+        async def fake_text_judge(evaluators, user_prompt, *a, **k):
+            return {evaluators[0]["name"]: {"match": True, "reasoning": "ok"}}
+
+        with patch("calibrate.llm.run_tests.text_judge", side_effect=fake_text_judge):
+            result = asyncio.run(evaluate_tool_calls(
+                [{"tool": "a",
+                  "arguments": {"note": "looks good", "token": "anything-goes"}}],
+                [{"tool": "a", "arguments": {
+                    "note": {"match_type": "llm_judge", "criteria": "positive"},
+                    "token": "any"}}],
+            ))
+        self.assertTrue(result["passed"])
+        judgments = result["tool_call_results"][0]["param_judgments"]
+        params = [r["param"] for r in judgments]
+        self.assertNotIn("token", params)
+        self.assertEqual(params, ["note"])
+
+    def test_sync_pair_mismatch_wildcard_absent_matches(self):
+        from calibrate.llm.run_tests import _tool_call_pair_mismatch
+
+        # Parity contract: when the only difference is an absent wildcard param,
+        # the sync matcher (used by _per_slot_tool_passes / the leaderboard)
+        # agrees with the async path and reports a match.
+        self.assertIsNone(_tool_call_pair_mismatch(
+            {"tool": "lookup", "arguments": {"city": "London"}},
+            {"tool": "lookup", "arguments": {"city": "London", "token": "any"}},
+        ))
+
+    def test_sync_pair_mismatch_wildcard_present_matches(self):
+        from calibrate.llm.run_tests import _tool_call_pair_mismatch
+
+        # Parity contract: when the ONLY difference is a wildcard param carrying
+        # an arbitrary value, the sync matcher agrees with the async
+        # evaluate_tool_calls and reports a match.
+        self.assertIsNone(_tool_call_pair_mismatch(
+            {"tool": "lookup", "arguments": {"city": "London", "token": "xyz-123"}},
+            {"tool": "lookup", "arguments": {"city": "London", "token": "any"}},
+        ))
+
+
 class TestArgumentLevelTicksAndCrosses(unittest.TestCase):
     @staticmethod
     def _judge_returning(match, reasoning="because"):

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -635,17 +635,20 @@ class TestEvaluateToolCallsCriteria(unittest.TestCase):
 
 
 class TestAnyWildcardParam(unittest.TestCase):
-    """The ``"any"`` expected value is a wildcard — the parameter is ignored."""
+    """A ``{"match_type": "any"}`` expected value is a wildcard — param ignored."""
 
-    def test_is_any_sentinel(self):
-        from calibrate.llm.run_tests import _is_any_sentinel
+    ANY = {"match_type": "any"}
 
-        self.assertTrue(_is_any_sentinel("any"))
-        self.assertFalse(_is_any_sentinel("Any"))
-        self.assertFalse(_is_any_sentinel("anything"))
-        self.assertFalse(_is_any_sentinel(""))
-        self.assertFalse(_is_any_sentinel(None))
-        self.assertFalse(_is_any_sentinel({"match_type": "exact", "value": "any"}))
+    def test_is_any_spec(self):
+        from calibrate.llm.run_tests import _is_any_spec
+
+        self.assertTrue(_is_any_spec({"match_type": "any"}))
+        # A plain "any" string is an ordinary literal, not the wildcard.
+        self.assertFalse(_is_any_spec("any"))
+        self.assertFalse(_is_any_spec("anything"))
+        self.assertFalse(_is_any_spec(None))
+        self.assertFalse(_is_any_spec({"match_type": "exact", "value": "any"}))
+        self.assertFalse(_is_any_spec({"match_type": "llm_judge", "criteria": "x"}))
 
     def test_wildcard_absent_from_output_passes(self):
         from calibrate.llm.run_tests import evaluate_tool_calls
@@ -653,7 +656,7 @@ class TestAnyWildcardParam(unittest.TestCase):
         with patch("calibrate.llm.run_tests.text_judge") as mock_judge:
             result = asyncio.run(evaluate_tool_calls(
                 [{"tool": "lookup", "arguments": {"city": "London"}}],
-                [{"tool": "lookup", "arguments": {"city": "London", "token": "any"}}],
+                [{"tool": "lookup", "arguments": {"city": "London", "token": self.ANY}}],
             ))
         self.assertTrue(result["passed"])
         self.assertEqual(result["tool_call_results"], [{"tool": "lookup", "passed": True}])
@@ -666,7 +669,7 @@ class TestAnyWildcardParam(unittest.TestCase):
             result = asyncio.run(evaluate_tool_calls(
                 [{"tool": "lookup",
                   "arguments": {"city": "London", "token": "xyz-123"}}],
-                [{"tool": "lookup", "arguments": {"city": "London", "token": "any"}}],
+                [{"tool": "lookup", "arguments": {"city": "London", "token": self.ANY}}],
             ))
         self.assertTrue(result["passed"])
         self.assertEqual(result["tool_call_results"], [{"tool": "lookup", "passed": True}])
@@ -679,7 +682,7 @@ class TestAnyWildcardParam(unittest.TestCase):
             result = asyncio.run(evaluate_tool_calls(
                 [{"tool": "lookup",
                   "arguments": {"city": "Paris", "token": "whatever"}}],
-                [{"tool": "lookup", "arguments": {"city": "London", "token": "any"}}],
+                [{"tool": "lookup", "arguments": {"city": "London", "token": self.ANY}}],
             ))
         self.assertFalse(result["passed"])
         self.assertIn("city", result["reasoning"])
@@ -695,7 +698,7 @@ class TestAnyWildcardParam(unittest.TestCase):
                 [{"tool": "book",
                   "arguments": {"patient": {"name": "John Doe", "session": "s-999"}}}],
                 [{"tool": "book",
-                  "arguments": {"patient": {"name": "John Doe", "session": "any"}}}],
+                  "arguments": {"patient": {"name": "John Doe", "session": self.ANY}}}],
             ))
         self.assertTrue(result["passed"])
         # Also passes when the wildcard sub-key is absent entirely.
@@ -703,24 +706,23 @@ class TestAnyWildcardParam(unittest.TestCase):
             result_absent = asyncio.run(evaluate_tool_calls(
                 [{"tool": "book", "arguments": {"patient": {"name": "John Doe"}}}],
                 [{"tool": "book",
-                  "arguments": {"patient": {"name": "John Doe", "session": "any"}}}],
+                  "arguments": {"patient": {"name": "John Doe", "session": self.ANY}}}],
             ))
         self.assertTrue(result_absent["passed"])
         mock_judge.assert_not_called()
 
-    def test_exact_spec_escape_hatch_matches_literal_any(self):
+    def test_plain_any_string_is_an_exact_literal(self):
         from calibrate.llm.run_tests import evaluate_tool_calls
 
+        # A bare "any" string is NOT the wildcard — it must match exactly.
         with patch("calibrate.llm.run_tests.text_judge") as mock_judge:
             passing = asyncio.run(evaluate_tool_calls(
                 [{"tool": "a", "arguments": {"x": "any"}}],
-                [{"tool": "a",
-                  "arguments": {"x": {"match_type": "exact", "value": "any"}}}],
+                [{"tool": "a", "arguments": {"x": "any"}}],
             ))
             failing = asyncio.run(evaluate_tool_calls(
                 [{"tool": "a", "arguments": {"x": "other"}}],
-                [{"tool": "a",
-                  "arguments": {"x": {"match_type": "exact", "value": "any"}}}],
+                [{"tool": "a", "arguments": {"x": "any"}}],
             ))
         self.assertTrue(passing["passed"])
         self.assertFalse(failing["passed"])
@@ -741,7 +743,7 @@ class TestAnyWildcardParam(unittest.TestCase):
                   "arguments": {"note": "looks good", "token": "anything-goes"}}],
                 [{"tool": "a", "arguments": {
                     "note": {"match_type": "llm_judge", "criteria": "positive"},
-                    "token": "any"}}],
+                    "token": self.ANY}}],
             ))
         self.assertTrue(result["passed"])
         judgments = result["tool_call_results"][0]["param_judgments"]
@@ -757,7 +759,7 @@ class TestAnyWildcardParam(unittest.TestCase):
         # agrees with the async path and reports a match.
         self.assertIsNone(_tool_call_pair_mismatch(
             {"tool": "lookup", "arguments": {"city": "London"}},
-            {"tool": "lookup", "arguments": {"city": "London", "token": "any"}},
+            {"tool": "lookup", "arguments": {"city": "London", "token": self.ANY}},
         ))
 
     def test_sync_pair_mismatch_wildcard_present_matches(self):
@@ -768,7 +770,7 @@ class TestAnyWildcardParam(unittest.TestCase):
         # evaluate_tool_calls and reports a match.
         self.assertIsNone(_tool_call_pair_mismatch(
             {"tool": "lookup", "arguments": {"city": "London", "token": "xyz-123"}},
-            {"tool": "lookup", "arguments": {"city": "London", "token": "any"}},
+            {"tool": "lookup", "arguments": {"city": "London", "token": self.ANY}},
         ))
 
 


### PR DESCRIPTION
## What
- A `tool_call` evaluation argument whose expected value is the literal string `"any"` is now ignored — the parameter need not appear in the produced call, and any value is accepted. Lets a test pin only the arguments that matter.
- Use `{"match_type": "exact", "value": "any"}` to match the literal string `"any"` verbatim.
- Fixes the sync `_tool_call_pair_mismatch` (leaderboard per-slot stats) to agree with the async eval path when the only differences are wildcards.

## Notes
- Honored in both nested and top-level arguments; the wildcard contributes no record to the per-parameter breakdown.
- Adds unit tests, a docs section, and an `any-wildcard` example scenario.