### PR TITLE
Add always-on intent & entity STT metrics

### DIFF
--- a/calibrate/stt/benchmark.py
+++ b/calibrate/stt/benchmark.py
@@ -312,13 +312,18 @@ async def main():
         metrics = result.get("metrics", {})
         wer = metrics.get("wer", 0)
         cer = metrics.get("cer", 0)
+        intent = metrics.get("intent", 0)
+        entity = metrics.get("entity", 0)
         judge_scores = {
             k: v["mean"]
             for k, v in metrics.items()
             if isinstance(v, dict) and "type" in v
         }
         judge_str = ", ".join(f"{k}={v:.4f}" for k, v in judge_scores.items())
-        print(f"  WER={wer:.4f}, CER={cer:.4f}, {judge_str}")
+        print(
+            f"  WER={wer:.4f}, CER={cer:.4f}, Intent={intent:.4f}, "
+            f"Entity={entity:.4f}, {judge_str}"
+        )
         return
 
     # Benchmark (multi-provider) mode: mirror stdout/stderr into a single
@@ -374,6 +379,8 @@ async def main():
                 metrics = prov_result.get("metrics", {})
                 wer = metrics.get("wer", 0)
                 cer = metrics.get("cer", 0)
+                intent = metrics.get("intent", 0)
+                entity = metrics.get("entity", 0)
                 # Evaluator entries are dicts carrying a ``type`` field.
                 judge_scores = {
                     k: v["mean"]
@@ -383,7 +390,10 @@ async def main():
                 judge_str = ", ".join(
                     f"{k}={v:.4f}" for k, v in judge_scores.items()
                 )
-                print(f"  {provider}: WER={wer:.4f}, CER={cer:.4f}, {judge_str}")
+                print(
+                    f"  {provider}: WER={wer:.4f}, CER={cer:.4f}, "
+                    f"Intent={intent:.4f}, Entity={entity:.4f}, {judge_str}"
+                )
 
         if has_errors:
             sys.exit(1)

--- a/calibrate/stt/benchmark.py
+++ b/calibrate/stt/benchmark.py
@@ -312,18 +312,15 @@ async def main():
         metrics = result.get("metrics", {})
         wer = metrics.get("wer", 0)
         cer = metrics.get("cer", 0)
-        intent = metrics.get("intent", 0)
-        entity = metrics.get("entity", 0)
+        intent = metrics.get("sarvam_intent_score", 0)
+        entity = metrics.get("sarvam_entity_score", 0)
         judge_scores = {
             k: v["mean"]
             for k, v in metrics.items()
             if isinstance(v, dict) and "type" in v
         }
         judge_str = ", ".join(f"{k}={v:.4f}" for k, v in judge_scores.items())
-        print(
-            f"  WER={wer:.4f}, CER={cer:.4f}, Intent={intent:.4f}, "
-            f"Entity={entity:.4f}, {judge_str}"
-        )
+        print(f"  WER={wer:.4f}, CER={cer:.4f}, Sarvam Intent Score={intent:.4f}, Sarvam Entity Score={entity:.4f}, {judge_str}")
         return
 
     # Benchmark (multi-provider) mode: mirror stdout/stderr into a single
@@ -379,8 +376,8 @@ async def main():
                 metrics = prov_result.get("metrics", {})
                 wer = metrics.get("wer", 0)
                 cer = metrics.get("cer", 0)
-                intent = metrics.get("intent", 0)
-                entity = metrics.get("entity", 0)
+                intent = metrics.get("sarvam_intent_score", 0)
+                entity = metrics.get("sarvam_entity_score", 0)
                 # Evaluator entries are dicts carrying a ``type`` field.
                 judge_scores = {
                     k: v["mean"]
@@ -390,10 +387,7 @@ async def main():
                 judge_str = ", ".join(
                     f"{k}={v:.4f}" for k, v in judge_scores.items()
                 )
-                print(
-                    f"  {provider}: WER={wer:.4f}, CER={cer:.4f}, "
-                    f"Intent={intent:.4f}, Entity={entity:.4f}, {judge_str}"
-                )
+                print(f"  {provider}: WER={wer:.4f}, CER={cer:.4f}, Sarvam Intent Score={intent:.4f}, Sarvam Entity Score={entity:.4f}, {judge_str}")
 
         if has_errors:
             sys.exit(1)

--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -1071,8 +1071,7 @@ async def _score_and_write_results(
         gt_transcripts, pred_transcripts, language=language
     )
     _log(
-        f"Intent: {intent_entity_results['intent']:.4f}  "
-        f"Entity: {intent_entity_results['entity']:.4f}",
+        f"Sarvam Intent Score: {intent_entity_results['intent']:.4f}  Sarvam Entity Score: {intent_entity_results['entity']:.4f}",
         to_terminal=False,
     )
 

--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -996,6 +996,7 @@ async def run_single_provider_eval(
             output_dir=provider_output_dir,
             evaluator_config_dir=output_dir,
             judge_evaluators=judge_evaluators,
+            language=language,
         )
 
         return {
@@ -1050,6 +1051,7 @@ async def _score_and_write_results(
     output_dir: str,
     evaluator_config_dir: str,
     judge_evaluators: list[dict] = None,
+    language: str = "english",
 ) -> dict:
     """Run WER + LLM-judge evaluators over (gt, pred) pairs and write outputs.
 
@@ -1066,7 +1068,7 @@ async def _score_and_write_results(
     # Intent + entity preservation are always computed, independent of the
     # user-supplied evaluators, and reported alongside WER as top-level floats.
     intent_entity_results = await get_intent_entity_score(
-        gt_transcripts, pred_transcripts
+        gt_transcripts, pred_transcripts, language=language
     )
     _log(
         f"Intent: {intent_entity_results['intent']:.4f}  "
@@ -1138,6 +1140,7 @@ async def run_eval_only(
     dataset_path: str,
     output_dir: str,
     judge_evaluators: list[dict] = None,
+    language: str = "english",
 ) -> dict:
     """Run evaluators only on a pre-existing dataset of (gt, pred) pairs.
 
@@ -1149,6 +1152,8 @@ async def run_eval_only(
         output_dir: Directory to write results and metrics.
         judge_evaluators: Optional list of evaluator dicts. Defaults to the
             built-in STT evaluator when omitted.
+        language: Language of the dataset, used to normalize text before the
+            intent/entity judge. Defaults to ``english``.
 
     Returns:
         dict with status, metrics, and output_dir.
@@ -1181,6 +1186,7 @@ async def run_eval_only(
             output_dir=output_dir,
             evaluator_config_dir=output_dir,
             judge_evaluators=judge_evaluators,
+            language=language,
         )
 
         return {

--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -36,6 +36,7 @@ from calibrate.stt.metrics import (
     get_cer_score,
     get_llm_judge_score,
 )
+from calibrate.stt.intent_entity import get_intent_entity_score
 from calibrate.judges import (
     is_rating,
     DEFAULT_STT_EVALUATOR,
@@ -1062,6 +1063,17 @@ async def _score_and_write_results(
     cer_results = get_cer_score(gt_transcripts, pred_transcripts)
     _log(f"CER: {cer_results['score']}", to_terminal=False)
 
+    # Intent + entity preservation are always computed, independent of the
+    # user-supplied evaluators, and reported alongside WER as top-level floats.
+    intent_entity_results = await get_intent_entity_score(
+        gt_transcripts, pred_transcripts
+    )
+    _log(
+        f"Intent: {intent_entity_results['intent']:.4f}  "
+        f"Entity: {intent_entity_results['entity']:.4f}",
+        to_terminal=False,
+    )
+
     _evaluators = judge_evaluators if judge_evaluators else [DEFAULT_STT_EVALUATOR]
     require_unique_evaluator_names(_evaluators)
     write_evaluator_config(evaluator_config_dir, _evaluators)
@@ -1075,17 +1087,23 @@ async def _score_and_write_results(
 
     _evaluators_by_name = {ev["name"]: ev for ev in _evaluators}
 
-    metrics_data = {"wer": wer_results["score"], "cer": cer_results["score"]}
+    metrics_data = {
+        "wer": wer_results["score"],
+        "cer": cer_results["score"],
+        "intent": intent_entity_results["intent"],
+        "entity": intent_entity_results["entity"],
+    }
     for name, score_dict in llm_results["scores"].items():
         metrics_data[name] = score_dict
 
     data = []
-    for _id, gt_text, pred_text, wer, cer, llm_row in zip(
+    for _id, gt_text, pred_text, wer, cer, ie_row, llm_row in zip(
         ids,
         gt_transcripts,
         pred_transcripts,
         wer_results["per_row"],
         cer_results["per_row"],
+        intent_entity_results["per_row"],
         llm_results["per_row"],
     ):
         row = {
@@ -1094,6 +1112,10 @@ async def _score_and_write_results(
             "pred": pred_text,
             "wer": wer,
             "cer": cer,
+            "intent": int(ie_row["intent_score"]),
+            "intent_reasoning": ie_row["intent_explanation"],
+            "entity": float(ie_row["entity_score"]),
+            "entity_reasoning": ie_row["entity_explanation"],
         }
         for name, ev in _evaluators_by_name.items():
             ev_result = llm_row[name]
@@ -1293,6 +1315,8 @@ async def main():
         metrics = result.get("metrics", {})
         wer = metrics.get("wer", 0)
         cer = metrics.get("cer", 0)
+        intent = metrics.get("intent", 0)
+        entity = metrics.get("entity", 0)
         # Evaluator entries are dicts carrying a ``type`` field; that's the
         # marker we use to pick them out from other top-level metrics.
         judge_scores = {
@@ -1301,7 +1325,10 @@ async def main():
             if isinstance(v, dict) and "type" in v
         }
         judge_str = ", ".join(f"{k}={v:.4f}" for k, v in judge_scores.items())
-        print(f"  {provider}: WER={wer:.4f}, CER={cer:.4f}, {judge_str}")
+        print(
+            f"  {provider}: WER={wer:.4f}, CER={cer:.4f}, Intent={intent:.4f}, "
+            f"Entity={entity:.4f}, {judge_str}"
+        )
 
 
 if __name__ == "__main__":

--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -1092,8 +1092,8 @@ async def _score_and_write_results(
     metrics_data = {
         "wer": wer_results["score"],
         "cer": cer_results["score"],
-        "intent": intent_entity_results["intent"],
-        "entity": intent_entity_results["entity"],
+        "sarvam_intent_score": intent_entity_results["intent"],
+        "sarvam_entity_score": intent_entity_results["entity"],
     }
     for name, score_dict in llm_results["scores"].items():
         metrics_data[name] = score_dict
@@ -1114,10 +1114,10 @@ async def _score_and_write_results(
             "pred": pred_text,
             "wer": wer,
             "cer": cer,
-            "intent": int(ie_row["intent_score"]),
-            "intent_reasoning": ie_row["intent_explanation"],
-            "entity": float(ie_row["entity_score"]),
-            "entity_reasoning": ie_row["entity_explanation"],
+            "sarvam_intent_score": int(ie_row["intent_score"]),
+            "sarvam_intent_reasoning": ie_row["intent_explanation"],
+            "sarvam_entity_score": float(ie_row["entity_score"]),
+            "sarvam_entity_reasoning": ie_row["entity_explanation"],
         }
         for name, ev in _evaluators_by_name.items():
             ev_result = llm_row[name]
@@ -1321,8 +1321,8 @@ async def main():
         metrics = result.get("metrics", {})
         wer = metrics.get("wer", 0)
         cer = metrics.get("cer", 0)
-        intent = metrics.get("intent", 0)
-        entity = metrics.get("entity", 0)
+        intent = metrics.get("sarvam_intent_score", 0)
+        entity = metrics.get("sarvam_entity_score", 0)
         # Evaluator entries are dicts carrying a ``type`` field; that's the
         # marker we use to pick them out from other top-level metrics.
         judge_scores = {
@@ -1331,10 +1331,7 @@ async def main():
             if isinstance(v, dict) and "type" in v
         }
         judge_str = ", ".join(f"{k}={v:.4f}" for k, v in judge_scores.items())
-        print(
-            f"  {provider}: WER={wer:.4f}, CER={cer:.4f}, Intent={intent:.4f}, "
-            f"Entity={entity:.4f}, {judge_str}"
-        )
+        print(f"  {provider}: WER={wer:.4f}, CER={cer:.4f}, Sarvam Intent Score={intent:.4f}, Sarvam Entity Score={entity:.4f}, {judge_str}")
 
 
 if __name__ == "__main__":

--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -35,8 +35,8 @@ from calibrate.stt.metrics import (
     get_wer_score,
     get_cer_score,
     get_llm_judge_score,
+    get_intent_entity_score,
 )
-from calibrate.stt.intent_entity import get_intent_entity_score
 from calibrate.judges import (
     is_rating,
     DEFAULT_STT_EVALUATOR,

--- a/calibrate/stt/intent_entity.py
+++ b/calibrate/stt/intent_entity.py
@@ -14,14 +14,14 @@ A single judge call per row returns both intent (0/1) and entity (0–1) scores.
 import backoff
 import instructor
 
-from calibrate.judges import _build_openrouter_client, DEFAULT_TEXT_JUDGE_MODEL
+from calibrate.judges import _build_openrouter_client
 from calibrate.langfuse import observe, langfuse, langfuse_enabled
 from calibrate.utils import log_judge_io
 from calibrate.stt.sarvam_intent_entity import IntentEntityResponse, build_prompt
 
-# Model used to grade intent/entity. The rubric is strict and linguistically
-# nuanced, so a capable model is the default; it matches the text-judge default.
-DEFAULT_INTENT_ENTITY_MODEL = DEFAULT_TEXT_JUDGE_MODEL
+# Model used to grade intent/entity. Matches Sarvam's llm_intent_entity flow,
+# which judges with google/gemini-2.5-flash (reached here via OpenRouter).
+DEFAULT_INTENT_ENTITY_MODEL = "google/gemini-2.5-flash"
 
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=5, factor=2)

--- a/calibrate/stt/intent_entity.py
+++ b/calibrate/stt/intent_entity.py
@@ -1,0 +1,307 @@
+"""
+Intent & Entity preservation scoring for STT transcriptions.
+
+Two meaning-preservation metrics that are *always* computed for every STT run,
+independent of the user-supplied evaluators, and reported alongside ``wer``:
+
+- **intent** — binary (0/1) per row: is the core meaning/intent preserved?
+  Aggregated as a pass-rate (mean of 0/1).
+- **entity** — float (0–1) per row: fraction of key entities preserved.
+  Aggregated as a mean, like ``wer``.
+
+A single judge call per row returns both scores (faithful to Sarvam's original
+single-prompt design, and half the cost of two separate calls).
+
+The rubric in ``INTENT_ENTITY_SYSTEM_PROMPT`` is adapted from Sarvam AI's
+``llm_intent_entity`` evaluation prompt:
+https://github.com/sarvamai/llm_intent_entity (prompt_template.txt).
+See also: https://www.sarvam.ai/blogs/evaluating-indian-language-asr
+"""
+
+import json
+from typing import List
+
+import backoff
+import instructor
+import numpy as np
+from pydantic import BaseModel, Field
+from tqdm.asyncio import tqdm_asyncio
+
+from calibrate.judges import _build_openrouter_client, DEFAULT_TEXT_JUDGE_MODEL
+from calibrate.langfuse import observe, langfuse, langfuse_enabled
+from calibrate.utils import log_judge_io
+
+# Model used to grade intent/entity. The rubric is strict and linguistically
+# nuanced, so a capable model is the default; it matches the text-judge default.
+DEFAULT_INTENT_ENTITY_MODEL = DEFAULT_TEXT_JUDGE_MODEL
+
+
+INTENT_ENTITY_SYSTEM_PROMPT = """# Persona
+You are an expert linguistic evaluation assistant specializing in intent and entity extraction analysis for Indian languages.
+
+# Primary Goal
+Your primary goal is to evaluate how well intent and entities are captured by comparing an ASR (Automatic Speech Recognition) model's output against a provided ground truth sentence. You need to score both intent preservation and entity extraction accuracy.
+
+# Evaluation Guidelines
+
+## TASK 1: Intent Scoring
+Scoring Guidelines for Intent:
+- Score 1 ONLY if the core meaning or intent of the sentence is preserved, which means that the action and subject are preserved.
+- Be EXTREMELY strict in matching intent - even subtle differences that change who is doing what should result in a score of 0:
+    * "No, I can talk to Ajay Gupta" vs "No, I can have you speak with Ajay Gupta" (different actors)
+    * "I need to call him" vs "I need him to call me" (reversed direction of action)
+    * "You should speak to the manager" vs "I should speak to the manager" (different subject)
+    * "Can I help you with that?" vs "Can you help me with that?" (reversed roles)
+- Be strict about questions vs statements - they have fundamentally different intents:
+    * "I will come tomorrow" vs "Can I come tomorrow?" (statement vs question)
+    * "You should open the door" vs "Can you open the door?" (instruction vs request)
+    * "The meeting is at 5" vs "Is the meeting at 5?" (information vs confirmation)
+- Be strict about pronouns - they often change the meaning significantly:
+    * "Can you speak in Malayalam?" is different from "Can we speak in Malayalam?"
+    * "I will do it" is different from "You will do it" or "He will do it"
+    * "My house" is different from "Your house" or "Their house"
+- Score 1 for equivalent acknowledgments/fillers, for example:
+    * "yes" = "yeah" = "hmm" = "aha" = "okay" = "right"
+    * "no" = "nah" = "nope" = "uh-uh"
+- Score 1 for equivalent requests that preserve the core intent:
+    * "Please repeat the question" = "Ask the question again" = "Ask the question" (all request repetition)
+    * "Can you say that again?" = "Please repeat" = "Repeat" (all request repetition)
+    * For short imperative sentences, focus on the core action being requested rather than exact wording
+- Score 1 for repeated words or phrases that convey the same meaning:
+    * "Thank you, thank you" = "Thank you" (repetition for emphasis)
+    * "Yes, yes" = "Yes" (repetition for emphasis)
+- Score 1 for equivalent instructions about language preference:
+    * "Kannada. Speak in Kannada" = "Speak in Kannada" (both instruct to use Kannada)
+    * "[Language name]. Speak in [Language name]" = "Speak in [Language name]"
+- Score 1 if numbers match in meaning, regardless of format:
+    * "twenty five" = "25" = "two five"
+    * "first" = "1st" = "one"
+- Score 1 for minor variations that preserve intent WITHOUT changing subjects or pronouns:
+    * "I agree" = "I agree with that"
+    * "don't know" = "I don't know"
+    * "I agree with that" = "I agree"
+- Score 1 if the ASR model's output is a direct acknowledgement of the ground truth sentence.
+    * "Yes, I will clear the loan immediately." = "Yes."
+- Be EXTREMELY strict with critical personal information - score 0 unless these are preserved EXACTLY:
+    * Proper nouns and names (e.g., "John Smith" vs "Jon Smith")
+    * Dates of birth (e.g., "January 5th, 1980" vs "January 15th, 1980")
+    * Email addresses (e.g., "john@example.com" vs "jon@example.com")
+    * Phone numbers (e.g., "555-123-4567" vs "555-124-4567")
+    * Account numbers, IDs, or any numerical identifiers
+    * Addresses and other location information
+- Score 0 if a statement is changed to a question or vice versa:
+    * "I will come tomorrow" vs "Can I come tomorrow?" (different speech acts)
+    * "He left the office" vs "Did he leave the office?" (statement vs question)
+    * "Close the window" vs "Should I close the window?" (command vs question)
+- Score 0 if pronouns or subjects differ, even slightly:
+    * "Can you help me?" vs "Can we help you?" (different subjects and objects)
+    * "She is coming" vs "I am coming" (different subjects)
+    * "This is my car" vs "This is your car" (different possessive pronouns)
+- Score 0 for any other differences in meaning:
+    * "yes" vs "no"
+    * "three" vs "seven"
+    * "I agree" vs "I disagree"
+- Score 0 if ground truth is completely empty as intent is not preserved.
+
+## TASK 2: Entity Scoring
+Identify and score how well entities are preserved:
+1. First, identify the key entities in the ground truth:
+   - Entities include people, places, organizations, objects, dates, numbers, and specific references.
+   - For short sentences and commands, consider the object of the action as an entity (e.g., in "Please repeat the question", "question" is an entity, in I will come tomorrow, "tomorrow" is an entity)
+   - In short requests or commands, focus on the essential object being referenced (e.g., "Check balance" and "Show balance" both have "balance" as the entity)
+   - Do not include generic words unless essential for understanding.
+   - Be especially careful with pronouns and honorifics in Indic languages as they often represent important entities.
+   - Sentences like "hello, "how are you","mostly yes", "will do it", etc have no entities in such cases output NA and score 1 since there are no entities to preserve
+
+2. Score entity preservation (0 to 1):
+   - Score 1 if ALL key entities from ground truth are correctly present in the ASR output.
+   - Score 0 if NONE of the key entities are preserved correctly.
+   - Score 1 if there is no entity in the ground truth.
+   - For partial preservation, provide a score between 0 and 1 based on:
+     * The fraction of correctly preserved entities.
+     * The importance of preserved vs. missing entities.
+     * Penalize for incorrectly substituted entities (e.g., "John" → "Tom").
+
+3. Pay special attention to Indic language-specific considerations:
+   * Hindi (Pronoun): "मैं कल आऊंगा" (I will come tomorrow) vs "वह कल आएगा" (He will come tomorrow) - Different pronoun completely changes who is coming
+   * Hindi (Subject-object): "राम ने श्याम को देखा" (Ram saw Shyam) vs "श्याम ने राम को देखा" (Shyam saw Ram) - Reversed relationship
+   * Bengali (Named-entity): "আমি কলকাতায় যাব" (I will go to Kolkata) vs "আমি দিল্লীতে যাব" (I will go to Delhi) - Different named entity (place)
+   * Marathi (Tense): "मी जेवलो" (I ate) vs "मी जेवणार" (I will eat) - Different tense
+   * Malayalam (Interrogative-declarative): "നിങ്ങൾ എവിടെ പോകുന്നു?" (Where are you going?) vs "നിങ്ങൾ അവിടെ പോകുന്നു" (You are going there) - Question vs statement
+   * Kannada (Singular-plural): "ಮಗು ಓದುತ್ತಿದೆ" (The child is reading) vs "ಮಕ್ಕಳು ಓದುತ್ತಿದ್ದಾರೆ" (The children are reading) - Singular vs plural
+   * Tamil (Alphanumeric): "என் தொலைபேசி எண் 9876543210" (My phone number is 9876543210) vs "என் தொலைபேசி எண் 9876543211" (My phone number is 9876543211) - Incorrect number
+   * Telugu (Subject-object): "రాము సీతను చూశాడు" (Rama saw Sita) vs "సీత రాముని చూసింది" (Sita saw Rama) - Reversed relationship
+   * Gujarati (Negation): "મને ભૂખ નથી" (I am not hungry) vs "મને ભૂખ છે" (I am hungry) - Missing negation
+   * Odia (Named-entity): "ମୁଁ ଭୁବନେଶ୍ୱରରେ ରହେ" (I live in Bhubaneswar) vs "ମୁଁ କଟକରେ ରହେ" (I live in Cuttack) - Different place name
+   * Punjabi (Tense): "ਮੈਂ ਖਾਧਾ ਸੀ" (I had eaten) vs "ਮੈਂ ਖਾਂਦਾ ਹਾਂ" (I eat) - Different tense
+
+# Input Format:
+You will be given a JSON object with the following structure:
+
+```json
+{
+  "index": int,
+  "hypothesis": str,
+  "ground_truth": str,
+  "context": str
+}
+```
+
+# Output Format
+Your final output must be a single JSON object with the following structure:
+
+```json
+{
+    "index": int,
+    "intent_score": int, // 0 or 1
+    "intent_explanation": str, // Brief explanation of your intent score
+    "entity_score": float, // between 0 and 1
+    "ground_truth_entities": str, // comma-separated list of entities from ground truth
+    "preserved_entities": str, // comma-separated list of correctly preserved entities
+    "missing_entities": str, // comma-separated list of missing or incorrect entities
+    "entity_explanation": str // Brief explanation of your entity score
+}
+```"""
+
+
+class IntentEntityResult(BaseModel):
+    """Combined intent + entity judgement for a single (ground_truth, hypothesis) pair."""
+
+    index: int = Field(default=0, description="Row index echoed from the input.")
+    intent_score: int = Field(
+        ...,
+        ge=0,
+        le=1,
+        description="1 if the core meaning/intent is preserved, else 0.",
+    )
+    intent_explanation: str = Field(
+        ..., description="Brief explanation of the intent score."
+    )
+    entity_score: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Fraction (0 to 1) of key entities preserved.",
+    )
+    ground_truth_entities: str = Field(
+        default="",
+        description="Comma-separated list of key entities in the ground truth ('NA' if none).",
+    )
+    preserved_entities: str = Field(
+        default="", description="Comma-separated list of correctly preserved entities."
+    )
+    missing_entities: str = Field(
+        default="",
+        description="Comma-separated list of missing or incorrect entities.",
+    )
+    entity_explanation: str = Field(
+        ..., description="Brief explanation of the entity score."
+    )
+
+
+@backoff.on_exception(backoff.expo, Exception, max_tries=5, factor=2)
+@observe(name="stt_intent_entity_judge", capture_input=False)
+async def intent_entity_judge(
+    reference: str,
+    prediction: str,
+    model: str = DEFAULT_INTENT_ENTITY_MODEL,
+    index: int = 0,
+    context: str = "",
+) -> dict:
+    """Score intent (0/1) and entity (0–1) preservation for one transcription.
+
+    Args:
+        reference: Ground-truth text.
+        prediction: STT hypothesis.
+        model: OpenRouter model id used for grading.
+        index: Row index echoed into the input/output JSON.
+        context: Optional context passed through to the judge.
+
+    Returns:
+        Dict matching :class:`IntentEntityResult` fields.
+    """
+    client = instructor.apatch(_build_openrouter_client())
+
+    # Input shape matches the prompt's "Input Format" JSON object.
+    user_prompt = json.dumps(
+        {
+            "index": index,
+            "hypothesis": prediction,
+            "ground_truth": reference,
+            "context": context,
+        },
+        ensure_ascii=False,
+    )
+
+    response = await client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": INTENT_ENTITY_SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ],
+        response_model=IntentEntityResult,
+        temperature=0,
+        max_completion_tokens=8192,
+    )
+
+    result = response.model_dump()
+
+    log_judge_io(
+        evaluator="intent_entity",
+        model=model,
+        system_prompt=INTENT_ENTITY_SYSTEM_PROMPT,
+        user_input=user_prompt,
+        output=result,
+    )
+
+    if langfuse_enabled and langfuse:
+        langfuse.update_current_trace(
+            input={"reference": reference, "prediction": prediction},
+            output=result,
+            metadata={
+                "reference": reference,
+                "prediction": prediction,
+                "model": model,
+            },
+        )
+
+    return result
+
+
+async def get_intent_entity_score(
+    references: List[str],
+    predictions: List[str],
+    model: str = DEFAULT_INTENT_ENTITY_MODEL,
+) -> dict:
+    """Run the intent/entity judge across all rows and aggregate.
+
+    Returns:
+        {
+            "intent": float,          # pass-rate of intent (mean of 0/1)
+            "entity": float,          # mean entity-preservation fraction
+            "per_row": [ {<IntentEntityResult fields>}, ... ],
+        }
+
+    ``per_row`` order matches the input order (``asyncio.gather`` preserves
+    coroutine order).
+    """
+    coroutines = [
+        intent_entity_judge(str(reference), str(prediction), model=model, index=i)
+        for i, (reference, prediction) in enumerate(zip(references, predictions))
+    ]
+
+    results = await tqdm_asyncio.gather(
+        *coroutines,
+        desc="Running intent/entity judge",
+    )
+
+    intent_values = [float(int(row["intent_score"])) for row in results]
+    entity_values = [
+        float(np.clip(float(row["entity_score"]), 0.0, 1.0)) for row in results
+    ]
+
+    return {
+        "intent": float(np.mean(intent_values)) if intent_values else 0.0,
+        "entity": float(np.mean(entity_values)) if entity_values else 0.0,
+        "per_row": results,
+    }

--- a/calibrate/stt/intent_entity.py
+++ b/calibrate/stt/intent_entity.py
@@ -1,201 +1,27 @@
 """
 Intent & Entity judge for STT transcriptions (support for ``stt/metrics.py``).
 
-This module holds the per-row judge call plus its prompt, model, and result
-schema. The aggregation entry point used by the eval pipeline,
-``get_intent_entity_score``, lives in ``stt/metrics.py`` alongside the other
-metric roots (``get_wer_score``, ``get_cer_score``, ``get_llm_judge_score``).
+This module is a thin wrapper around the vendored Sarvam flow in
+``stt/sarvam_intent_entity/``: it builds the prompt with their ``build_prompt``,
+asks for their ``IntentEntityResponse`` schema, and routes the call through
+calibrate's OpenRouter + ``instructor`` client. The aggregation entry point used
+by the eval pipeline, ``get_intent_entity_score``, lives in ``stt/metrics.py``
+alongside the other metric roots.
 
-Two meaning-preservation metrics are produced per row:
-
-- **intent** — binary (0/1): is the core meaning/intent preserved?
-- **entity** — float (0–1): fraction of key entities preserved.
-
-A single judge call per row returns both scores (faithful to Sarvam's original
-single-prompt design, and half the cost of two separate calls).
-
-The rubric in ``INTENT_ENTITY_SYSTEM_PROMPT`` is adapted from Sarvam AI's
-``llm_intent_entity`` evaluation prompt:
-https://github.com/sarvamai/llm_intent_entity (prompt_template.txt).
-See also: https://www.sarvam.ai/blogs/evaluating-indian-language-asr
+A single judge call per row returns both intent (0/1) and entity (0–1) scores.
 """
-
-import json
 
 import backoff
 import instructor
-from pydantic import BaseModel, Field
 
 from calibrate.judges import _build_openrouter_client, DEFAULT_TEXT_JUDGE_MODEL
 from calibrate.langfuse import observe, langfuse, langfuse_enabled
 from calibrate.utils import log_judge_io
+from calibrate.stt.sarvam_intent_entity import IntentEntityResponse, build_prompt
 
 # Model used to grade intent/entity. The rubric is strict and linguistically
 # nuanced, so a capable model is the default; it matches the text-judge default.
 DEFAULT_INTENT_ENTITY_MODEL = DEFAULT_TEXT_JUDGE_MODEL
-
-
-INTENT_ENTITY_SYSTEM_PROMPT = """# Persona
-You are an expert linguistic evaluation assistant specializing in intent and entity extraction analysis for Indian languages.
-
-# Primary Goal
-Your primary goal is to evaluate how well intent and entities are captured by comparing an ASR (Automatic Speech Recognition) model's output against a provided ground truth sentence. You need to score both intent preservation and entity extraction accuracy.
-
-# Evaluation Guidelines
-
-## TASK 1: Intent Scoring
-Scoring Guidelines for Intent:
-- Score 1 ONLY if the core meaning or intent of the sentence is preserved, which means that the action and subject are preserved.
-- Be EXTREMELY strict in matching intent - even subtle differences that change who is doing what should result in a score of 0:
-    * "No, I can talk to Ajay Gupta" vs "No, I can have you speak with Ajay Gupta" (different actors)
-    * "I need to call him" vs "I need him to call me" (reversed direction of action)
-    * "You should speak to the manager" vs "I should speak to the manager" (different subject)
-    * "Can I help you with that?" vs "Can you help me with that?" (reversed roles)
-- Be strict about questions vs statements - they have fundamentally different intents:
-    * "I will come tomorrow" vs "Can I come tomorrow?" (statement vs question)
-    * "You should open the door" vs "Can you open the door?" (instruction vs request)
-    * "The meeting is at 5" vs "Is the meeting at 5?" (information vs confirmation)
-- Be strict about pronouns - they often change the meaning significantly:
-    * "Can you speak in Malayalam?" is different from "Can we speak in Malayalam?"
-    * "I will do it" is different from "You will do it" or "He will do it"
-    * "My house" is different from "Your house" or "Their house"
-- Score 1 for equivalent acknowledgments/fillers, for example:
-    * "yes" = "yeah" = "hmm" = "aha" = "okay" = "right"
-    * "no" = "nah" = "nope" = "uh-uh"
-- Score 1 for equivalent requests that preserve the core intent:
-    * "Please repeat the question" = "Ask the question again" = "Ask the question" (all request repetition)
-    * "Can you say that again?" = "Please repeat" = "Repeat" (all request repetition)
-    * For short imperative sentences, focus on the core action being requested rather than exact wording
-- Score 1 for repeated words or phrases that convey the same meaning:
-    * "Thank you, thank you" = "Thank you" (repetition for emphasis)
-    * "Yes, yes" = "Yes" (repetition for emphasis)
-- Score 1 for equivalent instructions about language preference:
-    * "Kannada. Speak in Kannada" = "Speak in Kannada" (both instruct to use Kannada)
-    * "[Language name]. Speak in [Language name]" = "Speak in [Language name]"
-- Score 1 if numbers match in meaning, regardless of format:
-    * "twenty five" = "25" = "two five"
-    * "first" = "1st" = "one"
-- Score 1 for minor variations that preserve intent WITHOUT changing subjects or pronouns:
-    * "I agree" = "I agree with that"
-    * "don't know" = "I don't know"
-    * "I agree with that" = "I agree"
-- Score 1 if the ASR model's output is a direct acknowledgement of the ground truth sentence.
-    * "Yes, I will clear the loan immediately." = "Yes."
-- Be EXTREMELY strict with critical personal information - score 0 unless these are preserved EXACTLY:
-    * Proper nouns and names (e.g., "John Smith" vs "Jon Smith")
-    * Dates of birth (e.g., "January 5th, 1980" vs "January 15th, 1980")
-    * Email addresses (e.g., "john@example.com" vs "jon@example.com")
-    * Phone numbers (e.g., "555-123-4567" vs "555-124-4567")
-    * Account numbers, IDs, or any numerical identifiers
-    * Addresses and other location information
-- Score 0 if a statement is changed to a question or vice versa:
-    * "I will come tomorrow" vs "Can I come tomorrow?" (different speech acts)
-    * "He left the office" vs "Did he leave the office?" (statement vs question)
-    * "Close the window" vs "Should I close the window?" (command vs question)
-- Score 0 if pronouns or subjects differ, even slightly:
-    * "Can you help me?" vs "Can we help you?" (different subjects and objects)
-    * "She is coming" vs "I am coming" (different subjects)
-    * "This is my car" vs "This is your car" (different possessive pronouns)
-- Score 0 for any other differences in meaning:
-    * "yes" vs "no"
-    * "three" vs "seven"
-    * "I agree" vs "I disagree"
-- Score 0 if ground truth is completely empty as intent is not preserved.
-
-## TASK 2: Entity Scoring
-Identify and score how well entities are preserved:
-1. First, identify the key entities in the ground truth:
-   - Entities include people, places, organizations, objects, dates, numbers, and specific references.
-   - For short sentences and commands, consider the object of the action as an entity (e.g., in "Please repeat the question", "question" is an entity, in I will come tomorrow, "tomorrow" is an entity)
-   - In short requests or commands, focus on the essential object being referenced (e.g., "Check balance" and "Show balance" both have "balance" as the entity)
-   - Do not include generic words unless essential for understanding.
-   - Be especially careful with pronouns and honorifics in Indic languages as they often represent important entities.
-   - Sentences like "hello, "how are you","mostly yes", "will do it", etc have no entities in such cases output NA and score 1 since there are no entities to preserve
-
-2. Score entity preservation (0 to 1):
-   - Score 1 if ALL key entities from ground truth are correctly present in the ASR output.
-   - Score 0 if NONE of the key entities are preserved correctly.
-   - Score 1 if there is no entity in the ground truth.
-   - For partial preservation, provide a score between 0 and 1 based on:
-     * The fraction of correctly preserved entities.
-     * The importance of preserved vs. missing entities.
-     * Penalize for incorrectly substituted entities (e.g., "John" → "Tom").
-
-3. Pay special attention to Indic language-specific considerations:
-   * Hindi (Pronoun): "मैं कल आऊंगा" (I will come tomorrow) vs "वह कल आएगा" (He will come tomorrow) - Different pronoun completely changes who is coming
-   * Hindi (Subject-object): "राम ने श्याम को देखा" (Ram saw Shyam) vs "श्याम ने राम को देखा" (Shyam saw Ram) - Reversed relationship
-   * Bengali (Named-entity): "আমি কলকাতায় যাব" (I will go to Kolkata) vs "আমি দিল্লীতে যাব" (I will go to Delhi) - Different named entity (place)
-   * Marathi (Tense): "मी जेवलो" (I ate) vs "मी जेवणार" (I will eat) - Different tense
-   * Malayalam (Interrogative-declarative): "നിങ്ങൾ എവിടെ പോകുന്നു?" (Where are you going?) vs "നിങ്ങൾ അവിടെ പോകുന്നു" (You are going there) - Question vs statement
-   * Kannada (Singular-plural): "ಮಗು ಓದುತ್ತಿದೆ" (The child is reading) vs "ಮಕ್ಕಳು ಓದುತ್ತಿದ್ದಾರೆ" (The children are reading) - Singular vs plural
-   * Tamil (Alphanumeric): "என் தொலைபேசி எண் 9876543210" (My phone number is 9876543210) vs "என் தொலைபேசி எண் 9876543211" (My phone number is 9876543211) - Incorrect number
-   * Telugu (Subject-object): "రాము సీతను చూశాడు" (Rama saw Sita) vs "సీత రాముని చూసింది" (Sita saw Rama) - Reversed relationship
-   * Gujarati (Negation): "મને ભૂખ નથી" (I am not hungry) vs "મને ભૂખ છે" (I am hungry) - Missing negation
-   * Odia (Named-entity): "ମୁଁ ଭୁବନେଶ୍ୱରରେ ରହେ" (I live in Bhubaneswar) vs "ମୁଁ କଟକରେ ରହେ" (I live in Cuttack) - Different place name
-   * Punjabi (Tense): "ਮੈਂ ਖਾਧਾ ਸੀ" (I had eaten) vs "ਮੈਂ ਖਾਂਦਾ ਹਾਂ" (I eat) - Different tense
-
-# Input Format:
-You will be given a JSON object with the following structure:
-
-```json
-{
-  "index": int,
-  "hypothesis": str,
-  "ground_truth": str,
-  "context": str
-}
-```
-
-# Output Format
-Your final output must be a single JSON object with the following structure:
-
-```json
-{
-    "index": int,
-    "intent_score": int, // 0 or 1
-    "intent_explanation": str, // Brief explanation of your intent score
-    "entity_score": float, // between 0 and 1
-    "ground_truth_entities": str, // comma-separated list of entities from ground truth
-    "preserved_entities": str, // comma-separated list of correctly preserved entities
-    "missing_entities": str, // comma-separated list of missing or incorrect entities
-    "entity_explanation": str // Brief explanation of your entity score
-}
-```"""
-
-
-class IntentEntityResult(BaseModel):
-    """Combined intent + entity judgement for a single (ground_truth, hypothesis) pair."""
-
-    index: int = Field(default=0, description="Row index echoed from the input.")
-    intent_score: int = Field(
-        ...,
-        ge=0,
-        le=1,
-        description="1 if the core meaning/intent is preserved, else 0.",
-    )
-    intent_explanation: str = Field(
-        ..., description="Brief explanation of the intent score."
-    )
-    entity_score: float = Field(
-        ...,
-        ge=0.0,
-        le=1.0,
-        description="Fraction (0 to 1) of key entities preserved.",
-    )
-    ground_truth_entities: str = Field(
-        default="",
-        description="Comma-separated list of key entities in the ground truth ('NA' if none).",
-    )
-    preserved_entities: str = Field(
-        default="", description="Comma-separated list of correctly preserved entities."
-    )
-    missing_entities: str = Field(
-        default="",
-        description="Comma-separated list of missing or incorrect entities.",
-    )
-    entity_explanation: str = Field(
-        ..., description="Brief explanation of the entity score."
-    )
 
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=5, factor=2)
@@ -210,35 +36,30 @@ async def intent_entity_judge(
     """Score intent (0/1) and entity (0–1) preservation for one transcription.
 
     Args:
-        reference: Ground-truth text.
-        prediction: STT hypothesis.
+        reference: Ground-truth text (already normalized by the caller).
+        prediction: STT hypothesis (already normalized by the caller).
         model: OpenRouter model id used for grading.
         index: Row index echoed into the input/output JSON.
         context: Optional context passed through to the judge.
 
     Returns:
-        Dict matching :class:`IntentEntityResult` fields.
+        Dict matching :class:`IntentEntityResponse` fields.
     """
     client = instructor.apatch(_build_openrouter_client())
 
-    # Input shape matches the prompt's "Input Format" JSON object.
-    user_prompt = json.dumps(
+    prompt = build_prompt(
         {
             "index": index,
             "hypothesis": prediction,
             "ground_truth": reference,
             "context": context,
-        },
-        ensure_ascii=False,
+        }
     )
 
     response = await client.chat.completions.create(
         model=model,
-        messages=[
-            {"role": "system", "content": INTENT_ENTITY_SYSTEM_PROMPT},
-            {"role": "user", "content": user_prompt},
-        ],
-        response_model=IntentEntityResult,
+        messages=[{"role": "user", "content": prompt}],
+        response_model=IntentEntityResponse,
         temperature=0,
         max_completion_tokens=8192,
     )
@@ -248,8 +69,8 @@ async def intent_entity_judge(
     log_judge_io(
         evaluator="intent_entity",
         model=model,
-        system_prompt=INTENT_ENTITY_SYSTEM_PROMPT,
-        user_input=user_prompt,
+        system_prompt="",
+        user_input=prompt,
         output=result,
     )
 

--- a/calibrate/stt/intent_entity.py
+++ b/calibrate/stt/intent_entity.py
@@ -1,13 +1,15 @@
 """
-Intent & Entity preservation scoring for STT transcriptions.
+Intent & Entity judge for STT transcriptions (support for ``stt/metrics.py``).
 
-Two meaning-preservation metrics that are *always* computed for every STT run,
-independent of the user-supplied evaluators, and reported alongside ``wer``:
+This module holds the per-row judge call plus its prompt, model, and result
+schema. The aggregation entry point used by the eval pipeline,
+``get_intent_entity_score``, lives in ``stt/metrics.py`` alongside the other
+metric roots (``get_wer_score``, ``get_cer_score``, ``get_llm_judge_score``).
 
-- **intent** — binary (0/1) per row: is the core meaning/intent preserved?
-  Aggregated as a pass-rate (mean of 0/1).
-- **entity** — float (0–1) per row: fraction of key entities preserved.
-  Aggregated as a mean, like ``wer``.
+Two meaning-preservation metrics are produced per row:
+
+- **intent** — binary (0/1): is the core meaning/intent preserved?
+- **entity** — float (0–1): fraction of key entities preserved.
 
 A single judge call per row returns both scores (faithful to Sarvam's original
 single-prompt design, and half the cost of two separate calls).
@@ -19,13 +21,10 @@ See also: https://www.sarvam.ai/blogs/evaluating-indian-language-asr
 """
 
 import json
-from typing import List
 
 import backoff
 import instructor
-import numpy as np
 from pydantic import BaseModel, Field
-from tqdm.asyncio import tqdm_asyncio
 
 from calibrate.judges import _build_openrouter_client, DEFAULT_TEXT_JUDGE_MODEL
 from calibrate.langfuse import observe, langfuse, langfuse_enabled
@@ -266,42 +265,3 @@ async def intent_entity_judge(
         )
 
     return result
-
-
-async def get_intent_entity_score(
-    references: List[str],
-    predictions: List[str],
-    model: str = DEFAULT_INTENT_ENTITY_MODEL,
-) -> dict:
-    """Run the intent/entity judge across all rows and aggregate.
-
-    Returns:
-        {
-            "intent": float,          # pass-rate of intent (mean of 0/1)
-            "entity": float,          # mean entity-preservation fraction
-            "per_row": [ {<IntentEntityResult fields>}, ... ],
-        }
-
-    ``per_row`` order matches the input order (``asyncio.gather`` preserves
-    coroutine order).
-    """
-    coroutines = [
-        intent_entity_judge(str(reference), str(prediction), model=model, index=i)
-        for i, (reference, prediction) in enumerate(zip(references, predictions))
-    ]
-
-    results = await tqdm_asyncio.gather(
-        *coroutines,
-        desc="Running intent/entity judge",
-    )
-
-    intent_values = [float(int(row["intent_score"])) for row in results]
-    entity_values = [
-        float(np.clip(float(row["entity_score"]), 0.0, 1.0)) for row in results
-    ]
-
-    return {
-        "intent": float(np.mean(intent_values)) if intent_values else 0.0,
-        "entity": float(np.mean(entity_values)) if entity_values else 0.0,
-        "per_row": results,
-    }

--- a/calibrate/stt/metrics.py
+++ b/calibrate/stt/metrics.py
@@ -20,6 +20,11 @@ from calibrate.judges import (
 from calibrate.langfuse import observe, langfuse, langfuse_enabled
 from calibrate.stt import intent_entity
 from calibrate.stt.intent_entity import DEFAULT_INTENT_ENTITY_MODEL
+from calibrate.stt.sarvam_intent_entity import (
+    IndicNormalizer,
+    calculate_intent_accuracy,
+    calculate_entity_metrics,
+)
 
 normalizer = BasicTextNormalizer()
 
@@ -184,29 +189,47 @@ async def get_llm_judge_score(
 async def get_intent_entity_score(
     references: List[str],
     predictions: List[str],
+    language: str = "english",
     model: str = DEFAULT_INTENT_ENTITY_MODEL,
 ) -> dict:
-    """Run the intent/entity judge across all rows and aggregate.
+    """Normalize, judge, and aggregate intent/entity preservation.
 
-    The per-row judge call, prompt, and result schema live in
-    ``stt/intent_entity.py``; this is the metric root invoked by the eval
-    pipeline, mirroring ``get_wer_score`` / ``get_llm_judge_score``.
+    Mirrors Sarvam's flow: reference and prediction are first run through the
+    vendored ``IndicNormalizer``, then each normalized pair is scored by the
+    judge in ``stt/intent_entity.py``. Aggregation uses Sarvam's
+    ``calculate_intent_accuracy`` / ``calculate_entity_metrics``. This is the
+    metric root invoked by the eval pipeline, mirroring ``get_wer_score`` /
+    ``get_llm_judge_score``.
 
     Returns:
         {
-            "intent": float,          # pass-rate of intent (mean of 0/1)
+            "intent": float,          # intent accuracy (mean of 0/1)
             "entity": float,          # mean entity-preservation fraction
-            "per_row": [ {<IntentEntityResult fields>}, ... ],
+            "per_row": [ {<IntentEntityResponse fields>}, ... ],
         }
 
     ``per_row`` order matches the input order (``asyncio.gather`` preserves
     coroutine order).
     """
+    if not references:
+        return {"intent": 0.0, "entity": 0.0, "per_row": []}
+
+    langs = [language] * len(references)
+    normalizer = IndicNormalizer()
+    norm_references = normalizer.normalize_texts(
+        [str(r) for r in references], langs
+    )
+    norm_predictions = normalizer.normalize_texts(
+        [str(p) for p in predictions], langs
+    )
+
     coroutines = [
         intent_entity.intent_entity_judge(
             str(reference), str(prediction), model=model, index=i
         )
-        for i, (reference, prediction) in enumerate(zip(references, predictions))
+        for i, (reference, prediction) in enumerate(
+            zip(norm_references, norm_predictions)
+        )
     ]
 
     results = await tqdm_asyncio.gather(
@@ -214,13 +237,11 @@ async def get_intent_entity_score(
         desc="Running intent/entity judge",
     )
 
-    intent_values = [float(int(row["intent_score"])) for row in results]
-    entity_values = [
-        float(np.clip(float(row["entity_score"]), 0.0, 1.0)) for row in results
-    ]
+    intent_scores = [int(row["intent_score"]) for row in results]
+    entity_scores = [float(row["entity_score"]) for row in results]
 
     return {
-        "intent": float(np.mean(intent_values)) if intent_values else 0.0,
-        "entity": float(np.mean(entity_values)) if entity_values else 0.0,
+        "intent": float(calculate_intent_accuracy(intent_scores)),
+        "entity": float(calculate_entity_metrics(entity_scores)["mean"]),
         "per_row": results,
     }

--- a/calibrate/stt/metrics.py
+++ b/calibrate/stt/metrics.py
@@ -18,6 +18,8 @@ from calibrate.judges import (
     DEFAULT_STT_EVALUATOR,
 )
 from calibrate.langfuse import observe, langfuse, langfuse_enabled
+from calibrate.stt import intent_entity
+from calibrate.stt.intent_entity import DEFAULT_INTENT_ENTITY_MODEL
 
 normalizer = BasicTextNormalizer()
 
@@ -175,5 +177,50 @@ async def get_llm_judge_score(
     return {
         "scores": scores,
         "score": overall_score,
+        "per_row": results,
+    }
+
+
+async def get_intent_entity_score(
+    references: List[str],
+    predictions: List[str],
+    model: str = DEFAULT_INTENT_ENTITY_MODEL,
+) -> dict:
+    """Run the intent/entity judge across all rows and aggregate.
+
+    The per-row judge call, prompt, and result schema live in
+    ``stt/intent_entity.py``; this is the metric root invoked by the eval
+    pipeline, mirroring ``get_wer_score`` / ``get_llm_judge_score``.
+
+    Returns:
+        {
+            "intent": float,          # pass-rate of intent (mean of 0/1)
+            "entity": float,          # mean entity-preservation fraction
+            "per_row": [ {<IntentEntityResult fields>}, ... ],
+        }
+
+    ``per_row`` order matches the input order (``asyncio.gather`` preserves
+    coroutine order).
+    """
+    coroutines = [
+        intent_entity.intent_entity_judge(
+            str(reference), str(prediction), model=model, index=i
+        )
+        for i, (reference, prediction) in enumerate(zip(references, predictions))
+    ]
+
+    results = await tqdm_asyncio.gather(
+        *coroutines,
+        desc="Running intent/entity judge",
+    )
+
+    intent_values = [float(int(row["intent_score"])) for row in results]
+    entity_values = [
+        float(np.clip(float(row["entity_score"]), 0.0, 1.0)) for row in results
+    ]
+
+    return {
+        "intent": float(np.mean(intent_values)) if intent_values else 0.0,
+        "entity": float(np.mean(entity_values)) if entity_values else 0.0,
         "per_row": results,
     }

--- a/calibrate/stt/metrics.py
+++ b/calibrate/stt/metrics.py
@@ -18,9 +18,9 @@ from calibrate.judges import (
     DEFAULT_STT_EVALUATOR,
 )
 from calibrate.langfuse import observe, langfuse, langfuse_enabled
-from calibrate.stt import intent_entity
-from calibrate.stt.intent_entity import DEFAULT_INTENT_ENTITY_MODEL
+from calibrate.stt import sarvam_intent_entity
 from calibrate.stt.sarvam_intent_entity import (
+    DEFAULT_INTENT_ENTITY_MODEL,
     IndicNormalizer,
     calculate_intent_accuracy,
     calculate_entity_metrics,
@@ -196,7 +196,7 @@ async def get_intent_entity_score(
 
     Mirrors Sarvam's flow: reference and prediction are first run through the
     vendored ``IndicNormalizer``, then each normalized pair is scored by the
-    judge in ``stt/intent_entity.py``. Aggregation uses Sarvam's
+    judge in ``stt/sarvam_intent_entity/judge.py``. Aggregation uses Sarvam's
     ``calculate_intent_accuracy`` / ``calculate_entity_metrics``. This is the
     metric root invoked by the eval pipeline, mirroring ``get_wer_score`` /
     ``get_llm_judge_score``.
@@ -224,7 +224,7 @@ async def get_intent_entity_score(
     )
 
     coroutines = [
-        intent_entity.intent_entity_judge(
+        sarvam_intent_entity.intent_entity_judge(
             str(reference), str(prediction), model=model, index=i
         )
         for i, (reference, prediction) in enumerate(

--- a/calibrate/stt/sarvam_intent_entity/__init__.py
+++ b/calibrate/stt/sarvam_intent_entity/__init__.py
@@ -1,0 +1,32 @@
+"""
+Vendored from Sarvam AI's ``llm_intent_entity`` repo (no LICENSE published):
+https://github.com/sarvamai/llm_intent_entity
+
+Kept as close to the upstream source as practical so the intent/entity judge
+flow — prompt, response schema, ``build_prompt``, and the ``IndicNormalizer``
+text normalization — matches how Sarvam computes these scores. Only the parts
+the calibrate STT pipeline uses are included; the upstream Vertex AI client,
+Google Sheets export, and CLI orchestration are omitted.
+
+See also: https://www.sarvam.ai/blogs/evaluating-indian-language-asr
+"""
+
+from .main import IntentEntityResponse, build_prompt, PROMPT_TEMPLATE
+from .utilities import (
+    IndicNormalizer,
+    calculate_intent_accuracy,
+    calculate_entity_metrics,
+    lang_to_code,
+    indic_langs,
+)
+
+__all__ = [
+    "IntentEntityResponse",
+    "build_prompt",
+    "PROMPT_TEMPLATE",
+    "IndicNormalizer",
+    "calculate_intent_accuracy",
+    "calculate_entity_metrics",
+    "lang_to_code",
+    "indic_langs",
+]

--- a/calibrate/stt/sarvam_intent_entity/__init__.py
+++ b/calibrate/stt/sarvam_intent_entity/__init__.py
@@ -12,6 +12,7 @@ See also: https://www.sarvam.ai/blogs/evaluating-indian-language-asr
 """
 
 from .main import IntentEntityResponse, build_prompt, PROMPT_TEMPLATE
+from .judge import intent_entity_judge, DEFAULT_INTENT_ENTITY_MODEL
 from .utilities import (
     IndicNormalizer,
     calculate_intent_accuracy,
@@ -24,6 +25,8 @@ __all__ = [
     "IntentEntityResponse",
     "build_prompt",
     "PROMPT_TEMPLATE",
+    "intent_entity_judge",
+    "DEFAULT_INTENT_ENTITY_MODEL",
     "IndicNormalizer",
     "calculate_intent_accuracy",
     "calculate_entity_metrics",

--- a/calibrate/stt/sarvam_intent_entity/judge.py
+++ b/calibrate/stt/sarvam_intent_entity/judge.py
@@ -1,12 +1,11 @@
 """
-Intent & Entity judge for STT transcriptions (support for ``stt/metrics.py``).
+Per-row intent/entity judge.
 
-This module is a thin wrapper around the vendored Sarvam flow in
-``stt/sarvam_intent_entity/``: it builds the prompt with their ``build_prompt``,
-asks for their ``IntentEntityResponse`` schema, and routes the call through
-calibrate's OpenRouter + ``instructor`` client. The aggregation entry point used
-by the eval pipeline, ``get_intent_entity_score``, lives in ``stt/metrics.py``
-alongside the other metric roots.
+A thin wrapper over the vendored prompt/schema in this package: it builds the
+prompt with ``build_prompt``, asks for the ``IntentEntityResponse`` schema, and
+routes the call through calibrate's OpenRouter + ``instructor`` client. The
+aggregation entry point used by the eval pipeline, ``get_intent_entity_score``,
+lives in ``stt/metrics.py`` alongside the other metric roots.
 
 A single judge call per row returns both intent (0/1) and entity (0–1) scores.
 """
@@ -17,7 +16,7 @@ import instructor
 from calibrate.judges import _build_openrouter_client
 from calibrate.langfuse import observe, langfuse, langfuse_enabled
 from calibrate.utils import log_judge_io
-from calibrate.stt.sarvam_intent_entity import IntentEntityResponse, build_prompt
+from calibrate.stt.sarvam_intent_entity.main import IntentEntityResponse, build_prompt
 
 # Model used to grade intent/entity. Matches Sarvam's llm_intent_entity flow,
 # which judges with google/gemini-2.5-flash (reached here via OpenRouter).

--- a/calibrate/stt/sarvam_intent_entity/main.py
+++ b/calibrate/stt/sarvam_intent_entity/main.py
@@ -1,0 +1,47 @@
+"""
+Prompt + response schema for the intent/entity judge.
+
+Vendored from Sarvam AI's ``llm_intent_entity`` (src/llm_intent_entity/main.py).
+The prompt is read from the sibling ``prompt_template.txt`` rather than the
+upstream project root.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from pydantic import BaseModel
+
+PROMPT_PATH = Path(__file__).parent / "prompt_template.txt"
+
+try:
+    PROMPT_TEMPLATE = PROMPT_PATH.read_text()
+except FileNotFoundError:
+    raise FileNotFoundError(
+        f"prompt_template.txt not found at {PROMPT_PATH}. "
+        "Please ensure it exists alongside main.py."
+    )
+
+
+class IntentEntityResponse(BaseModel):
+    index: int
+    intent_score: int
+    intent_explanation: str
+    entity_score: float
+    ground_truth_entities: str
+    preserved_entities: str
+    missing_entities: str
+    entity_explanation: str
+
+
+def build_prompt(item: Dict[str, Any]) -> str:
+    """Build prompt for intent entity evaluation"""
+    prompt = PROMPT_TEMPLATE + "\n\n**INPUT:**\n"
+    json_object = {
+        "index": item["index"],
+        "hypothesis": item["hypothesis"],
+        "ground_truth": item["ground_truth"],
+        "context": item.get("context", ""),
+    }
+    prompt += json.dumps(json_object, indent=2, ensure_ascii=False)
+    return prompt

--- a/calibrate/stt/sarvam_intent_entity/prompt_template.txt
+++ b/calibrate/stt/sarvam_intent_entity/prompt_template.txt
@@ -1,0 +1,126 @@
+# Persona
+You are an expert linguistic evaluation assistant specializing in intent and entity extraction analysis for Indian languages.
+
+# Primary Goal
+Your primary goal is to evaluate how well intent and entities are captured by comparing an ASR (Automatic Speech Recognition) model's output against a provided ground truth sentence. You need to score both intent preservation and entity extraction accuracy.
+
+# Evaluation Guidelines
+
+## TASK 1: Intent Scoring
+Scoring Guidelines for Intent:
+- Score 1 ONLY if the core meaning or intent of the sentence is preserved, which means that the action and subject are preserved.
+- Be EXTREMELY strict in matching intent - even subtle differences that change who is doing what should result in a score of 0:
+    * "No, I can talk to Ajay Gupta" vs "No, I can have you speak with Ajay Gupta" (different actors)
+    * "I need to call him" vs "I need him to call me" (reversed direction of action)
+    * "You should speak to the manager" vs "I should speak to the manager" (different subject)
+    * "Can I help you with that?" vs "Can you help me with that?" (reversed roles)
+- Be strict about questions vs statements - they have fundamentally different intents:
+    * "I will come tomorrow" vs "Can I come tomorrow?" (statement vs question)
+    * "You should open the door" vs "Can you open the door?" (instruction vs request)
+    * "The meeting is at 5" vs "Is the meeting at 5?" (information vs confirmation)
+- Be strict about pronouns - they often change the meaning significantly:
+    * "Can you speak in Malayalam?" is different from "Can we speak in Malayalam?"
+    * "I will do it" is different from "You will do it" or "He will do it"
+    * "My house" is different from "Your house" or "Their house"
+- Score 1 for equivalent acknowledgments/fillers, for example:
+    * "yes" = "yeah" = "hmm" = "aha" = "okay" = "right"
+    * "no" = "nah" = "nope" = "uh-uh"
+- Score 1 for equivalent requests that preserve the core intent:
+    * "Please repeat the question" = "Ask the question again" = "Ask the question" (all request repetition)
+    * "Can you say that again?" = "Please repeat" = "Repeat" (all request repetition)
+    * For short imperative sentences, focus on the core action being requested rather than exact wording
+- Score 1 for repeated words or phrases that convey the same meaning:
+    * "Thank you, thank you" = "Thank you" (repetition for emphasis)
+    * "Yes, yes" = "Yes" (repetition for emphasis)
+- Score 1 for equivalent instructions about language preference:
+    * "Kannada. Speak in Kannada" = "Speak in Kannada" (both instruct to use Kannada)
+    * "[Language name]. Speak in [Language name]" = "Speak in [Language name]"
+- Score 1 if numbers match in meaning, regardless of format:
+    * "twenty five" = "25" = "two five"
+    * "first" = "1st" = "one"
+- Score 1 for minor variations that preserve intent WITHOUT changing subjects or pronouns:
+    * "I agree" = "I agree with that" 
+    * "don't know" = "I don't know"
+    * "I agree with that" = "I agree"
+- Score 1 if the ASR model's output is a direct acknowledgement of the ground truth sentence.
+    * "Yes, I will clear the loan immediately." = "Yes." 
+- Be EXTREMELY strict with critical personal information - score 0 unless these are preserved EXACTLY:
+    * Proper nouns and names (e.g., "John Smith" vs "Jon Smith")
+    * Dates of birth (e.g., "January 5th, 1980" vs "January 15th, 1980")
+    * Email addresses (e.g., "john@example.com" vs "jon@example.com")
+    * Phone numbers (e.g., "555-123-4567" vs "555-124-4567")
+    * Account numbers, IDs, or any numerical identifiers
+    * Addresses and other location information
+- Score 0 if a statement is changed to a question or vice versa:
+    * "I will come tomorrow" vs "Can I come tomorrow?" (different speech acts)
+    * "He left the office" vs "Did he leave the office?" (statement vs question)
+    * "Close the window" vs "Should I close the window?" (command vs question)
+- Score 0 if pronouns or subjects differ, even slightly:
+    * "Can you help me?" vs "Can we help you?" (different subjects and objects)
+    * "She is coming" vs "I am coming" (different subjects)
+    * "This is my car" vs "This is your car" (different possessive pronouns)
+- Score 0 for any other differences in meaning:
+    * "yes" vs "no"
+    * "three" vs "seven" 
+    * "I agree" vs "I disagree"
+- Score 0 if ground truth is completely empty as intent is not preserved.
+
+## TASK 2: Entity Scoring
+Identify and score how well entities are preserved:
+1. First, identify the key entities in the ground truth:
+   - Entities include people, places, organizations, objects, dates, numbers, and specific references.
+   - For short sentences and commands, consider the object of the action as an entity (e.g., in "Please repeat the question", "question" is an entity, in I will come tomorrow, "tomorrow" is an entity)
+   - In short requests or commands, focus on the essential object being referenced (e.g., "Check balance" and "Show balance" both have "balance" as the entity)
+   - Do not include generic words unless essential for understanding.
+   - Be especially careful with pronouns and honorifics in Indic languages as they often represent important entities.
+   - Sentences like "hello, "how are you","mostly yes", "will do it", etc have no entities in such cases output NA and score 1 since there are no entities to preserve
+
+2. Score entity preservation (0 to 1):
+   - Score 1 if ALL key entities from ground truth are correctly present in the ASR output.
+   - Score 0 if NONE of the key entities are preserved correctly.
+   - Score 1 if there is no entity in the ground truth.
+   - For partial preservation, provide a score between 0 and 1 based on:
+     * The fraction of correctly preserved entities.
+     * The importance of preserved vs. missing entities.
+     * Penalize for incorrectly substituted entities (e.g., "John" → "Tom").
+
+3. Pay special attention to Indic language-specific considerations:
+   * Hindi (Pronoun): "मैं कल आऊंगा" (I will come tomorrow) vs "वह कल आएगा" (He will come tomorrow) - Different pronoun completely changes who is coming
+   * Hindi (Subject-object): "राम ने श्याम को देखा" (Ram saw Shyam) vs "श्याम ने राम को देखा" (Shyam saw Ram) - Reversed relationship
+   * Bengali (Named-entity): "আমি কলকাতায় যাব" (I will go to Kolkata) vs "আমি দিল্লীতে যাব" (I will go to Delhi) - Different named entity (place)
+   * Marathi (Tense): "मी जेवलो" (I ate) vs "मी जेवणार" (I will eat) - Different tense
+   * Malayalam (Interrogative-declarative): "നിങ്ങൾ എവിടെ പോകുന്നു?" (Where are you going?) vs "നിങ്ങൾ അവിടെ പോകുന്നു" (You are going there) - Question vs statement
+   * Kannada (Singular-plural): "ಮಗು ಓದುತ್ತಿದೆ" (The child is reading) vs "ಮಕ್ಕಳು ಓದುತ್ತಿದ್ದಾರೆ" (The children are reading) - Singular vs plural
+   * Tamil (Alphanumeric): "என் தொலைபேசி எண் 9876543210" (My phone number is 9876543210) vs "என் தொலைபேசி எண் 9876543211" (My phone number is 9876543211) - Incorrect number
+   * Telugu (Subject-object): "రాము సీతను చూశాడు" (Rama saw Sita) vs "సీత రాముని చూసింది" (Sita saw Rama) - Reversed relationship
+   * Gujarati (Negation): "મને ભૂખ નથી" (I am not hungry) vs "મને ભૂખ છે" (I am hungry) - Missing negation
+   * Odia (Named-entity): "ମୁଁ ଭୁବନେଶ୍ୱରରେ ରହେ" (I live in Bhubaneswar) vs "ମୁଁ କଟକରେ ରହେ" (I live in Cuttack) - Different place name
+   * Punjabi (Tense): "ਮੈਂ ਖਾਧਾ ਸੀ" (I had eaten) vs "ਮੈਂ ਖਾਂਦਾ ਹਾਂ" (I eat) - Different tense
+
+# Input Format:
+You will be given a JSON object with the following structure:
+
+```json
+{
+  "index": int,
+  "hypothesis": str,
+  "ground_truth": str,
+  "context": str
+}
+```
+
+# Output Format
+Your final output must be a single JSON object with the following structure:
+
+```json
+{
+    "index": int,
+    "intent_score": int, // 0 or 1
+    "intent_explanation": str, // Brief explanation of your intent score
+    "entity_score": float, // between 0 and 1
+    "ground_truth_entities": str, // comma-separated list of entities from ground truth
+    "preserved_entities": str, // comma-separated list of correctly preserved entities
+    "missing_entities": str, // comma-separated list of missing or incorrect entities
+    "entity_explanation": str // Brief explanation of your entity score
+}
+```

--- a/calibrate/stt/sarvam_intent_entity/utilities.py
+++ b/calibrate/stt/sarvam_intent_entity/utilities.py
@@ -1,0 +1,125 @@
+"""
+Text normalization + score aggregation helpers.
+
+Vendored from Sarvam AI's ``llm_intent_entity`` (src/llm_intent_entity/utilities.py).
+Only the pieces the calibrate intent/entity flow uses are kept: the
+``IndicNormalizer`` (applied to reference/prediction before judging) and the
+``calculate_intent_accuracy`` / ``calculate_entity_metrics`` aggregators. The
+upstream Google Sheets export and ``IndicASRPostProcessor`` are omitted.
+"""
+
+import re
+import string
+from typing import List, Tuple
+
+import numpy as np
+import pandas as pd
+from indicnlp.normalize.indic_normalize import IndicNormalizerFactory
+from joblib import Parallel, delayed
+from tqdm import tqdm
+from transformers import WhisperProcessor
+
+lang_to_code = {
+    "hindi": "hi",
+    "bengali": "bn",
+    "tamil": "ta",
+    "telugu": "te",
+    "gujarati": "gu",
+    "kannada": "kn",
+    "malayalam": "ml",
+    "marathi": "mr",
+    "odia": "or",
+    "oria": "or",
+    "assamese": "or",
+    "punjabi": "pa",
+    "english": "en",
+}
+
+indic_langs = {"hi", "bn", "ta", "te", "gu", "kn", "ml", "mr", "or", "pa"}
+
+
+class IndicNormalizer:
+    def __init__(self):
+        self.indic_factory = IndicNormalizerFactory()
+        self.whisper_processor = WhisperProcessor.from_pretrained("openai/whisper-small")
+        self.whisper_tokenizer = self.whisper_processor.tokenizer  # type: ignore
+
+    def normalize_text(self, text: str, lang_code: str) -> str:
+        lang_code = lang_to_code.get(lang_code, lang_code)
+        if pd.isna(text) or not isinstance(text, str):
+            return text
+        if not text:
+            return text
+        base_lang = lang_code.split("-")[0].lower()
+        text = re.sub(r"([,\-\.\(\)\[\]\{\}/\\])\B", r" ", text)
+        INDIC_PUNCTUATION = "।॥॰''\"‛‟′″´˝^°¤।॥॰¯'—–‑°¬´ۭ۪\u200b\u200c\u200d\u200e\u200f"
+        text = text.translate(
+            str.maketrans("", "", string.punctuation + INDIC_PUNCTUATION)
+        ).lower()
+
+        if base_lang in indic_langs and base_lang != "ur":  # urdu has special handling
+            normalizer = self.indic_factory.get_normalizer(base_lang)
+            text = normalizer.normalize(text)
+        else:
+            text = self.whisper_tokenizer.normalize(text)
+        text = re.sub(" +", " ", text).strip()
+        return text
+
+    def _normalize_batch(
+        self, text_batch: List[str], lang_batch: List[str]
+    ) -> List[str]:
+        return [
+            self.normalize_text(text, lang)
+            for text, lang in zip(text_batch, lang_batch)
+        ]
+
+    def normalize_texts(
+        self,
+        text_list: List[str],
+        lang_list: List[str],
+        n_jobs: int = -1,
+        batch_size: int = 500,
+    ) -> List[str]:
+        if len(text_list) != len(lang_list):
+            raise ValueError("text_list and lang_list must have the same length")
+
+        if not text_list:
+            return []
+
+        batches: List[Tuple[List[str], List[str]]] = []
+        for i in range(0, len(text_list), batch_size):
+            batches.append((text_list[i : i + batch_size], lang_list[i : i + batch_size]))
+
+        processed_batches = Parallel(n_jobs=n_jobs)(
+            delayed(self._normalize_batch)(text_batch, lang_batch)
+            for text_batch, lang_batch in tqdm(
+                batches, desc="Normalizing text batches"
+            )
+        )
+
+        if processed_batches:
+            return [item for sublist in processed_batches for item in sublist]  # type: ignore
+        return []
+
+
+# METRICS FOR INTENT AND ENTITY EVALUATION
+
+
+def calculate_intent_accuracy(intent_scores: List[int]) -> float:
+    """Calculate accuracy for intent scores (0 or 1)"""
+    if not intent_scores:
+        return 0.0
+    return sum(intent_scores) / len(intent_scores)
+
+
+def calculate_entity_metrics(entity_scores: List[float]) -> dict:
+    """Calculate metrics for entity scores (0 to 1)"""
+    if not entity_scores:
+        return {"mean": 0.0, "median": 0.0, "std": 0.0}
+
+    entity_scores_array = np.array(entity_scores)
+    return {
+        "mean": float(np.mean(entity_scores_array)),
+        "median": float(np.median(entity_scores_array)),
+        "std": float(np.std(entity_scores_array)),
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,10 @@ dependencies = [
     "backoff>=2.2.1",
     "elevenlabs>=2.31.0",
     "evaluate>=0.4.6",
+    "indic-nlp-library>=0.92",
     "instructor>=1.13.0",
     "jiwer>=4.0.0",
+    "joblib>=1.3.0",
     "langfuse==3.3.0",
     "matplotlib>=3.10.7",
     "natsort>=8.4.0",
@@ -69,6 +71,7 @@ exclude = ["ui*", "examples*", "docs*", "images*"]
 [tool.setuptools.package-data]
 "calibrate" = [
     "ui/cli.bundle.mjs",
+    "stt/sarvam_intent_entity/prompt_template.txt",
 ]
 
 [tool.setuptools_scm]

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -287,8 +287,8 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             self.assertIn("wer", metrics)
             self.assertIn("semantic_match", metrics)
             # Intent + entity are always reported as top-level floats.
-            self.assertEqual(metrics["intent"], 1.0)
-            self.assertEqual(metrics["entity"], 1.0)
+            self.assertEqual(metrics["sarvam_intent_score"], 1.0)
+            self.assertEqual(metrics["sarvam_entity_score"], 1.0)
             self.assertTrue((out / "metrics.json").exists())
             self.assertTrue((out / "results.csv").exists())
             df = pd.read_csv(out / "results.csv")
@@ -299,10 +299,10 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                     "gt",
                     "pred",
                     "wer",
-                    "intent",
-                    "intent_reasoning",
-                    "entity",
-                    "entity_reasoning",
+                    "sarvam_intent_score",
+                    "sarvam_intent_reasoning",
+                    "sarvam_entity_score",
+                    "sarvam_entity_reasoning",
                     "semantic_match",
                     "semantic_match_reasoning",
                 }
@@ -346,12 +346,12 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                 )
 
             # Even with a user-supplied evaluator, intent/entity still report.
-            self.assertEqual(metrics["intent"], 0.0)
-            self.assertEqual(metrics["entity"], 0.25)
+            self.assertEqual(metrics["sarvam_intent_score"], 0.0)
+            self.assertEqual(metrics["sarvam_entity_score"], 0.25)
             self.assertIn("completeness", metrics)
             df = pd.read_csv(out / "results.csv")
-            self.assertEqual(df.iloc[0]["intent"], 0)
-            self.assertEqual(df.iloc[0]["entity"], 0.25)
+            self.assertEqual(df.iloc[0]["sarvam_intent_score"], 0)
+            self.assertEqual(df.iloc[0]["sarvam_entity_score"], 0.25)
 
     async def test_rating_evaluator_writes_numeric_score(self):
         from calibrate.stt import eval as stt_eval

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -229,6 +229,30 @@ class TestTranscribeAudioRouter(unittest.IsolatedAsyncioTestCase):
         fake.assert_awaited_once()
 
 
+def _fake_intent_entity(intent=1, entity=1.0):
+    """Build a fake ``get_intent_entity_score`` returning fixed scores per row."""
+
+    async def _fn(refs, preds, model=None):
+        return {
+            "intent": float(intent),
+            "entity": float(entity),
+            "per_row": [
+                {
+                    "intent_score": intent,
+                    "intent_explanation": "ok",
+                    "entity_score": entity,
+                    "ground_truth_entities": "NA",
+                    "preserved_entities": "NA",
+                    "missing_entities": "",
+                    "entity_explanation": "ok",
+                }
+                for _ in refs
+            ],
+        }
+
+    return AsyncMock(side_effect=_fn)
+
+
 class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
     async def test_writes_metrics_and_results(self):
         from calibrate.stt import eval as stt_eval
@@ -249,6 +273,8 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             out = Path(tmp)
             with patch.object(
                 stt_eval, "get_llm_judge_score", AsyncMock(side_effect=fake_judge)
+            ), patch.object(
+                stt_eval, "get_intent_entity_score", _fake_intent_entity(1, 1.0)
             ):
                 metrics = await stt_eval._score_and_write_results(
                     ids=["1", "2"],
@@ -260,6 +286,9 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
 
             self.assertIn("wer", metrics)
             self.assertIn("semantic_match", metrics)
+            # Intent + entity are always reported as top-level floats.
+            self.assertEqual(metrics["intent"], 1.0)
+            self.assertEqual(metrics["entity"], 1.0)
             self.assertTrue((out / "metrics.json").exists())
             self.assertTrue((out / "results.csv").exists())
             df = pd.read_csv(out / "results.csv")
@@ -270,11 +299,59 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                     "gt",
                     "pred",
                     "wer",
+                    "intent",
+                    "intent_reasoning",
+                    "entity",
+                    "entity_reasoning",
                     "semantic_match",
                     "semantic_match_reasoning",
                 }
             )
             self.assertEqual(len(df), 2)
+
+    async def test_intent_entity_always_present_with_custom_evaluators(self):
+        from calibrate.stt import eval as stt_eval
+
+        custom = [
+            {
+                "name": "completeness",
+                "system_prompt": "nothing missing",
+                "judge_model": "openai/gpt-4.1",
+            }
+        ]
+
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+            return {
+                "scores": {"completeness": {"type": "binary", "mean": 0.5}},
+                "score": 0.5,
+                "per_row": [
+                    {"completeness": {"match": True, "reasoning": "ok"}} for _ in refs
+                ],
+            }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            with patch.object(
+                stt_eval, "get_llm_judge_score", AsyncMock(side_effect=fake_judge)
+            ), patch.object(
+                stt_eval, "get_intent_entity_score", _fake_intent_entity(0, 0.25)
+            ):
+                metrics = await stt_eval._score_and_write_results(
+                    ids=["a"],
+                    gt_transcripts=["hi"],
+                    pred_transcripts=["bye"],
+                    output_dir=str(out),
+                    evaluator_config_dir=str(out),
+                    judge_evaluators=custom,
+                )
+
+            # Even with a user-supplied evaluator, intent/entity still report.
+            self.assertEqual(metrics["intent"], 0.0)
+            self.assertEqual(metrics["entity"], 0.25)
+            self.assertIn("completeness", metrics)
+            df = pd.read_csv(out / "results.csv")
+            self.assertEqual(df.iloc[0]["intent"], 0)
+            self.assertEqual(df.iloc[0]["entity"], 0.25)
 
     async def test_rating_evaluator_writes_numeric_score(self):
         from calibrate.stt import eval as stt_eval
@@ -308,6 +385,8 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             out = Path(tmp)
             with patch.object(
                 stt_eval, "get_llm_judge_score", AsyncMock(side_effect=fake_judge)
+            ), patch.object(
+                stt_eval, "get_intent_entity_score", _fake_intent_entity(1, 1.0)
             ):
                 await stt_eval._score_and_write_results(
                     ids=["1"],
@@ -349,6 +428,8 @@ class TestSTTRunEvalOnly(unittest.IsolatedAsyncioTestCase):
 
             with patch.object(
                 stt_eval, "get_llm_judge_score", AsyncMock(side_effect=fake_judge)
+            ), patch.object(
+                stt_eval, "get_intent_entity_score", _fake_intent_entity(1, 1.0)
             ):
                 result = await stt_eval.run_eval_only(
                     dataset_path=str(ds_path),

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -232,7 +232,7 @@ class TestTranscribeAudioRouter(unittest.IsolatedAsyncioTestCase):
 def _fake_intent_entity(intent=1, entity=1.0):
     """Build a fake ``get_intent_entity_score`` returning fixed scores per row."""
 
-    async def _fn(refs, preds, model=None):
+    async def _fn(refs, preds, language="english", model=None):
         return {
             "intent": float(intent),
             "entity": float(entity),

--- a/tests/stt/test_eval_extra.py
+++ b/tests/stt/test_eval_extra.py
@@ -16,7 +16,7 @@ import pandas as pd
 def _fake_intent_entity(intent=1, entity=1.0):
     """Adaptive ``get_intent_entity_score`` mock — one row per input pair."""
 
-    async def _fn(refs, preds, model=None):
+    async def _fn(refs, preds, language="english", model=None):
         return {
             "intent": float(intent),
             "entity": float(entity),

--- a/tests/stt/test_eval_extra.py
+++ b/tests/stt/test_eval_extra.py
@@ -13,6 +13,27 @@ from unittest.mock import patch, AsyncMock, MagicMock
 import pandas as pd
 
 
+def _fake_intent_entity(intent=1, entity=1.0):
+    """Adaptive ``get_intent_entity_score`` mock — one row per input pair."""
+
+    async def _fn(refs, preds, model=None):
+        return {
+            "intent": float(intent),
+            "entity": float(entity),
+            "per_row": [
+                {
+                    "intent_score": intent,
+                    "intent_explanation": "ok",
+                    "entity_score": entity,
+                    "entity_explanation": "ok",
+                }
+                for _ in refs
+            ],
+        }
+
+    return AsyncMock(side_effect=_fn)
+
+
 # --- load_audio -----------------------------------------------------------
 
 class TestLoadAudio(unittest.TestCase):
@@ -281,6 +302,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
         with tempfile.TemporaryDirectory() as tmp:
             with patch.object(E, "get_wer_score", return_value={"score": 0.1, "per_row": [0.1, 0.1]}), \
                  patch.object(E, "get_cer_score", return_value={"score": 0.2, "per_row": [0.2, 0.2]}), \
+                 patch.object(E, "get_intent_entity_score", _fake_intent_entity()), \
                  patch.object(E, "get_llm_judge_score", AsyncMock(return_value={
                      "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                      "per_row": [
@@ -314,6 +336,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
         with tempfile.TemporaryDirectory() as tmp, \
              patch.object(E, "get_wer_score", return_value={"score": 0.05, "per_row": [0.05]}), \
              patch.object(E, "get_cer_score", return_value={"score": 0.03, "per_row": [0.03]}), \
+             patch.object(E, "get_intent_entity_score", _fake_intent_entity()), \
              patch.object(E, "get_llm_judge_score", AsyncMock(return_value={
                  "scores": {"r": {"type": "rating", "mean": 4.0, "scale_min": 1, "scale_max": 5}},
                  "per_row": [{"r": {"score": 4, "reasoning": "ok"}}],
@@ -350,6 +373,7 @@ class TestRunEvalOnly(unittest.IsolatedAsyncioTestCase):
             out = Path(tmp) / "out"
             with patch.object(E, "get_wer_score", return_value={"score": 0.1, "per_row": [0.1, 0.1]}), \
                  patch.object(E, "get_cer_score", return_value={"score": 0.2, "per_row": [0.2, 0.2]}), \
+                 patch.object(E, "get_intent_entity_score", _fake_intent_entity()), \
                  patch.object(E, "get_llm_judge_score", AsyncMock(return_value={
                      "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                      "per_row": [
@@ -415,6 +439,7 @@ class TestRunSingleProviderEval(unittest.IsolatedAsyncioTestCase):
             with patch.object(E, "transcribe_audio", AsyncMock(return_value="hello")), \
                  patch.object(E, "get_wer_score", return_value={"score": 0.0, "per_row": [0.0]}), \
                  patch.object(E, "get_cer_score", return_value={"score": 0.0, "per_row": [0.0]}), \
+                 patch.object(E, "get_intent_entity_score", _fake_intent_entity()), \
                  patch.object(E, "get_llm_judge_score", AsyncMock(return_value={
                      "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                      "per_row": [{"semantic_match": {"match": True, "reasoning": "ok"}}],
@@ -476,6 +501,7 @@ class TestRunSingleProviderEval(unittest.IsolatedAsyncioTestCase):
             with patch.object(E, "transcribe_audio", AsyncMock(return_value="hello")), \
                  patch.object(E, "get_wer_score", return_value={"score": 0.0, "per_row": [0.0]}), \
                  patch.object(E, "get_cer_score", return_value={"score": 0.0, "per_row": [0.0]}), \
+                 patch.object(E, "get_intent_entity_score", _fake_intent_entity()), \
                  patch.object(E, "get_llm_judge_score", AsyncMock(return_value={
                      "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                      "per_row": [{"semantic_match": {"match": True, "reasoning": "ok"}}],

--- a/tests/stt/test_eval_more.py
+++ b/tests/stt/test_eval_more.py
@@ -10,6 +10,27 @@ from unittest.mock import patch, AsyncMock, MagicMock
 import pandas as pd
 
 
+def _fake_intent_entity(intent=1, entity=1.0):
+    """Adaptive ``get_intent_entity_score`` mock — one row per input pair."""
+
+    async def _fn(refs, preds, model=None):
+        return {
+            "intent": float(intent),
+            "entity": float(entity),
+            "per_row": [
+                {
+                    "intent_score": intent,
+                    "intent_explanation": "ok",
+                    "entity_score": entity,
+                    "entity_explanation": "ok",
+                }
+                for _ in refs
+            ],
+        }
+
+    return AsyncMock(side_effect=_fn)
+
+
 class TestValidateSTTInputDirEdges(unittest.TestCase):
     def test_input_path_not_directory(self):
         from calibrate.stt.eval import validate_stt_input_dir
@@ -85,6 +106,7 @@ class TestRunSinglProviderEvalProgressNoChange(unittest.IsolatedAsyncioTestCase)
                               return_value={"score": 0.0, "per_row": [0.0, 0.0]}), \
                  patch.object(E, "get_cer_score",
                               return_value={"score": 0.0, "per_row": [0.0, 0.0]}), \
+                 patch.object(E, "get_intent_entity_score", _fake_intent_entity()), \
                  patch.object(E, "get_llm_judge_score", AsyncMock(return_value={
                      "scores": {"semantic_match": {"type": "binary", "mean": 0.5}},
                      "per_row": [
@@ -131,6 +153,7 @@ class TestRunSinglProviderEvalAlreadyAllProcessed(unittest.IsolatedAsyncioTestCa
                               return_value={"score": 0.0, "per_row": [0.0]}), \
                  patch.object(E, "get_cer_score",
                               return_value={"score": 0.0, "per_row": [0.0]}), \
+                 patch.object(E, "get_intent_entity_score", _fake_intent_entity()), \
                  patch.object(E, "get_llm_judge_score", AsyncMock(return_value={
                      "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                      "per_row": [{"semantic_match": {"match": True, "reasoning": "ok"}}],

--- a/tests/stt/test_eval_more.py
+++ b/tests/stt/test_eval_more.py
@@ -13,7 +13,7 @@ import pandas as pd
 def _fake_intent_entity(intent=1, entity=1.0):
     """Adaptive ``get_intent_entity_score`` mock — one row per input pair."""
 
-    async def _fn(refs, preds, model=None):
+    async def _fn(refs, preds, language="english", model=None):
         return {
             "intent": float(intent),
             "entity": float(entity),

--- a/tests/stt/test_intent_entity.py
+++ b/tests/stt/test_intent_entity.py
@@ -1,0 +1,74 @@
+"""
+Tests for calibrate/stt/intent_entity.py — intent/entity judge aggregation.
+
+Run with:
+    python -m unittest tests.stt.test_intent_entity -v
+"""
+
+import unittest
+from unittest.mock import patch, AsyncMock
+
+
+def _row(intent, entity):
+    return {
+        "intent_score": intent,
+        "intent_explanation": "because",
+        "entity_score": entity,
+        "ground_truth_entities": "x",
+        "preserved_entities": "x" if entity else "",
+        "missing_entities": "" if entity else "x",
+        "entity_explanation": "because",
+    }
+
+
+class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
+    async def test_aggregates_intent_as_passrate_and_entity_as_mean(self):
+        from calibrate.stt import intent_entity as ie
+
+        # Return per (reference, prediction): order preserved by gather.
+        async def fake_judge(reference, prediction, model=None, index=0, context=""):
+            mapping = {
+                ("a", "a"): _row(1, 1.0),
+                ("b", "x"): _row(0, 0.5),
+            }
+            return mapping[(reference, prediction)]
+
+        with patch.object(ie, "intent_entity_judge", AsyncMock(side_effect=fake_judge)):
+            result = await ie.get_intent_entity_score(
+                references=["a", "b"],
+                predictions=["a", "x"],
+            )
+
+        self.assertEqual(result["intent"], 0.5)  # one 1, one 0
+        self.assertEqual(result["entity"], 0.75)  # mean(1.0, 0.5)
+        self.assertEqual(len(result["per_row"]), 2)
+
+    async def test_entity_score_clamped_to_unit_interval(self):
+        from calibrate.stt import intent_entity as ie
+
+        async def fake_judge(reference, prediction, model=None, index=0, context=""):
+            # A misbehaving judge returns out-of-range entity scores.
+            return _row(1, 1.7) if reference == "hi" else _row(1, -0.3)
+
+        with patch.object(ie, "intent_entity_judge", AsyncMock(side_effect=fake_judge)):
+            result = await ie.get_intent_entity_score(
+                references=["hi", "lo"],
+                predictions=["hi", "lo"],
+            )
+
+        # 1.7 -> 1.0 and -0.3 -> 0.0; mean = 0.5
+        self.assertEqual(result["entity"], 0.5)
+
+    async def test_empty_inputs(self):
+        from calibrate.stt import intent_entity as ie
+
+        with patch.object(ie, "intent_entity_judge", AsyncMock()):
+            result = await ie.get_intent_entity_score(references=[], predictions=[])
+
+        self.assertEqual(result["intent"], 0.0)
+        self.assertEqual(result["entity"], 0.0)
+        self.assertEqual(result["per_row"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/stt/test_intent_entity.py
+++ b/tests/stt/test_intent_entity.py
@@ -4,7 +4,7 @@ Tests for the intent/entity judge aggregation.
 ``get_intent_entity_score`` lives in ``calibrate/stt/metrics.py`` (the metric
 root). It normalizes reference/prediction via the vendored ``IndicNormalizer``
 (mocked here to avoid downloading a model), then delegates to the per-row judge
-in ``calibrate/stt/intent_entity.py``, and aggregates with Sarvam's
+in ``calibrate/stt/sarvam_intent_entity/judge.py``, and aggregates with Sarvam's
 ``calculate_intent_accuracy`` / ``calculate_entity_metrics``.
 
 Run with:
@@ -37,7 +37,7 @@ def _identity_normalizer():
 
 class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
     async def test_intent_accuracy_and_entity_mean(self):
-        from calibrate.stt import intent_entity as ie
+        from calibrate.stt import sarvam_intent_entity as sie
         from calibrate.stt import metrics
 
         async def fake_judge(reference, prediction, model=None, index=0, context=""):
@@ -48,7 +48,7 @@ class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
             return mapping[(reference, prediction)]
 
         with patch.object(metrics, "IndicNormalizer", _identity_normalizer()), \
-             patch.object(ie, "intent_entity_judge", AsyncMock(side_effect=fake_judge)):
+             patch.object(sie, "intent_entity_judge", AsyncMock(side_effect=fake_judge)):
             result = await metrics.get_intent_entity_score(
                 references=["a", "b"],
                 predictions=["a", "x"],
@@ -59,7 +59,7 @@ class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(result["per_row"]), 2)
 
     async def test_normalized_text_is_passed_to_judge(self):
-        from calibrate.stt import intent_entity as ie
+        from calibrate.stt import sarvam_intent_entity as sie
         from calibrate.stt import metrics
 
         # Normalizer lowercases — the judge must receive the normalized form.
@@ -76,7 +76,7 @@ class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
             return _row(1, 1.0)
 
         with patch.object(metrics, "IndicNormalizer", norm_cls), \
-             patch.object(ie, "intent_entity_judge", AsyncMock(side_effect=fake_judge)):
+             patch.object(sie, "intent_entity_judge", AsyncMock(side_effect=fake_judge)):
             await metrics.get_intent_entity_score(
                 references=["HELLO"],
                 predictions=["Hello"],
@@ -85,11 +85,11 @@ class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(seen, [("hello", "hello")])
 
     async def test_empty_inputs(self):
-        from calibrate.stt import intent_entity as ie
+        from calibrate.stt import sarvam_intent_entity as sie
         from calibrate.stt import metrics
 
         with patch.object(metrics, "IndicNormalizer", _identity_normalizer()), \
-             patch.object(ie, "intent_entity_judge", AsyncMock()):
+             patch.object(sie, "intent_entity_judge", AsyncMock()):
             result = await metrics.get_intent_entity_score(references=[], predictions=[])
 
         self.assertEqual(result["intent"], 0.0)
@@ -99,7 +99,7 @@ class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
 
 class TestIntentEntityJudge(unittest.IsolatedAsyncioTestCase):
     async def test_judge_builds_prompt_and_returns_model_dump(self):
-        from calibrate.stt import intent_entity as ie
+        from calibrate.stt.sarvam_intent_entity import judge as ie
 
         fake_result = {
             "index": 3,

--- a/tests/stt/test_intent_entity.py
+++ b/tests/stt/test_intent_entity.py
@@ -1,5 +1,9 @@
 """
-Tests for calibrate/stt/intent_entity.py — intent/entity judge aggregation.
+Tests for the intent/entity judge aggregation.
+
+``get_intent_entity_score`` lives in ``calibrate/stt/metrics.py`` (the metric
+root); it delegates to the per-row judge in ``calibrate/stt/intent_entity.py``,
+which is what these tests patch.
 
 Run with:
     python -m unittest tests.stt.test_intent_entity -v
@@ -24,6 +28,7 @@ def _row(intent, entity):
 class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
     async def test_aggregates_intent_as_passrate_and_entity_as_mean(self):
         from calibrate.stt import intent_entity as ie
+        from calibrate.stt import metrics
 
         # Return per (reference, prediction): order preserved by gather.
         async def fake_judge(reference, prediction, model=None, index=0, context=""):
@@ -34,7 +39,7 @@ class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
             return mapping[(reference, prediction)]
 
         with patch.object(ie, "intent_entity_judge", AsyncMock(side_effect=fake_judge)):
-            result = await ie.get_intent_entity_score(
+            result = await metrics.get_intent_entity_score(
                 references=["a", "b"],
                 predictions=["a", "x"],
             )
@@ -45,13 +50,14 @@ class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
 
     async def test_entity_score_clamped_to_unit_interval(self):
         from calibrate.stt import intent_entity as ie
+        from calibrate.stt import metrics
 
         async def fake_judge(reference, prediction, model=None, index=0, context=""):
             # A misbehaving judge returns out-of-range entity scores.
             return _row(1, 1.7) if reference == "hi" else _row(1, -0.3)
 
         with patch.object(ie, "intent_entity_judge", AsyncMock(side_effect=fake_judge)):
-            result = await ie.get_intent_entity_score(
+            result = await metrics.get_intent_entity_score(
                 references=["hi", "lo"],
                 predictions=["hi", "lo"],
             )
@@ -61,9 +67,10 @@ class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
 
     async def test_empty_inputs(self):
         from calibrate.stt import intent_entity as ie
+        from calibrate.stt import metrics
 
         with patch.object(ie, "intent_entity_judge", AsyncMock()):
-            result = await ie.get_intent_entity_score(references=[], predictions=[])
+            result = await metrics.get_intent_entity_score(references=[], predictions=[])
 
         self.assertEqual(result["intent"], 0.0)
         self.assertEqual(result["entity"], 0.0)

--- a/tests/stt/test_intent_entity.py
+++ b/tests/stt/test_intent_entity.py
@@ -97,5 +97,47 @@ class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["per_row"], [])
 
 
+class TestIntentEntityJudge(unittest.IsolatedAsyncioTestCase):
+    async def test_judge_builds_prompt_and_returns_model_dump(self):
+        from calibrate.stt import intent_entity as ie
+
+        fake_result = {
+            "index": 3,
+            "intent_score": 1,
+            "intent_explanation": "ok",
+            "entity_score": 0.5,
+            "ground_truth_entities": "x",
+            "preserved_entities": "x",
+            "missing_entities": "",
+            "entity_explanation": "ok",
+        }
+        fake_response = MagicMock()
+        fake_response.model_dump.return_value = fake_result
+
+        fake_client = MagicMock()
+        fake_client.chat.completions.create = AsyncMock(return_value=fake_response)
+
+        # Bypass the real decorators (backoff/observe) and skip the network.
+        inner = ie.intent_entity_judge
+        while hasattr(inner, "__wrapped__"):
+            inner = inner.__wrapped__
+
+        with patch.object(ie, "_build_openrouter_client", return_value=MagicMock()), \
+             patch.object(ie.instructor, "apatch", return_value=fake_client):
+            result = await inner(
+                "hello world", "helo world", model="m", index=3, context="ctx"
+            )
+
+        self.assertEqual(result, fake_result)
+        # The vendored build_prompt was used: the user message carries the
+        # input JSON with the normalized hypothesis/ground_truth.
+        _, kwargs = fake_client.chat.completions.create.call_args
+        sent = kwargs["messages"][0]["content"]
+        self.assertIn('"hypothesis": "helo world"', sent)
+        self.assertIn('"ground_truth": "hello world"', sent)
+        self.assertEqual(kwargs["temperature"], 0)
+        self.assertEqual(kwargs["response_model"], ie.IntentEntityResponse)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/stt/test_intent_entity.py
+++ b/tests/stt/test_intent_entity.py
@@ -2,15 +2,17 @@
 Tests for the intent/entity judge aggregation.
 
 ``get_intent_entity_score`` lives in ``calibrate/stt/metrics.py`` (the metric
-root); it delegates to the per-row judge in ``calibrate/stt/intent_entity.py``,
-which is what these tests patch.
+root). It normalizes reference/prediction via the vendored ``IndicNormalizer``
+(mocked here to avoid downloading a model), then delegates to the per-row judge
+in ``calibrate/stt/intent_entity.py``, and aggregates with Sarvam's
+``calculate_intent_accuracy`` / ``calculate_entity_metrics``.
 
 Run with:
     python -m unittest tests.stt.test_intent_entity -v
 """
 
 import unittest
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, MagicMock
 
 
 def _row(intent, entity):
@@ -25,12 +27,19 @@ def _row(intent, entity):
     }
 
 
+def _identity_normalizer():
+    """Mock IndicNormalizer whose normalize_texts returns inputs unchanged."""
+    inst = MagicMock()
+    inst.normalize_texts.side_effect = lambda texts, langs: list(texts)
+    cls = MagicMock(return_value=inst)
+    return cls
+
+
 class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
-    async def test_aggregates_intent_as_passrate_and_entity_as_mean(self):
+    async def test_intent_accuracy_and_entity_mean(self):
         from calibrate.stt import intent_entity as ie
         from calibrate.stt import metrics
 
-        # Return per (reference, prediction): order preserved by gather.
         async def fake_judge(reference, prediction, model=None, index=0, context=""):
             mapping = {
                 ("a", "a"): _row(1, 1.0),
@@ -38,38 +47,49 @@ class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
             }
             return mapping[(reference, prediction)]
 
-        with patch.object(ie, "intent_entity_judge", AsyncMock(side_effect=fake_judge)):
+        with patch.object(metrics, "IndicNormalizer", _identity_normalizer()), \
+             patch.object(ie, "intent_entity_judge", AsyncMock(side_effect=fake_judge)):
             result = await metrics.get_intent_entity_score(
                 references=["a", "b"],
                 predictions=["a", "x"],
             )
 
-        self.assertEqual(result["intent"], 0.5)  # one 1, one 0
-        self.assertEqual(result["entity"], 0.75)  # mean(1.0, 0.5)
+        self.assertEqual(result["intent"], 0.5)  # accuracy of [1, 0]
+        self.assertEqual(result["entity"], 0.75)  # mean of [1.0, 0.5]
         self.assertEqual(len(result["per_row"]), 2)
 
-    async def test_entity_score_clamped_to_unit_interval(self):
+    async def test_normalized_text_is_passed_to_judge(self):
         from calibrate.stt import intent_entity as ie
         from calibrate.stt import metrics
 
-        async def fake_judge(reference, prediction, model=None, index=0, context=""):
-            # A misbehaving judge returns out-of-range entity scores.
-            return _row(1, 1.7) if reference == "hi" else _row(1, -0.3)
+        # Normalizer lowercases — the judge must receive the normalized form.
+        norm_inst = MagicMock()
+        norm_inst.normalize_texts.side_effect = lambda texts, langs: [
+            t.lower() for t in texts
+        ]
+        norm_cls = MagicMock(return_value=norm_inst)
 
-        with patch.object(ie, "intent_entity_judge", AsyncMock(side_effect=fake_judge)):
-            result = await metrics.get_intent_entity_score(
-                references=["hi", "lo"],
-                predictions=["hi", "lo"],
+        seen = []
+
+        async def fake_judge(reference, prediction, model=None, index=0, context=""):
+            seen.append((reference, prediction))
+            return _row(1, 1.0)
+
+        with patch.object(metrics, "IndicNormalizer", norm_cls), \
+             patch.object(ie, "intent_entity_judge", AsyncMock(side_effect=fake_judge)):
+            await metrics.get_intent_entity_score(
+                references=["HELLO"],
+                predictions=["Hello"],
             )
 
-        # 1.7 -> 1.0 and -0.3 -> 0.0; mean = 0.5
-        self.assertEqual(result["entity"], 0.5)
+        self.assertEqual(seen, [("hello", "hello")])
 
     async def test_empty_inputs(self):
         from calibrate.stt import intent_entity as ie
         from calibrate.stt import metrics
 
-        with patch.object(ie, "intent_entity_judge", AsyncMock()):
+        with patch.object(metrics, "IndicNormalizer", _identity_normalizer()), \
+             patch.object(ie, "intent_entity_judge", AsyncMock()):
             result = await metrics.get_intent_entity_score(references=[], predictions=[])
 
         self.assertEqual(result["intent"], 0.0)

--- a/tests/stt/test_sarvam_intent_entity.py
+++ b/tests/stt/test_sarvam_intent_entity.py
@@ -1,0 +1,126 @@
+"""
+Tests for the vendored Sarvam intent/entity helpers.
+
+Covers ``build_prompt`` + ``IntentEntityResponse`` (main.py) and the
+``IndicNormalizer`` / score aggregators (utilities.py). The normalizer is
+exercised with its heavyweight backends (Whisper tokenizer + indic-nlp factory)
+mocked so no model is downloaded.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+
+class TestBuildPrompt(unittest.TestCase):
+    def test_prompt_carries_input_json_and_template(self):
+        from calibrate.stt.sarvam_intent_entity.main import build_prompt, PROMPT_TEMPLATE
+
+        prompt = build_prompt(
+            {
+                "index": 2,
+                "hypothesis": "helo",
+                "ground_truth": "hello",
+                "context": "greeting",
+            }
+        )
+        self.assertTrue(prompt.startswith(PROMPT_TEMPLATE))
+        self.assertIn("**INPUT:**", prompt)
+        self.assertIn('"index": 2', prompt)
+        self.assertIn('"hypothesis": "helo"', prompt)
+        self.assertIn('"ground_truth": "hello"', prompt)
+        self.assertIn('"context": "greeting"', prompt)
+
+    def test_context_defaults_to_empty(self):
+        from calibrate.stt.sarvam_intent_entity.main import build_prompt
+
+        prompt = build_prompt({"index": 0, "hypothesis": "a", "ground_truth": "b"})
+        self.assertIn('"context": ""', prompt)
+
+    def test_response_model_fields_are_bare(self):
+        from calibrate.stt.sarvam_intent_entity.main import IntentEntityResponse
+
+        self.assertEqual(
+            list(IntentEntityResponse.model_fields.keys()),
+            [
+                "index",
+                "intent_score",
+                "intent_explanation",
+                "entity_score",
+                "ground_truth_entities",
+                "preserved_entities",
+                "missing_entities",
+                "entity_explanation",
+            ],
+        )
+
+
+class TestScoreAggregators(unittest.TestCase):
+    def test_intent_accuracy(self):
+        from calibrate.stt.sarvam_intent_entity.utilities import (
+            calculate_intent_accuracy,
+        )
+
+        self.assertEqual(calculate_intent_accuracy([1, 0, 1, 0]), 0.5)
+        self.assertEqual(calculate_intent_accuracy([]), 0.0)
+
+    def test_entity_metrics(self):
+        from calibrate.stt.sarvam_intent_entity.utilities import (
+            calculate_entity_metrics,
+        )
+
+        m = calculate_entity_metrics([1.0, 0.0])
+        self.assertEqual(m["mean"], 0.5)
+        self.assertEqual(m["median"], 0.5)
+        self.assertEqual(calculate_entity_metrics([]), {"mean": 0.0, "median": 0.0, "std": 0.0})
+
+
+def _normalizer_with_mocks():
+    """IndicNormalizer instance with its model backends mocked (no download)."""
+    from calibrate.stt.sarvam_intent_entity.utilities import IndicNormalizer
+
+    norm = object.__new__(IndicNormalizer)  # skip __init__ (model download)
+    indic_normalizer = MagicMock()
+    indic_normalizer.normalize.side_effect = lambda t: t
+    norm.indic_factory = MagicMock()
+    norm.indic_factory.get_normalizer.return_value = indic_normalizer
+    norm.whisper_tokenizer = MagicMock()
+    norm.whisper_tokenizer.normalize.side_effect = lambda t: t
+    return norm
+
+
+class TestIndicNormalizer(unittest.TestCase):
+    def test_english_uses_whisper_path_and_strips_punctuation(self):
+        norm = _normalizer_with_mocks()
+        out = norm.normalize_text("Hello, World!", "english")
+        self.assertEqual(out, "hello world")
+        norm.whisper_tokenizer.normalize.assert_called_once()
+        norm.indic_factory.get_normalizer.assert_not_called()
+
+    def test_indic_lang_uses_indic_normalizer(self):
+        norm = _normalizer_with_mocks()
+        norm.normalize_text("Ram", "hindi")
+        norm.indic_factory.get_normalizer.assert_called_once_with("hi")
+        norm.whisper_tokenizer.normalize.assert_not_called()
+
+    def test_empty_and_non_str_passthrough(self):
+        norm = _normalizer_with_mocks()
+        self.assertEqual(norm.normalize_text("", "english"), "")
+        self.assertIsNone(norm.normalize_text(None, "english"))
+
+    def test_normalize_texts_batches(self):
+        norm = _normalizer_with_mocks()
+        out = norm.normalize_texts(["Hi!", "Bye."], ["english", "english"], n_jobs=1)
+        self.assertEqual(out, ["hi", "bye"])
+
+    def test_normalize_texts_empty(self):
+        norm = _normalizer_with_mocks()
+        self.assertEqual(norm.normalize_texts([], [], n_jobs=1), [])
+
+    def test_normalize_texts_length_mismatch_raises(self):
+        norm = _normalizer_with_mocks()
+        with self.assertRaises(ValueError):
+            norm.normalize_texts(["a"], ["english", "hindi"], n_jobs=1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -201,6 +201,15 @@ wheels = [
 ]
 
 [[package]]
+name = "alabaster"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210, upload-time = "2024-07-26T18:15:03.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b", size = 13929, upload-time = "2024-07-26T18:15:02.05Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -358,6 +367,15 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
 name = "backoff"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -373,8 +391,10 @@ dependencies = [
     { name = "backoff" },
     { name = "elevenlabs" },
     { name = "evaluate" },
+    { name = "indic-nlp-library" },
     { name = "instructor" },
     { name = "jiwer" },
+    { name = "joblib" },
     { name = "langfuse" },
     { name = "matplotlib" },
     { name = "natsort" },
@@ -410,10 +430,12 @@ requires-dist = [
     { name = "backoff", specifier = ">=2.2.1" },
     { name = "elevenlabs", specifier = ">=2.31.0" },
     { name = "evaluate", specifier = ">=0.4.6" },
+    { name = "indic-nlp-library", specifier = ">=0.92" },
     { name = "instructor", specifier = ">=1.13.0" },
     { name = "ipdb", marker = "extra == 'dev'", specifier = ">=0.13.13" },
     { name = "ipython", marker = "extra == 'dev'", specifier = ">=8.37.0" },
     { name = "jiwer", specifier = ">=4.0.0" },
+    { name = "joblib", specifier = ">=1.3.0" },
     { name = "langfuse", specifier = "==3.3.0" },
     { name = "matplotlib", specifier = ">=3.10.7" },
     { name = "natsort", specifier = ">=8.4.0" },
@@ -1161,6 +1183,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.21.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
 ]
 
 [[package]]
@@ -2065,6 +2114,15 @@ wheels = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
+]
+
+[[package]]
 name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2074,6 +2132,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
+]
+
+[[package]]
+name = "indic-nlp-library"
+version = "0.92"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "morfessor" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "sphinx-argparse" },
+    { name = "sphinx-rtd-theme" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/f6/bcd6b5c49351d5261ee3873f78d66fd7aa11d410f5c12e4cc1a4ee85c8f9/indic_nlp_library-0.92.tar.gz", hash = "sha256:5e83e54a1016873cbd7417e5376c12ca87411151760ad92809b2af8824982d73", size = 32250, upload-time = "2023-05-15T06:58:13.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/21/61240bcf965cedfec993497b38c42f054b149b9669e6d6cddeb1dee09d51/indic_nlp_library-0.92-py3-none-any.whl", hash = "sha256:6cbc38886184e94f71c9a59e7448a9cae086c7cb222ffd9aef6fd74ea0daf895", size = 40259, upload-time = "2023-05-15T06:58:10.28Z" },
 ]
 
 [[package]]
@@ -2749,6 +2823,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
+]
+
+[[package]]
+name = "morfessor"
+version = "2.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/5e/760a41def80f7e48e4f95937a8de73057871f655c0ec459f7aff3c1f95a2/Morfessor-2.0.6.tar.gz", hash = "sha256:bb3beac234341724c5f640f65803071f62373a50dba854d5a398567f9aefbab2", size = 34341, upload-time = "2019-07-31T12:35:10.401Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/e6/7afea30be2ee4d29ce9de0fa53acbb033163615f849515c0b1956ad074ee/Morfessor-2.0.6-py3-none-any.whl", hash = "sha256:7215e37909ebd2bafeeec5fdf4e339a25e61aee4895ff99317b9fb44eddab562", size = 35784, upload-time = "2019-07-31T12:35:08.945Z" },
 ]
 
 [[package]]
@@ -4688,6 +4771,15 @@ wheels = [
 ]
 
 [[package]]
+name = "roman-numerals"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
+]
+
+[[package]]
 name = "rsa"
 version = "4.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4941,6 +5033,15 @@ wheels = [
 ]
 
 [[package]]
+name = "snowballstemmer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/f8/0a71edf031f03c40db17503cb8ca78a69a171254e568e7db241b0ab57ea1/snowballstemmer-3.1.1.tar.gz", hash = "sha256:e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260", size = 123314, upload-time = "2026-06-03T00:56:40.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl", hash = "sha256:7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752", size = 104164, upload-time = "2026-06-03T00:56:38.614Z" },
+]
+
+[[package]]
 name = "sounddevice"
 version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4979,6 +5080,202 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/38/bad15a9e615215c8219652ca554b601663ac3b7ac82a284aca53ec2ff48c/soxr-0.5.0.post1-cp312-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd052a66471a7335b22a6208601a9d0df7b46b8d087dce4ff6e13eed6a33a2a1", size = 216564, upload-time = "2024-08-31T03:43:20.789Z" },
     { url = "https://files.pythonhosted.org/packages/e1/1a/569ea0420a0c4801c2c8dd40d8d544989522f6014d51def689125f3f2935/soxr-0.5.0.post1-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3f16810dd649ab1f433991d2a9661e9e6a116c2b4101039b53b3c3e90a094fc", size = 248455, upload-time = "2024-08-31T03:43:22.165Z" },
     { url = "https://files.pythonhosted.org/packages/bc/10/440f1ba3d4955e0dc740bbe4ce8968c254a3d644d013eb75eea729becdb8/soxr-0.5.0.post1-cp312-abi3-win_amd64.whl", hash = "sha256:b1be9fee90afb38546bdbd7bde714d1d9a8c5a45137f97478a83b65e7f3146f6", size = 164937, upload-time = "2024-08-31T03:43:23.671Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "8.1.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "alabaster", marker = "python_full_version < '3.11'" },
+    { name = "babel", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "imagesize", marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "requests", marker = "python_full_version < '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/60/1ddff83a56d33aaf6f10ec8ce84b4c007d9368b21008876fceda7e7381ef/sphinx-8.1.3-py3-none-any.whl", hash = "sha256:09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2", size = 3487125, upload-time = "2024-10-13T20:27:10.448Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "9.0.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
+    { name = "babel", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
+    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
+    { name = "packaging", marker = "python_full_version == '3.11.*'" },
+    { name = "pygments", marker = "python_full_version == '3.11.*'" },
+    { name = "requests", marker = "python_full_version == '3.11.*'" },
+    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
+    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/3f/4bbd76424c393caead2e1eb89777f575dee5c8653e2d4b6afd7a564f5974/sphinx-9.0.4-py3-none-any.whl", hash = "sha256:5bebc595a5e943ea248b99c13814c1c5e10b3ece718976824ffa7959ff95fffb", size = 3917713, upload-time = "2025-12-04T07:45:24.944Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "9.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+]
+dependencies = [
+    { name = "alabaster", marker = "python_full_version >= '3.12'" },
+    { name = "babel", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "imagesize", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pygments", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl", hash = "sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978", size = 3921742, upload-time = "2025-12-31T15:09:25.561Z" },
+]
+
+[[package]]
+name = "sphinx-argparse"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/21/a8c64e6633652111e6e4f89703182a53cbc3ed67233523e47472101358b6/sphinx_argparse-0.5.2.tar.gz", hash = "sha256:e5352f8fa894b6fb6fda0498ba28a9f8d435971ef4bbc1a6c9c6414e7644f032", size = 27838, upload-time = "2024-07-17T12:08:08.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/43/9f0e9bfb3ce02cbf7747aa2185c48a9d6e42ba95736a5e8f511a5054d976/sphinx_argparse-0.5.2-py3-none-any.whl", hash = "sha256:d771b906c36d26dee669dbdbb5605c558d9440247a5608b810f7fa6e26ab1fd3", size = 12547, upload-time = "2024-07-17T12:08:06.307Z" },
+]
+
+[[package]]
+name = "sphinx-rtd-theme"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-jquery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/68/a1bfbf38c0f7bccc9b10bbf76b94606f64acb1552ae394f0b8285bfaea25/sphinx_rtd_theme-3.1.0.tar.gz", hash = "sha256:b44276f2c276e909239a4f6c955aa667aaafeb78597923b1c60babc76db78e4c", size = 7620915, upload-time = "2026-01-12T16:03:31.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/c7/b5c8015d823bfda1a346adb2c634a2101d50bb75d421eb6dcb31acd25ebc/sphinx_rtd_theme-3.1.0-py2.py3-none-any.whl", hash = "sha256:1785824ae8e6632060490f67cf3a72d404a85d2d9fc26bce3619944de5682b89", size = 7655617, upload-time = "2026-01-12T16:03:28.101Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053, upload-time = "2024-07-29T01:09:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300, upload-time = "2024-07-29T01:08:58.99Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad", size = 12967, upload-time = "2024-07-29T01:09:23.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2", size = 82530, upload-time = "2024-07-29T01:09:21.945Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-jquery"
+version = "4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/f3/aa67467e051df70a6330fe7770894b3e4f09436dea6881ae0b4f3d87cad8/sphinxcontrib-jquery-4.1.tar.gz", hash = "sha256:1620739f04e36a2c779f1a131a2dfd49b2fd07351bf1968ced074365933abc7a", size = 122331, upload-time = "2023-03-14T15:01:01.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/85/749bd22d1a68db7291c89e2ebca53f4306c3f205853cf31e9de279034c3c/sphinxcontrib_jquery-4.1-py2.py3-none-any.whl", hash = "sha256:f936030d7d0147dd026a4f2b5a57343d233f1fc7b363f68b3d4f1cb0993878ae", size = 121104, upload-time = "2023-03-14T15:01:00.356Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab", size = 17165, upload-time = "2024-07-29T01:09:56.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb", size = 88743, upload-time = "2024-07-29T01:09:54.885Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
- Always compute intent (binary) and entity (0–1 fraction) preservation scores for every STT run, independent of user-supplied evaluators, reported alongside WER/CER in metrics.json, results.csv, CLI summaries, and the leaderboard.
- Scores come from a single combined judge call per row, routed through calibrate's existing OpenRouter + instructor plumbing.
- Judge prompt is taken verbatim from Sarvam AI's `llm_intent_entity` prompt_template.txt.

## Notes
- Entity is modeled as a top-level float (like WER/CER), not an evaluator dict, since it's a continuous fraction rather than binary/rating.
- Prompt is tuned for Indian languages (per the source) but scores any language.