### PR TITLE
Support per-row variable injection in general task eval

### DIFF
--- a/calibrate/general/eval.py
+++ b/calibrate/general/eval.py
@@ -39,7 +39,9 @@ def validate_general_eval_dataset(
     """Validate a general eval dataset JSON file.
 
     Expected format: a JSON list of objects, each with ``id``, ``input`` and
-    ``output`` fields.
+    ``output`` fields. Each row may optionally carry an ``arguments`` dict used
+    to render evaluator ``{{var}}`` placeholders; if present it must be an
+    object.
 
     Returns:
         tuple[bool, str, list[dict]]: (is_valid, error_message, parsed_rows)
@@ -72,6 +74,8 @@ def validate_general_eval_dataset(
                 f"Each row needs 'id', 'input', 'output'.",
                 [],
             )
+        if "arguments" in row and not isinstance(row["arguments"], dict):
+            return False, f"Row {i} field 'arguments' must be an object", []
         row_id = row["id"]
         if row_id in seen_ids:
             return False, f"Duplicate row id: {row_id!r}", []
@@ -109,11 +113,17 @@ async def _score_and_write_results(
     outputs: List[str],
     evaluators: List[dict],
     output_dir: str,
+    arguments_list: Optional[List[Optional[dict]]] = None,
 ) -> dict:
     """Run the general judge over (input, output) pairs and write outputs.
 
     Writes ``results.csv`` and ``metrics.json`` plus the resolved evaluator
     ``config.json`` under ``output_dir``. Returns the metrics_data dict.
+
+    Args:
+        arguments_list: Optional per-row ``arguments`` dicts (one entry per
+            row, ``None`` for rows with no injection) forwarded to the judge to
+            render evaluator ``{{var}}`` placeholders.
     """
     write_evaluator_config(output_dir, evaluators)
 
@@ -121,6 +131,7 @@ async def _score_and_write_results(
         inputs,
         outputs,
         evaluators=evaluators,
+        arguments_list=arguments_list,
     )
     for name, score_dict in llm_results["scores"].items():
         _log(f"  {name}: {score_dict['mean']:.4f}")
@@ -196,6 +207,7 @@ async def run_general_eval(
         ids = [r["id"] for r in rows]
         inputs = [str(r["input"]) if r["input"] is not None else "" for r in rows]
         outputs = [str(r["output"]) if r["output"] is not None else "" for r in rows]
+        arguments_list = [r.get("arguments") for r in rows]
 
         metrics_data = await _score_and_write_results(
             ids=ids,
@@ -203,6 +215,7 @@ async def run_general_eval(
             outputs=outputs,
             evaluators=evaluators,
             output_dir=output_dir,
+            arguments_list=arguments_list,
         )
 
         return {

--- a/calibrate/general/eval.py
+++ b/calibrate/general/eval.py
@@ -39,9 +39,11 @@ def validate_general_eval_dataset(
     """Validate a general eval dataset JSON file.
 
     Expected format: a JSON list of objects, each with ``id``, ``input`` and
-    ``output`` fields. Each row may optionally carry an ``arguments`` dict used
-    to render evaluator ``{{var}}`` placeholders; if present it must be an
-    object.
+    ``output`` fields. Each row may optionally carry an ``arguments`` object
+    keyed by evaluator ``name`` → that evaluator's variable dict, used to render
+    that evaluator's ``{{var}}`` placeholders (mirroring ``llm`` per-criteria
+    ``arguments``). If present, ``arguments`` and each of its values must be
+    objects.
 
     Returns:
         tuple[bool, str, list[dict]]: (is_valid, error_message, parsed_rows)
@@ -74,8 +76,18 @@ def validate_general_eval_dataset(
                 f"Each row needs 'id', 'input', 'output'.",
                 [],
             )
