### PR TITLE
Run agent-benchmark models in a single parallel pass

### DIFF
--- a/calibrate/cli.py
+++ b/calibrate/cli.py
@@ -645,24 +645,24 @@ Examples:
                 from calibrate.llm.tests_leaderboard import generate_leaderboard
                 from calibrate.llm._output import print_benchmark_summary
 
-                # Run — one model at a time so output is clearly separated
+                # Run — all models together (tests.run fans them out in parallel)
                 if _models:
-                    _model_results = {}
-                    for _m in _models:
-                        print(f"\n\033[92m{'='*60}\033[0m")
-                        print(f"\033[92m  Model: {_m}\033[0m")
-                        print(f"\033[92m{'='*60}\033[0m\n")
-                        _result = asyncio.run(
-                            _tests.run(
-                                agent=_agent,
-                                test_cases=_config["test_cases"],
-                                output_dir=args.output_dir,
-                                models=[_m],
-                                evaluators=_config.get("evaluators"),
-                                test_parallel=args.parallel,
-                            )
+                    print(f"\n\033[92m{'='*60}\033[0m")
+                    print(f"\033[92m  Models: {', '.join(_models)}\033[0m")
+                    print(f"\033[92m{'='*60}\033[0m\n")
+                    _results = asyncio.run(
+                        _tests.run(
+                            agent=_agent,
+                            test_cases=_config["test_cases"],
+                            output_dir=args.output_dir,
+                            models=_models,
+                            evaluators=_config.get("evaluators"),
+                            test_parallel=args.parallel,
                         )
-                        _model_results[_m] = _result.get(_m, _result)
+                    )
+                    _model_results = {
+                        _m: _results.get(_m, _results) for _m in _models
+                    }
 
                     _lb_dir = os.path.join(args.output_dir, "leaderboard")
                     generate_leaderboard(output_dir=args.output_dir, save_dir=_lb_dir)

--- a/calibrate/llm/__init__.py
+++ b/calibrate/llm/__init__.py
@@ -326,8 +326,20 @@ class _Tests:
                         test_parallel=test_parallel,
                     )
 
-            results = await asyncio.gather(*[run_agent_model(m) for m in models])
-            return {m: r for m, r in zip(models, results)}
+            # ``return_exceptions=True`` so one model's hard failure (e.g. the
+            # agent backend timing out or returning an error after retries) is
+            # recorded against that model instead of cancelling the others and
+            # aborting the whole benchmark.
+            results = await asyncio.gather(
+                *[run_agent_model(m) for m in models], return_exceptions=True
+            )
+            results_by_model: dict = {}
+            for m, r in zip(models, results):
+                if isinstance(r, Exception):
+                    results_by_model[m] = {"status": "error", "error": str(r)}
+                else:
+                    results_by_model[m] = r
+            return results_by_model
 
         # External agent: single run (no model selection) — pass empty model so
         # no model — save directly to output_dir (no subfolder)

--- a/calibrate/llm/__init__.py
+++ b/calibrate/llm/__init__.py
@@ -171,10 +171,11 @@ class _Tests:
                     evaluators=resolved_evaluators,
                 )
 
+            label_prefix = f"[{model}] " if (agent is not None and model) else ""
             if result["metrics"]["passed"]:
-                log_and_print(f"✅ Test case {test_case_index + 1} passed")
+                log_and_print(f"{label_prefix}✅ Test case {test_case_index + 1} passed")
             else:
-                log_and_print(f"❌ Test case {test_case_index + 1} failed")
+                log_and_print(f"{label_prefix}❌ Test case {test_case_index + 1} failed")
             if "reasoning" in result["metrics"]:
                 log_and_print(result["metrics"]["reasoning"])
 

--- a/calibrate/llm/__init__.py
+++ b/calibrate/llm/__init__.py
@@ -83,8 +83,15 @@ class _Tests:
         agent: Optional["TextAgentConnection"] = None,
         evaluators: Optional[List[dict]] = None,
         test_parallel: Optional[int] = None,
+        label_output: bool = False,
     ) -> dict:
-        """Run tests for a single model (or external agent)."""
+        """Run tests for a single model (or external agent).
+
+        Args:
+            label_output: When True, prefix per-test-case log lines with
+                ``[model]``. Set for multi-model parallel runs (internal or
+                agent) so interleaved output stays attributable.
+        """
         from calibrate.llm.run_tests import (
             run_test as _run_test,
             run_test_external as _run_test_external,
@@ -171,7 +178,7 @@ class _Tests:
                     evaluators=resolved_evaluators,
                 )
 
-            label_prefix = f"[{model}] " if (agent is not None and model) else ""
+            label_prefix = f"[{model}] " if (label_output and model) else ""
             if result["metrics"]["passed"]:
                 log_and_print(f"{label_prefix}✅ Test case {test_case_index + 1} passed")
             else:
