### PR TITLE
Resume LLM test runs and parallelize agent benchmarks

### DIFF
--- a/calibrate/cli.py
+++ b/calibrate/cli.py
@@ -320,6 +320,11 @@ Examples:
         help="Number of test cases to evaluate in debug mode (default: 5)",
     )
     llm_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Force a clean run instead of resuming completed test cases from a prior results.json",
+    )
+    llm_parser.add_argument(
         "--verify",
         action="store_true",
         help="Verify an external agent connection by sending a preset message and checking the response format",
@@ -658,6 +663,7 @@ Examples:
                             models=_models,
                             evaluators=_config.get("evaluators"),
                             test_parallel=args.parallel,
+                            overwrite=args.overwrite,
                         )
                     )
                     _model_results = {
@@ -681,6 +687,7 @@ Examples:
                             output_dir=args.output_dir,
                             evaluators=_config.get("evaluators"),
                             test_parallel=args.parallel,
+                            overwrite=args.overwrite,
                         )
                     )
             else:
@@ -694,6 +701,8 @@ Examples:
                 argv.extend(["-p", args.provider])
                 if getattr(args, "parallel", None) is not None:
                     argv.extend(["-n", str(args.parallel)])
+                if getattr(args, "overwrite", False):
+                    argv.append("--overwrite")
                 if getattr(args, "debug", False):
                     argv.append("-d")
                     argv.extend(["-dc", str(args.debug_count)])

--- a/calibrate/llm/__init__.py
+++ b/calibrate/llm/__init__.py
@@ -334,6 +334,13 @@ class _Tests:
         """
         tools = tools or []
 
+        from calibrate.llm.run_tests import ensure_test_case_ids
+
+        # Validate id uniqueness and backfill content-hash ids once, up front,
+        # so duplicate ids fail fast (before fanning models out) and resume has
+        # a stable key for every case even when none were supplied.
+        ensure_test_case_ids(test_cases)
+
         # External agent benchmark: run once per model, passing model hint in each request
         if agent is not None and models and len(models) > 0:
             semaphore = asyncio.Semaphore(max_parallel)

--- a/calibrate/llm/__init__.py
+++ b/calibrate/llm/__init__.py
@@ -84,6 +84,7 @@ class _Tests:
         evaluators: Optional[List[dict]] = None,
         test_parallel: Optional[int] = None,
         label_output: bool = False,
+        overwrite: bool = False,
     ) -> dict:
         """Run tests for a single model (or external agent).
 
@@ -91,6 +92,8 @@ class _Tests:
             label_output: When True, prefix per-test-case log lines with
                 ``[model]``. Set for multi-model parallel runs (internal or
                 agent) so interleaved output stays attributable.
+            overwrite: When False, resume by skipping test cases already present
+                in a prior ``results.json``; when True, rerun everything.
         """
         from calibrate.llm.run_tests import (
             run_test as _run_test,
@@ -99,6 +102,7 @@ class _Tests:
             _evaluators_for_config_output,
             _resolve_evaluators_for_test_case,
             _run_items_parallel,
+            _load_resumable_results,
         )
         from calibrate.judges import write_evaluator_config
         from calibrate.utils import configure_print_logger, log_and_print
@@ -192,8 +196,19 @@ class _Tests:
             log_and_print("-" * 40)
             return result
 
+        initial_results = _load_resumable_results(
+            results_file_path, test_cases, overwrite
+        )
+        resumed_count = sum(1 for r in initial_results if r is not None)
+        if resumed_count:
+            label_prefix = f"[{model}] " if (label_output and model) else ""
+            log_and_print(
+                f"{label_prefix}↻ Resuming: {resumed_count}/{len(test_cases)} "
+                f"test case(s) already completed; re-running the rest"
+            )
+
         results = await _run_items_parallel(
-            test_cases, process, results_file_path, test_parallel
+            test_cases, process, results_file_path, test_parallel, initial_results
         )
 
         total_passed = sum(1 for r in results if r["metrics"]["passed"])
@@ -263,6 +278,7 @@ class _Tests:
         agent: Optional["TextAgentConnection"] = None,
         evaluators: Optional[List[dict]] = None,
         test_parallel: Optional[int] = None,
+        overwrite: bool = False,
     ) -> dict:
         """
         Run LLM tests with the given configuration.
@@ -285,6 +301,10 @@ class _Tests:
             run_name: Optional name for this run (used in output folder name)
             max_parallel: Maximum number of models to run in parallel (default: 2)
             test_parallel: Max test cases to evaluate concurrently per model.
+            overwrite: When False (default), reuse completed results from a prior
+                ``results.json`` (matched by test-case ``id``) so an interrupted
+                run resumes instead of re-evaluating everything. True forces a
+                clean run.
             agent: Optional external agent connection. When provided, routes all
                 test cases to the external agent instead of an internal LLM.
             evaluators: Optional list of evaluator dicts (each with ``name``,
@@ -332,6 +352,7 @@ class _Tests:
                         evaluators=evaluators,
                         test_parallel=test_parallel,
                         label_output=True,
+                        overwrite=overwrite,
                     )
 
             # ``return_exceptions=True`` so one model's hard failure (e.g. the