-        if "arguments" in row and not isinstance(row["arguments"], dict):
-            return False, f"Row {i} field 'arguments' must be an object", []
+        if "arguments" in row:
+            row_args = row["arguments"]
+            if not isinstance(row_args, dict):
+                return False, f"Row {i} field 'arguments' must be an object", []
+            for ev_name, ev_args in row_args.items():
+                if not isinstance(ev_args, dict):
+                    return (
+                        False,
+                        f"Row {i} field 'arguments[{ev_name!r}]' must be an "
+                        f"object mapping variable names to values",
+                        [],
+                    )
         row_id = row["id"]
         if row_id in seen_ids:
             return False, f"Duplicate row id: {row_id!r}", []

--- a/calibrate/general/metrics.py
+++ b/calibrate/general/metrics.py
@@ -15,6 +15,7 @@ from calibrate.judges import (
     general_task_judge,
     is_rating,
     evaluator_result_value,
+    render_evaluator,
     require_unique_evaluator_names,
     DEFAULT_TEXT_JUDGE_MODEL,
 )
@@ -90,11 +91,21 @@ async def get_general_judge_score(
     outputs: List[str],
     evaluators: List[dict],
     fallback_model: str = DEFAULT_GENERAL_JUDGE_MODEL,
+    arguments_list: Optional[List[Optional[dict]]] = None,
 ) -> dict:
     """Run the general judge across all rows and aggregate per-evaluator scores.
 
     ``inputs`` and ``outputs`` are positionally paired; ``inputs[i]`` may be
     ``None`` to judge ``outputs[i]`` on its own.
+
+    ``arguments_list`` optionally supplies per-row template variables. When
+    provided it must have the same length as ``inputs``/``outputs``. For each
+    row whose ``arguments_list[i]`` is truthy, every evaluator's
+    ``system_prompt`` is rendered against those arguments (via
+    :func:`calibrate.judges.render_evaluator`) before being passed to the judge;
+    rows with ``None``/empty arguments use the evaluators unchanged. Rendering
+    only changes ``system_prompt`` — ``name``/``type``/``scale_*`` are untouched,
+    so aggregation remains keyed off the base ``evaluators`` list.
 
     Returns:
         {
@@ -122,15 +133,27 @@ async def get_general_judge_score(
             f"(got {len(inputs)} inputs, {len(outputs)} outputs)."
         )
 
-    coroutines = [
-        general_judge(
-            None if input_text is None else str(input_text),
-            str(output),
-            evaluators=evaluators,
-            fallback_model=fallback_model,
+    if arguments_list is not None and len(arguments_list) != len(inputs):
+        raise ValueError(
+            f"arguments_list must be the same length as inputs "
+            f"(got {len(arguments_list)} arguments, {len(inputs)} inputs)."
         )
-        for input_text, output in zip(inputs, outputs)
-    ]
+
+    coroutines = []
+    for i, (input_text, output) in enumerate(zip(inputs, outputs)):
+        row_arguments = arguments_list[i] if arguments_list is not None else None
+        if row_arguments:
+            row_evaluators = [render_evaluator(ev, row_arguments) for ev in evaluators]
+        else:
+            row_evaluators = evaluators
+        coroutines.append(
+            general_judge(
+                None if input_text is None else str(input_text),
+                str(output),
+                evaluators=row_evaluators,
+                fallback_model=fallback_model,
+            )
+        )
 
     results = await tqdm_asyncio.gather(
         *coroutines,

--- a/calibrate/general/metrics.py
+++ b/calibrate/general/metrics.py
@@ -106,9 +106,11 @@ async def get_general_judge_score(
     ``ev``'s ``system_prompt`` is rendered against ``arguments_list[i][ev["name"]]``
     (via :func:`calibrate.judges.render_evaluator`) before being passed to the
     judge; evaluators with no entry — and rows with ``None``/empty arguments —
-    are left unchanged. Rendering only changes ``system_prompt`` —
-    ``name``/``type``/``scale_*`` are untouched, so aggregation remains keyed off
-    the base ``evaluators`` list.
+    are left unchanged. An ``arguments`` key that names no known evaluator
+    raises ``ValueError`` (mirroring ``llm``, which rejects unknown ``criteria``
+    references rather than silently ignoring them). Rendering only changes
+    ``system_prompt`` — ``name``/``type``/``scale_*`` are untouched, so
+    aggregation remains keyed off the base ``evaluators`` list.
 
     Returns:
         {
@@ -142,10 +144,19 @@ async def get_general_judge_score(
             f"(got {len(arguments_list)} arguments, {len(inputs)} inputs)."
         )
 
+    evaluator_names = {ev["name"] for ev in evaluators}
+
     coroutines = []
     for i, (input_text, output) in enumerate(zip(inputs, outputs)):
         row_arguments = arguments_list[i] if arguments_list is not None else None
         if row_arguments:
+            unknown = [name for name in row_arguments if name not in evaluator_names]
+            if unknown:
+                raise ValueError(
+                    f"Row {i} arguments reference unknown evaluator(s) "
+                    f"{sorted(unknown)}. Define them under config.evaluators "
+                    f"(known: {sorted(evaluator_names)})."
+                )
             row_evaluators = [
                 render_evaluator(ev, row_arguments.get(ev["name"]))
                 for ev in evaluators

--- a/calibrate/general/metrics.py
+++ b/calibrate/general/metrics.py
@@ -98,14 +98,17 @@ async def get_general_judge_score(
     ``inputs`` and ``outputs`` are positionally paired; ``inputs[i]`` may be
     ``None`` to judge ``outputs[i]`` on its own.
 
-    ``arguments_list`` optionally supplies per-row template variables. When
-    provided it must have the same length as ``inputs``/``outputs``. For each
-    row whose ``arguments_list[i]`` is truthy, every evaluator's
-    ``system_prompt`` is rendered against those arguments (via
-    :func:`calibrate.judges.render_evaluator`) before being passed to the judge;
-    rows with ``None``/empty arguments use the evaluators unchanged. Rendering
-    only changes ``system_prompt`` — ``name``/``type``/``scale_*`` are untouched,
-    so aggregation remains keyed off the base ``evaluators`` list.
+    ``arguments_list`` optionally supplies per-row, per-evaluator template
+    variables. When provided it must have the same length as
+    ``inputs``/``outputs``. Each entry is a dict keyed by evaluator ``name`` →
+    that evaluator's argument dict (mirroring how ``llm`` test cases attach
+    ``arguments`` to each ``criteria`` ref). For row ``i`` and evaluator ``ev``,
+    ``ev``'s ``system_prompt`` is rendered against ``arguments_list[i][ev["name"]]``
+    (via :func:`calibrate.judges.render_evaluator`) before being passed to the
+    judge; evaluators with no entry — and rows with ``None``/empty arguments —
+    are left unchanged. Rendering only changes ``system_prompt`` —
+    ``name``/``type``/``scale_*`` are untouched, so aggregation remains keyed off
+    the base ``evaluators`` list.
 
     Returns:
         {
@@ -143,7 +146,10 @@ async def get_general_judge_score(
     for i, (input_text, output) in enumerate(zip(inputs, outputs)):
         row_arguments = arguments_list[i] if arguments_list is not None else None
         if row_arguments:
-            row_evaluators = [render_evaluator(ev, row_arguments) for ev in evaluators]
+            row_evaluators = [
+                render_evaluator(ev, row_arguments.get(ev["name"]))
+                for ev in evaluators
+            ]
         else:
             row_evaluators = evaluators
         coroutines.append(

--- a/calibrate/general/metrics.py
+++ b/calibrate/general/metrics.py
@@ -15,6 +15,7 @@ from calibrate.judges import (
     general_task_judge,
     is_rating,
     evaluator_result_value,
+    ensure_known_evaluator_names,
     render_evaluator,
     require_unique_evaluator_names,
     DEFAULT_TEXT_JUDGE_MODEL,
@@ -150,13 +151,9 @@ async def get_general_judge_score(
     for i, (input_text, output) in enumerate(zip(inputs, outputs)):
         row_arguments = arguments_list[i] if arguments_list is not None else None
         if row_arguments:
-            unknown = [name for name in row_arguments if name not in evaluator_names]
-            if unknown:
-                raise ValueError(
-                    f"Row {i} arguments reference unknown evaluator(s) "
-                    f"{sorted(unknown)}. Define them under config.evaluators "
-                    f"(known: {sorted(evaluator_names)})."
-                )
+            ensure_known_evaluator_names(
+                row_arguments, evaluator_names, context=f"Row {i} arguments"
+            )
             row_evaluators = [
                 render_evaluator(ev, row_arguments.get(ev["name"]))
                 for ev in evaluators

--- a/calibrate/judges.py
+++ b/calibrate/judges.py
@@ -408,6 +408,27 @@ def render_evaluator(evaluator: dict, arguments: Optional[dict] = None) -> dict:
     return rendered
 
 
+def ensure_known_evaluator_names(referenced, known, context: str = "") -> None:
+    """Raise ``ValueError`` if any name in ``referenced`` is not in ``known``.
+
+    Shared guard for the places that attach per-evaluator ``arguments`` by name
+    (``llm`` test-case criteria, ``general`` row arguments) so an unknown /
+    misspelled evaluator name fails loudly instead of being silently ignored.
+
+    Args:
+        referenced: Iterable of evaluator names referenced by the caller.
+        known: Container of valid evaluator names (e.g. a set or name→evaluator dict).
+        context: Optional prefix for the error (e.g. ``"Row 3 arguments"``).
+    """
+    unknown = sorted({name for name in referenced if name not in known})
+    if unknown:
+        prefix = f"{context}: " if context else ""
+        raise ValueError(
+            f"{prefix}unknown evaluator(s) {unknown} referenced. Define them "
+            f"under config.evaluators (known: {sorted(known)})."
+        )
+
+
 def _model_for(evaluator: dict, fallback: str) -> str:
     """Return the model id for ``evaluator``, falling back when none is set."""
     return evaluator.get("judge_model") or fallback

--- a/calibrate/judges.py
+++ b/calibrate/judges.py
@@ -120,7 +120,7 @@ DEFAULT_GENERAL_TASK_EVALUATOR = {
     "system_prompt": (
         "You are a highly accurate evaluator assessing the output produced for "
         "a task.\n\n"
-        "You will be given the task input (when one is provided) and the output "
+        "You will be given the task input and the output "
         "produced for it. Judge the output on its own merits — do not assume the "
         "input is a conversation or that the output is a reply to a user.\n\n"
         "Mark `match` true only if the output satisfies the following criteria, "

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -53,6 +53,7 @@ from calibrate.llm._metrics_utils import _numeric_or_none
 from calibrate.judges import (
     DEFAULT_LLM_TEST_EVALUATOR,
     attach_evaluator_id,
+    ensure_known_evaluator_names,
     is_rating,
     render_evaluator,
     require_unique_evaluator_names,
@@ -155,17 +156,13 @@ def _resolve_evaluators_for_test_case(
 ) -> list[dict]:
     """Resolve a test case's ``evaluation.criteria`` to rendered evaluator dicts."""
     refs = _normalize_criteria_refs(evaluation.get("criteria"))
