### PR TITLE
Add --debug flag to `calibrate llm`

### DIFF
--- a/calibrate/cli.py
+++ b/calibrate/cli.py
@@ -307,6 +307,19 @@ Examples:
         help="Number of test cases to evaluate in parallel per model",
     )
     llm_parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="Debug mode: evaluate only the first N test cases (see --debug_count)",
+    )
+    llm_parser.add_argument(
+        "-dc",
+        "--debug_count",
+        type=int,
+        default=5,
+        help="Number of test cases to evaluate in debug mode (default: 5)",
+    )
+    llm_parser.add_argument(
         "--verify",
         action="store_true",
         help="Verify an external agent connection by sending a preset message and checking the response format",
@@ -573,6 +586,9 @@ Examples:
             ]
             if getattr(args, "parallel", None) is not None:
                 argv.extend(["-n", str(args.parallel)])
+            if getattr(args, "debug", False):
+                argv.append("-d")
+                argv.extend(["-dc", str(args.debug_count)])
             sys.argv = argv
             asyncio.run(llm_run_tests_main())
         elif getattr(args, "verify", False):
@@ -590,9 +606,15 @@ Examples:
         else:
             # Direct mode: run tests with provided config
             import json as _json
+            from calibrate.utils import apply_debug_limit
 
             with open(args.config) as _f:
                 _config = _json.load(_f)
+
+            if getattr(args, "debug", False) and _config.get("test_cases"):
+                _config["test_cases"] = apply_debug_limit(
+                    _config["test_cases"], True, args.debug_count
+                )
 
             if _config.get("agent_url"):
                 # Agent connection path
@@ -672,6 +694,9 @@ Examples:
                 argv.extend(["-p", args.provider])
                 if getattr(args, "parallel", None) is not None:
                     argv.extend(["-n", str(args.parallel)])
+                if getattr(args, "debug", False):
+                    argv.append("-d")
+                    argv.extend(["-dc", str(args.debug_count)])
 
                 sys.argv = argv
                 asyncio.run(llm_benchmark_main())

--- a/calibrate/llm/benchmark.py
+++ b/calibrate/llm/benchmark.py
@@ -29,7 +29,7 @@ from os.path import exists, join
 from calibrate.llm.run_tests import display_label, run_model_tests
 from calibrate.llm.tests_leaderboard import generate_leaderboard
 from calibrate.llm._output import print_benchmark_summary
-from calibrate.utils import StreamTee
+from calibrate.utils import StreamTee, apply_debug_limit
 
 # Maximum number of models to run in parallel
 MAX_PARALLEL_MODELS = 2
@@ -151,12 +151,30 @@ async def main():
         default=None,
         help="Number of test cases to evaluate in parallel per model",
     )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="Debug mode: evaluate only the first N test cases (see --debug_count)",
+    )
+    parser.add_argument(
+        "-dc",
+        "--debug_count",
+        type=int,
+        default=5,
+        help="Number of test cases to evaluate in debug mode (default: 5)",
+    )
 
     args = parser.parse_args()
 
     models = args.model
 
     config = json.load(open(args.config))
+
+    if args.debug and config.get("test_cases"):
+        config["test_cases"] = apply_debug_limit(
+            config["test_cases"], args.debug, args.debug_count
+        )
 
     # ``exist_ok=True`` makes this safe when several ``calibrate llm``
     # subprocesses (e.g. one per model spawned by the interactive UI) race to

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -19,6 +19,7 @@ from calibrate.utils import (
     log_and_print,
     build_tools_schema,
     provider_log_file,
+    apply_debug_limit,
 )
 from pipecat.frames.frames import (
     TranscriptionFrame,
@@ -2142,6 +2143,19 @@ async def main():
         help="Number of test cases to evaluate in parallel",
     )
     parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="Debug mode: evaluate only the first N test cases (see --debug_count)",