@@ -363,6 +384,7 @@ class _Tests:
                 agent=agent,
                 evaluators=evaluators,
                 test_parallel=test_parallel,
+                overwrite=overwrite,
             )
 
         # If models list is provided, run in parallel
@@ -382,6 +404,7 @@ class _Tests:
                         evaluators=evaluators,
                         test_parallel=test_parallel,
                         label_output=True,
+                        overwrite=overwrite,
                     )
 
             tasks = [run_with_semaphore(m) for m in models]
@@ -415,6 +438,7 @@ class _Tests:
             run_name=run_name,
             evaluators=evaluators,
             test_parallel=test_parallel,
+            overwrite=overwrite,
         )
 
     @staticmethod

--- a/calibrate/llm/__init__.py
+++ b/calibrate/llm/__init__.py
@@ -334,12 +334,11 @@ class _Tests:
         """
         tools = tools or []
 
-        from calibrate.llm.run_tests import ensure_test_case_ids
+        from calibrate.llm.run_tests import require_unique_test_case_ids
 
-        # Validate id uniqueness and backfill content-hash ids once, up front,
-        # so duplicate ids fail fast (before fanning models out) and resume has
-        # a stable key for every case even when none were supplied.
-        ensure_test_case_ids(test_cases)
+        # Validate id uniqueness once, up front, so duplicate ids fail fast
+        # before fanning models out. Cases without ids just won't resume.
+        require_unique_test_case_ids(test_cases)
 
         # External agent benchmark: run once per model, passing model hint in each request
         if agent is not None and models and len(models) > 0:

--- a/calibrate/llm/benchmark.py
+++ b/calibrate/llm/benchmark.py
@@ -42,6 +42,7 @@ async def run(
     output_dir: str = "./out",
     max_parallel: int = MAX_PARALLEL_MODELS,
     test_parallel: int | None = None,
+    overwrite: bool = False,
 ) -> dict:
     """
     Run LLM tests for multiple models in parallel and generate a leaderboard.
@@ -56,6 +57,8 @@ async def run(
             Results saved to output_dir/model_name/ for each model
         max_parallel: Maximum number of models to run in parallel (default: 2)
         test_parallel: Max test cases to evaluate concurrently per model.
+        overwrite: When False (default), resume each model from its prior
+            ``results.json`` instead of re-evaluating completed test cases.
 
     Returns:
         dict: Results summary with status and output paths
@@ -84,6 +87,7 @@ async def run(
                 config=config,
                 output_dir=output_dir,
                 test_parallel=test_parallel,
+                overwrite=overwrite,
             )
             return (model, result)
 
@@ -152,6 +156,11 @@ async def main():
         help="Number of test cases to evaluate in parallel per model",
     )
     parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Force a clean run instead of resuming completed test cases from a prior results.json",