-    rendered: list[dict] = []
-    for ref in refs:
-        name = ref["name"]
-        if name not in name_to_evaluator:
-            raise ValueError(
-                f"Unknown evaluator '{name}' referenced in test case. Define "
-                f"it under config.evaluators (or use "
-                f"'{DEFAULT_LLM_TEST_EVALUATOR['name']}')."
-            )
-        rendered.append(render_evaluator(name_to_evaluator[name], ref.get("arguments")))
-    return rendered
+    ensure_known_evaluator_names(
+        [ref["name"] for ref in refs], name_to_evaluator, context="test case criteria"
+    )
+    return [
+        render_evaluator(name_to_evaluator[ref["name"]], ref.get("arguments"))
+        for ref in refs
+    ]
 
 
 class Processor(FrameProcessor):

--- a/tests/general/test_eval.py
+++ b/tests/general/test_eval.py
@@ -97,6 +97,41 @@ class TestValidateDataset(unittest.TestCase):
         self.assertEqual(err, "")
         self.assertEqual(rows, rows_in)
 
+    def test_valid_with_arguments_dict(self):
+        rows_in = [
+            {"id": "1", "input": "a", "output": "b", "arguments": {"k": "v"}},
+        ]
+        path = _write_json(rows_in)
+        try:
+            ok, err, rows = validate_general_eval_dataset(path)
+        finally:
+            os.unlink(path)
+        self.assertTrue(ok)
+        self.assertEqual(err, "")
+        self.assertEqual(rows, rows_in)
+
+    def test_valid_without_arguments(self):
+        # arguments is optional — rows missing it are still valid.
+        rows_in = [{"id": "1", "input": "a", "output": "b"}]
+        path = _write_json(rows_in)
+        try:
+            ok, err, _ = validate_general_eval_dataset(path)
+        finally:
+            os.unlink(path)
+        self.assertTrue(ok)
+        self.assertEqual(err, "")
+
+    def test_arguments_not_a_dict_rejected(self):
+        path = _write_json(
+            [{"id": "1", "input": "a", "output": "b", "arguments": "nope"}]
+        )
+        try:
+            ok, err, _ = validate_general_eval_dataset(path)
+        finally:
+            os.unlink(path)
+        self.assertFalse(ok)
+        self.assertEqual(err, "Row 0 field 'arguments' must be an object")
+
 
 class TestResolveEvaluators(unittest.TestCase):
     def test_missing_evaluators_raises(self):