@@ -324,6 +331,7 @@ class _Tests:
                         agent=agent,
                         evaluators=evaluators,
                         test_parallel=test_parallel,
+                        label_output=True,
                     )
 
             # ``return_exceptions=True`` so one model's hard failure (e.g. the
@@ -373,6 +381,7 @@ class _Tests:
                         run_name=run_name,
                         evaluators=evaluators,
                         test_parallel=test_parallel,
+                        label_output=True,
                     )
 
             tasks = [run_with_semaphore(m) for m in models]

--- a/tests/llm/test_init_extra.py
+++ b/tests/llm/test_init_extra.py
@@ -183,6 +183,40 @@ class TestLLMTestsRun(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(set(result.keys()), {"m1"})
         self.assertEqual(result["m1"]["metrics"]["passed"], 0)
 
+    async def test_run_agent_benchmark_one_model_failure_isolated(self):
+        from calibrate.llm import tests
+
+        # One model's hard failure must not cancel the others: it's recorded as
+        # an error entry while the healthy model still completes.
+        fake_ok = {
+            "output": {"response": "Hi", "tool_calls": []},
+            "metrics": {"passed": True, "judge_results": {}},
+        }
+
+        async def flaky_external(*args, **kwargs):
+            if kwargs.get("model") == "bad":
+                raise RuntimeError("agent timed out")
+            return fake_ok
+
+        fake_agent = MagicMock()
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch("calibrate.llm.run_tests.run_test_external",
+                   AsyncMock(side_effect=flaky_external)):
+            result = await tests.run(
+                test_cases=[{
+                    "history": [{"role": "user", "content": "hi"}],
+                    "evaluation": {"type": "response", "criteria": "x"},
+                }],
+                output_dir=tmp,
+                agent=fake_agent,
+                models=["good", "bad"],
+            )
+        self.assertEqual(set(result.keys()), {"good", "bad"})
+        self.assertEqual(result["bad"]["status"], "error")
+        self.assertIn("agent timed out", result["bad"]["error"])
+        # The healthy model still produced real metrics.
+        self.assertEqual(result["good"]["metrics"]["passed"], 1)
+
     async def test_run_single(self):
         from calibrate.llm import tests
 

--- a/tests/llm/test_init_extra.py
+++ b/tests/llm/test_init_extra.py
@@ -1,5 +1,6 @@
 """Cover llm/__init__.py public API entry points via heavy mocking."""
 
+import asyncio
 import os
 import json
 import tempfile
@@ -216,6 +217,39 @@ class TestLLMTestsRun(unittest.IsolatedAsyncioTestCase):
         self.assertIn("agent timed out", result["bad"]["error"])
         # The healthy model still produced real metrics.
         self.assertEqual(result["good"]["metrics"]["passed"], 1)
+
+    async def test_agent_benchmark_runs_models_concurrently(self):
+        from calibrate.llm import tests
+
+        # A 2-party barrier proves real concurrency: each model's request blocks
+        # until *both* models have arrived. If the runner were sequential the
+        # first model would wait alone and time out, failing the test.
+        barrier = asyncio.Barrier(2)
+
+        async def gated_external(*args, **kwargs):
+            await asyncio.wait_for(barrier.wait(), timeout=2)
+            return {
+                "output": {"response": "Hi", "tool_calls": []},
+                "metrics": {"passed": True, "judge_results": {}},
+            }
+
+        fake_agent = MagicMock()
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch("calibrate.llm.run_tests.run_test_external",
+                   AsyncMock(side_effect=gated_external)):
+            result = await tests.run(
+                test_cases=[{
+                    "history": [{"role": "user", "content": "hi"}],
+                    "evaluation": {"type": "response", "criteria": "x"},
+                }],
+                output_dir=tmp,
+                agent=fake_agent,
+                models=["a", "b"],
+                max_parallel=2,
+            )
+        self.assertEqual(set(result.keys()), {"a", "b"})
+        self.assertEqual(result["a"]["metrics"]["passed"], 1)
+        self.assertEqual(result["b"]["metrics"]["passed"], 1)
 
     async def test_run_single(self):
         from calibrate.llm import tests

--- a/tests/llm/test_init_extra.py
+++ b/tests/llm/test_init_extra.py
@@ -157,6 +157,32 @@ class TestLLMTestsRun(unittest.IsolatedAsyncioTestCase):
             )
         self.assertEqual(set(result.keys()), {"m1", "m2"})
 
