### PR TITLE
STT: adopt Gnani.ai jiwer-based WER/CER methodology

### DIFF
--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -1244,10 +1244,10 @@ async def _score_and_write_results(
     judge is skipped entirely — no normalizer model is loaded, no judge calls
     are made, and the ``sarvam_*`` columns/metrics are omitted.
     """
-    wer_results = get_wer_score(gt_transcripts, pred_transcripts)
+    wer_results = get_wer_score(gt_transcripts, pred_transcripts, language=language)
     _log(f"WER: {wer_results['score']}", to_terminal=False)
 
-    cer_results = get_cer_score(gt_transcripts, pred_transcripts)
+    cer_results = get_cer_score(gt_transcripts, pred_transcripts, language=language)
     _log(f"CER: {cer_results['score']}", to_terminal=False)
 
     # Intent + entity preservation are opt-in via ``run_sarvam_judges``;

--- a/calibrate/stt/metrics.py
+++ b/calibrate/stt/metrics.py
@@ -3,13 +3,13 @@ STT evaluation metrics.
 """
 
 import asyncio
+import unicodedata
 from functools import lru_cache
 from typing import List, Optional
 
 import numpy as np
-from evaluate import load
+import jiwer
 from tqdm.asyncio import tqdm_asyncio
-from transformers.models.whisper.english_normalizer import BasicTextNormalizer
 import backoff
 
 from calibrate.judges import (
@@ -26,10 +26,22 @@ from calibrate.langfuse import observe, langfuse, langfuse_enabled
 # indic-nlp, and joblib, which we want to avoid unless intent/entity scoring is
 # actually requested (it's opt-in via ``--sarvam-judges``).
 
-normalizer = BasicTextNormalizer()
-
 # Re-export for existing imports
 DEFAULT_STT_JUDGE_MODEL = DEFAULT_TEXT_JUDGE_MODEL
+
+# jiwer preprocessing pipeline, following Gnani.ai's Indic ASR benchmarking
+# methodology (https://www.gnani.ai/resources/research/benchmarking-indic-asr-models-a-technical-deep-dive):
+# collapse whitespace, strip, case-fold, and drop punctuation before scoring.
+# Unicode NFC normalization is applied separately (below) so composed vs.
+# decomposed forms of Indic vowel diacritics don't register as spurious edits.
+_EDIT_CLEANUP = [
+    jiwer.RemoveMultipleSpaces(),
+    jiwer.Strip(),
+    jiwer.ToLowerCase(),
+    jiwer.RemovePunctuation(),
+]
+_WER_TRANSFORM = jiwer.Compose(_EDIT_CLEANUP + [jiwer.ReduceToListOfListOfWords()])
+_CER_TRANSFORM = jiwer.Compose(_EDIT_CLEANUP + [jiwer.ReduceToListOfListOfChars()])
 
 
 @lru_cache(maxsize=1)
@@ -72,35 +84,61 @@ def _resolve_evaluators(evaluators: Optional[List[dict]]) -> List[dict]:
     return list(evaluators) if evaluators else [DEFAULT_STT_EVALUATOR]
 
 
-def _edit_metric(name: str, references: List[str], predictions: List[str]) -> dict:
-    """Compute a normalized per-row edit-distance metric from ``evaluate``.
+def _nfc(text: str) -> str:
+    """Unicode NFC-normalize so composed/decomposed Indic diacritics match."""
+    return unicodedata.normalize("NFC", text)
 
-    Shared by WER and CER: both normalize ref/pred with the Whisper
-    ``BasicTextNormalizer``, score each row independently via the
-    HuggingFace ``evaluate`` metric ``name`` (``"wer"`` / ``"cer"``), and
-    return the macro-mean plus the per-row list.
+
+def _edit_metric(
+    metric_fn, transform, references: List[str], predictions: List[str]
+) -> dict:
+    """Compute a jiwer edit-distance metric, dataset-level plus per-row.
+
+    Shared by WER and CER. References/predictions are NFC-normalized, then
+    ``jiwer`` applies ``transform`` (whitespace collapse, strip, case-fold,
+    punctuation removal, tokenization) before scoring.
+
+    ``score`` is the **dataset-level** rate — total substitutions, deletions,
+    and insertions across all utterances divided by total reference length —
+    matching the NIST definition Gnani.ai uses. This differs from a macro-mean
+    of per-utterance rates, which over-weights short utterances. ``per_row``
+    holds the per-utterance rates, kept for row-level reporting.
     """
-    metric = load(name)
-
-    references = [normalizer(str(ref)) for ref in references]
+    references = [_nfc(str(ref)) for ref in references]
     predictions = [
-        normalizer(str(pred)) if isinstance(pred, str) else "" for pred in predictions
+        _nfc(str(pred)) if isinstance(pred, str) else "" for pred in predictions
     ]
 
     per_row = [
-        metric.compute(predictions=[p], references=[r])
-        for p, r in zip(predictions, references)
+        metric_fn(
+            reference=[r],
+            hypothesis=[p],
+            reference_transform=transform,
+            hypothesis_transform=transform,
+        )
+        for r, p in zip(references, predictions)
     ]
 
-    return {"score": np.mean(per_row), "per_row": per_row}
+    score = (
+        metric_fn(
+            reference=references,
+            hypothesis=predictions,
+            reference_transform=transform,
+            hypothesis_transform=transform,
+        )
+        if references
+        else 0.0
+    )
+
+    return {"score": float(score), "per_row": per_row}
 
 
 def get_wer_score(references: List[str], predictions: List[str]) -> dict:
-    return _edit_metric("wer", references, predictions)
+    return _edit_metric(jiwer.wer, _WER_TRANSFORM, references, predictions)
 
 
 def get_cer_score(references: List[str], predictions: List[str]) -> dict:
-    return _edit_metric("cer", references, predictions)
+    return _edit_metric(jiwer.cer, _CER_TRANSFORM, references, predictions)
 
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=5, factor=2)

--- a/calibrate/stt/metrics.py
+++ b/calibrate/stt/metrics.py
@@ -43,11 +43,6 @@ _EDIT_CLEANUP = [
 _WER_TRANSFORM = jiwer.Compose(_EDIT_CLEANUP + [jiwer.ReduceToListOfListOfWords()])
 _CER_TRANSFORM = jiwer.Compose(_EDIT_CLEANUP + [jiwer.ReduceToListOfListOfChars()])
 
-# Placeholder swapped in for a reference that normalizes to nothing, mirroring
-# Vistaar. An empty reference would otherwise make jiwer's dataset-level rate
-# divide by ~0 and blow past 1.0.
-_EMPTY_REF = "<empty>"
-
 # calibrate language name / ISO code -> indic-nlp-library normalizer code.
 # Languages absent here (english, urdu, …) get NFC-only normalization: Vistaar
 # skips the IndicNormalizer for Urdu, and indic-nlp has no English normalizer.
@@ -175,14 +170,19 @@ def _edit_metric(
     References/predictions are normalized (NFC + language-specific
     ``IndicNormalizer``), then ``jiwer`` applies ``transform`` (whitespace
     collapse, strip, case-fold, punctuation removal, tokenization) before
-    scoring. References that reduce to nothing are replaced with a placeholder
-    (see ``_EMPTY_REF``).
+    scoring.
 
     ``score`` is the **dataset-level** rate — total substitutions, deletions,
     and insertions across all utterances divided by total reference length —
     matching the NIST definition Vistaar uses. This differs from a macro-mean
     of per-utterance rates, which over-weights short utterances. ``per_row``
     holds the per-utterance rates, kept for row-level reporting.
+
+    Empty references need no placeholder: jiwer pools them correctly at the
+    dataset level (an empty ref with an empty hypothesis contributes nothing;
+    a hallucinated hypothesis contributes insertions). The only degenerate
+    case is a dataset with *no* reference words at all — guarded below to
+    avoid jiwer returning an unbounded count instead of a rate.
     """
     normalizer = _indic_normalizer(language)
 
@@ -191,7 +191,6 @@ def _edit_metric(
         _normalize_text(pred, normalizer) if isinstance(pred, str) else ""
         for pred in predictions
     ]
-    references = [ref if transform([ref])[0] else _EMPTY_REF for ref in references]
 
     # Per-clip rates — for results.csv only, never averaged into `score`.
     per_row = [
@@ -212,7 +211,7 @@ def _edit_metric(
             reference_transform=transform,
             hypothesis_transform=transform,
         )
-        if references
+        if any(transform([ref])[0] for ref in references)
         else 0.0
     )
 

--- a/calibrate/stt/metrics.py
+++ b/calibrate/stt/metrics.py
@@ -29,11 +29,11 @@ from calibrate.langfuse import observe, langfuse, langfuse_enabled
 # Re-export for existing imports
 DEFAULT_STT_JUDGE_MODEL = DEFAULT_TEXT_JUDGE_MODEL
 
-# jiwer preprocessing pipeline, following Gnani.ai's Indic ASR benchmarking
-# methodology (https://www.gnani.ai/resources/research/benchmarking-indic-asr-models-a-technical-deep-dive):
+# jiwer preprocessing pipeline, following AI4Bharat's Vistaar Indic ASR
+# benchmark (https://github.com/AI4Bharat/vistaar/blob/master/evaluation.py):
 # collapse whitespace, strip, case-fold, and drop punctuation before scoring.
-# Unicode NFC normalization is applied separately (below) so composed vs.
-# decomposed forms of Indic vowel diacritics don't register as spurious edits.
+# Text normalization (NFC + language-specific ``IndicNormalizer``) is applied
+# separately, upstream of these transforms — see ``_normalize_text``.
 _EDIT_CLEANUP = [
     jiwer.RemoveMultipleSpaces(),
     jiwer.Strip(),
@@ -42,6 +42,79 @@ _EDIT_CLEANUP = [
 ]
 _WER_TRANSFORM = jiwer.Compose(_EDIT_CLEANUP + [jiwer.ReduceToListOfListOfWords()])
 _CER_TRANSFORM = jiwer.Compose(_EDIT_CLEANUP + [jiwer.ReduceToListOfListOfChars()])
+
+# Placeholder swapped in for a reference that normalizes to nothing, mirroring
+# Vistaar. An empty reference would otherwise make jiwer's dataset-level rate
+# divide by ~0 and blow past 1.0.
+_EMPTY_REF = "<empty>"
+
+# calibrate language name / ISO code -> indic-nlp-library normalizer code.
+# Languages absent here (english, urdu, …) get NFC-only normalization: Vistaar
+# skips the IndicNormalizer for Urdu, and indic-nlp has no English normalizer.
+_INDIC_NLP_LANG_CODES = {
+    "hindi": "hi",
+    "marathi": "mr",
+    "sanskrit": "sa",
+    "nepali": "ne",
+    "konkani": "kK",
+    "bengali": "bn",
+    "assamese": "as",
+    "punjabi": "pa",
+    "gujarati": "gu",
+    "odia": "or",
+    "oriya": "or",
+    "tamil": "ta",
+    "telugu": "te",
+    "kannada": "kn",
+    "malayalam": "ml",
+}
+
+
+def _resolve_indic_code(language: Optional[str]) -> Optional[str]:
+    """Map a language name or ISO code to an indic-nlp normalizer code."""
+    key = (language or "").strip().lower()
+    if key in _INDIC_NLP_LANG_CODES:
+        return _INDIC_NLP_LANG_CODES[key]
+    if key in set(_INDIC_NLP_LANG_CODES.values()):
+        return key
+    return None
+
+
+@lru_cache(maxsize=None)
+def _indic_normalizer_for_code(code: str):
+    """Build (and cache) the indic-nlp normalizer for ``code``, or None.
+
+    This is the lightweight ``indic-nlp-library`` normalizer Vistaar uses —
+    distinct from the heavy vendored Sarvam ``IndicNormalizer`` in
+    ``_get_indic_normalizer`` (which loads a Whisper processor). Any failure
+    (unsupported language, missing optional dep like ``urduhack`` for Urdu)
+    falls back to None so scoring proceeds with NFC-only normalization.
+    """
+    try:
+        from indicnlp.normalize.indic_normalize import IndicNormalizerFactory
+
+        return IndicNormalizerFactory().get_normalizer(code)
+    except Exception:
+        return None
+
+
+def _indic_normalizer(language: Optional[str]):
+    """Return the indic-nlp normalizer for ``language``, or None if unsupported."""
+    code = _resolve_indic_code(language)
+    return _indic_normalizer_for_code(code) if code else None
+
+
+def _normalize_text(text: str, normalizer) -> str:
+    """NFC-normalize, then apply ``normalizer`` (indic-nlp) if provided.
+
+    NFC folds composed vs. decomposed diacritics; the ``IndicNormalizer``
+    additionally canonicalizes script variants (nukta forms, ZWJ/ZWNJ,
+    alternate spellings) that NFC alone leaves distinct.
+    """
+    text = unicodedata.normalize("NFC", str(text))
+    if normalizer is not None:
+        text = normalizer.normalize(text)
+    return text
 
 
 @lru_cache(maxsize=1)
@@ -84,31 +157,38 @@ def _resolve_evaluators(evaluators: Optional[List[dict]]) -> List[dict]:
     return list(evaluators) if evaluators else [DEFAULT_STT_EVALUATOR]
 
 
-def _nfc(text: str) -> str:
-    """Unicode NFC-normalize so composed/decomposed Indic diacritics match."""
-    return unicodedata.normalize("NFC", text)
-
-
 def _edit_metric(
-    metric_fn, transform, references: List[str], predictions: List[str]
+    metric_fn,
+    transform,
+    references: List[str],
+    predictions: List[str],
+    language: str,
 ) -> dict:
     """Compute a jiwer edit-distance metric, dataset-level plus per-row.
 
-    Shared by WER and CER. References/predictions are NFC-normalized, then
-    ``jiwer`` applies ``transform`` (whitespace collapse, strip, case-fold,
-    punctuation removal, tokenization) before scoring.
+    Shared by WER and CER, mirroring AI4Bharat's Vistaar benchmark.
+    References/predictions are normalized (NFC + language-specific
+    ``IndicNormalizer``), then ``jiwer`` applies ``transform`` (whitespace
+    collapse, strip, case-fold, punctuation removal, tokenization) before
+    scoring. References that reduce to nothing are replaced with a placeholder
+    (see ``_EMPTY_REF``).
 
     ``score`` is the **dataset-level** rate — total substitutions, deletions,
     and insertions across all utterances divided by total reference length —
-    matching the NIST definition Gnani.ai uses. This differs from a macro-mean
+    matching the NIST definition Vistaar uses. This differs from a macro-mean
     of per-utterance rates, which over-weights short utterances. ``per_row``
     holds the per-utterance rates, kept for row-level reporting.
     """
-    references = [_nfc(str(ref)) for ref in references]
-    predictions = [
-        _nfc(str(pred)) if isinstance(pred, str) else "" for pred in predictions
-    ]
+    normalizer = _indic_normalizer(language)
 
+    references = [_normalize_text(ref, normalizer) for ref in references]
+    predictions = [
+        _normalize_text(pred, normalizer) if isinstance(pred, str) else ""
+        for pred in predictions
+    ]
+    references = [ref if transform([ref])[0] else _EMPTY_REF for ref in references]
+
+    # Per-clip rates — for results.csv only, never averaged into `score`.
     per_row = [
         metric_fn(
             reference=[r],
@@ -119,6 +199,7 @@ def _edit_metric(
         for r, p in zip(references, predictions)
     ]
 
+    # Headline score — pooled over the whole dataset, not a per-row average.
     score = (
         metric_fn(
             reference=references,
@@ -133,12 +214,16 @@ def _edit_metric(
     return {"score": float(score), "per_row": per_row}
 
 
-def get_wer_score(references: List[str], predictions: List[str]) -> dict:
-    return _edit_metric(jiwer.wer, _WER_TRANSFORM, references, predictions)
+def get_wer_score(
+    references: List[str], predictions: List[str], language: str = "english"
+) -> dict:
+    return _edit_metric(jiwer.wer, _WER_TRANSFORM, references, predictions, language)
 
 
-def get_cer_score(references: List[str], predictions: List[str]) -> dict:
-    return _edit_metric(jiwer.cer, _CER_TRANSFORM, references, predictions)
+def get_cer_score(
+    references: List[str], predictions: List[str], language: str = "english"
+) -> dict:
+    return _edit_metric(jiwer.cer, _CER_TRANSFORM, references, predictions, language)
 
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=5, factor=2)

--- a/calibrate/stt/metrics.py
+++ b/calibrate/stt/metrics.py
@@ -81,7 +81,7 @@ def _resolve_indic_code(language: Optional[str]) -> Optional[str]:
 
 
 @lru_cache(maxsize=None)
-def _indic_normalizer_for_code(lang_code: str):
+def _indic_normalizer_for_lang_code(lang_code: str):
     """Build (and cache) the indic-nlp normalizer for ``lang_code``, or None.
 
     ``lang_code`` is an indic-nlp-library language code (e.g. ``"hi"``,
@@ -103,7 +103,7 @@ def _indic_normalizer_for_code(lang_code: str):
 def _indic_normalizer(language: Optional[str]):
     """Return the indic-nlp normalizer for ``language``, or None if unsupported."""
     lang_code = _resolve_indic_code(language)
-    return _indic_normalizer_for_code(lang_code) if lang_code else None
+    return _indic_normalizer_for_lang_code(lang_code) if lang_code else None
 
 
 def _normalize_text(text: str, normalizer) -> str:

--- a/calibrate/stt/metrics.py
+++ b/calibrate/stt/metrics.py
@@ -110,6 +110,9 @@ def _normalize_text(text: str, normalizer) -> str:
     NFC folds composed vs. decomposed diacritics; the ``IndicNormalizer``
     additionally canonicalizes script variants (nukta forms, ZWJ/ZWNJ,
     alternate spellings) that NFC alone leaves distinct.
+
+    Mirrors the per-utterance normalization in AI4Bharat's Vistaar:
+    https://github.com/AI4Bharat/vistaar/blob/master/evaluation.py
     """
     text = unicodedata.normalize("NFC", str(text))
     if normalizer is not None:

--- a/calibrate/stt/metrics.py
+++ b/calibrate/stt/metrics.py
@@ -81,27 +81,29 @@ def _resolve_indic_code(language: Optional[str]) -> Optional[str]:
 
 
 @lru_cache(maxsize=None)
-def _indic_normalizer_for_code(code: str):
-    """Build (and cache) the indic-nlp normalizer for ``code``, or None.
+def _indic_normalizer_for_code(lang_code: str):
+    """Build (and cache) the indic-nlp normalizer for ``lang_code``, or None.
 
-    This is the lightweight ``indic-nlp-library`` normalizer Vistaar uses —
-    distinct from the heavy vendored Sarvam ``IndicNormalizer`` in
-    ``_get_indic_normalizer`` (which loads a Whisper processor). Any failure
-    (unsupported language, missing optional dep like ``urduhack`` for Urdu)
-    falls back to None so scoring proceeds with NFC-only normalization.
+    ``lang_code`` is an indic-nlp-library language code (e.g. ``"hi"``,
+    ``"ta"``) as produced by ``_resolve_indic_code``. This is the lightweight
+    ``indic-nlp-library`` normalizer Vistaar uses — distinct from the heavy
+    vendored Sarvam ``IndicNormalizer`` in ``_get_indic_normalizer`` (which
+    loads a Whisper processor). Any failure (unsupported language, missing
+    optional dep like ``urduhack`` for Urdu) falls back to None so scoring
+    proceeds with NFC-only normalization.
     """
     try:
         from indicnlp.normalize.indic_normalize import IndicNormalizerFactory
 
-        return IndicNormalizerFactory().get_normalizer(code)
+        return IndicNormalizerFactory().get_normalizer(lang_code)
     except Exception:
         return None
 
 
 def _indic_normalizer(language: Optional[str]):
     """Return the indic-nlp normalizer for ``language``, or None if unsupported."""
-    code = _resolve_indic_code(language)
-    return _indic_normalizer_for_code(code) if code else None
+    lang_code = _resolve_indic_code(language)
+    return _indic_normalizer_for_code(lang_code) if lang_code else None
 
 
 def _normalize_text(text: str, normalizer) -> str:

--- a/tests/stt/test_metrics.py
+++ b/tests/stt/test_metrics.py
@@ -96,14 +96,29 @@ class TestEditMetrics(unittest.TestCase):
             0.0,
         )
 
-    def test_empty_reference_uses_sentinel_not_inflated_score(self):
+    def test_empty_reference_pooled_correctly(self):
         from calibrate.stt import metrics as M
 
-        # A reference that normalizes to nothing becomes the <empty> sentinel:
-        # it contributes one ordinary word error, so the score stays at 1.0
-        # instead of blowing past 1.0 (the pre-sentinel behaviour).
-        result = M.get_wer_score(["", "..."], ["hello", "world"], language="hindi")
-        self.assertEqual(result["score"], 1.0)
+        # Empty GT + empty prediction is correct behaviour → contributes nothing
+        # to the pooled score (not penalized).
+        mixed = M.get_wer_score(["hello world", ""], ["hello world", ""])
+        self.assertEqual(mixed["score"], 0.0)
+
+        # Empty GT + hallucinated prediction → the extra words count as
+        # insertions and are penalized. One real ref (4 words, 1 sub) plus two
+        # inserted junk words → (1 + 2) / 4 = 0.75.
+        halluc = M.get_wer_score(
+            ["a b c d", ""], ["a b x d", "junk here"]
+        )
+        self.assertAlmostEqual(halluc["score"], 0.75)
+
+    def test_all_empty_references_guarded(self):
+        from calibrate.stt import metrics as M
+
+        # A dataset with no reference words at all would make jiwer return an
+        # unbounded count; the guard returns 0.0 instead.
+        self.assertEqual(M.get_wer_score(["", "..."], ["", "junk"])["score"], 0.0)
+        self.assertEqual(M.get_cer_score([""], ["hello"])["score"], 0.0)
 
     def test_unsupported_language_falls_back_gracefully(self):
         from calibrate.stt import metrics as M

--- a/tests/stt/test_metrics.py
+++ b/tests/stt/test_metrics.py
@@ -6,58 +6,74 @@ Run with:
 """
 
 import unittest
-from unittest.mock import patch, AsyncMock, MagicMock
+from unittest.mock import patch, AsyncMock
 
 
 class TestEditMetrics(unittest.TestCase):
-    """WER/CER share ``_edit_metric``; ``load`` is mocked to stay pure-unit."""
+    """WER/CER via jiwer — real computation, no network (jiwer is pure-Python)."""
 
-    def _fake_load(self, recorder):
-        """Return a fake ``evaluate`` metric that records the per-row inputs."""
-        metric = MagicMock()
-
-        def compute(predictions, references):
-            recorder.append((references[0], predictions[0]))
-            # toy score: 1.0 when ref/pred differ, else 0.0
-            return 0.0 if references[0] == predictions[0] else 1.0
-
-        metric.compute.side_effect = compute
-        return metric
-
-    def test_get_wer_score_loads_wer_and_normalizes(self):
+    def test_get_wer_score_normalizes_case_and_punctuation(self):
         from calibrate.stt import metrics as M
 
-        seen = []
-        with patch.object(M, "load", return_value=self._fake_load(seen)) as mock_load:
-            result = M.get_wer_score(["Hello World", "foo"], ["hello world", "bar"])
+        # Row 1: case-only diff normalizes to identical -> 0.0.
+        # Row 2: one of two words wrong -> 0.5.
+        result = M.get_wer_score(["Hello, World!", "foo bar"], ["hello world", "foo baz"])
 
-        mock_load.assert_called_once_with("wer")
-        # Row 1 ref/pred normalize identically (case-folded) -> 0.0; row 2 differs -> 1.0.
-        self.assertEqual(result["per_row"], [0.0, 1.0])
-        self.assertEqual(result["score"], 0.5)
-        # Normalizer was applied before scoring (case-folded to the same string).
-        self.assertEqual(seen[0], ("hello world", "hello world"))
+        self.assertEqual(result["per_row"], [0.0, 0.5])
 
-    def test_get_cer_score_loads_cer(self):
+    def test_score_is_dataset_level_not_macro_mean(self):
         from calibrate.stt import metrics as M
 
-        seen = []
-        with patch.object(M, "load", return_value=self._fake_load(seen)) as mock_load:
-            result = M.get_cer_score(["abc"], ["abc"])
+        # Row A: 1 error / 2 words. Row B: 0 errors / 4 words.
+        # Macro-mean of per-row = (0.5 + 0.0)/2 = 0.25.
+        # Dataset-level = total errors / total words = 1/6 ≈ 0.1667.
+        result = M.get_wer_score(["hello world", "a b c d"], ["hello word", "a b c d"])
 
-        mock_load.assert_called_once_with("cer")
+        self.assertEqual(result["per_row"], [0.5, 0.0])
+        self.assertAlmostEqual(result["score"], 1 / 6)
+        # Confirm it is NOT the naive macro-mean.
+        self.assertNotAlmostEqual(result["score"], 0.25)
+
+    def test_get_cer_score_character_level(self):
+        from calibrate.stt import metrics as M
+
+        result = M.get_cer_score(["abc"], ["abc"])
         self.assertEqual(result["per_row"], [0.0])
         self.assertEqual(result["score"], 0.0)
+
+        # One char substitution out of three source chars -> 1/3.
+        result = M.get_cer_score(["abc"], ["abx"])
+        self.assertAlmostEqual(result["score"], 1 / 3)
 
     def test_non_string_prediction_becomes_empty(self):
         from calibrate.stt import metrics as M
 
-        seen = []
-        with patch.object(M, "load", return_value=self._fake_load(seen)):
-            M.get_cer_score(["abc"], [None])
+        # None prediction is coerced to "" -> all reference chars are deletions.
+        result = M.get_cer_score(["abc"], [None])
+        self.assertEqual(result["score"], 1.0)
 
-        # None prediction is coerced to "" before scoring.
-        self.assertEqual(seen[0][1], "")
+    def test_nfc_normalization_matches_decomposed_forms(self):
+        from calibrate.stt import metrics as M
+
+        # Devanagari QA: precomposed single code point (U+0958) vs decomposed
+        # KA + NUKTA (U+0915 U+093C). Different raw code points, same character.
+        composed = "क़"
+        decomposed = "क़"
+        self.assertNotEqual(composed, decomposed)
+
+        # NFC folds them together, so no spurious character-level edit is counted.
+        result = M.get_cer_score([composed], [decomposed])
+        self.assertEqual(result["score"], 0.0)
+
+        # Also holds for Latin composed vs decomposed accents.
+        self.assertEqual(M.get_cer_score(["café"], ["café"])["score"], 0.0)
+
+    def test_empty_input_returns_zero_score(self):
+        from calibrate.stt import metrics as M
+
+        result = M.get_wer_score([], [])
+        self.assertEqual(result["score"], 0.0)
+        self.assertEqual(result["per_row"], [])
 
 
 class TestSTTGetLLMJudgeScore(unittest.IsolatedAsyncioTestCase):

--- a/tests/stt/test_metrics.py
+++ b/tests/stt/test_metrics.py
@@ -75,6 +75,49 @@ class TestEditMetrics(unittest.TestCase):
         self.assertEqual(result["score"], 0.0)
         self.assertEqual(result["per_row"], [])
 
+    def test_language_aware_indic_normalization_folds_script_variants(self):
+        from calibrate.stt import metrics as M
+
+        # Same Hindi word with vs. without a zero-width joiner (ZWJ). NFC and
+        # punctuation removal leave the ZWJ in place; the Hindi IndicNormalizer
+        # strips it, so the two spellings become identical.
+        with_zwj = "क्‍ष"
+        without_zwj = "क्ष"
+        self.assertNotEqual(with_zwj, without_zwj)
+
+        # english path (no IndicNormalizer) still sees a difference...
+        self.assertGreater(
+            M.get_cer_score([with_zwj], [without_zwj], language="english")["score"],
+            0.0,
+        )
+        # ...but the Hindi path folds them to zero error.
+        self.assertEqual(
+            M.get_cer_score([with_zwj], [without_zwj], language="hindi")["score"],
+            0.0,
+        )
+
+    def test_empty_reference_uses_sentinel_not_inflated_score(self):
+        from calibrate.stt import metrics as M
+
+        # A reference that normalizes to nothing becomes the <empty> sentinel:
+        # it contributes one ordinary word error, so the score stays at 1.0
+        # instead of blowing past 1.0 (the pre-sentinel behaviour).
+        result = M.get_wer_score(["", "..."], ["hello", "world"], language="hindi")
+        self.assertEqual(result["score"], 1.0)
+
+    def test_unsupported_language_falls_back_gracefully(self):
+        from calibrate.stt import metrics as M
+
+        # Urdu (needs an optional dep indic-nlp lacks here) and an unknown
+        # language must not crash — they fall back to NFC-only normalization.
+        for lang in ("urdu", "klingon"):
+            result = M.get_wer_score(
+                ["hello world"], ["hello world"], language=lang
+            )
+            self.assertEqual(result["score"], 0.0)
+        self.assertIsNone(M._indic_normalizer("english"))
+        self.assertIsNotNone(M._indic_normalizer("hindi"))
+
 
 class TestSTTGetLLMJudgeScore(unittest.IsolatedAsyncioTestCase):
     async def test_default_evaluator_single_judge(self):


### PR DESCRIPTION
## What

Reworks WER/CER computation in `calibrate/stt/metrics.py` to follow the established Indic ASR benchmarking methodology from [Gnani.ai's deep-dive](https://www.gnani.ai/resources/research/benchmarking-indic-asr-models-a-technical-deep-dive) and, for text normalization, [AI4Bharat's Vistaar](https://github.com/AI4Bharat/vistaar/blob/master/evaluation.py).

## Changes

**1. Engine: HuggingFace `evaluate` + Whisper `BasicTextNormalizer` → `jiwer`** (already a dependency, `>=4.0.0`).

**2. Dataset-level aggregation.** Top-level `score` is now the corpus-level rate — total substitutions + deletions + insertions across all utterances ÷ total reference length — instead of a macro-mean of per-utterance rates, which over-weights short utterances. `per_row` still holds per-utterance rates (needed for `results.csv`), so the `{"score", "per_row"}` contract `stt/eval.py` relies on is unchanged.

**3. Language-aware Indic normalization (matches Vistaar).** Each reference/prediction is normalized with NFC **plus** the language-specific `IndicNormalizer` from `indic-nlp-library`. This canonicalizes script variants — nukta forms, ZWJ/ZWNJ joiners, alternate spellings — that plain NFC leaves as spurious errors. Uses the lightweight indic-nlp normalizer, not the heavy vendored Sarvam one (which loads a Whisper processor).
- `language` is threaded through `get_wer_score` / `get_cer_score` and the `_score_and_write_results` call site (backward-compatible default `"english"`).
- Unsupported languages (english, urdu, unknown) fall back to NFC-only without crashing — indic-nlp has no English normalizer, Urdu needs an optional dep, and Vistaar itself skips the normalizer for Urdu.

**4. Empty-reference handling.** No sentinel: jiwer already pools empty references correctly at the dataset level (an empty GT with an empty prediction contributes nothing; a hallucinated prediction contributes insertions and is penalized). This matches the Gnani methodology, which uses no placeholder. A guard covers the one degenerate case — a dataset with no reference words at all — returning 0.0 instead of jiwer's unbounded count.

### Deliberately kept (divergence from Vistaar)

- **Lowercasing** — Vistaar drops it; kept here. No effect on pure Indic scripts, better for code-mixed English.
- **Punctuation set** — kept jiwer's built-in `RemovePunctuation` (all Unicode punctuation, a superset of Vistaar's fixed `string.punctuation + "।۔'-॥"`). Both strip the Devanagari danda.
- **Empty-reference sentinel** — Vistaar substitutes `<empty>`, which wrongly penalizes a correct empty transcription; dropped in favor of jiwer's native pooling (see #4).

## Tests

`tests/stt/test_metrics.py`: replaced the old `evaluate.load`-mocking cases with real jiwer computation. Coverage includes:
- case/punctuation folding, character-level CER, non-string prediction coercion, empty input
- explicit **dataset-level-vs-macro-mean** assertion (1/6 ≠ 0.25)
- NFC folding (Devanagari QA precomposed vs. decomposed + Latin accents)
- **language-aware** ZWJ folding (english path sees a difference, hindi path folds to 0)
- empty references pooled correctly (empty+empty → 0, empty+hallucination → penalized) and the all-empty-dataset guard
- graceful fallback for unsupported languages (urdu, unknown)

All 120 STT tests pass locally; CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)