@@ -206,6 +241,43 @@ class TestRunGeneralEval(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(cfg["evaluators"][0]["name"], "faithful")
         finally:
             os.unlink(dataset_path)
+
+    async def test_arguments_list_passed_to_judge(self):
+        rows = [
+            {"id": "row_a", "input": "doc A", "output": "sum A",
+             "arguments": {"name": "Ann"}},
+            {"id": "row_b", "input": "doc B", "output": "sum B"},
+        ]
+        dataset_path = _write_json(rows)
+
+        fake_score = {
+            "scores": {"faithful": {"type": "binary", "mean": 1.0}},
+            "score": 1.0,
+            "per_row": [
+                {"faithful": {"reasoning": "ok", "match": True}},
+                {"faithful": {"reasoning": "ok", "match": True}},
+            ],
+        }
+        judge_mock = AsyncMock(return_value=fake_score)
+        try:
+            with tempfile.TemporaryDirectory() as out_dir:
+                with patch(
+                    "calibrate.general.eval.get_general_judge_score", judge_mock
+                ):
+                    result = await run_general_eval(
+                        dataset_path=dataset_path,
+                        output_dir=out_dir,
+                        evaluators=[BINARY_EV],
+                    )
+                self.assertEqual(result["status"], "completed")
+        finally:
+            os.unlink(dataset_path)
+
+        judge_mock.assert_awaited_once()
+        self.assertEqual(
+            judge_mock.call_args.kwargs["arguments_list"],
+            [{"name": "Ann"}, None],
+        )
 
 
 class TestMain(unittest.IsolatedAsyncioTestCase):

--- a/tests/general/test_eval.py
+++ b/tests/general/test_eval.py
@@ -98,8 +98,14 @@ class TestValidateDataset(unittest.TestCase):
         self.assertEqual(rows, rows_in)
 
     def test_valid_with_arguments_dict(self):
+        # arguments is keyed by evaluator name → that evaluator's var dict.
         rows_in = [
-            {"id": "1", "input": "a", "output": "b", "arguments": {"k": "v"}},
+            {
+                "id": "1",
+                "input": "a",
+                "output": "b",
+                "arguments": {"faithful": {"reference": "v"}},
+            },
         ]
         path = _write_json(rows_in)
         try:
@@ -131,6 +137,28 @@ class TestValidateDataset(unittest.TestCase):
             os.unlink(path)
         self.assertFalse(ok)
         self.assertEqual(err, "Row 0 field 'arguments' must be an object")
+
+    def test_arguments_evaluator_value_not_a_dict_rejected(self):
+        path = _write_json(
+            [
+                {
+                    "id": "1",
+                    "input": "a",
+                    "output": "b",
+                    "arguments": {"faithful": "nope"},
+                }
+            ]
+        )
+        try:
+            ok, err, _ = validate_general_eval_dataset(path)
+        finally:
+            os.unlink(path)
+        self.assertFalse(ok)
+        self.assertEqual(
+            err,
+            "Row 0 field 'arguments['faithful']' must be an object "
+            "mapping variable names to values",
+        )
 
 
 class TestResolveEvaluators(unittest.TestCase):
@@ -245,7 +273,7 @@ class TestRunGeneralEval(unittest.IsolatedAsyncioTestCase):
     async def test_arguments_list_passed_to_judge(self):
         rows = [
             {"id": "row_a", "input": "doc A", "output": "sum A",
-             "arguments": {"name": "Ann"}},
+             "arguments": {"faithful": {"name": "Ann"}}},
             {"id": "row_b", "input": "doc B", "output": "sum B"},
         ]
         dataset_path = _write_json(rows)