+    async def test_run_agent_benchmark_failed_case_labeled(self):
+        from calibrate.llm import tests
+
+        # A failing case in the agent-benchmark path exercises the labeled
+        # "[model] ❌ ... failed" log branch (the passing branch is covered above).
+        fake_test_result = {
+            "output": {"response": "Hi", "tool_calls": []},
+            "metrics": {"passed": False, "judge_results": {}},
+        }
+        fake_agent = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch("calibrate.llm.run_tests.run_test_external",
+                   AsyncMock(return_value=fake_test_result)):
+            result = await tests.run(
+                test_cases=[{
+                    "history": [{"role": "user", "content": "hi"}],
+                    "evaluation": {"type": "response", "criteria": "x"},
+                }],
+                output_dir=tmp,
+                agent=fake_agent,
+                models=["m1"],
+            )
+        self.assertEqual(set(result.keys()), {"m1"})
+        self.assertEqual(result["m1"]["metrics"]["passed"], 0)
+
     async def test_run_single(self):
         from calibrate.llm import tests
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -247,9 +247,11 @@ class TestAgentBenchmark:
 
     def test_model_headers_in_stdout(self, agent_config):
         result, _, _ = self._run_benchmark(agent_config)
+        # Models now run in parallel; the combined header lists every model and
+        # each model's per-test output is prefixed with its label.
         for model in self.MODELS:
-            assert f"Model: {model}" in result.stdout, (
-                f"'Model: {model}' not in stdout.\nstdout: {result.stdout}"
+            assert f"[{model}]" in result.stdout, (
+                f"'[{model}]' label not in stdout.\nstdout: {result.stdout}"
             )
 
     def test_overall_summary_in_stdout(self, agent_config):
@@ -258,17 +260,18 @@ class TestAgentBenchmark:
             f"'Overall Summary' not in stdout.\nstdout: {result.stdout}"
         )
 
-    def test_models_run_in_order(self, agent_config):
-        """gpt-4.1 output appears before gpt-5.1 output in stdout."""
+    def test_models_run_in_parallel(self, agent_config):
+        """Both models are dispatched in a single parallel run.
+
+        Output is no longer strictly ordered per model, but each model's
+        labeled test output must be present.
+        """
         result, _, _ = self._run_benchmark(agent_config)
         stdout = result.stdout
-        pos_41 = stdout.find("gpt-4.1")
-        pos_51 = stdout.find("gpt-5.1")
-        assert pos_41 != -1, "gpt-4.1 not found in stdout"
-        assert pos_51 != -1, "gpt-5.1 not found in stdout"
-        assert pos_41 < pos_51, (
-            "Expected gpt-4.1 to appear before gpt-5.1 in stdout"
-        )
+        for model in self.MODELS:
+            assert f"[{model}]" in stdout, (
+                f"'[{model}]' labeled output not found in stdout:\n{stdout}"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -245,10 +245,10 @@ class TestAgentBenchmark:
                 f"Model '{model}' not found in request bodies. Got: {model_hints}"
             )
 
-    def test_model_headers_in_stdout(self, agent_config):
+    def test_per_model_labels_in_stdout(self, agent_config):
         result, _, _ = self._run_benchmark(agent_config)
-        # Models now run in parallel; the combined header lists every model and
-        # each model's per-test output is prefixed with its label.
+        # Models run in parallel, so per-test output interleaves; every model's
+        # lines must carry its ``[model]`` label to stay attributable.
         for model in self.MODELS:
             assert f"[{model}]" in result.stdout, (
                 f"'[{model}]' label not in stdout.\nstdout: {result.stdout}"
@@ -259,19 +259,6 @@ class TestAgentBenchmark:
         assert "Overall Summary" in result.stdout, (
             f"'Overall Summary' not in stdout.\nstdout: {result.stdout}"
         )
-
-    def test_models_run_in_parallel(self, agent_config):
-        """Both models are dispatched in a single parallel run.
-
-        Output is no longer strictly ordered per model, but each model's
-        labeled test output must be present.
-        """
-        result, _, _ = self._run_benchmark(agent_config)
-        stdout = result.stdout
-        for model in self.MODELS:
-            assert f"[{model}]" in stdout, (
-                f"'[{model}]' labeled output not found in stdout:\n{stdout}"
-            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The CLI agent-benchmark path looped over models one at a time, even though `tests.run` already fans models out in parallel via an internal semaphore.
- Call `tests.run(models=_models)` once so all models run concurrently, print a combined `Models: ...` header, and prefix each model's per-test output with a `[model]` label so the interleaved parallel output stays attributable.

## Test plan
- [x] `tests/test_cli.py` (subprocess integration vs fake agent): per-model `[model]` labels present in stdout; both models' labeled output appears under a single parallel run
- [x] `tests/llm/test_init_extra.py`: agent multi-model run still aggregates correctly

Made with [Cursor](https://cursor.com)