### PR TITLE
Report p50/p95/p99 latency in aggregate metrics

### DIFF
--- a/calibrate/llm/_metrics_utils.py
+++ b/calibrate/llm/_metrics_utils.py
@@ -4,7 +4,8 @@ leaderboard. Kept separate from ``run_tests`` (heavy: pipecat) and
 dependency in the wrong direction.
 """
 
-from typing import Optional
+import math
+from typing import List, Optional
 
 
 def _numeric_or_none(value: object) -> Optional[float]:
@@ -17,3 +18,36 @@ def _numeric_or_none(value: object) -> Optional[float]:
     if isinstance(value, bool):
         return None
     return value if isinstance(value, (int, float)) else None
+
+
+def _percentile(sorted_values: List[float], pct: float) -> float:
+    """Linear-interpolated percentile over a pre-sorted list (numpy ``linear``).
+
+    ``sorted_values`` must be non-empty and ascending. ``pct`` is 0–100.
+    """
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = (pct / 100.0) * (len(sorted_values) - 1)
+    lo = int(math.floor(rank))
+    hi = int(math.ceil(rank))
+    if lo == hi:
+        return sorted_values[lo]
+    frac = rank - lo
+    return sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * frac
+
+
+def _latency_percentiles(values: List[float]) -> Optional[dict]:
+    """Aggregate raw latency/ttfb samples into ``{p50, p95, p99, count}``.
+
+    Returns ``None`` for an empty input so callers can omit the block. Values
+    are returned as-is (not rounded) — callers round to their unit.
+    """
+    if not values:
+        return None
+    ordered = sorted(values)
+    return {
+        "p50": _percentile(ordered, 50),
+        "p95": _percentile(ordered, 95),
+        "p99": _percentile(ordered, 99),
+        "count": len(ordered),
+    }

--- a/calibrate/llm/_metrics_utils.py
+++ b/calibrate/llm/_metrics_utils.py
@@ -4,8 +4,9 @@ leaderboard. Kept separate from ``run_tests`` (heavy: pipecat) and
 dependency in the wrong direction.
 """
 
-import math
 from typing import List, Optional
+
+import numpy as np
 
 
 def _numeric_or_none(value: object) -> Optional[float]:
@@ -20,34 +21,20 @@ def _numeric_or_none(value: object) -> Optional[float]:
     return value if isinstance(value, (int, float)) else None
 
 
-def _percentile(sorted_values: List[float], pct: float) -> float:
-    """Linear-interpolated percentile over a pre-sorted list (numpy ``linear``).
-
-    ``sorted_values`` must be non-empty and ascending. ``pct`` is 0–100.
-    """
-    if len(sorted_values) == 1:
-        return sorted_values[0]
-    rank = (pct / 100.0) * (len(sorted_values) - 1)
-    lo = int(math.floor(rank))
-    hi = int(math.ceil(rank))
-    if lo == hi:
-        return sorted_values[lo]
-    frac = rank - lo
-    return sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * frac
-
-
 def _latency_percentiles(values: List[float]) -> Optional[dict]:
     """Aggregate raw latency/ttfb samples into ``{p50, p95, p99, count}``.
 
     Returns ``None`` for an empty input so callers can omit the block. Values
-    are returned as-is (not rounded) — callers round to their unit.
+    are cast to plain ``float`` (``np.percentile`` returns ``np.float64``, which
+    isn't JSON-serializable) and otherwise left unrounded — callers round to
+    their unit.
     """
     if not values:
         return None
-    ordered = sorted(values)
+    p50, p95, p99 = np.percentile(values, [50, 95, 99])
     return {
-        "p50": _percentile(ordered, 50),
-        "p95": _percentile(ordered, 95),
-        "p99": _percentile(ordered, 99),
-        "count": len(ordered),
+        "p50": float(p50),
+        "p95": float(p95),
+        "p99": float(p99),
+        "count": len(values),
     }