@@ -276,7 +304,7 @@ class TestRunGeneralEval(unittest.IsolatedAsyncioTestCase):
         judge_mock.assert_awaited_once()
         self.assertEqual(
             judge_mock.call_args.kwargs["arguments_list"],
-            [{"name": "Ann"}, None],
+            [{"faithful": {"name": "Ann"}}, None],
         )
 
 

--- a/tests/general/test_metrics.py
+++ b/tests/general/test_metrics.py
@@ -176,6 +176,7 @@ class TestGetGeneralJudgeScoreArguments(unittest.IsolatedAsyncioTestCase):
             )
 
     async def test_arguments_injected_per_row(self):
+        # Per-row args are keyed by evaluator name (mirrors llm criteria args).
         seen_by_output = {}
 
         async def fake(_input, output, evaluators, **kwargs):
@@ -189,10 +190,42 @@ class TestGetGeneralJudgeScoreArguments(unittest.IsolatedAsyncioTestCase):
                 inputs=["i1", "i2"],
                 outputs=["o1", "o2"],
                 evaluators=[TEMPLATED_EV],
-                arguments_list=[{"reference": "gold-A"}, {"reference": "gold-B"}],
+                arguments_list=[
+                    {"faithful": {"reference": "gold-A"}},
+                    {"faithful": {"reference": "gold-B"}},
+                ],
             )
         self.assertEqual(seen_by_output["o1"], "judge against gold-A")
         self.assertEqual(seen_by_output["o2"], "judge against gold-B")