+    )
+    parser.add_argument(
         "-d",
         "--debug",
         action="store_true",
@@ -215,6 +224,7 @@ async def main():
             provider=args.provider,
             output_dir=args.output_dir,
             test_parallel=args.parallel,
+            overwrite=args.overwrite,
         )
 
         has_errors = print_benchmark_summary(

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -1,6 +1,5 @@
 import asyncio
 import argparse
-import hashlib
 import re
 import sys
 import time
@@ -1761,40 +1760,12 @@ def _aggregate_tool_calls(results: List[dict]) -> dict:
     return aggregated
 
 
-def _derive_test_case_id(test_case: dict) -> str:
-    """Derive a stable content-hash id from a test case's ``history`` +
-    ``evaluation``.
+def require_unique_test_case_ids(test_cases: List[dict]) -> None:
+    """Raise ``ValueError`` if two test cases share the same explicit ``id``.
 
-    Used to give resume a stable key for test cases that don't carry an
-    explicit ``id``. Two cases with identical history+evaluation hash to the
-    same id (they are effectively the same test). The ``auto:`` prefix
-    namespaces derived ids away from user-supplied ones.
-    """
-    payload = json.dumps(
-        {
-            "history": test_case.get("history"),
-            "evaluation": test_case.get("evaluation"),
-        },
-        sort_keys=True,
-        ensure_ascii=False,
-        default=str,
-    )
-    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
-    return f"auto:{digest}"
-
-
-def ensure_test_case_ids(test_cases: List[dict]) -> List[dict]:
-    """Guarantee every test case has a stable, unique ``id`` (in place).
-
-    - Raises ``ValueError`` if two test cases carry the same explicit ``id``,
-      since duplicates would let resume wrongly skip work (they collide to one
-      prior record).
-    - Fills any test case missing an ``id`` with a content hash of its
-      ``history`` + ``evaluation`` (see :func:`_derive_test_case_id`) so resume
-      works out of the box without user-supplied ids.
-
-    Idempotent: re-running on already-prepared cases is a no-op. Returns the
-    same list for convenience.
+    Duplicate ids would let resume wrongly skip work (both cases collapse onto
+    one prior record). Cases without an ``id`` are left alone — they simply
+    don't participate in resume.
     """
     seen: dict = {}
     for i, tc in enumerate(test_cases):
@@ -1809,11 +1780,6 @@ def ensure_test_case_ids(test_cases: List[dict]) -> List[dict]:
                 "Test case ids must be unique so interrupted runs resume correctly."
             )
         seen[tid] = i
-
-    for tc in test_cases:
-        if isinstance(tc, dict) and tc.get("id") is None:
-            tc["id"] = _derive_test_case_id(tc)
-    return test_cases
 
 
 def _resumable_id(record: dict) -> Optional[str]:
@@ -1933,7 +1899,7 @@ async def run_model_tests(
     tools = config.get("tools") or []
     system_prompt = config.get("system_prompt", "")
 
-    ensure_test_case_ids(config["test_cases"])
+    require_unique_test_case_ids(config["test_cases"])
 
     async def process(test_case_index: int, test_case: dict) -> dict:
         evaluation = test_case["evaluation"]

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -309,6 +309,7 @@ async def _run_items_parallel(
     process: "Callable[[int, Any], Awaitable[dict]]",
     results_file_path: str,
     test_parallel: Optional[int] = None,
+    initial_results: Optional[List[Optional[dict]]] = None,
 ) -> List[dict]:
     """Run ``process(index, item)`` over ``items`` with bounded concurrency.
 
@@ -316,8 +317,15 @@ async def _run_items_parallel(
     are collected in input order regardless of completion order, and the
     partial (in-order) ``results.json`` is rewritten after each item completes.
     Returns the ordered list of results.
+
+    ``initial_results`` (same length as ``items``) pre-seeds already-computed
+    entries — used to resume a partial run. Indices that are non-``None`` are
+    kept as-is and never re-processed; only ``None`` slots invoke ``process``.
     """
-    results: List[Optional[dict]] = [None] * len(items)
+    if initial_results is not None:
+        results: List[Optional[dict]] = list(initial_results)
+    else:
+        results = [None] * len(items)
     semaphore = asyncio.Semaphore(_resolve_test_parallel(test_parallel))
     write_lock = asyncio.Lock()
 
@@ -329,7 +337,13 @@ async def _run_items_parallel(
                 with open(results_file_path, "w") as f:
                     json.dump([r for r in results if r is not None], f, indent=4)
 
-    await asyncio.gather(*[run_one(i, item) for i, item in enumerate(items)])
+    await asyncio.gather(
+        *[
+            run_one(i, item)
+            for i, item in enumerate(items)
+            if results[i] is None
+        ]
+    )
     return results
 
 
@@ -1746,12 +1760,70 @@ def _aggregate_tool_calls(results: List[dict]) -> dict:
     return aggregated
 
 
+def _resumable_id(record: dict) -> Optional[str]:
+    """Pull the test-case id out of a prior result record, if present.
+
+    Prefers the top-level ``test_case_id`` written by :func:`run_model_tests`,
+    falling back to the embedded ``test_case["id"]``.
+    """
+    rid = record.get("test_case_id")
+    if rid is None:
+        tc = record.get("test_case")
+        if isinstance(tc, dict):
+            rid = tc.get("id")
+    return rid
+
+
+def _load_resumable_results(
+    results_file_path: str,
+    test_cases: List[dict],
+    overwrite: bool,
+) -> List[Optional[dict]]:
+    """Build a pre-seeded results list to resume a partial run.
+
+    Reads a previously written ``results.json`` and, for every current test
+    case whose ``id`` matches a completed prior result, reuses that result so
+    it is not re-evaluated. Returns a list aligned with ``test_cases`` (a prior
+    result dict for resumable slots, ``None`` for slots that must run).
+
+    Resume is skipped entirely (all ``None``) when ``overwrite`` is set, the
+    file is missing/unreadable, or test cases lack ids. A prior record is only
+    considered complete if it carries a ``metrics`` block.
+    """
+    if overwrite or not exists(results_file_path):
+        return [None] * len(test_cases)
+
+    try:
+        with open(results_file_path) as f:
+            prior = json.load(f)
+    except (json.JSONDecodeError, OSError, ValueError):
+        return [None] * len(test_cases)
+
+    if not isinstance(prior, list):
+        return [None] * len(test_cases)
+
+    by_id: dict = {}
+    for record in prior:
+        if not isinstance(record, dict) or "metrics" not in record:
+            continue
+        rid = _resumable_id(record)
+        if rid is not None:
+            by_id[rid] = record
+
+    initial: List[Optional[dict]] = []
+    for tc in test_cases:
+        tcid = tc.get("id") if isinstance(tc, dict) else None
+        initial.append(by_id.get(tcid) if tcid is not None else None)
+    return initial
+
+
 async def run_model_tests(
     model: str,
     provider: str,
     config: dict,
     output_dir: str,
     test_parallel: Optional[int] = None,
+    overwrite: bool = False,
 ) -> dict:
     """Run tests for a single model and return results.
 
@@ -1761,6 +1833,9 @@ async def run_model_tests(
         config: Test configuration dict
         output_dir: Base output directory - results saved to output_dir/model_name/
         test_parallel: Max test cases to evaluate concurrently.
+        overwrite: When False (default), reuse completed results from a prior
+            ``results.json`` (matched by test-case ``id``) so an interrupted run
+            resumes instead of re-evaluating everything. Set True for a clean run.
     """
     # Build model folder name: for openai provider, prefix with provider name
     save_folder_name = f"{provider}/{model}" if provider == "openai" else f"{model}"
@@ -1851,8 +1926,23 @@ async def run_model_tests(
         result["test_case"] = test_case
         return result
 
+    initial_results = _load_resumable_results(
+        results_file_path, config["test_cases"], overwrite
+    )
+    resumed_count = sum(1 for r in initial_results if r is not None)
+    if resumed_count:
+        _print_and_log(
+            f"[{label}] ↻ Resuming: {resumed_count}/{len(config['test_cases'])} "
+            f"test case(s) already completed; re-running the rest",
+            print_log_save_path,
+        )
+
     results = await _run_items_parallel(
-        config["test_cases"], process, results_file_path, test_parallel
+        config["test_cases"],
+        process,
+        results_file_path,
+        test_parallel,
+        initial_results=initial_results,
     )
 
     total_passed = sum(1 for result in results if result["metrics"]["passed"])

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -1,5 +1,6 @@
 import asyncio
 import argparse
+import hashlib
 import re
 import sys
 import time
@@ -1760,6 +1761,61 @@ def _aggregate_tool_calls(results: List[dict]) -> dict:
     return aggregated
 
 
+def _derive_test_case_id(test_case: dict) -> str:
+    """Derive a stable content-hash id from a test case's ``history`` +
+    ``evaluation``.
+
+    Used to give resume a stable key for test cases that don't carry an
+    explicit ``id``. Two cases with identical history+evaluation hash to the
+    same id (they are effectively the same test). The ``auto:`` prefix
+    namespaces derived ids away from user-supplied ones.
+    """
+    payload = json.dumps(
+        {
+            "history": test_case.get("history"),
+            "evaluation": test_case.get("evaluation"),
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+        default=str,
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+    return f"auto:{digest}"
+
+
+def ensure_test_case_ids(test_cases: List[dict]) -> List[dict]:
+    """Guarantee every test case has a stable, unique ``id`` (in place).
+
+    - Raises ``ValueError`` if two test cases carry the same explicit ``id``,
+      since duplicates would let resume wrongly skip work (they collide to one
+      prior record).
+    - Fills any test case missing an ``id`` with a content hash of its
+      ``history`` + ``evaluation`` (see :func:`_derive_test_case_id`) so resume
+      works out of the box without user-supplied ids.
+
+    Idempotent: re-running on already-prepared cases is a no-op. Returns the
+    same list for convenience.
+    """
+    seen: dict = {}
+    for i, tc in enumerate(test_cases):
+        if not isinstance(tc, dict):
+            continue
+        tid = tc.get("id")
+        if tid is None:
+            continue
+        if tid in seen:
+            raise ValueError(
+                f"Duplicate test case id {tid!r} (indices {seen[tid]} and {i}). "
+                "Test case ids must be unique so interrupted runs resume correctly."
+            )
+        seen[tid] = i
+
+    for tc in test_cases:
+        if isinstance(tc, dict) and tc.get("id") is None:
+            tc["id"] = _derive_test_case_id(tc)
+    return test_cases
+
+
 def _resumable_id(record: dict) -> Optional[str]:
     """Pull the test-case id out of a prior result record, if present.
 
@@ -1876,6 +1932,8 @@ async def run_model_tests(
 
     tools = config.get("tools") or []
     system_prompt = config.get("system_prompt", "")
+
+    ensure_test_case_ids(config["test_cases"])
 
     async def process(test_case_index: int, test_case: dict) -> dict:
         evaluation = test_case["evaluation"]

--- a/tests/llm/test_benchmark.py
+++ b/tests/llm/test_benchmark.py
@@ -316,8 +316,11 @@ class TestBenchmarkDebugFlag(unittest.IsolatedAsyncioTestCase):
 
         captured = {}
 
-        async def fake_run(*, config, models, provider, output_dir, test_parallel=None):
+        async def fake_run(
+            *, config, models, provider, output_dir, test_parallel=None, overwrite=False
+        ):
             captured["config"] = config
+            captured["overwrite"] = overwrite
             return {
                 "status": "completed",
                 "output_dir": output_dir,
@@ -336,7 +339,16 @@ class TestBenchmarkDebugFlag(unittest.IsolatedAsyncioTestCase):
                  patch("calibrate.llm.benchmark.run", side_effect=fake_run), \
                  patch("calibrate.llm.benchmark.print_benchmark_summary", return_value=False):
                 await benchmark.main()
+        self._captured = captured
         return captured["config"]
+
+    async def test_overwrite_flag_forwarded(self):
+        await self._run_main(["--overwrite"])
+        self.assertTrue(self._captured["overwrite"])
+
+    async def test_overwrite_defaults_false(self):
+        await self._run_main([])
+        self.assertFalse(self._captured["overwrite"])
 
     async def test_debug_truncates_test_cases(self):
         config = await self._run_main(["-d", "-dc", "3"])

--- a/tests/llm/test_init_extra.py
+++ b/tests/llm/test_init_extra.py
@@ -181,6 +181,70 @@ class TestLLMTestsRun(unittest.IsolatedAsyncioTestCase):
         # overwrite=True ignores the prior results — both cases re-run.
         self.assertEqual(mock_external.await_count, 2)
 
+    async def test_run_raises_on_duplicate_ids_before_running(self):
+        from calibrate.llm import tests
+
+        fake_agent = MagicMock()
+        test_cases = [
+            {"id": "dup", "history": [{"role": "user", "content": "a"}],
+             "evaluation": {"type": "response", "criteria": "x"}},
+            {"id": "dup", "history": [{"role": "user", "content": "b"}],
+             "evaluation": {"type": "response", "criteria": "y"}},
+        ]
+        mock_external = AsyncMock(return_value={
+            "output": {"response": "Hi", "tool_calls": []},
+            "metrics": {"passed": True, "judge_results": {}},
+        })
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch("calibrate.llm.run_tests.run_test_external", mock_external):
+            with self.assertRaises(ValueError):
+                await tests.run(
+                    test_cases=test_cases, output_dir=tmp, agent=fake_agent,
+                )
+        # Fail-fast: no test cases were dispatched.
+        self.assertEqual(mock_external.await_count, 0)
+
+    async def test_run_resumes_without_ids_via_content_hash(self):
+        from calibrate.llm import tests
+
+        # Fresh dict per call: a shared return_value object would be aliased
+        # across both records (last write wins on test_case_id) and mask resume.
+        async def fresh_result(*args, **kwargs):
+            return {
+                "output": {"response": "Hi", "tool_calls": []},
+                "metrics": {"passed": True, "judge_results": {}},
+            }
+        fake_agent = MagicMock()
+
+        # No explicit ids — resume must still work via derived content-hash ids.
+        # Build fresh (id-less) dicts each run so the second run re-derives ids
+        # from scratch rather than reusing ids the first run backfilled in place.
+        def make_cases():
+            return [
+                {"history": [{"role": "user", "content": "a"}],
+                 "evaluation": {"type": "response", "criteria": "x"}},
+                {"history": [{"role": "user", "content": "b"}],
+                 "evaluation": {"type": "response", "criteria": "y"}},
+            ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            mock_external = AsyncMock(side_effect=fresh_result)
+            with patch("calibrate.llm.run_tests.run_test_external", mock_external):
+                # First run writes results.json with derived ids embedded.
+                await tests.run(
+                    test_cases=make_cases(), output_dir=tmp, agent=fake_agent,
+                )
+                first_count = mock_external.await_count
+
+                # Re-run the exact same dataset: every case is resumed, nothing reruns.
+                mock_external.reset_mock()
+                await tests.run(
+                    test_cases=make_cases(), output_dir=tmp, agent=fake_agent,
+                )
+
+        self.assertEqual(first_count, 2)
+        self.assertEqual(mock_external.await_count, 0)
+
     async def test_run_with_agent_aggregates_cost_latency_and_tokens(self):
         from calibrate.llm import tests
 

--- a/tests/llm/test_init_extra.py
+++ b/tests/llm/test_init_extra.py
@@ -204,11 +204,9 @@ class TestLLMTestsRun(unittest.IsolatedAsyncioTestCase):
         # Fail-fast: no test cases were dispatched.
         self.assertEqual(mock_external.await_count, 0)
 
-    async def test_run_resumes_without_ids_via_content_hash(self):
+    async def test_run_without_ids_does_not_resume(self):
         from calibrate.llm import tests
 
-        # Fresh dict per call: a shared return_value object would be aliased
-        # across both records (last write wins on test_case_id) and mask resume.
         async def fresh_result(*args, **kwargs):
             return {
                 "output": {"response": "Hi", "tool_calls": []},
@@ -216,9 +214,8 @@ class TestLLMTestsRun(unittest.IsolatedAsyncioTestCase):
             }
         fake_agent = MagicMock()
 
-        # No explicit ids — resume must still work via derived content-hash ids.
-        # Build fresh (id-less) dicts each run so the second run re-derives ids
-        # from scratch rather than reusing ids the first run backfilled in place.
+        # No ids on the cases — there's no stable key to resume by, so a re-run
+        # of the same dataset must re-evaluate everything (no false skips).
         def make_cases():
             return [
                 {"history": [{"role": "user", "content": "a"}],
@@ -230,20 +227,16 @@ class TestLLMTestsRun(unittest.IsolatedAsyncioTestCase):
         with tempfile.TemporaryDirectory() as tmp:
             mock_external = AsyncMock(side_effect=fresh_result)
             with patch("calibrate.llm.run_tests.run_test_external", mock_external):
-                # First run writes results.json with derived ids embedded.
                 await tests.run(
                     test_cases=make_cases(), output_dir=tmp, agent=fake_agent,
                 )
-                first_count = mock_external.await_count
-
-                # Re-run the exact same dataset: every case is resumed, nothing reruns.
                 mock_external.reset_mock()
                 await tests.run(
                     test_cases=make_cases(), output_dir=tmp, agent=fake_agent,
                 )
 
-        self.assertEqual(first_count, 2)
-        self.assertEqual(mock_external.await_count, 0)
+        # Second run re-ran both cases since they carry no resumable id.
+        self.assertEqual(mock_external.await_count, 2)
 
     async def test_run_with_agent_aggregates_cost_latency_and_tokens(self):
         from calibrate.llm import tests

--- a/tests/llm/test_init_extra.py
+++ b/tests/llm/test_init_extra.py
@@ -93,6 +93,94 @@ class TestLLMTestsRun(unittest.IsolatedAsyncioTestCase):
             )
         self.assertEqual(result["status"], "completed")
 
+    async def test_run_with_agent_resumes_completed_test_cases(self):
+        from calibrate.llm import tests
+
+        fake_test_result = {
+            "output": {"response": "Hi", "tool_calls": []},
+            "metrics": {"passed": True, "judge_results": {}},
+        }
+        fake_agent = MagicMock()
+        test_cases = [
+            {
+                "id": "tc1",
+                "history": [{"role": "user", "content": "a"}],
+                "evaluation": {"type": "response", "criteria": "x"},
+            },
+            {
+                "id": "tc2",
+                "history": [{"role": "user", "content": "b"}],
+                "evaluation": {"type": "response", "criteria": "y"},
+            },
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            # Pre-seed a prior run where tc1 already completed.
+            prior = [{
+                "test_case_id": "tc1",
+                "output": {"response": "done", "tool_calls": []},
+                "metrics": {"passed": True, "judge_results": {}},
+                "test_case": test_cases[0],
+            }]
+            with open(os.path.join(tmp, "results.json"), "w") as f:
+                json.dump(prior, f)
+
+            mock_external = AsyncMock(return_value=fake_test_result)
+            with patch(
+                "calibrate.llm.run_tests.run_test_external", mock_external
+            ):
+                result = await tests.run(
+                    test_cases=test_cases,
+                    output_dir=tmp,
+                    agent=fake_agent,
+                )
+
+        self.assertEqual(result["status"], "completed")
+        # Only tc2 should have been (re-)run; tc1 was resumed from disk.
+        self.assertEqual(mock_external.await_count, 1)
+        self.assertEqual(result["metrics"]["total"], 2)
+
+    async def test_run_with_agent_overwrite_reruns_everything(self):
+        from calibrate.llm import tests
+
+        fake_test_result = {
+            "output": {"response": "Hi", "tool_calls": []},
+            "metrics": {"passed": True, "judge_results": {}},
+        }
+        fake_agent = MagicMock()
+        test_cases = [
+            {
+                "id": "tc1",
+                "history": [{"role": "user", "content": "a"}],
+                "evaluation": {"type": "response", "criteria": "x"},
+            },
+            {
+                "id": "tc2",
+                "history": [{"role": "user", "content": "b"}],
+                "evaluation": {"type": "response", "criteria": "y"},
+            },
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with open(os.path.join(tmp, "results.json"), "w") as f:
+                json.dump(
+                    [{"test_case_id": "tc1", "metrics": {"passed": True}}], f
+                )
+
+            mock_external = AsyncMock(return_value=fake_test_result)
+            with patch(
+                "calibrate.llm.run_tests.run_test_external", mock_external
+            ):
+                await tests.run(
+                    test_cases=test_cases,
+                    output_dir=tmp,
+                    agent=fake_agent,
+                    overwrite=True,
+                )
+
+        # overwrite=True ignores the prior results — both cases re-run.
+        self.assertEqual(mock_external.await_count, 2)
+
     async def test_run_with_agent_aggregates_cost_latency_and_tokens(self):
         from calibrate.llm import tests
 

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -2809,6 +2809,62 @@ class TestLoadResumableResults(unittest.TestCase):
         self.assertEqual(out, [None])
 
 
+class TestEnsureTestCaseIds(unittest.TestCase):
+    def test_raises_on_duplicate_explicit_ids(self):
+        from calibrate.llm.run_tests import ensure_test_case_ids
+
+        cases = [
+            {"id": "a", "history": [], "evaluation": {}},
+            {"id": "a", "history": [{"role": "user"}], "evaluation": {}},
+        ]
+        with self.assertRaises(ValueError) as ctx:
+            ensure_test_case_ids(cases)
+        self.assertIn("Duplicate test case id 'a'", str(ctx.exception))
+
+    def test_backfills_missing_ids_with_content_hash(self):
+        from calibrate.llm.run_tests import ensure_test_case_ids
+
+        cases = [
+            {"history": [{"role": "user", "content": "hi"}],
+             "evaluation": {"type": "response", "criteria": "x"}},
+            {"history": [{"role": "user", "content": "bye"}],
+             "evaluation": {"type": "response", "criteria": "y"}},
+        ]
+        ensure_test_case_ids(cases)
+        for c in cases:
+            self.assertTrue(c["id"].startswith("auto:"))
+        self.assertNotEqual(cases[0]["id"], cases[1]["id"])
+
+    def test_derived_id_is_stable_for_same_content(self):
+        from calibrate.llm.run_tests import _derive_test_case_id
+
+        tc = {"history": [{"role": "user", "content": "hi"}],
+              "evaluation": {"type": "response", "criteria": "x"}}
+        # Order of dict keys / a fresh equivalent object must not change the id.
+        same = {"evaluation": {"criteria": "x", "type": "response"},
+                "history": [{"content": "hi", "role": "user"}]}
+        self.assertEqual(_derive_test_case_id(tc), _derive_test_case_id(same))
+
+    def test_explicit_ids_preserved(self):
+        from calibrate.llm.run_tests import ensure_test_case_ids
+
+        cases = [{"id": "keep", "history": [], "evaluation": {}},
+                 {"history": [{"role": "user"}], "evaluation": {}}]
+        ensure_test_case_ids(cases)
+        self.assertEqual(cases[0]["id"], "keep")
+        self.assertTrue(cases[1]["id"].startswith("auto:"))
+
+    def test_idempotent(self):
+        from calibrate.llm.run_tests import ensure_test_case_ids
+
+        cases = [{"history": [{"role": "user", "content": "hi"}],
+                  "evaluation": {"type": "response"}}]
+        ensure_test_case_ids(cases)
+        first = cases[0]["id"]
+        ensure_test_case_ids(cases)  # no raise, no change
+        self.assertEqual(cases[0]["id"], first)
+
+
 class TestRunItemsParallelResume(unittest.IsolatedAsyncioTestCase):
     async def test_initial_results_skip_processing(self):
         from calibrate.llm.run_tests import _run_items_parallel

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -2736,5 +2736,123 @@ class TestRunTestsMainDebug(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(captured["config"]["test_cases"]), 3)
 
 
+class TestLoadResumableResults(unittest.TestCase):
+    def _write(self, tmp, records):
+        path = Path(tmp) / "results.json"
+        path.write_text(json.dumps(records))
+        return str(path)
+
+    def test_missing_file_returns_all_none(self):
+        from calibrate.llm.run_tests import _load_resumable_results
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = str(Path(tmp) / "results.json")
+            out = _load_resumable_results(path, [{"id": "a"}, {"id": "b"}], False)
+        self.assertEqual(out, [None, None])
+
+    def test_overwrite_ignores_existing(self):
+        from calibrate.llm.run_tests import _load_resumable_results
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(
+                tmp, [{"test_case_id": "a", "metrics": {"passed": True}}]
+            )
+            out = _load_resumable_results(path, [{"id": "a"}], overwrite=True)
+        self.assertEqual(out, [None])
+
+    def test_matches_by_test_case_id(self):
+        from calibrate.llm.run_tests import _load_resumable_results
+
+        done = {"test_case_id": "a", "metrics": {"passed": True}}
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, [done])
+            out = _load_resumable_results(
+                path, [{"id": "a"}, {"id": "b"}], overwrite=False
+            )
+        self.assertEqual(out, [done, None])
+
+    def test_matches_by_embedded_test_case_id(self):
+        from calibrate.llm.run_tests import _load_resumable_results
+
+        done = {"metrics": {"passed": False}, "test_case": {"id": "b"}}
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, [done])
+            out = _load_resumable_results(
+                path, [{"id": "a"}, {"id": "b"}], overwrite=False
+            )
+        self.assertEqual(out, [None, done])
+
+    def test_records_without_metrics_are_not_resumed(self):
+        from calibrate.llm.run_tests import _load_resumable_results
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, [{"test_case_id": "a"}])  # no metrics block
+            out = _load_resumable_results(path, [{"id": "a"}], overwrite=False)
+        self.assertEqual(out, [None])
+
+    def test_corrupt_json_falls_back_to_all_none(self):
+        from calibrate.llm.run_tests import _load_resumable_results
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "results.json"
+            path.write_text("{not json")
+            out = _load_resumable_results(str(path), [{"id": "a"}], overwrite=False)
+        self.assertEqual(out, [None])
+
+    def test_test_cases_without_ids_not_resumed(self):
+        from calibrate.llm.run_tests import _load_resumable_results
+
+        done = {"test_case_id": "a", "metrics": {"passed": True}}
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, [done])
+            out = _load_resumable_results(path, [{"history": []}], overwrite=False)
+        self.assertEqual(out, [None])
+
+
+class TestRunItemsParallelResume(unittest.IsolatedAsyncioTestCase):
+    async def test_initial_results_skip_processing(self):
+        from calibrate.llm.run_tests import _run_items_parallel
+
+        processed = []
+
+        async def process(index, item):
+            processed.append(index)
+            return {"idx": index, "item": item, "metrics": {"passed": True}}
+
+        items = ["a", "b", "c"]
+        prior = {"idx": 1, "item": "b", "metrics": {"passed": True}}
+        initial = [None, prior, None]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = str(Path(tmp) / "results.json")
+            results = await _run_items_parallel(
+                items, process, path, test_parallel=2, initial_results=initial
+            )
+            on_disk = json.loads(Path(path).read_text())
+
+        # Index 1 was pre-seeded, so process() never ran for it.
+        self.assertEqual(sorted(processed), [0, 2])
+        # Output preserves input order and reuses the prior result.
+        self.assertEqual(results[1], prior)
+        self.assertEqual([r["idx"] for r in results], [0, 1, 2])
+        self.assertEqual(len(on_disk), 3)
+
+    async def test_no_initial_results_runs_all(self):
+        from calibrate.llm.run_tests import _run_items_parallel
+
+        processed = []
+
+        async def process(index, item):
+            processed.append(index)
+            return {"idx": index, "metrics": {"passed": True}}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = str(Path(tmp) / "results.json")
+            results = await _run_items_parallel(["a", "b"], process, path)
+
+        self.assertEqual(sorted(processed), [0, 1])
+        self.assertEqual(len(results), 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -2809,60 +2809,34 @@ class TestLoadResumableResults(unittest.TestCase):
         self.assertEqual(out, [None])
 
 
-class TestEnsureTestCaseIds(unittest.TestCase):
+class TestRequireUniqueTestCaseIds(unittest.TestCase):
     def test_raises_on_duplicate_explicit_ids(self):
-        from calibrate.llm.run_tests import ensure_test_case_ids
+        from calibrate.llm.run_tests import require_unique_test_case_ids
 
         cases = [
             {"id": "a", "history": [], "evaluation": {}},
             {"id": "a", "history": [{"role": "user"}], "evaluation": {}},
         ]
         with self.assertRaises(ValueError) as ctx:
-            ensure_test_case_ids(cases)
+            require_unique_test_case_ids(cases)
         self.assertIn("Duplicate test case id 'a'", str(ctx.exception))
 
-    def test_backfills_missing_ids_with_content_hash(self):
-        from calibrate.llm.run_tests import ensure_test_case_ids
+    def test_unique_ids_pass(self):
+        from calibrate.llm.run_tests import require_unique_test_case_ids
 
-        cases = [
-            {"history": [{"role": "user", "content": "hi"}],
-             "evaluation": {"type": "response", "criteria": "x"}},
-            {"history": [{"role": "user", "content": "bye"}],
-             "evaluation": {"type": "response", "criteria": "y"}},
-        ]
-        ensure_test_case_ids(cases)
-        for c in cases:
-            self.assertTrue(c["id"].startswith("auto:"))
-        self.assertNotEqual(cases[0]["id"], cases[1]["id"])
+        cases = [{"id": "a", "history": [], "evaluation": {}},
+                 {"id": "b", "history": [], "evaluation": {}}]
+        require_unique_test_case_ids(cases)  # no raise
 
-    def test_derived_id_is_stable_for_same_content(self):
-        from calibrate.llm.run_tests import _derive_test_case_id
+    def test_missing_ids_are_left_alone(self):
+        from calibrate.llm.run_tests import require_unique_test_case_ids
 
-        tc = {"history": [{"role": "user", "content": "hi"}],
-              "evaluation": {"type": "response", "criteria": "x"}}
-        # Order of dict keys / a fresh equivalent object must not change the id.
-        same = {"evaluation": {"criteria": "x", "type": "response"},
-                "history": [{"content": "hi", "role": "user"}]}
-        self.assertEqual(_derive_test_case_id(tc), _derive_test_case_id(same))
-
-    def test_explicit_ids_preserved(self):
-        from calibrate.llm.run_tests import ensure_test_case_ids
-
-        cases = [{"id": "keep", "history": [], "evaluation": {}},
+        cases = [{"history": [], "evaluation": {}},
                  {"history": [{"role": "user"}], "evaluation": {}}]
-        ensure_test_case_ids(cases)
-        self.assertEqual(cases[0]["id"], "keep")
-        self.assertTrue(cases[1]["id"].startswith("auto:"))
-
-    def test_idempotent(self):
-        from calibrate.llm.run_tests import ensure_test_case_ids
-
-        cases = [{"history": [{"role": "user", "content": "hi"}],
-                  "evaluation": {"type": "response"}}]
-        ensure_test_case_ids(cases)
-        first = cases[0]["id"]
-        ensure_test_case_ids(cases)  # no raise, no change
-        self.assertEqual(cases[0]["id"], first)
+        require_unique_test_case_ids(cases)  # no raise
+        # No ids are invented.
+        self.assertNotIn("id", cases[0])
+        self.assertNotIn("id", cases[1])
 
 
 class TestRunItemsParallelResume(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -260,7 +260,6 @@ class TestAgentBenchmark:
             f"'Overall Summary' not in stdout.\nstdout: {result.stdout}"
         )
 
-
 # ---------------------------------------------------------------------------
 # TestSkipVerify
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Resume:** LLM test runs now reuse completed test cases from a prior `results.json` (matched by test-case `id`) instead of re-evaluating everything, across both the model-benchmark path and the agent-connection path. Added a `--overwrite` flag to force a clean run.
  - `run_tests.py`: `_load_resumable_results` / `_resumable_id`; `_run_items_parallel` gained `initial_results` to pre-seed and skip completed slots; `run_model_tests` gained `overwrite`.
  - `benchmark.py` and `llm/__init__.py` thread `overwrite` through; `cli.py` exposes `--overwrite` and forwards it through all dispatch paths.
- **Agent-benchmark parallel run:** the CLI now runs agent-benchmark models in a single parallel `tests.run(models=...)` pass (using the existing parallel capability) with a combined header and `[model]`-prefixed per-test output, instead of looping one model at a time.

## Test plan
- [x] `TestLoadResumableResults` / `TestRunItemsParallelResume` — resume matching, overwrite, corrupt/missing files, pre-seeded skips
- [x] agent-path resume + overwrite (`test_init_extra.py`)
- [x] `--overwrite` forwarding (`test_benchmark.py`)
- [x] `tests/test_cli.py` updated for parallel agent-benchmark output (`[model]` labels)

Made with [Cursor](https://cursor.com)