### PR TITLE
Add ignore_case option for exact tool-call parameter matching

### DIFF
--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -615,6 +615,30 @@ def _sorted_union_dict_keys(left: dict, right: dict) -> List[Any]:
     return sorted(set(left) | set(right), key=lambda k: (type(k).__name__, repr(k)))
 
 
+def _values_equal(expected, actual, *, ignore_case: bool = False) -> bool:
+    """Return whether two argument values match under the given rules."""
+    if not ignore_case:
+        return expected == actual
+    if type(expected) is not type(actual):
+        return False
+    if isinstance(expected, str):
+        return expected.casefold() == actual.casefold()
+    if isinstance(expected, dict):
+        if set(expected.keys()) != set(actual.keys()):
+            return False
+        return all(
+            _values_equal(expected[k], actual[k], ignore_case=ignore_case)
+            for k in expected
+        )
+    if isinstance(expected, (list, tuple)):
+        if len(expected) != len(actual):
+            return False
+        return all(
+            _values_equal(e, a, ignore_case=ignore_case) for e, a in zip(expected, actual)
+        )
+    return expected == actual
+
+
 def _value_mismatch_detail(expected, actual) -> str:
     """The reason (no ``path`` prefix) two leaf values differ.
 
@@ -639,17 +663,26 @@ def _tool_call_argument_value_mismatch_line(key_path: str, expected, actual) -> 
 
 
 def _tool_call_arguments_diff_lines(
-    expected: dict, actual: dict, prefix: str = ""
+    expected: dict, actual: dict, prefix: str = "", *, ignore_case: bool = False
 ) -> List[str]:
     """List per-field mismatch lines for two argument dicts (recursive).
 
-    Criteria-agnostic: every value is compared literally. This is the
-    exact-match view used by the aggregation fallback and by ``exact`` specs
-    (whose value must be matched verbatim). It is a thin wrapper over
-    :func:`_collect_arg_diffs` with criteria interpretation disabled.
+    Criteria-agnostic except for ``exact`` specs (which are unwrapped and may
+    carry ``ignore_case``). This is the exact-match view used by the
+    aggregation fallback and by nested ``exact`` spec values. It is a thin
+    wrapper over :func:`_collect_arg_diffs` with full criteria interpretation
+    disabled.
     """
     lines: List[str] = []
-    _collect_arg_diffs(expected, actual, prefix, lines, [], criteria_aware=False)
+    _collect_arg_diffs(
+        expected,
+        actual,
+        prefix,
+        lines,
+        [],
+        criteria_aware=False,
+        ignore_case=ignore_case,
+    )
     return lines
 
 
@@ -716,6 +749,32 @@ def _is_any_spec(value) -> bool:
     return isinstance(value, dict) and value.get("match_type") == "any"
 
 
+def _parse_exact_spec(value: dict, key: str) -> dict:
+    """Normalize an ``exact`` match spec dict."""
+    if "value" not in value:
+        raise ValueError(
+            f"Tool-call parameter '{key}': an 'exact' match_type requires "
+            f"a 'value' field holding the literal to match."
+        )
+    ignore_case = value.get("ignore_case", False)
+    if not isinstance(ignore_case, bool):
+        raise ValueError(
+            f"Tool-call parameter '{key}': 'ignore_case' must be a boolean "
+            f"(got {type(ignore_case).__name__})."
+        )
+    spec = {"match_type": "exact", "value": value["value"]}
+    if ignore_case:
+        spec["ignore_case"] = True
+    return spec
+
+
+def _exact_param_spec(value, key: str) -> Optional[dict]:
+    """Like :func:`_param_criteria_spec`, but only for ``exact`` specs."""
+    if not isinstance(value, dict) or value.get("match_type") != "exact":
+        return None
+    return _parse_exact_spec(value, key)
+
+
 def _param_criteria_spec(value, key: str) -> Optional[dict]:
     """Interpret an expected-argument value as a per-parameter matching spec.
 
@@ -723,7 +782,7 @@ def _param_criteria_spec(value, key: str) -> Optional[dict]:
     single tool-call parameter out of exact matching::
 
         {"match_type": "llm_judge", "criteria": "...", "judge_model": "..."}
-        {"match_type": "exact", "value": <literal>}
+        {"match_type": "exact", "value": <literal>, "ignore_case": true|false}
 
     The ``{"match_type": "any"}`` wildcard is recognized and skipped by
     :func:`_is_any_spec` before this point, so it never reaches here.
@@ -747,12 +806,7 @@ def _param_criteria_spec(value, key: str) -> Optional[dict]:
             spec["judge_model"] = value["judge_model"]
         return spec
     if match_type == "exact":