+
+    async def test_arguments_target_only_named_evaluator(self):
+        # An evaluator with no entry in the row's args is left unrendered,
+        # while a sibling evaluator named in the args is rendered.
+        other_ev = {
+            "name": "quality",
+            "system_prompt": "rate against {{reference}}",
+            "judge_model": "openai/gpt-4.1",
+        }
+        seen = {}
+
+        async def fake(_input, output, evaluators, **kwargs):
+            seen.update({ev["name"]: ev["system_prompt"] for ev in evaluators})
+            return {
+                "faithful": {"reasoning": output, "match": True},
+                "quality": {"reasoning": output, "match": True},
+            }
+
+        with patch(
+            "calibrate.general.metrics.general_judge", AsyncMock(side_effect=fake)
+        ):
+            await get_general_judge_score(
+                inputs=["i1"],
+                outputs=["o1"],
+                evaluators=[TEMPLATED_EV, other_ev],
+                arguments_list=[{"faithful": {"reference": "gold-A"}}],
+            )
+        self.assertEqual(seen["faithful"], "judge against gold-A")
+        self.assertEqual(seen["quality"], "rate against {{reference}}")
 
     async def test_length_mismatch_raises(self):
         with self.assertRaises(ValueError):
@@ -200,7 +233,7 @@ class TestGetGeneralJudgeScoreArguments(unittest.IsolatedAsyncioTestCase):
                 inputs=["i1", "i2"],
                 outputs=["o1", "o2"],
                 evaluators=[TEMPLATED_EV],
