### PR TITLE
Gate Sarvam intent/entity STT scores behind a CLI flag

### DIFF
--- a/calibrate/cli.py
+++ b/calibrate/cli.py
@@ -234,7 +234,7 @@ Examples:
         help="Path to dataset JSON (list of {id, gt, pred}). Required with --eval-only.",
     )
     stt_parser.add_argument(
-        "--sarvam-intent-entity",
+        "--sarvam-judges",
         action="store_true",
         help=(
             "Also compute Sarvam intent & entity preservation scores. Off by "
@@ -526,8 +526,8 @@ Examples:
             argv.extend(["-o", args.output_dir])
             if args.config:
                 argv.extend(["--config", args.config])
-            if args.sarvam_intent_entity:
-                argv.append("--sarvam-intent-entity")
+            if args.sarvam_judges:
+                argv.append("--sarvam-judges")
 
             sys.argv = argv
             asyncio.run(stt_benchmark_main())
@@ -551,8 +551,8 @@ Examples:
                 argv.extend(["-s", args.save_dir])
             if args.config:
                 argv.extend(["--config", args.config])
-            if args.sarvam_intent_entity:
-                argv.append("--sarvam-intent-entity")
+            if args.sarvam_judges:
+                argv.append("--sarvam-judges")
 
             sys.argv = argv
             asyncio.run(stt_benchmark_main())

--- a/calibrate/cli.py
+++ b/calibrate/cli.py
@@ -233,6 +233,15 @@ Examples:
         default=None,
         help="Path to dataset JSON (list of {id, gt, pred}). Required with --eval-only.",
     )
+    stt_parser.add_argument(
+        "--sarvam-intent-entity",
+        action="store_true",
+        help=(
+            "Also compute Sarvam intent & entity preservation scores. Off by "
+            "default; enabling it loads a text-normalizer model and runs an "
+            "extra per-row LLM judge."
+        ),
+    )
 
     # ── TTS ───────────────────────────────────────────────────────
     # `calibrate tts` with no args → interactive UI
@@ -513,9 +522,12 @@ Examples:
                 sys.exit(1)
 
             argv = ["calibrate", "--eval-only", "--dataset", args.dataset]
+            argv.extend(["-l", args.language])
             argv.extend(["-o", args.output_dir])
             if args.config:
                 argv.extend(["--config", args.config])
+            if args.sarvam_intent_entity:
+                argv.append("--sarvam-intent-entity")
 
             sys.argv = argv
             asyncio.run(stt_benchmark_main())
@@ -539,6 +551,8 @@ Examples:
                 argv.extend(["-s", args.save_dir])
             if args.config:
                 argv.extend(["--config", args.config])
+            if args.sarvam_intent_entity:
+                argv.append("--sarvam-intent-entity")
 
             sys.argv = argv
             asyncio.run(stt_benchmark_main())

--- a/calibrate/stt/benchmark.py
+++ b/calibrate/stt/benchmark.py
@@ -77,7 +77,7 @@ async def run(
     overwrite: bool = False,
     max_parallel: int = MAX_PARALLEL_PROVIDERS,
     judge_evaluators: list[dict] = None,
-    score_intent_entity: bool = False,
+    run_sarvam_judges: bool = False,
 ) -> dict:
     """
     Run STT evaluation for one or more providers and generate a leaderboard.
@@ -98,7 +98,7 @@ async def run(
         judge_evaluators: Optional list of evaluator dicts (each with ``name``,
             ``system_prompt``, ``judge_model``, ``type``, ...). When omitted
             the implicit default STT evaluator runs.
-        score_intent_entity: When True, also run the Sarvam intent/entity judge
+        run_sarvam_judges: When True, also run the Sarvam intent/entity judge
             (loads a normalizer model + makes per-row judge calls). Off by
             default.
 
@@ -132,7 +132,7 @@ async def run(
                 ignore_retry=ignore_retry,
                 overwrite=overwrite,
                 judge_evaluators=judge_evaluators,
-                score_intent_entity=score_intent_entity,
+                run_sarvam_judges=run_sarvam_judges,
             )
             return (provider, result)
 
@@ -316,7 +316,7 @@ async def main():
             output_dir=args.output_dir,
             judge_evaluators=judge_evaluators,
             language=args.language,
-            score_intent_entity=args.sarvam_judges,
+            run_sarvam_judges=args.sarvam_judges,
         )
 
         print(f"\n\033[92m{'='*60}\033[0m")
@@ -362,7 +362,7 @@ async def main():
             ignore_retry=args.ignore_retry,
             overwrite=args.overwrite,
             judge_evaluators=judge_evaluators,
-            score_intent_entity=args.sarvam_judges,
+            run_sarvam_judges=args.sarvam_judges,
         )
 
         # Print summary

--- a/calibrate/stt/benchmark.py
+++ b/calibrate/stt/benchmark.py
@@ -246,7 +246,7 @@ async def main():
         help="Path to optional JSON config file with an `evaluators` list",
     )
     parser.add_argument(
-        "--sarvam-intent-entity",
+        "--sarvam-judges",
         action="store_true",
         help=(
             "Also compute Sarvam intent & entity preservation scores. Off by "
@@ -316,7 +316,7 @@ async def main():
             output_dir=args.output_dir,
             judge_evaluators=judge_evaluators,
             language=args.language,
-            score_intent_entity=args.sarvam_intent_entity,
+            score_intent_entity=args.sarvam_judges,
         )
 
         print(f"\n\033[92m{'='*60}\033[0m")
@@ -362,7 +362,7 @@ async def main():
             ignore_retry=args.ignore_retry,
             overwrite=args.overwrite,
             judge_evaluators=judge_evaluators,
-            score_intent_entity=args.sarvam_intent_entity,
+            score_intent_entity=args.sarvam_judges,
         )
 
         # Print summary

--- a/calibrate/stt/benchmark.py
+++ b/calibrate/stt/benchmark.py
@@ -28,6 +28,7 @@ from calibrate.stt.eval import (
     run_single_provider_eval,
     run_eval_only,
     validate_stt_input_dir,
+    format_metrics_summary,
     STT_PROVIDERS,
     STT_LANGUAGES,
 )
@@ -76,6 +77,7 @@ async def run(
     overwrite: bool = False,
     max_parallel: int = MAX_PARALLEL_PROVIDERS,
     judge_evaluators: list[dict] = None,
+    score_intent_entity: bool = False,
 ) -> dict:
     """
     Run STT evaluation for one or more providers and generate a leaderboard.
@@ -96,6 +98,9 @@ async def run(
         judge_evaluators: Optional list of evaluator dicts (each with ``name``,
             ``system_prompt``, ``judge_model``, ``type``, ...). When omitted
             the implicit default STT evaluator runs.
+        score_intent_entity: When True, also run the Sarvam intent/entity judge
+            (loads a normalizer model + makes per-row judge calls). Off by
+            default.
 
     Returns:
         dict: Results summary with status and output paths
@@ -127,6 +132,7 @@ async def run(
                 ignore_retry=ignore_retry,
                 overwrite=overwrite,
                 judge_evaluators=judge_evaluators,
+                score_intent_entity=score_intent_entity,
             )
             return (provider, result)
 
@@ -239,6 +245,15 @@ async def main():
         default=None,
         help="Path to optional JSON config file with an `evaluators` list",
     )
+    parser.add_argument(
+        "--sarvam-intent-entity",
+        action="store_true",
+        help=(
+            "Also compute Sarvam intent & entity preservation scores. Off by "
+            "default; enabling it loads a text-normalizer model and runs an "
+            "extra per-row LLM judge."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -292,6 +307,7 @@ async def main():
     if args.eval_only:
         print("\n\033[91mSTT Eval-Only\033[0m\n")
         print(f"Dataset: {args.dataset}")
+        print(f"Language: {args.language}")
         print(f"Output: {args.output_dir}")
         print("")
 
@@ -299,6 +315,8 @@ async def main():
             dataset_path=args.dataset,
             output_dir=args.output_dir,
             judge_evaluators=judge_evaluators,
+            language=args.language,
+            score_intent_entity=args.sarvam_intent_entity,
         )
 
         print(f"\n\033[92m{'='*60}\033[0m")
@@ -310,17 +328,7 @@ async def main():
             sys.exit(1)
 
         metrics = result.get("metrics", {})
-        wer = metrics.get("wer", 0)
-        cer = metrics.get("cer", 0)
-        intent = metrics.get("sarvam_intent_score", 0)
-        entity = metrics.get("sarvam_entity_score", 0)
-        judge_scores = {
-            k: v["mean"]
-            for k, v in metrics.items()
-            if isinstance(v, dict) and "type" in v
-        }
-        judge_str = ", ".join(f"{k}={v:.4f}" for k, v in judge_scores.items())
-        print(f"  WER={wer:.4f}, CER={cer:.4f}, Sarvam Intent Score={intent:.4f}, Sarvam Entity Score={entity:.4f}, {judge_str}")
+        print(format_metrics_summary(metrics))
         return
 
     # Benchmark (multi-provider) mode: mirror stdout/stderr into a single
@@ -354,6 +362,7 @@ async def main():
             ignore_retry=args.ignore_retry,
             overwrite=args.overwrite,
             judge_evaluators=judge_evaluators,
+            score_intent_entity=args.sarvam_intent_entity,
         )
 
         # Print summary
@@ -374,20 +383,7 @@ async def main():
                 has_errors = True
             else:
                 metrics = prov_result.get("metrics", {})
-                wer = metrics.get("wer", 0)
-                cer = metrics.get("cer", 0)
-                intent = metrics.get("sarvam_intent_score", 0)
-                entity = metrics.get("sarvam_entity_score", 0)
-                # Evaluator entries are dicts carrying a ``type`` field.
-                judge_scores = {
-                    k: v["mean"]
-                    for k, v in metrics.items()
-                    if isinstance(v, dict) and "type" in v
-                }
-                judge_str = ", ".join(
-                    f"{k}={v:.4f}" for k, v in judge_scores.items()
-                )
-                print(f"  {provider}: WER={wer:.4f}, CER={cer:.4f}, Sarvam Intent Score={intent:.4f}, Sarvam Entity Score={entity:.4f}, {judge_str}")
+                print(format_metrics_summary(metrics, prefix=f"{provider}: "))
 
         if has_errors:
             sys.exit(1)

--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -869,6 +869,7 @@ async def run_single_provider_eval(
     ignore_retry: bool,
     overwrite: bool,
     judge_evaluators: list[dict] = None,
+    score_intent_entity: bool = False,
 ) -> dict:
     """Run STT evaluation for a single provider."""
     provider_output_dir = join(output_dir, provider)
@@ -997,6 +998,7 @@ async def run_single_provider_eval(
             evaluator_config_dir=output_dir,
             judge_evaluators=judge_evaluators,
             language=language,
+            score_intent_entity=score_intent_entity,
         )
 
         return {
@@ -1052,12 +1054,17 @@ async def _score_and_write_results(
     evaluator_config_dir: str,
     judge_evaluators: list[dict] = None,
     language: str = "english",
+    score_intent_entity: bool = False,
 ) -> dict:
     """Run WER + LLM-judge evaluators over (gt, pred) pairs and write outputs.
 
     Writes ``results.csv`` and ``metrics.json`` under ``output_dir`` and the
     resolved evaluator config under ``evaluator_config_dir``. Returns the
     metrics_data dict.
+
+    When ``score_intent_entity`` is False (the default) the Sarvam intent/entity
+    judge is skipped entirely — no normalizer model is loaded, no judge calls
+    are made, and the ``sarvam_*`` columns/metrics are omitted.
     """
     wer_results = get_wer_score(gt_transcripts, pred_transcripts)
     _log(f"WER: {wer_results['score']}", to_terminal=False)
@@ -1065,15 +1072,17 @@ async def _score_and_write_results(
     cer_results = get_cer_score(gt_transcripts, pred_transcripts)
     _log(f"CER: {cer_results['score']}", to_terminal=False)
 
-    # Intent + entity preservation are always computed, independent of the
-    # user-supplied evaluators, and reported alongside WER as top-level floats.
-    intent_entity_results = await get_intent_entity_score(
-        gt_transcripts, pred_transcripts, language=language
-    )
-    _log(
-        f"Sarvam Intent Score: {intent_entity_results['intent']:.4f}  Sarvam Entity Score: {intent_entity_results['entity']:.4f}",
-        to_terminal=False,
-    )
+    # Intent + entity preservation are opt-in via ``score_intent_entity``;
+    # skipping avoids loading the normalizer model and the per-row judge calls.
+    intent_entity_results = None
+    if score_intent_entity:
+        intent_entity_results = await get_intent_entity_score(
+            gt_transcripts, pred_transcripts, language=language
+        )
+        _log(
+            f"Sarvam Intent Score: {intent_entity_results['intent']:.4f}  Sarvam Entity Score: {intent_entity_results['entity']:.4f}",
+            to_terminal=False,
+        )
 
     _evaluators = judge_evaluators if judge_evaluators else [DEFAULT_STT_EVALUATOR]
     require_unique_evaluator_names(_evaluators)
@@ -1091,11 +1100,18 @@ async def _score_and_write_results(
     metrics_data = {
         "wer": wer_results["score"],
         "cer": cer_results["score"],
-        "sarvam_intent_score": intent_entity_results["intent"],
-        "sarvam_entity_score": intent_entity_results["entity"],
     }
+    if intent_entity_results is not None:
+        metrics_data["sarvam_intent_score"] = intent_entity_results["intent"]
+        metrics_data["sarvam_entity_score"] = intent_entity_results["entity"]
     for name, score_dict in llm_results["scores"].items():
         metrics_data[name] = score_dict
+
+    ie_per_row = (
+        intent_entity_results["per_row"]
+        if intent_entity_results is not None
+        else [None] * len(ids)
+    )
 
     data = []
     for _id, gt_text, pred_text, wer, cer, ie_row, llm_row in zip(
@@ -1104,7 +1120,7 @@ async def _score_and_write_results(
         pred_transcripts,
         wer_results["per_row"],
         cer_results["per_row"],
-        intent_entity_results["per_row"],
+        ie_per_row,
         llm_results["per_row"],
     ):
         row = {
@@ -1113,11 +1129,12 @@ async def _score_and_write_results(
             "pred": pred_text,
             "wer": wer,
             "cer": cer,
-            "sarvam_intent_score": int(ie_row["intent_score"]),
-            "sarvam_intent_reasoning": ie_row["intent_explanation"],
-            "sarvam_entity_score": float(ie_row["entity_score"]),
-            "sarvam_entity_reasoning": ie_row["entity_explanation"],
         }
+        if ie_row is not None:
+            row["sarvam_intent_score"] = int(ie_row["intent_score"])
+            row["sarvam_intent_reasoning"] = ie_row["intent_explanation"]
+            row["sarvam_entity_score"] = float(ie_row["entity_score"])
+            row["sarvam_entity_reasoning"] = ie_row["entity_explanation"]
         for name, ev in _evaluators_by_name.items():
             ev_result = llm_row[name]
             if is_rating(ev):
@@ -1140,6 +1157,7 @@ async def run_eval_only(
     output_dir: str,
     judge_evaluators: list[dict] = None,
     language: str = "english",
+    score_intent_entity: bool = False,
 ) -> dict:
     """Run evaluators only on a pre-existing dataset of (gt, pred) pairs.
 
@@ -1153,6 +1171,9 @@ async def run_eval_only(
             built-in STT evaluator when omitted.
         language: Language of the dataset, used to normalize text before the
             intent/entity judge. Defaults to ``english``.
+        score_intent_entity: When True, also run the Sarvam intent/entity judge.
+            Off by default — leaving it off skips the normalizer model load and
+            the judge calls entirely.
 
     Returns:
         dict with status, metrics, and output_dir.
@@ -1186,6 +1207,7 @@ async def run_eval_only(
             evaluator_config_dir=output_dir,
             judge_evaluators=judge_evaluators,
             language=language,
+            score_intent_entity=score_intent_entity,
         )
 
         return {
@@ -1195,6 +1217,31 @@ async def run_eval_only(
         }
     finally:
         _current_log_file.reset(token)
+
+
+def format_metrics_summary(metrics: dict, prefix: str = "") -> str:
+    """Build the one-line ``WER / CER / Sarvam Intent / Sarvam Entity / judge``
+    summary shared by the single-provider, multi-provider, and eval-only paths.
+
+    The Sarvam intent/entity fields are only included when present in
+    ``metrics`` (i.e. when intent/entity scoring was enabled for the run).
+    """
+    parts = [
+        f"WER={metrics.get('wer', 0):.4f}",
+        f"CER={metrics.get('cer', 0):.4f}",
+    ]
+    if "sarvam_intent_score" in metrics:
+        parts.append(f"Sarvam Intent Score={metrics['sarvam_intent_score']:.4f}")
+    if "sarvam_entity_score" in metrics:
+        parts.append(f"Sarvam Entity Score={metrics['sarvam_entity_score']:.4f}")
+    # Evaluator entries are dicts carrying a ``type`` field; that's the marker
+    # we use to pick them out from other top-level metrics.
+    parts.extend(
+        f"{k}={v['mean']:.4f}"
+        for k, v in metrics.items()
+        if isinstance(v, dict) and "type" in v
+    )
+    return f"  {prefix}" + ", ".join(parts)
 
 
 async def main():
@@ -1265,6 +1312,15 @@ async def main():
         action="store_true",
         help="Overwrite existing results instead of resuming from last checkpoint",
     )
+    parser.add_argument(
+        "--sarvam-intent-entity",
+        action="store_true",
+        help=(
+            "Also compute Sarvam intent & entity preservation scores. Off by "
+            "default; enabling it loads a text-normalizer model and runs an "
+            "extra per-row LLM judge."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -1306,6 +1362,7 @@ async def main():
         debug_count=args.debug_count,
         ignore_retry=args.ignore_retry,
         overwrite=args.overwrite,
+        score_intent_entity=args.sarvam_intent_entity,
     )
 
     # Print summary
@@ -1318,19 +1375,7 @@ async def main():
         sys.exit(1)
     else:
         metrics = result.get("metrics", {})
-        wer = metrics.get("wer", 0)
-        cer = metrics.get("cer", 0)
-        intent = metrics.get("sarvam_intent_score", 0)
-        entity = metrics.get("sarvam_entity_score", 0)
-        # Evaluator entries are dicts carrying a ``type`` field; that's the
-        # marker we use to pick them out from other top-level metrics.
-        judge_scores = {
-            k: v["mean"]
-            for k, v in metrics.items()
-            if isinstance(v, dict) and "type" in v
-        }
-        judge_str = ", ".join(f"{k}={v:.4f}" for k, v in judge_scores.items())
-        print(f"  {provider}: WER={wer:.4f}, CER={cer:.4f}, Sarvam Intent Score={intent:.4f}, Sarvam Entity Score={entity:.4f}, {judge_str}")
+        print(format_metrics_summary(metrics, prefix=f"{provider}: "))
 
 
 if __name__ == "__main__":

--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -1313,7 +1313,7 @@ async def main():
         help="Overwrite existing results instead of resuming from last checkpoint",
     )
     parser.add_argument(
-        "--sarvam-intent-entity",
+        "--sarvam-judges",
         action="store_true",
         help=(
             "Also compute Sarvam intent & entity preservation scores. Off by "
@@ -1362,7 +1362,7 @@ async def main():
         debug_count=args.debug_count,
         ignore_retry=args.ignore_retry,
         overwrite=args.overwrite,
-        score_intent_entity=args.sarvam_intent_entity,
+        score_intent_entity=args.sarvam_judges,
     )
 
     # Print summary

--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -869,7 +869,7 @@ async def run_single_provider_eval(
     ignore_retry: bool,
     overwrite: bool,
     judge_evaluators: list[dict] = None,
-    score_intent_entity: bool = False,
+    run_sarvam_judges: bool = False,
 ) -> dict:
     """Run STT evaluation for a single provider."""
     provider_output_dir = join(output_dir, provider)
@@ -998,7 +998,7 @@ async def run_single_provider_eval(
             evaluator_config_dir=output_dir,
             judge_evaluators=judge_evaluators,
             language=language,
-            score_intent_entity=score_intent_entity,
+            run_sarvam_judges=run_sarvam_judges,
         )
 
         return {
@@ -1054,7 +1054,7 @@ async def _score_and_write_results(
     evaluator_config_dir: str,
     judge_evaluators: list[dict] = None,
     language: str = "english",
-    score_intent_entity: bool = False,
+    run_sarvam_judges: bool = False,
 ) -> dict:
     """Run WER + LLM-judge evaluators over (gt, pred) pairs and write outputs.
 
@@ -1062,7 +1062,7 @@ async def _score_and_write_results(
     resolved evaluator config under ``evaluator_config_dir``. Returns the
     metrics_data dict.
 
-    When ``score_intent_entity`` is False (the default) the Sarvam intent/entity
+    When ``run_sarvam_judges`` is False (the default) the Sarvam intent/entity
     judge is skipped entirely — no normalizer model is loaded, no judge calls
     are made, and the ``sarvam_*`` columns/metrics are omitted.
     """
@@ -1072,10 +1072,10 @@ async def _score_and_write_results(
     cer_results = get_cer_score(gt_transcripts, pred_transcripts)
     _log(f"CER: {cer_results['score']}", to_terminal=False)
 
-    # Intent + entity preservation are opt-in via ``score_intent_entity``;
+    # Intent + entity preservation are opt-in via ``run_sarvam_judges``;
     # skipping avoids loading the normalizer model and the per-row judge calls.
     intent_entity_results = None
-    if score_intent_entity:
+    if run_sarvam_judges:
         intent_entity_results = await get_intent_entity_score(
             gt_transcripts, pred_transcripts, language=language
         )
@@ -1157,7 +1157,7 @@ async def run_eval_only(
     output_dir: str,
     judge_evaluators: list[dict] = None,
     language: str = "english",
-    score_intent_entity: bool = False,
+    run_sarvam_judges: bool = False,
 ) -> dict:
     """Run evaluators only on a pre-existing dataset of (gt, pred) pairs.
 
@@ -1171,7 +1171,7 @@ async def run_eval_only(
             built-in STT evaluator when omitted.
         language: Language of the dataset, used to normalize text before the
             intent/entity judge. Defaults to ``english``.
-        score_intent_entity: When True, also run the Sarvam intent/entity judge.
+        run_sarvam_judges: When True, also run the Sarvam intent/entity judge.
             Off by default — leaving it off skips the normalizer model load and
             the judge calls entirely.
 
@@ -1207,7 +1207,7 @@ async def run_eval_only(
             evaluator_config_dir=output_dir,
             judge_evaluators=judge_evaluators,
             language=language,
-            score_intent_entity=score_intent_entity,
+            run_sarvam_judges=run_sarvam_judges,
         )
 
         return {
@@ -1362,7 +1362,7 @@ async def main():
         debug_count=args.debug_count,
         ignore_retry=args.ignore_retry,
         overwrite=args.overwrite,
-        score_intent_entity=args.sarvam_judges,
+        run_sarvam_judges=args.sarvam_judges,
     )
 
     # Print summary

--- a/calibrate/stt/metrics.py
+++ b/calibrate/stt/metrics.py
@@ -20,13 +20,11 @@ from calibrate.judges import (
     DEFAULT_STT_EVALUATOR,
 )
 from calibrate.langfuse import observe, langfuse, langfuse_enabled
-from calibrate.stt import sarvam_intent_entity
-from calibrate.stt.sarvam_intent_entity import (
-    DEFAULT_INTENT_ENTITY_MODEL,
-    IndicNormalizer,
-    calculate_intent_accuracy,
-    calculate_entity_metrics,
-)
+
+# NOTE: ``calibrate.stt.sarvam_intent_entity`` is imported lazily inside the
+# intent/entity functions below — importing it eagerly pulls in transformers,
+# indic-nlp, and joblib, which we want to avoid unless intent/entity scoring is
+# actually requested (it's opt-in via ``--sarvam-intent-entity``).
 
 normalizer = BasicTextNormalizer()
 
@@ -35,14 +33,17 @@ DEFAULT_STT_JUDGE_MODEL = DEFAULT_TEXT_JUDGE_MODEL
 
 
 @lru_cache(maxsize=1)
-def _get_indic_normalizer() -> IndicNormalizer:
+def _get_indic_normalizer():
     """Build the vendored ``IndicNormalizer`` once and reuse it.
 
     ``IndicNormalizer.__init__`` loads the ``openai/whisper-small`` processor
     from disk, so constructing one per scoring call (and per provider in a
     multi-provider benchmark) reloads the model repeatedly. Caching keeps a
-    single instance for the process lifetime.
+    single instance for the process lifetime. The import is deferred so the
+    heavy transformers/indic-nlp stack only loads when scoring is requested.
     """
+    from calibrate.stt.sarvam_intent_entity import IndicNormalizer
+
     return IndicNormalizer()
 
 
@@ -224,7 +225,7 @@ async def get_intent_entity_score(
     references: List[str],
     predictions: List[str],
     language: str = "english",
-    model: str = DEFAULT_INTENT_ENTITY_MODEL,
+    model: Optional[str] = None,
 ) -> dict:
     """Normalize, judge, and aggregate intent/entity preservation.
 
@@ -242,11 +243,23 @@ async def get_intent_entity_score(
             "per_row": [ {<IntentEntityResponse fields>}, ... ],
         }
 
+    ``model`` defaults to ``DEFAULT_INTENT_ENTITY_MODEL`` when omitted.
     ``per_row`` order matches the input order (``asyncio.gather`` preserves
     coroutine order).
     """
     if not references:
         return {"intent": 0.0, "entity": 0.0, "per_row": []}
+
+    # Deferred so the transformers/indic-nlp stack only loads when scoring runs.
+    from calibrate.stt import sarvam_intent_entity
+    from calibrate.stt.sarvam_intent_entity import (
+        DEFAULT_INTENT_ENTITY_MODEL,
+        calculate_intent_accuracy,
+        calculate_entity_metrics,
+    )
+
+    if model is None:
+        model = DEFAULT_INTENT_ENTITY_MODEL
 
     norm_references, norm_predictions = await asyncio.to_thread(
         _normalize_pairs, references, predictions, language

--- a/calibrate/stt/metrics.py
+++ b/calibrate/stt/metrics.py
@@ -24,7 +24,7 @@ from calibrate.langfuse import observe, langfuse, langfuse_enabled
 # NOTE: ``calibrate.stt.sarvam_intent_entity`` is imported lazily inside the
 # intent/entity functions below — importing it eagerly pulls in transformers,
 # indic-nlp, and joblib, which we want to avoid unless intent/entity scoring is
-# actually requested (it's opt-in via ``--sarvam-intent-entity``).
+# actually requested (it's opt-in via ``--sarvam-judges``).
 
 normalizer = BasicTextNormalizer()
 

--- a/calibrate/stt/metrics.py
+++ b/calibrate/stt/metrics.py
@@ -2,6 +2,8 @@
 STT evaluation metrics.
 """
 
+import asyncio
+from functools import lru_cache
 from typing import List, Optional
 
 import numpy as np
@@ -30,6 +32,38 @@ normalizer = BasicTextNormalizer()
 
 # Re-export for existing imports
 DEFAULT_STT_JUDGE_MODEL = DEFAULT_TEXT_JUDGE_MODEL
+
+
+@lru_cache(maxsize=1)
+def _get_indic_normalizer() -> IndicNormalizer:
+    """Build the vendored ``IndicNormalizer`` once and reuse it.
+
+    ``IndicNormalizer.__init__`` loads the ``openai/whisper-small`` processor
+    from disk, so constructing one per scoring call (and per provider in a
+    multi-provider benchmark) reloads the model repeatedly. Caching keeps a
+    single instance for the process lifetime.
+    """
+    return IndicNormalizer()
+
+
+def _normalize_pairs(
+    references: List[str], predictions: List[str], language: str
+) -> tuple[List[str], List[str]]:
+    """Normalize references/predictions with the cached normalizer.
+
+    Runs in-process (``n_jobs=1`` — no joblib subprocess fork) so it can be
+    offloaded to a worker thread without freezing the event loop.
+    """
+    normalizer = _get_indic_normalizer()
+    ref_langs = [language] * len(references)
+    pred_langs = [language] * len(predictions)
+    norm_references = normalizer.normalize_texts(
+        [str(r) for r in references], ref_langs, n_jobs=1
+    )
+    norm_predictions = normalizer.normalize_texts(
+        [str(p) for p in predictions], pred_langs, n_jobs=1
+    )
+    return norm_references, norm_predictions
 
 
 def _resolve_evaluators(evaluators: Optional[List[dict]]) -> List[dict]:
@@ -214,13 +248,8 @@ async def get_intent_entity_score(
     if not references:
         return {"intent": 0.0, "entity": 0.0, "per_row": []}
 
-    langs = [language] * len(references)
-    normalizer = IndicNormalizer()
-    norm_references = normalizer.normalize_texts(
-        [str(r) for r in references], langs
-    )
-    norm_predictions = normalizer.normalize_texts(
-        [str(p) for p in predictions], langs
+    norm_references, norm_predictions = await asyncio.to_thread(
+        _normalize_pairs, references, predictions, language
     )
 
     coroutines = [

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -282,11 +282,12 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                     pred_transcripts=["hello", "world"],
                     output_dir=str(out),
                     evaluator_config_dir=str(out),
+                    score_intent_entity=True,
                 )
 
             self.assertIn("wer", metrics)
             self.assertIn("semantic_match", metrics)
-            # Intent + entity are always reported as top-level floats.
+            # Intent + entity are reported as top-level floats when enabled.
             self.assertEqual(metrics["sarvam_intent_score"], 1.0)
             self.assertEqual(metrics["sarvam_entity_score"], 1.0)
             self.assertTrue((out / "metrics.json").exists())
@@ -309,7 +310,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             )
             self.assertEqual(len(df), 2)
 
-    async def test_intent_entity_always_present_with_custom_evaluators(self):
+    async def test_intent_entity_present_with_custom_evaluators_when_enabled(self):
         from calibrate.stt import eval as stt_eval
 
         custom = [
@@ -343,15 +344,54 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                     output_dir=str(out),
                     evaluator_config_dir=str(out),
                     judge_evaluators=custom,
+                    score_intent_entity=True,
                 )
 
-            # Even with a user-supplied evaluator, intent/entity still report.
+            # With the flag on, intent/entity report alongside a custom evaluator.
             self.assertEqual(metrics["sarvam_intent_score"], 0.0)
             self.assertEqual(metrics["sarvam_entity_score"], 0.25)
             self.assertIn("completeness", metrics)
             df = pd.read_csv(out / "results.csv")
             self.assertEqual(df.iloc[0]["sarvam_intent_score"], 0)
             self.assertEqual(df.iloc[0]["sarvam_entity_score"], 0.25)
+
+    async def test_intent_entity_skipped_by_default(self):
+        from calibrate.stt import eval as stt_eval
+
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+            return {
+                "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
+                "score": 1.0,
+                "per_row": [
+                    {"semantic_match": {"match": True, "reasoning": "ok"}}
+                    for _ in refs
+                ],
+            }
+
+        ie_mock = AsyncMock()
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            with patch.object(
+                stt_eval, "get_llm_judge_score", AsyncMock(side_effect=fake_judge)
+            ), patch.object(stt_eval, "get_intent_entity_score", ie_mock):
+                metrics = await stt_eval._score_and_write_results(
+                    ids=["1", "2"],
+                    gt_transcripts=["hello", "world"],
+                    pred_transcripts=["hello", "world"],
+                    output_dir=str(out),
+                    evaluator_config_dir=str(out),
+                )
+
+            # Default: the judge is never invoked and no sarvam_* keys appear.
+            ie_mock.assert_not_awaited()
+            self.assertNotIn("sarvam_intent_score", metrics)
+            self.assertNotIn("sarvam_entity_score", metrics)
+            df = pd.read_csv(out / "results.csv")
+            self.assertNotIn("sarvam_intent_score", df.columns)
+            self.assertNotIn("sarvam_entity_score", df.columns)
+            # WER/CER and the judge column are still written.
+            self.assertIn("wer", metrics)
+            self.assertIn("semantic_match", metrics)
 
     async def test_rating_evaluator_writes_numeric_score(self):
         from calibrate.stt import eval as stt_eval

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -282,7 +282,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                     pred_transcripts=["hello", "world"],
                     output_dir=str(out),
                     evaluator_config_dir=str(out),
-                    score_intent_entity=True,
+                    run_sarvam_judges=True,
                 )
 
             self.assertIn("wer", metrics)
@@ -344,7 +344,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                     output_dir=str(out),
                     evaluator_config_dir=str(out),
                     judge_evaluators=custom,
-                    score_intent_entity=True,
+                    run_sarvam_judges=True,
                 )
 
             # With the flag on, intent/entity report alongside a custom evaluator.

--- a/tests/stt/test_eval_extra.py
+++ b/tests/stt/test_eval_extra.py
@@ -34,6 +34,38 @@ def _fake_intent_entity(intent=1, entity=1.0):
     return AsyncMock(side_effect=_fn)
 
 
+# --- format_metrics_summary ----------------------------------------------
+
+class TestFormatMetricsSummary(unittest.TestCase):
+    def test_includes_sarvam_when_present(self):
+        from calibrate.stt.eval import format_metrics_summary
+
+        line = format_metrics_summary(
+            {
+                "wer": 0.1,
+                "cer": 0.2,
+                "sarvam_intent_score": 0.9,
+                "sarvam_entity_score": 0.8,
+                "semantic": {"type": "binary", "mean": 0.75},
+            },
+            prefix="deepgram: ",
+        )
+        self.assertEqual(
+            line,
+            "  deepgram: WER=0.1000, CER=0.2000, Sarvam Intent Score=0.9000, "
+            "Sarvam Entity Score=0.8000, semantic=0.7500",
+        )
+
+    def test_omits_sarvam_when_absent(self):
+        from calibrate.stt.eval import format_metrics_summary
+
+        line = format_metrics_summary(
+            {"wer": 0.1, "cer": 0.2, "semantic": {"type": "binary", "mean": 0.75}}
+        )
+        self.assertEqual(line, "  WER=0.1000, CER=0.2000, semantic=0.7500")
+        self.assertNotIn("Sarvam", line)
+
+
 # --- load_audio -----------------------------------------------------------
 
 class TestLoadAudio(unittest.TestCase):

--- a/tests/stt/test_intent_entity.py
+++ b/tests/stt/test_intent_entity.py
@@ -28,11 +28,10 @@ def _row(intent, entity):
 
 
 def _identity_normalizer():
-    """Mock IndicNormalizer whose normalize_texts returns inputs unchanged."""
+    """Mock normalizer whose normalize_texts returns inputs unchanged."""
     inst = MagicMock()
-    inst.normalize_texts.side_effect = lambda texts, langs: list(texts)
-    cls = MagicMock(return_value=inst)
-    return cls
+    inst.normalize_texts.side_effect = lambda texts, langs, n_jobs=1: list(texts)
+    return inst
 
 
 class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
@@ -47,7 +46,7 @@ class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
             }
             return mapping[(reference, prediction)]
 
-        with patch.object(metrics, "IndicNormalizer", _identity_normalizer()), \
+        with patch.object(metrics, "_get_indic_normalizer", return_value=_identity_normalizer()), \
              patch.object(sie, "intent_entity_judge", AsyncMock(side_effect=fake_judge)):
             result = await metrics.get_intent_entity_score(
                 references=["a", "b"],
@@ -64,10 +63,9 @@ class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
 
         # Normalizer lowercases — the judge must receive the normalized form.
         norm_inst = MagicMock()
-        norm_inst.normalize_texts.side_effect = lambda texts, langs: [
+        norm_inst.normalize_texts.side_effect = lambda texts, langs, n_jobs=1: [
             t.lower() for t in texts
         ]
-        norm_cls = MagicMock(return_value=norm_inst)
 
         seen = []
 
@@ -75,7 +73,7 @@ class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
             seen.append((reference, prediction))
             return _row(1, 1.0)
 
-        with patch.object(metrics, "IndicNormalizer", norm_cls), \
+        with patch.object(metrics, "_get_indic_normalizer", return_value=norm_inst), \
              patch.object(sie, "intent_entity_judge", AsyncMock(side_effect=fake_judge)):
             await metrics.get_intent_entity_score(
                 references=["HELLO"],
@@ -88,13 +86,29 @@ class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
         from calibrate.stt import sarvam_intent_entity as sie
         from calibrate.stt import metrics
 
-        with patch.object(metrics, "IndicNormalizer", _identity_normalizer()), \
+        with patch.object(metrics, "_get_indic_normalizer", return_value=_identity_normalizer()), \
              patch.object(sie, "intent_entity_judge", AsyncMock()):
             result = await metrics.get_intent_entity_score(references=[], predictions=[])
 
         self.assertEqual(result["intent"], 0.0)
         self.assertEqual(result["entity"], 0.0)
         self.assertEqual(result["per_row"], [])
+
+
+class TestNormalizerCaching(unittest.TestCase):
+    def test_indic_normalizer_built_once(self):
+        from calibrate.stt import metrics
+
+        metrics._get_indic_normalizer.cache_clear()
+        fake_cls = MagicMock()
+        try:
+            with patch.object(metrics, "IndicNormalizer", fake_cls):
+                first = metrics._get_indic_normalizer()
+                second = metrics._get_indic_normalizer()
+            self.assertIs(first, second)
+            fake_cls.assert_called_once()
+        finally:
+            metrics._get_indic_normalizer.cache_clear()
 
 
 class TestIntentEntityJudge(unittest.IsolatedAsyncioTestCase):

--- a/tests/stt/test_intent_entity.py
+++ b/tests/stt/test_intent_entity.py
@@ -98,17 +98,44 @@ class TestGetIntentEntityScore(unittest.IsolatedAsyncioTestCase):
 class TestNormalizerCaching(unittest.TestCase):
     def test_indic_normalizer_built_once(self):
         from calibrate.stt import metrics
+        from calibrate.stt import sarvam_intent_entity as sie
 
         metrics._get_indic_normalizer.cache_clear()
         fake_cls = MagicMock()
         try:
-            with patch.object(metrics, "IndicNormalizer", fake_cls):
+            # ``_get_indic_normalizer`` imports ``IndicNormalizer`` lazily from
+            # the package, so patch it there (not on ``metrics``).
+            with patch.object(sie, "IndicNormalizer", fake_cls):
                 first = metrics._get_indic_normalizer()
                 second = metrics._get_indic_normalizer()
             self.assertIs(first, second)
             fake_cls.assert_called_once()
         finally:
             metrics._get_indic_normalizer.cache_clear()
+
+
+class TestLazyImports(unittest.TestCase):
+    def test_importing_stt_does_not_load_sarvam_stack(self):
+        import subprocess
+        import sys
+
+        # Fresh interpreter: importing the STT entry points must not pull in the
+        # vendored sarvam package or its indic-nlp dependency (model loading /
+        # heavy imports are deferred until intent/entity scoring is requested).
+        code = (
+            "import sys\n"
+            "import calibrate.stt.benchmark\n"
+            "import calibrate.stt.eval\n"
+            "import calibrate.stt.metrics\n"
+            "assert 'calibrate.stt.sarvam_intent_entity' not in sys.modules, 'sarvam pkg loaded'\n"
+            "assert 'indicnlp' not in sys.modules, 'indicnlp loaded'\n"
+            "print('ok')\n"
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("ok", proc.stdout)
 
 
 class TestIntentEntityJudge(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -138,6 +138,23 @@ class TestSTTBenchmarkRun(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["status"], "completed")
         self.assertIn("deepgram", result["providers"])
 
+    async def test_run_forwards_intent_entity_to_provider_eval(self):
+        from calibrate.stt import benchmark as B
+
+        fake_result = {"provider": "deepgram", "status": "completed",
+                       "metrics": {"wer": 0.1}}
+        mock_eval = AsyncMock(return_value=fake_result)
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch.object(B, "run_single_provider_eval", mock_eval), \
+             patch.object(B, "generate_leaderboard"):
+            await B.run(
+                providers=["deepgram"],
+                input_dir=tmp,
+                output_dir=tmp,
+                score_intent_entity=True,
+            )
+        self.assertTrue(mock_eval.call_args.kwargs["score_intent_entity"])
+
     async def test_run_leaderboard_error(self):
         from calibrate.stt import benchmark as B
 
@@ -207,6 +224,62 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
                  patch.object(B, "run_eval_only", AsyncMock(return_value=fake_result)):
                 await B.main()
 
+    async def test_main_eval_only_forwards_language(self):
+        from calibrate.stt import benchmark as B
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            ds = base / "ds.json"
+            ds.write_text(json.dumps([{"id": "a", "gt": "hi", "pred": "hi"}]))
+            out = base / "out"
+
+            fake_result = {"status": "completed", "metrics": {"wer": 0.1}}
+            mock_eval = AsyncMock(return_value=fake_result)
+            argv = ["b.py", "--eval-only", "--dataset", str(ds),
+                    "-o", str(out), "--language", "hindi"]
+            with patch.object(sys, "argv", argv), \
+                 patch.object(B, "run_eval_only", mock_eval):
+                await B.main()
+
+            self.assertEqual(mock_eval.call_args.kwargs["language"], "hindi")
+
+    async def test_main_eval_only_intent_entity_off_by_default(self):
+        from calibrate.stt import benchmark as B
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            ds = base / "ds.json"
+            ds.write_text(json.dumps([{"id": "a", "gt": "hi", "pred": "hi"}]))
+            out = base / "out"
+
+            fake_result = {"status": "completed", "metrics": {"wer": 0.1}}
+            mock_eval = AsyncMock(return_value=fake_result)
+            argv = ["b.py", "--eval-only", "--dataset", str(ds), "-o", str(out)]
+            with patch.object(sys, "argv", argv), \
+                 patch.object(B, "run_eval_only", mock_eval):
+                await B.main()
+
+            self.assertFalse(mock_eval.call_args.kwargs["score_intent_entity"])
+
+    async def test_main_eval_only_forwards_intent_entity_flag(self):
+        from calibrate.stt import benchmark as B
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            ds = base / "ds.json"
+            ds.write_text(json.dumps([{"id": "a", "gt": "hi", "pred": "hi"}]))
+            out = base / "out"
+
+            fake_result = {"status": "completed", "metrics": {"wer": 0.1}}
+            mock_eval = AsyncMock(return_value=fake_result)
+            argv = ["b.py", "--eval-only", "--dataset", str(ds),
+                    "-o", str(out), "--sarvam-intent-entity"]
+            with patch.object(sys, "argv", argv), \
+                 patch.object(B, "run_eval_only", mock_eval):
+                await B.main()
+
+            self.assertTrue(mock_eval.call_args.kwargs["score_intent_entity"])
+
     async def test_main_eval_only_error(self):
         from calibrate.stt import benchmark as B
 
@@ -263,6 +336,36 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
             with patch.object(sys, "argv", argv), \
                  patch.object(B, "run", AsyncMock(return_value=fake_run_result)):
                 await B.main()
+
+    async def test_main_forwards_intent_entity_flag_to_run(self):
+        from calibrate.stt import benchmark as B
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            self._make_input_dir(base)
+            out = base / "out"
+
+            fake_run_result = {
+                "status": "completed",
+                "output_dir": str(out),
+                "leaderboard_dir": str(out / "leaderboard"),
+                "providers": {
+                    "deepgram": {"status": "completed", "metrics": {"wer": 0.1}},
+                },
+            }
+            mock_run = AsyncMock(return_value=fake_run_result)
+
+            # Default off.
+            argv = ["b.py", "-p", "deepgram", "-i", str(base), "-o", str(out)]
+            with patch.object(sys, "argv", argv), patch.object(B, "run", mock_run):
+                await B.main()
+            self.assertFalse(mock_run.call_args.kwargs["score_intent_entity"])
+
+            # Flag on.
+            argv.append("--sarvam-intent-entity")
+            with patch.object(sys, "argv", argv), patch.object(B, "run", mock_run):
+                await B.main()
+            self.assertTrue(mock_run.call_args.kwargs["score_intent_entity"])
 
     async def test_main_error_provider_exits(self):
         from calibrate.stt import benchmark as B

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -273,7 +273,7 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
             fake_result = {"status": "completed", "metrics": {"wer": 0.1}}
             mock_eval = AsyncMock(return_value=fake_result)
             argv = ["b.py", "--eval-only", "--dataset", str(ds),
-                    "-o", str(out), "--sarvam-intent-entity"]
+                    "-o", str(out), "--sarvam-judges"]
             with patch.object(sys, "argv", argv), \
                  patch.object(B, "run_eval_only", mock_eval):
                 await B.main()
@@ -362,7 +362,7 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
             self.assertFalse(mock_run.call_args.kwargs["score_intent_entity"])
 
             # Flag on.
-            argv.append("--sarvam-intent-entity")
+            argv.append("--sarvam-judges")
             with patch.object(sys, "argv", argv), patch.object(B, "run", mock_run):
                 await B.main()
             self.assertTrue(mock_run.call_args.kwargs["score_intent_entity"])

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -151,9 +151,9 @@ class TestSTTBenchmarkRun(unittest.IsolatedAsyncioTestCase):
                 providers=["deepgram"],
                 input_dir=tmp,
                 output_dir=tmp,
-                score_intent_entity=True,
+                run_sarvam_judges=True,
             )
-        self.assertTrue(mock_eval.call_args.kwargs["score_intent_entity"])
+        self.assertTrue(mock_eval.call_args.kwargs["run_sarvam_judges"])
 
     async def test_run_leaderboard_error(self):
         from calibrate.stt import benchmark as B
@@ -259,7 +259,7 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
                  patch.object(B, "run_eval_only", mock_eval):
                 await B.main()
 
-            self.assertFalse(mock_eval.call_args.kwargs["score_intent_entity"])
+            self.assertFalse(mock_eval.call_args.kwargs["run_sarvam_judges"])
 
     async def test_main_eval_only_forwards_intent_entity_flag(self):
         from calibrate.stt import benchmark as B
@@ -278,7 +278,7 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
                  patch.object(B, "run_eval_only", mock_eval):
                 await B.main()
 
-            self.assertTrue(mock_eval.call_args.kwargs["score_intent_entity"])
+            self.assertTrue(mock_eval.call_args.kwargs["run_sarvam_judges"])
 
     async def test_main_eval_only_error(self):
         from calibrate.stt import benchmark as B
@@ -359,13 +359,13 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
             argv = ["b.py", "-p", "deepgram", "-i", str(base), "-o", str(out)]
             with patch.object(sys, "argv", argv), patch.object(B, "run", mock_run):
                 await B.main()
-            self.assertFalse(mock_run.call_args.kwargs["score_intent_entity"])
+            self.assertFalse(mock_run.call_args.kwargs["run_sarvam_judges"])
 
             # Flag on.
             argv.append("--sarvam-judges")
             with patch.object(sys, "argv", argv), patch.object(B, "run", mock_run):
                 await B.main()
-            self.assertTrue(mock_run.call_args.kwargs["score_intent_entity"])
+            self.assertTrue(mock_run.call_args.kwargs["run_sarvam_judges"])
 
     async def test_main_error_provider_exits(self):
         from calibrate.stt import benchmark as B

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -186,6 +186,74 @@ class TestMainDispatch(unittest.TestCase):
                     "-o", tmp,
                 ])
 
+    def test_stt_benchmark_forwards_sarvam_flag(self):
+        captured = {}
+
+        async def fake_main():
+            captured["argv"] = list(sys.argv)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            (base / "audios").mkdir()
+            import pandas as pd
+            pd.DataFrame({"id": ["a"], "text": ["hi"]}).to_csv(
+                base / "stt.csv", index=False
+            )
+            (base / "audios" / "a.wav").write_bytes(b"\x00")
+
+            with patch("calibrate.stt.benchmark.main",
+                       AsyncMock(side_effect=fake_main)):
+                self._run_with_argv([
+                    "calibrate", "stt", "-p", "deepgram",
+                    "-i", str(base), "-o", str(base / "out"),
+                    "--sarvam-intent-entity",
+                ])
+
+        self.assertIn("--sarvam-intent-entity", captured["argv"])
+
+    def test_stt_benchmark_omits_sarvam_flag_by_default(self):
+        captured = {}
+
+        async def fake_main():
+            captured["argv"] = list(sys.argv)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            (base / "audios").mkdir()
+            import pandas as pd
+            pd.DataFrame({"id": ["a"], "text": ["hi"]}).to_csv(
+                base / "stt.csv", index=False
+            )
+            (base / "audios" / "a.wav").write_bytes(b"\x00")
+
+            with patch("calibrate.stt.benchmark.main",
+                       AsyncMock(side_effect=fake_main)):
+                self._run_with_argv([
+                    "calibrate", "stt", "-p", "deepgram",
+                    "-i", str(base), "-o", str(base / "out"),
+                ])
+
+        self.assertNotIn("--sarvam-intent-entity", captured["argv"])
+
+    def test_stt_eval_only_forwards_sarvam_flag_and_language(self):
+        captured = {}
+
+        async def fake_main():
+            captured["argv"] = list(sys.argv)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            ds = Path(tmp) / "ds.json"
+            ds.write_text("[]")
+            with patch("calibrate.stt.benchmark.main",
+                       AsyncMock(side_effect=fake_main)):
+                self._run_with_argv([
+                    "calibrate", "stt", "--eval-only", "--dataset", str(ds),
+                    "-o", tmp, "-l", "hindi", "--sarvam-intent-entity",
+                ])
+
+        self.assertIn("--sarvam-intent-entity", captured["argv"])
+        self.assertIn("hindi", captured["argv"])
+
     def test_tts_no_provider_launches_ui(self):
         from calibrate import cli
         with patch.object(cli, "_launch_ink_ui") as mock:

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -206,10 +206,10 @@ class TestMainDispatch(unittest.TestCase):
                 self._run_with_argv([
                     "calibrate", "stt", "-p", "deepgram",
                     "-i", str(base), "-o", str(base / "out"),
-                    "--sarvam-intent-entity",
+                    "--sarvam-judges",
                 ])
 
-        self.assertIn("--sarvam-intent-entity", captured["argv"])
+        self.assertIn("--sarvam-judges", captured["argv"])
 
     def test_stt_benchmark_omits_sarvam_flag_by_default(self):
         captured = {}
@@ -233,7 +233,7 @@ class TestMainDispatch(unittest.TestCase):
                     "-i", str(base), "-o", str(base / "out"),
                 ])
 
-        self.assertNotIn("--sarvam-intent-entity", captured["argv"])
+        self.assertNotIn("--sarvam-judges", captured["argv"])
 
     def test_stt_eval_only_forwards_sarvam_flag_and_language(self):
         captured = {}
@@ -248,10 +248,10 @@ class TestMainDispatch(unittest.TestCase):
                        AsyncMock(side_effect=fake_main)):
                 self._run_with_argv([
                     "calibrate", "stt", "--eval-only", "--dataset", str(ds),
-                    "-o", tmp, "-l", "hindi", "--sarvam-intent-entity",
+                    "-o", tmp, "-l", "hindi", "--sarvam-judges",
                 ])
 
-        self.assertIn("--sarvam-intent-entity", captured["argv"])
+        self.assertIn("--sarvam-judges", captured["argv"])
         self.assertIn("hindi", captured["argv"])
 
     def test_tts_no_provider_launches_ui(self):


### PR DESCRIPTION
## What
- Make the Sarvam intent & entity STT scores opt-in via `--sarvam-intent-entity` (default off); when absent, no normalizer model loads, no judge runs, and no `sarvam_*` columns/metrics are emitted.
- Cache the `IndicNormalizer` (it reloaded the whisper-small model on every call) and run normalization off the event loop with `n_jobs=1` instead of a blocking joblib multiprocess job.
- Forward `--language` and the new flag through the `--eval-only` CLI path (language was previously dropped, defaulting non-English data to English normalization).
- Dedup the WER/CER/Sarvam summary line into a shared `format_metrics_summary` helper.

## Notes
- The flag is per-run, so all providers in a benchmark are scored consistently; the leaderboard reads metrics generically, so columns drop cleanly when off.
- Module-level imports of the vendored `sarvam_intent_entity` package still run at import time (transformers/indicnlp/joblib) but load no model; only the model download/load and judge calls are gated.