-        if "value" not in value:
-            raise ValueError(
-                f"Tool-call parameter '{key}': an 'exact' match_type requires "
-                f"a 'value' field holding the literal to match."
-            )
-        return {"match_type": "exact", "value": value["value"]}
+        return _parse_exact_spec(value, key)
     raise ValueError(
         f"Tool-call parameter '{key}': match_type must be 'exact', "
         f"'llm_judge', or 'any' (got {match_type!r})."
@@ -824,6 +878,7 @@ def _collect_arg_diffs(
     *,
     criteria_aware: bool = True,
     records: Optional[List[dict]] = None,
+    ignore_case: bool = False,
 ) -> None:
     """Recursively diff expected vs. actual argument dicts.
 
@@ -872,7 +927,10 @@ def _collect_arg_diffs(
         if _is_any_spec(expected[key]):
             continue
 
-        spec = _param_criteria_spec(expected[key], path) if criteria_aware else None
+        if criteria_aware:
+            spec = _param_criteria_spec(expected[key], path)
+        else:
+            spec = _exact_param_spec(expected[key], path)
         if spec is not None and spec["match_type"] == "llm_judge":
             if not in_act:
                 _record_failure(
@@ -897,6 +955,9 @@ def _collect_arg_diffs(
             continue
 
         ev = spec["value"] if spec is not None else expected[key]
+        leaf_ignore_case = (
+            spec.get("ignore_case", False) if spec is not None else ignore_case
+        )
         if not in_act:
             _record_failure(
                 path,
@@ -907,17 +968,20 @@ def _collect_arg_diffs(
             )
             continue
         av = actual[key]
-        if ev == av:
+        if _values_equal(ev, av, ignore_case=leaf_ignore_case):
             if records is not None:
-                records.append(
-                    {"param": path, "match_type": "exact", "match": True}
-                )
+                record = {"param": path, "match_type": "exact", "match": True}
+                if leaf_ignore_case:
+                    record["ignore_case"] = True
+                records.append(record)
             continue
         if isinstance(ev, dict) and isinstance(av, dict):
             if spec is not None:
                 # exact spec → compare its value literally (specs inside an
                 # exact value are not re-interpreted)
-                sub_lines = _tool_call_arguments_diff_lines(ev, av, path)
+                sub_lines = _tool_call_arguments_diff_lines(
+                    ev, av, path, ignore_case=leaf_ignore_case
+                )
                 lines.extend(sub_lines)
                 if records is not None:
                     records.append(
@@ -939,6 +1003,7 @@ def _collect_arg_diffs(
                     judge_jobs,
                     criteria_aware=criteria_aware,
                     records=records,
+                    ignore_case=ignore_case,
                 )
             continue
         _record_failure(path, _value_mismatch_detail(ev, av), lines, records)

--- a/docs/cli/text-to-text.mdx
+++ b/docs/cli/text-to-text.mdx
@@ -194,7 +194,7 @@ A plain literal value (e.g. `"555-123-4567"`) is matched exactly, as usual. To o
 
 | `match_type`  | Shape                                            | Behavior                                                      |
 | ------------- | ------------------------------------------------ | ------------------------------------------------------------- |
-| `"exact"`     | `{"match_type": "exact", "value": <literal>}`    | Check if the produced value is equal to the `<literal>` value |
+| `"exact"`     | `{"match_type": "exact", "value": <literal>, "ignore_case": true\|false}` | Check if the produced value equals `<literal>`; set `"ignore_case": true` for case-insensitive string matching (default `false`) |
 | `"llm_judge"` | `{"match_type": "llm_judge", "criteria": "..."}` | An LLM judge checks the produced value against `criteria`     |
 | `"any"`       | `{"match_type": "any"}`                          | Wildcard — the argument is ignored entirely (see below)       |
 

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -401,6 +401,36 @@ class TestParamCriteriaSpec(unittest.TestCase):
         spec = _param_criteria_spec({"match_type": "exact", "value": 42}, "x")
         self.assertEqual(spec, {"match_type": "exact", "value": 42})
 
+    def test_exact_spec_ignore_case_true(self):
+        from calibrate.llm.run_tests import _param_criteria_spec
+
+        spec = _param_criteria_spec(
+            {"match_type": "exact", "value": "Hello", "ignore_case": True},
+            "x",
+        )
+        self.assertEqual(
+            spec,
+            {"match_type": "exact", "value": "Hello", "ignore_case": True},
+        )
+
+    def test_exact_spec_ignore_case_false_omitted(self):
+        from calibrate.llm.run_tests import _param_criteria_spec
+
+        spec = _param_criteria_spec(
+            {"match_type": "exact", "value": "Hello", "ignore_case": False},
+            "x",
+        )
+        self.assertEqual(spec, {"match_type": "exact", "value": "Hello"})
+
+    def test_exact_spec_ignore_case_must_be_bool(self):
+        from calibrate.llm.run_tests import _param_criteria_spec
+
+        with self.assertRaises(ValueError):
+            _param_criteria_spec(
+                {"match_type": "exact", "value": "Hello", "ignore_case": "true"},
+                "x",
+            )
+
     def test_exact_requires_value(self):
         from calibrate.llm.run_tests import _param_criteria_spec
 
@@ -523,6 +553,56 @@ class TestEvaluateToolCallsCriteria(unittest.TestCase):
                 [{"tool": "a", "arguments": {
                     "x": {"match_type": "exact",
                           "value": {"match_type": "exact", "value": 1}}}}],
+            ))
+        self.assertTrue(result["passed"])
+        mock_judge.assert_not_called()
+
+    def test_exact_spec_ignore_case_pass(self):
+        from calibrate.llm.run_tests import evaluate_tool_calls
+
+        with patch("calibrate.llm.run_tests.text_judge") as mock_judge:
+            result = asyncio.run(evaluate_tool_calls(
+                [{"tool": "a", "arguments": {"city": "mumbai"}}],
+                [{"tool": "a", "arguments": {
+                    "city": {
+                        "match_type": "exact",
+                        "value": "Mumbai",
+                        "ignore_case": True,
+                    },
+                }}],
+            ))
+        self.assertTrue(result["passed"])
+        mock_judge.assert_not_called()
+
+    def test_exact_spec_ignore_case_fail_when_disabled(self):
+        from calibrate.llm.run_tests import evaluate_tool_calls
+
+        result = asyncio.run(evaluate_tool_calls(
+            [{"tool": "a", "arguments": {"city": "mumbai"}}],
+            [{"tool": "a", "arguments": {
+                "city": {
+                    "match_type": "exact",
+                    "value": "Mumbai",
+                    "ignore_case": False,
+                },
+            }}],
+        ))
+        self.assertFalse(result["passed"])
+        self.assertIn("city", result["reasoning"])
+
+    def test_exact_spec_ignore_case_nested_dict(self):
+        from calibrate.llm.run_tests import evaluate_tool_calls
+
+        with patch("calibrate.llm.run_tests.text_judge") as mock_judge:
+            result = asyncio.run(evaluate_tool_calls(
+                [{"tool": "a", "arguments": {"loc": {"city": "paris"}}}],
+                [{"tool": "a", "arguments": {
+                    "loc": {
+                        "match_type": "exact",
+                        "value": {"city": "Paris"},
+                        "ignore_case": True,
+                    },
+                }}],
             ))
         self.assertTrue(result["passed"])
         mock_judge.assert_not_called()
@@ -771,6 +851,20 @@ class TestAnyWildcardParam(unittest.TestCase):
         self.assertIsNone(_tool_call_pair_mismatch(
             {"tool": "lookup", "arguments": {"city": "London", "token": "xyz-123"}},
             {"tool": "lookup", "arguments": {"city": "London", "token": self.ANY}},
+        ))
+
+    def test_sync_pair_mismatch_ignore_case_matches(self):
+        from calibrate.llm.run_tests import _tool_call_pair_mismatch
+
+        self.assertIsNone(_tool_call_pair_mismatch(
+            {"tool": "lookup", "arguments": {"city": "mumbai"}},
+            {"tool": "lookup", "arguments": {
+                "city": {
+                    "match_type": "exact",
+                    "value": "Mumbai",
+                    "ignore_case": True,
+                },
+            }},
         ))
 
 


### PR DESCRIPTION
## Summary
- Add optional `ignore_case: true|false` to `match_type: "exact"` tool-call argument specs for case-insensitive string matching (default remains case-sensitive).
- Apply `ignore_case` recursively for nested dict/list values inside an exact spec.
- Keep sync leaderboard matching (`_per_slot_tool_passes`) aligned with async evaluation for exact specs with `ignore_case`.
- Document the new parameter in the text-to-text CLI docs.

## Test plan
- [x] `uv run pytest tests/llm/test_run_tests_extra.py::TestParamCriteriaSpec tests/llm/test_run_tests_extra.py::TestEvaluateToolCallsCriteria tests/llm/test_run_tests_extra.py::TestAnyWildcardParam::test_sync_pair_mismatch_ignore_case_matches -v`


Made with [Cursor](https://cursor.com)