-                arguments_list=[{"reference": "gold-A"}],
+                arguments_list=[{"faithful": {"reference": "gold-A"}}],
             )
 
     async def test_none_row_leaves_prompt_unrendered(self):
@@ -217,7 +250,7 @@ class TestGetGeneralJudgeScoreArguments(unittest.IsolatedAsyncioTestCase):
                 inputs=["i1", "i2"],
                 outputs=["o1", "o2"],
                 evaluators=[TEMPLATED_EV],
-                arguments_list=[None, {"reference": "gold-B"}],
+                arguments_list=[None, {"faithful": {"reference": "gold-B"}}],
             )
         self.assertEqual(seen_by_output["o1"], "judge against {{reference}}")
         self.assertEqual(seen_by_output["o2"], "judge against gold-B")

--- a/tests/general/test_metrics.py
+++ b/tests/general/test_metrics.py
@@ -227,6 +227,18 @@ class TestGetGeneralJudgeScoreArguments(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(seen["faithful"], "judge against gold-A")
         self.assertEqual(seen["quality"], "rate against {{reference}}")
 
+    async def test_unknown_evaluator_in_arguments_raises(self):
+        # A typo'd / stale evaluator name in a row's args must fail loudly,
+        # not silently skip injection (mirrors llm's unknown-criteria error).
+        with self.assertRaises(ValueError) as ctx:
+            await get_general_judge_score(
+                inputs=["i1"],
+                outputs=["o1"],
+                evaluators=[TEMPLATED_EV],
+                arguments_list=[{"faithfull": {"reference": "gold-A"}}],
+            )
+        self.assertIn("faithfull", str(ctx.exception))
+
     async def test_length_mismatch_raises(self):
         with self.assertRaises(ValueError):
             await get_general_judge_score(

--- a/tests/general/test_metrics.py
+++ b/tests/general/test_metrics.py
@@ -145,5 +145,83 @@ class TestGetGeneralJudgeScore(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(args[1], "only-output")
 
 
+TEMPLATED_EV = {
+    "name": "faithful",
+    "system_prompt": "judge against {{reference}}",
+    "judge_model": "openai/gpt-4.1",
+}
+
+
+class TestGetGeneralJudgeScoreArguments(unittest.IsolatedAsyncioTestCase):
+    async def test_arguments_list_none_regression(self):
+        # arguments_list=None: evaluators reach the judge untouched.
+        seen = []
+
+        async def fake(_input, output, evaluators, **kwargs):
+            seen.append(evaluators)
+            return {"faithful": {"reasoning": output, "match": True}}
+
+        with patch(
+            "calibrate.general.metrics.general_judge", AsyncMock(side_effect=fake)
+        ):
+            result = await get_general_judge_score(
+                inputs=["i1", "i2"],
+                outputs=["o1", "o2"],
+                evaluators=[TEMPLATED_EV],
+            )
+        self.assertAlmostEqual(result["scores"]["faithful"]["mean"], 1.0)
+        for evaluators in seen:
+            self.assertEqual(
+                evaluators[0]["system_prompt"], "judge against {{reference}}"
+            )
+
+    async def test_arguments_injected_per_row(self):
+        seen_by_output = {}
+
+        async def fake(_input, output, evaluators, **kwargs):
+            seen_by_output[output] = evaluators[0]["system_prompt"]
+            return {"faithful": {"reasoning": output, "match": True}}
+
+        with patch(
+            "calibrate.general.metrics.general_judge", AsyncMock(side_effect=fake)
+        ):
+            await get_general_judge_score(
+                inputs=["i1", "i2"],
+                outputs=["o1", "o2"],
+                evaluators=[TEMPLATED_EV],
+                arguments_list=[{"reference": "gold-A"}, {"reference": "gold-B"}],
+            )
+        self.assertEqual(seen_by_output["o1"], "judge against gold-A")
+        self.assertEqual(seen_by_output["o2"], "judge against gold-B")
+
+    async def test_length_mismatch_raises(self):
+        with self.assertRaises(ValueError):
+            await get_general_judge_score(
+                inputs=["i1", "i2"],
+                outputs=["o1", "o2"],
+                evaluators=[TEMPLATED_EV],
+                arguments_list=[{"reference": "gold-A"}],
+            )
+
+    async def test_none_row_leaves_prompt_unrendered(self):
+        seen_by_output = {}
+
+        async def fake(_input, output, evaluators, **kwargs):
+            seen_by_output[output] = evaluators[0]["system_prompt"]
+            return {"faithful": {"reasoning": output, "match": True}}
+
+        with patch(
+            "calibrate.general.metrics.general_judge", AsyncMock(side_effect=fake)
+        ):
+            await get_general_judge_score(
+                inputs=["i1", "i2"],
+                outputs=["o1", "o2"],
+                evaluators=[TEMPLATED_EV],
+                arguments_list=[None, {"reference": "gold-B"}],
+            )
+        self.assertEqual(seen_by_output["o1"], "judge against {{reference}}")
+        self.assertEqual(seen_by_output["o2"], "judge against gold-B")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_judges.py
+++ b/tests/test_judges.py
@@ -28,6 +28,7 @@ from calibrate.judges import (
     evaluator_result_value,
     render_template,
     render_evaluator,
+    ensure_known_evaluator_names,
     format_conversation,
     _result_model_for_evaluator,
     _sanitize_evaluator_for_tool_model,
@@ -134,6 +135,22 @@ class TestRenderEvaluator(unittest.TestCase):
         }
         render_evaluator(ev, {"criteria": "x"})
         self.assertEqual(ev["system_prompt"], "Evaluate: {{criteria}}")
+
+
+class TestEnsureKnownEvaluatorNames(unittest.TestCase):
+    def test_all_known_is_noop(self):
+        # Accepts both a set and a name->evaluator dict as `known`.
+        ensure_known_evaluator_names(["a", "b"], {"a", "b", "c"})
+        ensure_known_evaluator_names(["a"], {"a": {}, "b": {}})
+
+    def test_unknown_raises_with_names_and_context(self):
+        with self.assertRaises(ValueError) as ctx:
+            ensure_known_evaluator_names(
+                ["a", "typo"], {"a", "b"}, context="Row 3 arguments"
+            )
+        msg = str(ctx.exception)
+        self.assertIn("typo", msg)
+        self.assertIn("Row 3 arguments", msg)
 
 
 class TestToolCallParamEvaluator(unittest.TestCase):


### PR DESCRIPTION
## What
- `calibrate general` dataset rows can now carry an optional `arguments` dict, whose values are injected into evaluator `{{var}}` placeholders per row — matching `calibrate llm`.
- Reuses the existing `render_evaluator` helper; no new templating code.

## Notes
- `arguments` is optional and validated to be a dict; required fields stay `{id, input, output}`.
- Rendered arguments are deliberately not written to `results.csv` (matches LLM runner behavior).
- All 41 general tests pass.