### PR TITLE
Add CER alongside WER to STT metrics

### DIFF
--- a/calibrate/stt/benchmark.py
+++ b/calibrate/stt/benchmark.py
@@ -311,13 +311,14 @@ async def main():
 
         metrics = result.get("metrics", {})
         wer = metrics.get("wer", 0)
+        cer = metrics.get("cer", 0)
         judge_scores = {
             k: v["mean"]
             for k, v in metrics.items()
             if isinstance(v, dict) and "type" in v
         }
         judge_str = ", ".join(f"{k}={v:.4f}" for k, v in judge_scores.items())
-        print(f"  WER={wer:.4f}, {judge_str}")
+        print(f"  WER={wer:.4f}, CER={cer:.4f}, {judge_str}")
         return
 
     # Benchmark (multi-provider) mode: mirror stdout/stderr into a single
@@ -372,6 +373,7 @@ async def main():
             else:
                 metrics = prov_result.get("metrics", {})
                 wer = metrics.get("wer", 0)
+                cer = metrics.get("cer", 0)
                 # Evaluator entries are dicts carrying a ``type`` field.
                 judge_scores = {
                     k: v["mean"]
@@ -381,7 +383,7 @@ async def main():
                 judge_str = ", ".join(
                     f"{k}={v:.4f}" for k, v in judge_scores.items()
                 )
-                print(f"  {provider}: WER={wer:.4f}, {judge_str}")
+                print(f"  {provider}: WER={wer:.4f}, CER={cer:.4f}, {judge_str}")
 
         if has_errors:
             sys.exit(1)

--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -33,6 +33,7 @@ from calibrate.utils import (
 )
 from calibrate.stt.metrics import (
     get_wer_score,
+    get_cer_score,
     get_llm_judge_score,
 )
 from calibrate.judges import (
@@ -1058,6 +1059,9 @@ async def _score_and_write_results(
     wer_results = get_wer_score(gt_transcripts, pred_transcripts)
     _log(f"WER: {wer_results['score']}", to_terminal=False)
 
+    cer_results = get_cer_score(gt_transcripts, pred_transcripts)
+    _log(f"CER: {cer_results['score']}", to_terminal=False)
+
     _evaluators = judge_evaluators if judge_evaluators else [DEFAULT_STT_EVALUATOR]
     require_unique_evaluator_names(_evaluators)
     write_evaluator_config(evaluator_config_dir, _evaluators)
@@ -1071,16 +1075,17 @@ async def _score_and_write_results(
 
     _evaluators_by_name = {ev["name"]: ev for ev in _evaluators}
 
-    metrics_data = {"wer": wer_results["score"]}
+    metrics_data = {"wer": wer_results["score"], "cer": cer_results["score"]}
     for name, score_dict in llm_results["scores"].items():
         metrics_data[name] = score_dict
 
     data = []
-    for _id, gt_text, pred_text, wer, llm_row in zip(
+    for _id, gt_text, pred_text, wer, cer, llm_row in zip(
         ids,
         gt_transcripts,
         pred_transcripts,
         wer_results["per_row"],
+        cer_results["per_row"],
         llm_results["per_row"],
     ):
         row = {
@@ -1088,6 +1093,7 @@ async def _score_and_write_results(
             "gt": gt_text,
             "pred": pred_text,
             "wer": wer,
+            "cer": cer,
         }
         for name, ev in _evaluators_by_name.items():
             ev_result = llm_row[name]
@@ -1286,6 +1292,7 @@ async def main():
     else:
         metrics = result.get("metrics", {})
         wer = metrics.get("wer", 0)
+        cer = metrics.get("cer", 0)
         # Evaluator entries are dicts carrying a ``type`` field; that's the
         # marker we use to pick them out from other top-level metrics.
         judge_scores = {
@@ -1294,7 +1301,7 @@ async def main():
             if isinstance(v, dict) and "type" in v
         }
         judge_str = ", ".join(f"{k}={v:.4f}" for k, v in judge_scores.items())
-        print(f"  {provider}: WER={wer:.4f}, {judge_str}")
+        print(f"  {provider}: WER={wer:.4f}, CER={cer:.4f}, {judge_str}")
 
 
 if __name__ == "__main__":

--- a/calibrate/stt/metrics.py
+++ b/calibrate/stt/metrics.py
@@ -30,20 +30,35 @@ def _resolve_evaluators(evaluators: Optional[List[dict]]) -> List[dict]:
     return list(evaluators) if evaluators else [DEFAULT_STT_EVALUATOR]
 
 
-def get_wer_score(references: List[str], predictions: List[str]) -> float:
-    wer_metric = load("wer")
+def _edit_metric(name: str, references: List[str], predictions: List[str]) -> dict:
+    """Compute a normalized per-row edit-distance metric from ``evaluate``.
+
+    Shared by WER and CER: both normalize ref/pred with the Whisper
+    ``BasicTextNormalizer``, score each row independently via the
+    HuggingFace ``evaluate`` metric ``name`` (``"wer"`` / ``"cer"``), and
+    return the macro-mean plus the per-row list.
+    """
+    metric = load(name)
 
     references = [normalizer(str(ref)) for ref in references]
     predictions = [
         normalizer(str(pred)) if isinstance(pred, str) else "" for pred in predictions
     ]
 
-    per_row_wer = [
-        wer_metric.compute(predictions=[p], references=[r])
+    per_row = [
+        metric.compute(predictions=[p], references=[r])
         for p, r in zip(predictions, references)
     ]
 
-    return {"score": np.mean(per_row_wer), "per_row": per_row_wer}
+    return {"score": np.mean(per_row), "per_row": per_row}
+
+
+def get_wer_score(references: List[str], predictions: List[str]) -> dict:
+    return _edit_metric("wer", references, predictions)
+
+
+def get_cer_score(references: List[str], predictions: List[str]) -> dict:
+    return _edit_metric("cer", references, predictions)
 
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=5, factor=2)

--- a/tests/stt/test_eval_extra.py
+++ b/tests/stt/test_eval_extra.py
@@ -280,6 +280,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             with patch.object(E, "get_wer_score", return_value={"score": 0.1, "per_row": [0.1, 0.1]}), \
+                 patch.object(E, "get_cer_score", return_value={"score": 0.2, "per_row": [0.2, 0.2]}), \
                  patch.object(E, "get_llm_judge_score", AsyncMock(return_value={
                      "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                      "per_row": [
@@ -295,8 +296,14 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
                     evaluator_config_dir=tmp,
                 )
             self.assertEqual(result["wer"], 0.1)
+            self.assertEqual(result["cer"], 0.2)
             self.assertIn("semantic_match", result)
             self.assertTrue((Path(tmp) / "metrics.json").exists())
+
+            import pandas as _pd
+            df = _pd.read_csv(Path(tmp) / "results.csv")
+            self.assertIn("cer", df.columns)
+            self.assertEqual(list(df["cer"]), [0.2, 0.2])
 
     async def test_rating_evaluator(self):
         from calibrate.stt import eval as E
@@ -306,6 +313,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
 
         with tempfile.TemporaryDirectory() as tmp, \
              patch.object(E, "get_wer_score", return_value={"score": 0.05, "per_row": [0.05]}), \
+             patch.object(E, "get_cer_score", return_value={"score": 0.03, "per_row": [0.03]}), \
              patch.object(E, "get_llm_judge_score", AsyncMock(return_value={
                  "scores": {"r": {"type": "rating", "mean": 4.0, "scale_min": 1, "scale_max": 5}},
                  "per_row": [{"r": {"score": 4, "reasoning": "ok"}}],
@@ -341,6 +349,7 @@ class TestRunEvalOnly(unittest.IsolatedAsyncioTestCase):
             ]))
             out = Path(tmp) / "out"
             with patch.object(E, "get_wer_score", return_value={"score": 0.1, "per_row": [0.1, 0.1]}), \
+                 patch.object(E, "get_cer_score", return_value={"score": 0.2, "per_row": [0.2, 0.2]}), \
                  patch.object(E, "get_llm_judge_score", AsyncMock(return_value={
                      "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                      "per_row": [
@@ -405,6 +414,7 @@ class TestRunSingleProviderEval(unittest.IsolatedAsyncioTestCase):
 
             with patch.object(E, "transcribe_audio", AsyncMock(return_value="hello")), \
                  patch.object(E, "get_wer_score", return_value={"score": 0.0, "per_row": [0.0]}), \
+                 patch.object(E, "get_cer_score", return_value={"score": 0.0, "per_row": [0.0]}), \
                  patch.object(E, "get_llm_judge_score", AsyncMock(return_value={
                      "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                      "per_row": [{"semantic_match": {"match": True, "reasoning": "ok"}}],
@@ -465,6 +475,7 @@ class TestRunSingleProviderEval(unittest.IsolatedAsyncioTestCase):
 
             with patch.object(E, "transcribe_audio", AsyncMock(return_value="hello")), \
                  patch.object(E, "get_wer_score", return_value={"score": 0.0, "per_row": [0.0]}), \
+                 patch.object(E, "get_cer_score", return_value={"score": 0.0, "per_row": [0.0]}), \
                  patch.object(E, "get_llm_judge_score", AsyncMock(return_value={
                      "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                      "per_row": [{"semantic_match": {"match": True, "reasoning": "ok"}}],

--- a/tests/stt/test_eval_more.py
+++ b/tests/stt/test_eval_more.py
@@ -83,6 +83,8 @@ class TestRunSinglProviderEvalProgressNoChange(unittest.IsolatedAsyncioTestCase)
                               AsyncMock(side_effect=Exception("provider down"))), \
                  patch.object(E, "get_wer_score",
                               return_value={"score": 0.0, "per_row": [0.0, 0.0]}), \
+                 patch.object(E, "get_cer_score",
+                              return_value={"score": 0.0, "per_row": [0.0, 0.0]}), \
                  patch.object(E, "get_llm_judge_score", AsyncMock(return_value={
                      "scores": {"semantic_match": {"type": "binary", "mean": 0.5}},
                      "per_row": [
@@ -126,6 +128,8 @@ class TestRunSinglProviderEvalAlreadyAllProcessed(unittest.IsolatedAsyncioTestCa
             )
 
             with patch.object(E, "get_wer_score",
+                              return_value={"score": 0.0, "per_row": [0.0]}), \
+                 patch.object(E, "get_cer_score",
                               return_value={"score": 0.0, "per_row": [0.0]}), \
                  patch.object(E, "get_llm_judge_score", AsyncMock(return_value={
                      "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},

--- a/tests/stt/test_metrics.py
+++ b/tests/stt/test_metrics.py
@@ -6,7 +6,58 @@ Run with:
 """
 
 import unittest
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, MagicMock
+
+
+class TestEditMetrics(unittest.TestCase):
+    """WER/CER share ``_edit_metric``; ``load`` is mocked to stay pure-unit."""
+
+    def _fake_load(self, recorder):
+        """Return a fake ``evaluate`` metric that records the per-row inputs."""
+        metric = MagicMock()
+
+        def compute(predictions, references):
+            recorder.append((references[0], predictions[0]))
+            # toy score: 1.0 when ref/pred differ, else 0.0
+            return 0.0 if references[0] == predictions[0] else 1.0
+
+        metric.compute.side_effect = compute
+        return metric
+
+    def test_get_wer_score_loads_wer_and_normalizes(self):
+        from calibrate.stt import metrics as M
+
+        seen = []
+        with patch.object(M, "load", return_value=self._fake_load(seen)) as mock_load:
+            result = M.get_wer_score(["Hello World", "foo"], ["hello world", "bar"])
+
+        mock_load.assert_called_once_with("wer")
+        # Row 1 ref/pred normalize identically (case-folded) -> 0.0; row 2 differs -> 1.0.
+        self.assertEqual(result["per_row"], [0.0, 1.0])
+        self.assertEqual(result["score"], 0.5)
+        # Normalizer was applied before scoring (case-folded to the same string).
+        self.assertEqual(seen[0], ("hello world", "hello world"))
+
+    def test_get_cer_score_loads_cer(self):
+        from calibrate.stt import metrics as M
+
+        seen = []
+        with patch.object(M, "load", return_value=self._fake_load(seen)) as mock_load:
+            result = M.get_cer_score(["abc"], ["abc"])
+
+        mock_load.assert_called_once_with("cer")
+        self.assertEqual(result["per_row"], [0.0])
+        self.assertEqual(result["score"], 0.0)
+
+    def test_non_string_prediction_becomes_empty(self):
+        from calibrate.stt import metrics as M
+
+        seen = []
+        with patch.object(M, "load", return_value=self._fake_load(seen)):
+            M.get_cer_score(["abc"], [None])
+
+        # None prediction is coerced to "" before scoring.
+        self.assertEqual(seen[0][1], "")
 
 
 class TestSTTGetLLMJudgeScore(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## What
- Add character error rate (CER) next to WER in STT eval, using HuggingFace `evaluate`'s `cer` metric — same standardized `jiwer`-backed path as WER, no new dependency.
- Factor the shared normalize-then-per-row logic into `_edit_metric`; `get_wer_score`/`get_cer_score` both delegate to it.
- CER flows through `metrics.json`, the per-row `cer` column in `results.csv`, and the eval/benchmark summary prints.

## Notes
- Leaderboard needed no change — `read_leaderboard_metrics` already passes bare floats through, so `cer` appears as its own column automatically.
- CER is more meaningful than WER for the agglutinative Indian languages this tool targets, where word segmentation is unreliable.
- Eval-level tests that call the metrics unmocked will trigger a one-time download of the `cer` builder script on CI's first run, same as `wer` already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)