--- a/calibrate/llm/run_tests.py
+++ b/calibrate/llm/run_tests.py
@@ -50,7 +50,7 @@ from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.services.openrouter.llm import OpenRouterLLMService
 from pipecat.observers.loggers.llm_log_observer import LLMLogObserver
 from calibrate.llm.metrics import test_response_llm_judge, evaluate_simuation
-from calibrate.llm._metrics_utils import _numeric_or_none
+from calibrate.llm._metrics_utils import _numeric_or_none, _latency_percentiles
 from calibrate.judges import (
     DEFAULT_LLM_TEST_EVALUATOR,
     attach_evaluator_id,
@@ -1661,8 +1661,7 @@ def _aggregate_cost(results: List[dict]) -> Optional[dict]:
     ``None`` when no result carries a cost so the metric is absent rather than a
     misleading ``0.0``.
 
-    Output shape mirrors :func:`_aggregate_latency`:
-    ``{"mean", "min", "max", "count"}`` with USD floats.
+    Output shape: ``{"mean", "min", "max", "count"}`` with USD floats.
     """
     costs = [
         c
@@ -2009,7 +2008,7 @@ def _aggregate_latency(results: List[dict]) -> Optional[dict]:
     results, which skip inference, have none. Returns ``None`` when no result
     carries a latency so eval-only ``metrics.json`` stays free of an empty block.
 
-    Output shape: ``{"mean", "min", "max", "count"}`` with millisecond ints.
+    Output shape: ``{"p50", "p95", "p99", "count"}`` with millisecond ints.
     """
     values = [
         r["latency_ms"]
@@ -2017,13 +2016,14 @@ def _aggregate_latency(results: List[dict]) -> Optional[dict]:
         if isinstance(r.get("latency_ms"), (int, float))
         and not isinstance(r.get("latency_ms"), bool)
     ]
-    if not values:
+    pct = _latency_percentiles(values)
+    if pct is None:
         return None
     return {
-        "mean": round(sum(values) / len(values)),
-        "min": min(values),
-        "max": max(values),
-        "count": len(values),
+        "p50": round(pct["p50"]),
+        "p95": round(pct["p95"]),
+        "p99": round(pct["p99"]),
+        "count": pct["count"],
     }
 
 

--- a/calibrate/llm/tests_leaderboard.py
+++ b/calibrate/llm/tests_leaderboard.py
@@ -99,12 +99,12 @@ def _build_leaderboard(
 ) -> pd.DataFrame:
     """Build leaderboard DataFrame.
 
-    Columns: model, passed, total, pass_rate, latency_ms, cost, total_tokens,
-    [criterion_1, ...]
+    Columns: model, passed, total, pass_rate, latency_p50, latency_p95,
+    latency_p99, cost, total_tokens, [criterion_1, ...]
 
-    ``latency_ms`` is the mean per-test-case response-generation latency (in
-    milliseconds, judge time excluded); ``None`` for runs without it (e.g.
-    eval-only).
+    ``latency_p50``/``latency_p95``/``latency_p99`` are percentiles of the
+    per-test-case response-generation latency (in milliseconds, judge time
+    excluded); ``None`` for runs without it (e.g. eval-only).
 
     ``cost`` is the mean per-test-case LLM cost in USD (``None`` when the run
     reported no cost, e.g. the OpenAI provider or external agents).
@@ -134,7 +134,9 @@ def _build_leaderboard(
             "passed": passed,
             "total": total,
             "pass_rate": _to_percent(passed, total),
-            "latency_ms": latency.get("mean"),
+            "latency_p50": latency.get("p50"),
+            "latency_p95": latency.get("p95"),
+            "latency_p99": latency.get("p99"),
             "cost": _numeric_or_none(cost.get("mean")),
             "total_tokens": _numeric_or_none(total_tokens.get("mean")),
         }

--- a/calibrate/tts/benchmark.py
+++ b/calibrate/tts/benchmark.py
@@ -278,9 +278,9 @@ async def main():
                         if isinstance(v, dict) and "type" in v
                     }
                     ttfb_data = metrics.get("ttfb", {})
-                    ttfb_mean = ttfb_data.get("mean", "N/A") if isinstance(ttfb_data, dict) else "N/A"
+                    ttfb_p50 = ttfb_data.get("p50", "N/A") if isinstance(ttfb_data, dict) else "N/A"
                     judge_str = ", ".join(f"{k}={v:.2f}" for k, v in judge_scores.items())
-                    ttfb_str = f"TTFB={ttfb_mean:.3f}s" if isinstance(ttfb_mean, float) else f"TTFB={ttfb_mean}"
+                    ttfb_str = f"TTFB(p50)={ttfb_p50:.3f}s" if isinstance(ttfb_p50, float) else f"TTFB(p50)={ttfb_p50}"
                     print(f"  {provider}: {judge_str}, {ttfb_str}")
 
         print(f"\n\033[92mLeaderboard saved to {result['leaderboard_dir']}\033[0m")

--- a/calibrate/tts/eval.py
+++ b/calibrate/tts/eval.py
@@ -31,6 +31,7 @@ from calibrate.utils import (
     provider_log_file as _current_log_file,
 )
 from calibrate.tts.metrics import get_tts_llm_judge_score
+from calibrate.llm._metrics_utils import _latency_percentiles
 from calibrate.judges import (
     is_rating,
     DEFAULT_TTS_EVALUATOR,
@@ -793,17 +794,19 @@ async def run_single_provider_eval(
         for name, score_dict in llm_judge_results["scores"].items():
             metrics_data[name] = score_dict
 
-        # Add ttfb metrics with mean, std, and values (filter out None/NaN values)
+        # Add ttfb percentile metrics (filter out None/NaN values)
         valid_ttfb = [
             t
             for t in all_ttfb
             if t is not None and not (isinstance(t, float) and np.isnan(t))
         ]
-        if valid_ttfb:
+        ttfb_pct = _latency_percentiles(valid_ttfb)
+        if ttfb_pct is not None:
             metrics_data["ttfb"] = {
-                "mean": float(np.mean(valid_ttfb)),
-                "std": float(np.std(valid_ttfb)),
-                "values": valid_ttfb,
+                "p50": float(ttfb_pct["p50"]),
+                "p95": float(ttfb_pct["p95"]),
+                "p99": float(ttfb_pct["p99"]),
+                "count": ttfb_pct["count"],
             }
 
         # Save metrics
@@ -963,14 +966,14 @@ async def main():
             if isinstance(v, dict) and "type" in v
         }
         ttfb_data = metrics.get("ttfb", {})
-        ttfb_mean = (
-            ttfb_data.get("mean", "N/A") if isinstance(ttfb_data, dict) else "N/A"
+        ttfb_p50 = (
+            ttfb_data.get("p50", "N/A") if isinstance(ttfb_data, dict) else "N/A"
         )
         judge_str = ", ".join(f"{k}={v:.2f}" for k, v in judge_scores.items())
         ttfb_str = (
-            f"TTFB={ttfb_mean:.3f}s"
-            if isinstance(ttfb_mean, float)
-            else f"TTFB={ttfb_mean}"
+            f"TTFB(p50)={ttfb_p50:.3f}s"
+            if isinstance(ttfb_p50, float)
+            else f"TTFB(p50)={ttfb_p50}"
         )
         print(f"  {provider}: {judge_str}, {ttfb_str}")
 

--- a/calibrate/utils.py
+++ b/calibrate/utils.py
@@ -2122,10 +2122,12 @@ def summarize_metric_distribution(
 def read_leaderboard_metrics(metrics_path: Path) -> dict:
     """Read a provider/run ``metrics.json`` into a flat ``{column: scalar}`` dict.
 
-    Shared by the STT and TTS leaderboards. Current format: evaluator and
-    ``ttfb`` entries are dicts carrying a ``mean`` — extracted into the
-    ``<key>`` column; plain numbers (e.g. ``wer``) are kept as-is. The legacy
-    ``metric_name``/list format is still supported for older runs.
+    Shared by the STT and TTS leaderboards. Current format: evaluator entries
+    are dicts carrying a ``mean`` — extracted into the ``<key>`` column;
+    latency dicts (e.g. ``ttfb``) carry ``p50``/``p95``/``p99`` — fanned out
+    into ``<key>_p50``/``<key>_p95``/``<key>_p99`` columns; plain numbers (e.g.
+    ``wer``) are kept as-is. The legacy ``metric_name``/list format is still
+    supported for older runs.
     """
     if not metrics_path.exists():
         print(f"[WARN] metrics.json missing for {metrics_path.parent.name}")
@@ -2139,6 +2141,10 @@ def read_leaderboard_metrics(metrics_path: Path) -> dict:
         for key, value in data.items():
             if isinstance(value, dict) and "mean" in value:
                 metrics[key] = value["mean"]
+            elif isinstance(value, dict) and "p50" in value:
+                for pct in ("p50", "p95", "p99"):
+                    if pct in value:
+                        metrics[f"{key}_{pct}"] = value[pct]
             elif isinstance(value, (int, float)):
                 metrics[key] = float(value)
         return metrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "langfuse==3.3.0",
     "matplotlib>=3.10.7",
     "natsort>=8.4.0",
+    "numpy>=1.26.0",
     "onnxruntime>=1.23.2",
     "openpyxl>=3.1.5",
     "opentelemetry-api>=1.38.0",

--- a/tests/llm/test_init_extra.py
+++ b/tests/llm/test_init_extra.py
@@ -273,7 +273,7 @@ class TestLLMTestsRun(unittest.IsolatedAsyncioTestCase):
         self.assertAlmostEqual(result["metrics"]["cost"]["mean"], 0.002768)
         self.assertIn("latency_ms", result["metrics"])
         self.assertEqual(result["metrics"]["latency_ms"]["count"], 1)
-        self.assertEqual(result["metrics"]["latency_ms"]["mean"], 1246)
+        self.assertEqual(result["metrics"]["latency_ms"]["p50"], 1246)
         self.assertIn("total_tokens", result["metrics"])
         self.assertEqual(result["metrics"]["total_tokens"]["count"], 1)
         self.assertEqual(result["metrics"]["total_tokens"]["mean"], 4387)

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -2555,7 +2555,7 @@ class TestAggregateLatency(unittest.TestCase):
         results = [{"metrics": {"passed": True}}, {"metrics": {"passed": False}}]
         self.assertIsNone(_aggregate_latency(results))
 
-    def test_mean_min_max_count(self):
+    def test_percentiles_and_count(self):
         from calibrate.llm.run_tests import _aggregate_latency
 
         results = [
@@ -2563,9 +2563,10 @@ class TestAggregateLatency(unittest.TestCase):
             {"latency_ms": 200},
             {"latency_ms": 600},
         ]
+        # sorted [100, 200, 600]: p50=200, p95=200+0.9*400=560, p99=200+0.98*400=592
         self.assertEqual(
             _aggregate_latency(results),
-            {"mean": 300, "min": 100, "max": 600, "count": 3},
+            {"p50": 200, "p95": 560, "p99": 592, "count": 3},
         )
 
     def test_ignores_missing_and_non_numeric(self):
@@ -2580,17 +2581,42 @@ class TestAggregateLatency(unittest.TestCase):
             {"latency_ms": True},
             {"latency_ms": 150},
         ]
+        # sorted [50, 150]: p50=100, p95=145, p99=149
         self.assertEqual(
             _aggregate_latency(results),
-            {"mean": 100, "min": 50, "max": 150, "count": 2},
+            {"p50": 100, "p95": 145, "p99": 149, "count": 2},
         )
 
-    def test_mean_is_rounded(self):
+    def test_percentiles_are_rounded(self):
         from calibrate.llm.run_tests import _aggregate_latency
 
-        # mean 100.5 -> 100
+        # sorted [100, 101]: p50=100.5 -> 100 (banker's rounding)
         agg = _aggregate_latency([{"latency_ms": 100}, {"latency_ms": 101}])
-        self.assertEqual(agg["mean"], 100)
+        self.assertEqual(agg["p50"], 100)
+        self.assertEqual(agg["p95"], 101)
+        self.assertEqual(agg["p99"], 101)
+
+
+class TestLatencyPercentilesHelper(unittest.TestCase):
+    def test_none_for_empty(self):
+        from calibrate.llm._metrics_utils import _latency_percentiles
+
+        self.assertIsNone(_latency_percentiles([]))
+
+    def test_single_value_repeats(self):
+        from calibrate.llm._metrics_utils import _latency_percentiles
+
+        self.assertEqual(
+            _latency_percentiles([0.42]),
+            {"p50": 0.42, "p95": 0.42, "p99": 0.42, "count": 1},
+        )
+
+    def test_unsorted_input_is_ordered(self):
+        from calibrate.llm._metrics_utils import _latency_percentiles
+
+        agg = _latency_percentiles([600, 100, 200])
+        self.assertEqual(agg["p50"], 200)
+        self.assertEqual(agg["count"], 3)
 
 
 class TestWriteOutputsLatency(unittest.TestCase):
@@ -2612,9 +2638,10 @@ class TestWriteOutputsLatency(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             _write_test_results_outputs(results, tmp, {})
             metrics = json.loads((Path(tmp) / "metrics.json").read_text())
+        # sorted [120, 180]: p50=150, p95=177, p99=179.4 -> 179
         self.assertEqual(
             metrics["latency_ms"],
-            {"mean": 150, "min": 120, "max": 180, "count": 2},
+            {"p50": 150, "p95": 177, "p99": 179, "count": 2},
         )
 
     def test_metrics_omits_latency_when_absent(self):

--- a/tests/llm/test_tests_leaderboard.py
+++ b/tests/llm/test_tests_leaderboard.py
@@ -124,11 +124,11 @@ class TestLeaderboardMultiCriteria(unittest.TestCase):
             self.assertIn("pass_rate", df.columns)
             self.assertIn("passed", df.columns)
             self.assertIn("total", df.columns)
-            # No criterion columns (latency_ms, cost and total_tokens are
-            # standard columns, empty here)
+            # No criterion columns (latency percentiles, cost and total_tokens
+            # are standard columns, empty here)
             expected_cols = {
-                "model", "passed", "total", "pass_rate", "latency_ms", "cost",
-                "total_tokens",
+                "model", "passed", "total", "pass_rate", "latency_p50",
+                "latency_p95", "latency_p99", "cost", "total_tokens",
             }
             self.assertEqual(set(df.columns), expected_cols)
             # Cost is absent in old-style metrics → empty column
@@ -240,12 +240,12 @@ class TestLeaderboardMultiCriteria(unittest.TestCase):
             )
 
     def test_latency_column(self):
-        """latency_ms shows the mean; absent → None/NaN."""
+        """latency percentiles are surfaced; absent → None/NaN."""
         with tempfile.TemporaryDirectory() as tmp:
             base = Path(tmp)
             _write_model(base, "model-a", {
                 "total": 2, "passed": 2,
-                "latency_ms": {"mean": 150, "min": 100, "max": 200, "count": 2},
+                "latency_ms": {"p50": 150, "p95": 190, "p99": 198, "count": 2},
             })
             # model-b has no latency (e.g. eval-only)
             _write_model(base, "model-b", {"total": 2, "passed": 1})
@@ -254,12 +254,16 @@ class TestLeaderboardMultiCriteria(unittest.TestCase):
             generate_leaderboard(str(base), str(save_dir))
 
             df = pd.read_csv(save_dir / "llm_leaderboard.csv")
-            self.assertIn("latency_ms", df.columns)
+            for col in ("latency_p50", "latency_p95", "latency_p99"):
+                self.assertIn(col, df.columns)
             self.assertEqual(
-                df.loc[df["model"] == "model-a", "latency_ms"].iloc[0], 150
+                df.loc[df["model"] == "model-a", "latency_p50"].iloc[0], 150
+            )
+            self.assertEqual(
+                df.loc[df["model"] == "model-a", "latency_p95"].iloc[0], 190
             )
             self.assertTrue(
-                pd.isna(df.loc[df["model"] == "model-b", "latency_ms"].iloc[0])
+                pd.isna(df.loc[df["model"] == "model-b", "latency_p50"].iloc[0])
             )
 
     def test_empty_output_dir(self):

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -320,7 +320,7 @@ class TestTTSBenchmarkRun(unittest.IsolatedAsyncioTestCase):
         from calibrate.tts import benchmark as B
 
         fake_result = {"provider": "openai", "status": "completed",
-                       "metrics": {"ttfb": {"mean": 0.5},
+                       "metrics": {"ttfb": {"p50": 0.5, "p95": 0.6, "p99": 0.6, "count": 2},
                                    "pronunciation": {"type": "binary", "mean": 0.9}}}
         with tempfile.TemporaryDirectory() as tmp, \
              patch.object(B, "run_single_provider_eval", AsyncMock(return_value=fake_result)), \
@@ -382,7 +382,7 @@ class TestTTSBenchmarkMain(unittest.IsolatedAsyncioTestCase):
                 "providers": {
                     "openai": {"status": "completed",
                                "metrics": {
-                                   "ttfb": {"mean": 0.5},
+                                   "ttfb": {"p50": 0.5, "p95": 0.6, "p99": 0.6, "count": 2},
                                    "pronunciation": {"type": "binary", "mean": 0.9},
                                }},
                 },

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -455,7 +455,7 @@ class TestRunTestExternalMetrics(unittest.IsolatedAsyncioTestCase):
             {"response": "hi", "tool_calls": [], "metrics": {"latency_ms": 200}}
         )
         agg = _aggregate_latency([result])
-        self.assertEqual(agg["mean"], 200)
+        self.assertEqual(agg["p50"], 200)
 
     async def test_agent_reported_total_tokens_lifted_to_output(self):
         result = await self._run(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -697,6 +697,21 @@ class TestReadLeaderboardMetrics(unittest.TestCase):
             self.assertEqual(out["ttfb"], 0.4)
             self.assertEqual(out["wer"], 0.1)
 
+    def test_percentile_dict_fans_out(self):
+        from calibrate.utils import read_leaderboard_metrics
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = self._write(Path(tmp) / "m.json", {
+                "wer": 0.1,
+                "ttfb": {"p50": 0.4, "p95": 0.55, "p99": 0.6, "count": 5},
+            })
+            out = read_leaderboard_metrics(p)
+            self.assertEqual(out["ttfb_p50"], 0.4)
+            self.assertEqual(out["ttfb_p95"], 0.55)
+            self.assertEqual(out["ttfb_p99"], 0.6)
+            self.assertNotIn("ttfb", out)
+            self.assertEqual(out["wer"], 0.1)
+
     def test_legacy_metric_name_format(self):
         from calibrate.utils import read_leaderboard_metrics
 

--- a/tests/tts/test_eval_extra.py
+++ b/tests/tts/test_eval_extra.py
@@ -438,7 +438,7 @@ class TestTTSMainCLI(unittest.IsolatedAsyncioTestCase):
             argv = ["e.py", "-p", "openai", "-i", str(inp), "-o", str(out)]
             fake_result = {"provider": "openai", "status": "completed",
                            "metrics": {"pronunciation": {"type": "binary", "mean": 0.9},
-                                       "ttfb": {"mean": 0.5}}}
+                                       "ttfb": {"p50": 0.5, "p95": 0.6, "p99": 0.6, "count": 2}}}
             with patch.object(sys, "argv", argv), \
                  patch.object(E, "run_single_provider_eval", AsyncMock(return_value=fake_result)):
                 await E.main()

--- a/tests/tts/test_leaderboard.py
+++ b/tests/tts/test_leaderboard.py
@@ -38,13 +38,13 @@ class TestTTSLeaderboard(unittest.TestCase):
             base = Path(tmp)
             _write_provider(base, "openai", {
                 "pronunciation": {"type": "binary", "mean": 0.95},
-                "ttfb": {"mean": 0.4, "std": 0.05, "values": [0.35, 0.45]},
+                "ttfb": {"p50": 0.4, "p95": 0.45, "p99": 0.46, "count": 2},
             }, results_rows=[
                 {"id": 1, "text": "hi", "pronunciation": True, "ttfb": 0.4},
             ])
             _write_provider(base, "elevenlabs", {
                 "pronunciation": {"type": "binary", "mean": 0.8},
-                "ttfb": {"mean": 0.3, "std": 0.02, "values": [0.29, 0.31]},
+                "ttfb": {"p50": 0.3, "p95": 0.31, "p99": 0.31, "count": 2},
             }, results_rows=[
                 {"id": 1, "text": "hi", "pronunciation": True, "ttfb": 0.3},
             ])
@@ -56,7 +56,9 @@ class TestTTSLeaderboard(unittest.TestCase):
             self.assertTrue(xlsx.exists())
             summary = pd.read_excel(xlsx, sheet_name="summary")
             self.assertIn("pronunciation", summary.columns)
-            self.assertIn("ttfb", summary.columns)
+            self.assertIn("ttfb_p50", summary.columns)
+            self.assertIn("ttfb_p95", summary.columns)
+            self.assertIn("ttfb_p99", summary.columns)
 
     def test_multi_criterion_metrics_surface_dynamically(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -64,7 +66,7 @@ class TestTTSLeaderboard(unittest.TestCase):
             _write_provider(base, "provider-a", {
                 "intelligibility": {"type": "binary", "mean": 0.9},
                 "pronunciation": {"type": "binary", "mean": 0.85},
-                "ttfb": {"mean": 0.4},
+                "ttfb": {"p50": 0.4, "p95": 0.45, "p99": 0.46, "count": 2},
             })
 
             save_dir = base / "leaderboard"
@@ -74,7 +76,7 @@ class TestTTSLeaderboard(unittest.TestCase):
             summary = pd.read_excel(xlsx, sheet_name="summary")
             self.assertIn("intelligibility", summary.columns)
             self.assertIn("pronunciation", summary.columns)
-            self.assertIn("ttfb", summary.columns)
+            self.assertIn("ttfb_p50", summary.columns)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Report latency as percentiles instead of mean/min/max.

## Output changes (CLI users)
- `metrics.json` LLM `latency_ms`: `{mean,min,max,count}` → `{p50,p95,p99,count}`
- `metrics.json` TTS `ttfb`: `{mean,std,values}` → `{p50,p95,p99,count}`
- Leaderboards: `latency_ms` / `ttfb` columns → `*_p50/_p95/_p99`
- TTS summaries print `TTFB(p50)=...`
- `cost` / `total_tokens`, STT and sim latency unchanged

## Internal
- Aggregation uses `np.percentile` via shared `_latency_percentiles`; `numpy` now a declared dep.

## Caveat
Pre-change `metrics.json` store `*.mean`; new leaderboard reader looks for `p50`, so latency columns drop for old runs (re-run to restore).

## Test
`uv run pytest tests/llm tests/tts tests/test_connections.py tests/test_utils.py tests/test_benchmarks.py` — green. Verified with real `calibrate tts` + `calibrate llm` runs.