+    )
+    parser.add_argument(
+        "-dc",
+        "--debug_count",
+        type=int,
+        default=5,
+        help="Number of test cases to evaluate in debug mode (default: 5)",
+    )
+    parser.add_argument(
         "--eval-only",
         action="store_true",
         help="Skip LLM inference and run evaluators on a dataset of (test_case, output) pairs",
@@ -2174,6 +2188,9 @@ async def main():
             print(f"\033[31mDataset validation error: {err}\033[0m")
             sys.exit(1)
 
+        if args.debug:
+            dataset = apply_debug_limit(dataset, args.debug, args.debug_count)
+
         print("\n\033[91mLLM Eval-Only\033[0m\n")
         print(f"Config: {args.config}")
         print(f"Dataset: {args.dataset}")
@@ -2198,6 +2215,11 @@ async def main():
     if not args.model:
         print("\033[31mError: --model is required (omit only with --eval-only)\033[0m")
         sys.exit(1)
+
+    if args.debug and config.get("test_cases"):
+        config["test_cases"] = apply_debug_limit(
+            config["test_cases"], args.debug, args.debug_count
+        )
 
     model = args.model
 

--- a/calibrate/utils.py
+++ b/calibrate/utils.py
@@ -181,6 +181,28 @@ def provider_log(message: object = "", *, to_terminal: bool = True) -> None:
             f.write(text + "\n")
 
 
+def apply_debug_limit(
+    items: list,
+    debug: bool,
+    debug_count: int,
+    *,
+    label: str = "test cases",
+) -> list:
+    """Truncate ``items`` to the first ``debug_count`` when ``debug`` is on.
+
+    Mirrors the STT/TTS ``--debug`` behaviour for the LLM commands: a quick
+    smoke-run mode that limits how many items are evaluated. Returns the
+    (possibly truncated) list and prints a banner when truncation happens.
+    """
+    if not debug or not items:
+        return items
+    n = min(debug_count, len(items))
+    print(
+        f"\033[93mrunning in debug mode: using first {n} {label} for evaluation\033[0m"
+    )
+    return items[:n]
+
+
 # Serializes concurrent judge-log writes within the process so two judges
 # running at once never split each other's entry.
 _judge_log_lock = threading.Lock()

--- a/tests/llm/test_benchmark.py
+++ b/tests/llm/test_benchmark.py
@@ -297,6 +297,61 @@ class TestFolderNaming(unittest.IsolatedAsyncioTestCase):
 
 
 # ---------------------------------------------------------------------------
+# Tests for --debug / --debug_count truncating test cases in benchmark.main
+# ---------------------------------------------------------------------------
+
+class TestBenchmarkDebugFlag(unittest.IsolatedAsyncioTestCase):
+    async def _run_main(self, argv_extra):
+        import json
+        import os
+        import sys
+        import tempfile
+        from calibrate.llm import benchmark
+
+        config = {
+            "system_prompt": "p",
+            "tools": [],
+            "test_cases": [{"id": str(i)} for i in range(10)],
+        }
+
+        captured = {}
+
+        async def fake_run(*, config, models, provider, output_dir, test_parallel=None):
+            captured["config"] = config
+            return {
+                "status": "completed",
+                "output_dir": output_dir,
+                "leaderboard_dir": os.path.join(output_dir, "leaderboard"),
+                "models": {},
+            }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg_path = os.path.join(tmpdir, "config.json")
+            with open(cfg_path, "w") as f:
+                json.dump(config, f)
+
+            argv = ["calibrate", "-c", cfg_path, "-m", "gpt-4.1", "-o", tmpdir]
+            argv.extend(argv_extra)
+            with patch.object(sys, "argv", argv), \
+                 patch("calibrate.llm.benchmark.run", side_effect=fake_run), \
+                 patch("calibrate.llm.benchmark.print_benchmark_summary", return_value=False):
+                await benchmark.main()
+        return captured["config"]
+
+    async def test_debug_truncates_test_cases(self):
+        config = await self._run_main(["-d", "-dc", "3"])
+        self.assertEqual(len(config["test_cases"]), 3)
+
+    async def test_debug_default_count(self):
+        config = await self._run_main(["-d"])
+        self.assertEqual(len(config["test_cases"]), 5)
+
+    async def test_no_debug_keeps_all_test_cases(self):
+        config = await self._run_main([])
+        self.assertEqual(len(config["test_cases"]), 10)
+
+
+# ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -2672,5 +2672,69 @@ class TestWriteOutputsTotalTokens(unittest.TestCase):
         self.assertNotIn("total_tokens", metrics)
 
 
+class TestRunTestsMainDebug(unittest.IsolatedAsyncioTestCase):
+    async def test_eval_only_debug_truncates_dataset(self):
+        from calibrate.llm import run_tests
+
+        captured = {}
+
+        async def fake_eval(**kwargs):
+            captured["dataset"] = kwargs["dataset"]
+            return {"passed": 1, "total": 1}
+
+        dataset = [
+            {
+                "test_case": {"history": [], "evaluation": {}},
+                "output": {"response": "x", "tool_calls": []},
+            }
+            for _ in range(5)
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "c.json"
+            cfg.write_text("{}")
+            ds = Path(tmp) / "d.json"
+            ds.write_text(json.dumps(dataset))
+            with patch.object(sys, "argv", [
+                "calibrate", "-c", str(cfg), "-o", tmp,
+                "--eval-only", "--dataset", str(ds), "-d", "-dc", "2",
+            ]), \
+                patch("calibrate.llm.run_tests.run_eval_only_tests",
+                      side_effect=fake_eval), \
+                patch("calibrate.llm.run_tests.validate_llm_eval_only_dataset",
+                      return_value=(True, "")):
+                await run_tests.main()
+        self.assertEqual(len(captured["dataset"]), 2)
+
+    async def test_debug_truncates_config_test_cases(self):
+        from calibrate.llm import run_tests
+
+        captured = {}
+
+        async def fake_run(**kwargs):
+            captured["config"] = kwargs["config"]
+            return {
+                "metrics": {"passed": 1, "total": 1},
+                "provider": "openrouter",
+                "model": "gpt-4.1",
+            }
+
+        config = {
+            "system_prompt": "sp",
+            "tools": [],
+            "test_cases": [{"id": str(i)} for i in range(10)],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "c.json"
+            cfg.write_text(json.dumps(config))
+            with patch.object(sys, "argv", [
+                "calibrate", "-c", str(cfg), "-o", tmp,
+                "-m", "gpt-4.1", "-d", "-dc", "3",
+            ]), \
+                patch("calibrate.llm.run_tests.run_model_tests",
+                      side_effect=fake_run):
+                await run_tests.main()
+        self.assertEqual(len(captured["config"]["test_cases"]), 3)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -294,6 +294,74 @@ class TestMainDispatch(unittest.TestCase):
                     "-o", tmp,
                 ])
 
+    def test_llm_eval_only_debug_forwards_flags(self):
+        captured = {}
+
+        def _capture():
+            captured["argv"] = list(sys.argv)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "config.json"
+            cfg.write_text("{}")
+            ds = Path(tmp) / "ds.json"
+            ds.write_text("[]")
+            with patch("calibrate.llm.run_tests.main",
+                       AsyncMock(side_effect=_capture)):
+                self._run_with_argv([
+                    "calibrate", "llm", "--eval-only",
+                    "-c", str(cfg), "--dataset", str(ds), "-o", tmp,
+                    "-d", "-dc", "2",
+                ])
+        argv = captured["argv"]
+        self.assertIn("-d", argv)
+        self.assertIn("-dc", argv)
+        self.assertIn("2", argv)
+
+    def test_llm_benchmark_debug_forwards_flags(self):
+        captured = {}
+
+        def _capture():
+            captured["argv"] = list(sys.argv)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "config.json"
+            cfg.write_text(json.dumps(
+                {"system_prompt": "sp", "tools": [], "test_cases": []}
+            ))
+            with patch("calibrate.llm.benchmark.main",
+                       AsyncMock(side_effect=_capture)):
+                self._run_with_argv([
+                    "calibrate", "llm", "-c", str(cfg),
+                    "-o", tmp, "-m", "gpt-4.1", "-d", "-dc", "2",
+                ])
+        argv = captured["argv"]
+        self.assertIn("-d", argv)
+        self.assertIn("-dc", argv)
+        self.assertIn("2", argv)
+
+    def test_llm_agent_debug_truncates_test_cases(self):
+        captured = {}
+
+        async def fake_run(**kwargs):
+            captured["test_cases"] = kwargs.get("test_cases")
+            return {}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "config.json"
+            cfg.write_text(json.dumps({
+                "agent_url": "http://x",
+                "test_cases": [
+                    {"id": str(i), "history": [], "evaluation": {"type": "tool_call"}}
+                    for i in range(4)
+                ],
+            }))
+            with patch("calibrate.llm.tests.run", side_effect=fake_run):
+                self._run_with_argv([
+                    "calibrate", "llm", "-c", str(cfg),
+                    "-o", tmp, "--skip-verify", "-d", "-dc", "1",
+                ])
+        self.assertEqual(len(captured["test_cases"]), 1)
+
     def test_simulations_verify(self):
         from calibrate import cli
         with patch.object(cli, "_run_agent_verify") as mock:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -705,6 +705,45 @@ class TestReadLeaderboardMetrics(unittest.TestCase):
             self.assertEqual(read_leaderboard_metrics(p), {"wer": 0.2})
 
 
+class TestApplyDebugLimit(unittest.TestCase):
+    def test_truncates_to_debug_count(self):
+        from calibrate.utils import apply_debug_limit
+
+        items = list(range(10))
+        result = apply_debug_limit(items, True, 3)
+        self.assertEqual(result, [0, 1, 2])
+
+    def test_noop_when_debug_off(self):
+        from calibrate.utils import apply_debug_limit
+
+        items = list(range(10))
+        result = apply_debug_limit(items, False, 3)
+        self.assertEqual(result, items)
+
+    def test_count_larger_than_list_returns_all(self):
+        from calibrate.utils import apply_debug_limit
+
+        items = [1, 2]
+        result = apply_debug_limit(items, True, 5)
+        self.assertEqual(result, [1, 2])
+
+    def test_empty_list(self):
+        from calibrate.utils import apply_debug_limit
+
+        self.assertEqual(apply_debug_limit([], True, 5), [])
+
+    def test_prints_banner_only_when_truncating(self):
+        from calibrate.utils import apply_debug_limit
+
+        with patch("builtins.print") as mock_print:
+            apply_debug_limit([1, 2, 3], True, 2)
+        self.assertTrue(mock_print.called)
+
+        with patch("builtins.print") as mock_print:
+            apply_debug_limit([1, 2, 3], False, 2)
+        self.assertFalse(mock_print.called)
+
+
 def pytest_approx(value, tol=1e-9):
     class _Approx:
         def __eq__(self, other):


### PR DESCRIPTION
## Summary
- Adds `-d/--debug` and `-dc/--debug_count` (default 5) to `calibrate llm`, mirroring the existing STT/TTS `--debug` behaviour: a quick smoke-run mode that truncates evaluation to the first N test cases.
- Introduces a shared `apply_debug_limit(items, debug, debug_count, label=...)` helper in `calibrate/utils.py` and wires it through every `llm` path — single-model (`run_tests.py`), multi-model benchmark (`benchmark.py`), the agent-URL path, and `--eval-only` (truncates the dataset).

## Usage
```bash
calibrate llm -c config.json -m gpt-4.1 --debug        # first 5 test cases
calibrate llm -c config.json -m gpt-4.1 -d -dc 3       # first 3 test cases
```

## Notes
- `--debug` also applies to the `--eval-only` path (truncates the dataset), slightly beyond STT where `--debug` only affects inference.
- `simulations` is intentionally left out of scope.

## Test plan
- [x] `tests/test_utils.py::TestApplyDebugLimit` — helper truncation/banner behaviour
- [x] `tests/llm/test_benchmark.py::TestBenchmarkDebugFlag` — `benchmark.main` truncates to `-dc`, defaults to 5, keeps all without `-d`
- [x] Regression: `tests/llm/test_run_tests.py` and `tests/test_cli.py` pass

Made with [Cursor](https://cursor.com)