### PR TITLE
Single-source STT/TTS provider model names across live agent and benchmarks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,14 +171,13 @@ per-provider params still need manual mirroring.)
 `tests/test_utils_factories.py` guards this: it asserts every provider's model
 in `create_*_service` comes from the shared constant, and that TTS voices match
 the eval literals. If you add a provider or change a default, update both sides
-and that test. **Sarvam STT is the known exception** — its STT model is
-intentionally left out of `STT_PROVIDER_MODELS` (the live agent stays on
-pipecat's default) and tracked separately. This started as a hard limitation in
-pipecat 0.0.98 (its `SarvamSTTService` routed `saaras` models to the *translate*
-endpoint with no `mode`, so it couldn't reproduce the benchmark's `saaras:v3`
-transcribe path); pipecat 1.0.0 now exposes `mode="transcribe"`, so it's a
-*parked* decision rather than a blocker — revisit before wiring it in. Sarvam
-**TTS** has no such history and *is* in `TTS_PROVIDER_MODELS` (`bulbul:v3`).
+and that test. **Sarvam STT** uses `saaras:v3` with `mode="transcribe"` (passed
+to pipecat's `SarvamSTTService`), which under pipecat 1.0.0 routes to the plain
+STT streaming endpoint — matching the benchmark's `transcribe_sarvam`. This was
+impossible under pipecat 0.0.98 (its wrapper forced `saaras` onto the *translate*
+endpoint with no `mode` param), so Sarvam STT was excluded there; the 1.0.0
+upgrade removed that limitation and it's now single-sourced like every other
+provider. Sarvam **TTS** is likewise in `TTS_PROVIDER_MODELS` (`bulbul:v3`).
 
 ### Resumability
 `run_stt_eval` / `run_tts_eval` write `results.csv` row-by-row and skip already

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,42 @@ the per-provider implementation in a dict and `await` it. For unit testing,
 call `router.__wrapped__(...)` to skip the decorators (the `@backoff` retry
 would otherwise mask `ValueError`s).
 
+### Keeping live-agent and eval defaults in sync
+There are **two** places that talk to each STT/TTS provider, and they MUST use
+the same per-provider defaults:
+
+- **The benchmarks** — the `transcribe_*` (`stt/eval.py`) and `synthesize_*`
+  (`tts/eval.py`) functions, which produce the leaderboards.
+- **The live agent** — `create_stt_service` / `create_tts_service` in
+  `calibrate/utils.py`, which the voice-agent simulation / tests actually run
+  (`agent/bot.py`, `agent/test.py`).
+
+If these drift, a leaderboard stops reflecting the config the agent deploys —
+you'd benchmark one voice/model and ship another. **Any time you change a
+provider's model, voice, endpoint, or other default on one side, change the
+other side too.**
+
+To make this structural rather than a discipline you have to remember, the
+**model names are single-sourced**: `STT_PROVIDER_MODELS` and
+`TTS_PROVIDER_MODELS` in `calibrate/utils.py` are the one place each provider's
+default model is defined, and **both** the eval functions and the
+`create_*_service` factories read from them. Change the model in that dict and
+both sides move together. Do **not** re-introduce a hardcoded model string in
+either place — reference the constant. (Voices live in `TTS_VOICE_IDS`; other
+per-provider params still need manual mirroring.)
+
+`tests/test_utils_factories.py` guards this: it asserts every provider's model
+in `create_*_service` comes from the shared constant, and that TTS voices match
+the eval literals. If you add a provider or change a default, update both sides
+and that test. **Sarvam STT is the known exception** — its STT model is
+intentionally left out of `STT_PROVIDER_MODELS` (the live agent stays on
+pipecat's default) and tracked separately. This started as a hard limitation in
+pipecat 0.0.98 (its `SarvamSTTService` routed `saaras` models to the *translate*
+endpoint with no `mode`, so it couldn't reproduce the benchmark's `saaras:v3`
+transcribe path); pipecat 1.0.0 now exposes `mode="transcribe"`, so it's a
+*parked* decision rather than a blocker — revisit before wiring it in. Sarvam
+**TTS** has no such history and *is* in `TTS_PROVIDER_MODELS` (`bulbul:v3`).
+
 ### Resumability
 `run_stt_eval` / `run_tts_eval` write `results.csv` row-by-row and skip already
 processed `id`s on retry. Use `--overwrite` to force a clean run. Beware:
@@ -244,7 +280,7 @@ pre-commit hook on `main`.
   `tests/`.
 - The `out/` folder appears inside several module dirs (e.g. `calibrate/stt/out`).
   These are gitignored runtime artifacts from local runs — don't commit them.
-- `pipecat-ai` is pinned to `0.0.98` because the API surface changes between
+- `pipecat-ai` is pinned to `1.0.0` because the API surface changes between
   versions; bump deliberately and re-test the agent simulation paths.
 
 ## Useful pointers when debugging

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,19 +160,21 @@ provider's model, voice, endpoint, or other default on one side, change the
 other side too.**
 
 To make this structural rather than a discipline you have to remember, the
-**model names and TTS voices are single-sourced**: `STT_PROVIDER_MODELS`,
-`TTS_PROVIDER_MODELS`, `TTS_PROVIDER_VOICES`, and `GOOGLE_TTS_VOICE_FAMILY` in
-`calibrate/utils.py` are the one place each provider's default model/voice is
-defined, and **both** the eval functions and the `create_*_service` factories
-read from them. Change a value in those dicts and both sides move together. Do
-**not** re-introduce a hardcoded model or voice string in either place —
-reference the constant. (Google's TTS voice name embeds the language code, so
-both sides build it as `{lang_code}-{GOOGLE_TTS_VOICE_FAMILY}`; other
+**model names and TTS voices are single-sourced** in `calibrate/utils.py`:
+`STT_PROVIDER_MODELS` / `TTS_PROVIDER_MODELS` define each provider's default
+model, and TTS voices resolve through `get_tts_voice(provider, language)` —
+which returns the per-language override in `TTS_PROVIDER_VOICES_BY_LANGUAGE` if
+one exists, else the provider default in `TTS_PROVIDER_VOICES` (Google builds
+`{lang_code}-{GOOGLE_TTS_VOICE_FAMILY}`). **Both** the eval functions and the
+`create_*_service` factories read from these. Change a value and both sides move
+together. Do **not** re-introduce a hardcoded model or voice string in either
+place — reference the constant / call `get_tts_voice`. (Voices are per-language:
+e.g. Cartesia and Smallest ship distinct Hindi/Kannada voices; other
 per-provider params still need manual mirroring.)
 
 `tests/test_utils_factories.py` guards this: it asserts every provider's model
-and voice in `create_*_service` comes from the shared constants. If you add a
-provider or change a default, update both sides
+and voice in `create_*_service` matches the shared source for every language. If
+you add a provider or change a default, update both sides
 and that test. **Sarvam STT** uses `saaras:v3` with `mode="transcribe"` (passed
 to pipecat's `SarvamSTTService`), which under pipecat 1.0.0 routes to the plain
 STT streaming endpoint — matching the benchmark's `transcribe_sarvam`. This was
@@ -226,6 +228,21 @@ Tests are pure unit tests — **no real API calls** are ever made:
   pass the "is the key set?" guard before the mocked code path runs.
 
 The suite runs in ~10s locally and contributes coverage to Codecov on CI.
+
+### Committing and pushing
+**Once a change is complete and its scoped tests pass, commit and push it
+without waiting for approval** — don't stop to ask first. This overrides the
+default "commit/push only when asked" behavior for this repo. Applies to normal
+feature/fix work on a branch:
+
+- Commit with a clear message; push the branch to its remote (`git push`, or
+  `git push -u origin HEAD` the first time).
+- If the branch already has an open PR whose commits were rebased/amended, use
+  `git push --force-with-lease` to update it.
+- If you're on `main`, branch first — never commit straight to `main`.
+- Still pause to ask before genuinely destructive or irreversible actions
+  (e.g. `git reset --hard` over uncommitted work, deleting remote branches,
+  history rewrites beyond your own un-merged branch, publishing a release).
 
 ### Git hooks
 `.githooks/pre-commit` runs `uv run --extra dev pytest tests/` **only when

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,17 +160,19 @@ provider's model, voice, endpoint, or other default on one side, change the
 other side too.**
 
 To make this structural rather than a discipline you have to remember, the
-**model names are single-sourced**: `STT_PROVIDER_MODELS` and
-`TTS_PROVIDER_MODELS` in `calibrate/utils.py` are the one place each provider's
-default model is defined, and **both** the eval functions and the
-`create_*_service` factories read from them. Change the model in that dict and
-both sides move together. Do **not** re-introduce a hardcoded model string in
-either place — reference the constant. (Voices live in `TTS_VOICE_IDS`; other
+**model names and TTS voices are single-sourced**: `STT_PROVIDER_MODELS`,
+`TTS_PROVIDER_MODELS`, `TTS_PROVIDER_VOICES`, and `GOOGLE_TTS_VOICE_FAMILY` in
+`calibrate/utils.py` are the one place each provider's default model/voice is
+defined, and **both** the eval functions and the `create_*_service` factories
+read from them. Change a value in those dicts and both sides move together. Do
+**not** re-introduce a hardcoded model or voice string in either place —
+reference the constant. (Google's TTS voice name embeds the language code, so
+both sides build it as `{lang_code}-{GOOGLE_TTS_VOICE_FAMILY}`; other
 per-provider params still need manual mirroring.)
 
 `tests/test_utils_factories.py` guards this: it asserts every provider's model
-in `create_*_service` comes from the shared constant, and that TTS voices match
-the eval literals. If you add a provider or change a default, update both sides
+and voice in `create_*_service` comes from the shared constants. If you add a
+provider or change a default, update both sides
 and that test. **Sarvam STT** uses `saaras:v3` with `mode="transcribe"` (passed
 to pipecat's `SarvamSTTService`), which under pipecat 1.0.0 routes to the plain
 STT streaming endpoint — matching the benchmark's `transcribe_sarvam`. This was

--- a/calibrate/agent/run_simulation.py
+++ b/calibrate/agent/run_simulation.py
@@ -1344,8 +1344,12 @@ async def _run_simulation_inner(
     # only the words actually spoken.
     elevenlabs_http_session = None
     if language == "kannada":
+        # Keep the simulated user distinct from the agent: the agent's
+        # Google-Kannada voice defaults to Achernar (GOOGLE_TTS_VOICE_FAMILY), so
+        # the female user uses a different Chirp3-HD speaker (Kore) to avoid both
+        # sides sounding identical.
         voice_id = (
-            "kn-IN-Chirp3-HD-Achernar"
+            "kn-IN-Chirp3-HD-Kore"
             if gender == "female"
             else "kn-IN-Chirp3-HD-Achird"
         )

--- a/calibrate/agent/run_simulation.py
+++ b/calibrate/agent/run_simulation.py
@@ -1372,7 +1372,7 @@ async def _run_simulation_inner(
     if voices["provider"] == "google":
         tts = create_tts_service("google", language, voice_id=voice_id)
         eval_logger.info(f"Using Google TTS voice: {voice_id}")
-    else:
+    elif voices["provider"] == "elevenlabs":
         eval_logger.info(f"Using ElevenLabs voice ID: {voice_id}")
         elevenlabs_http_session = aiohttp.ClientSession()
         tts = ElevenLabsHttpTTSService(
@@ -1381,6 +1381,10 @@ async def _run_simulation_inner(
             settings=ElevenLabsHttpTTSService.Settings(
                 voice=voice_id, language=tts_language
             ),
+        )
+    else:
+        raise ValueError(
+            f"Unsupported simulated-user TTS provider: {voices['provider']}"
         )
 
     llm = OpenAILLMService(

--- a/calibrate/agent/run_simulation.py
+++ b/calibrate/agent/run_simulation.py
@@ -178,6 +178,30 @@ TRANSCRIPT_FILE_NAME = "transcript.json"
 DEFAULT_SERIALIZER_NAME = "protobuf"
 SERIALIZER_REGISTRY = {"protobuf": ProtobufFrameSerializer}
 
+# Voices for the SIMULATED USER (the fake human), one place to see/edit them.
+# Deliberately kept distinct from the agent's voice (create_tts_service) so the
+# two speakers are distinguishable. ElevenLabs is used for its word-level HTTP
+# TTS (mid-utterance interrupts commit only the words actually spoken); Kannada
+# has no real ElevenLabs voice, so it uses Google Chirp3-HD (and its female voice
+# avoids the agent's Achernar default). Languages absent here fall back to english.
+SIMULATED_USER_VOICES = {
+    "kannada": {
+        "provider": "google",
+        "female": "kn-IN-Chirp3-HD-Kore",
+        "male": "kn-IN-Chirp3-HD-Achird",
+    },
+    "hindi": {
+        "provider": "elevenlabs",
+        "female": "dVTC43Yewy5fAIcmsISI",
+        "male": "hdkYGMdbdWZpANLZvmnk",
+    },
+    "english": {
+        "provider": "elevenlabs",
+        "female": "OHY6EjdeHKeQymoihwfz",
+        "male": "fPIfC3elMLbN9tNwMXkw",
+    },
+}
+
 
 def resolve_serializer(name: str) -> FrameSerializer:
     """Return a new serializer instance for ``name``.
@@ -1338,34 +1362,17 @@ async def _run_simulation_inner(
         else Language.HI if language == "hindi" else Language.EN
     )
 
-    # ElevenLabs has no real Kannada voice (it falls back to English), so the
-    # Kannada simulated user speaks via Google TTS (Chirp3 kn-IN). English and
-    # Hindi keep ElevenLabs word-level TTS, so mid-utterance interrupts commit
-    # only the words actually spoken.
+    # Simulated-user voice + provider come from SIMULATED_USER_VOICES (module
+    # top). Unlisted languages fall back to english, matching the previous
+    # behavior.
+    voices = SIMULATED_USER_VOICES.get(language, SIMULATED_USER_VOICES["english"])
+    voice_id = voices["female" if gender == "female" else "male"]
+
     elevenlabs_http_session = None
-    if language == "kannada":
-        # Keep the simulated user distinct from the agent: the agent's
-        # Google-Kannada voice defaults to Achernar (GOOGLE_TTS_VOICE_FAMILY), so
-        # the female user uses a different Chirp3-HD speaker (Kore) to avoid both
-        # sides sounding identical.
-        voice_id = (
-            "kn-IN-Chirp3-HD-Kore"
-            if gender == "female"
-            else "kn-IN-Chirp3-HD-Achird"
-        )
+    if voices["provider"] == "google":
         tts = create_tts_service("google", language, voice_id=voice_id)
         eval_logger.info(f"Using Google TTS voice: {voice_id}")
     else:
-        if language == "hindi":
-            if gender == "female":
-                voice_id = "dVTC43Yewy5fAIcmsISI"
-            else:
-                voice_id = "hdkYGMdbdWZpANLZvmnk"
-        else:
-            # Default to English voices
-            voice_id = (
-                "OHY6EjdeHKeQymoihwfz" if gender == "female" else "fPIfC3elMLbN9tNwMXkw"
-            )
         eval_logger.info(f"Using ElevenLabs voice ID: {voice_id}")
         elevenlabs_http_session = aiohttp.ClientSession()
         tts = ElevenLabsHttpTTSService(

--- a/calibrate/agent/run_simulation.py
+++ b/calibrate/agent/run_simulation.py
@@ -151,7 +151,6 @@ from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.runner.types import RunnerArguments
 from pipecat.services.cartesia.tts import CartesiaTTSService
-from pipecat.services.deepgram.stt import DeepgramSTTService
 from pipecat.services.llm_service import FunctionCallParams
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.services.elevenlabs.tts import ElevenLabsHttpTTSService

--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -24,6 +24,7 @@ import pandas as pd
 from calibrate.utils import (
     get_stt_language_code,
     validate_stt_language,
+    STT_PROVIDER_MODELS,
     provider_log as _log,
     provider_log_file as _current_log_file,
 )
@@ -141,7 +142,7 @@ async def transcribe_deepgram_streaming(audio_path: Path, language: str) -> str:
 
     endpoint = "wss://api.deepgram.com/v1/listen"
     params = {
-        "model": "nova-3",
+        "model": STT_PROVIDER_MODELS["deepgram"],
         "language": lang_code,
         "encoding": "linear16",
         "sample_rate": "16000",
@@ -231,7 +232,7 @@ async def transcribe_openai_streaming(audio_path: Path, language: str) -> str:
     # Supplying the input language (ISO-639-1) improves accuracy and latency
     # per the OpenAI transcription docs.
     stream = await client.audio.transcriptions.create(
-        model="gpt-4o-transcribe",
+        model=STT_PROVIDER_MODELS["openai"],
         file=audio_file,
         language=lang_code,
         response_format="text",
@@ -268,7 +269,7 @@ async def transcribe_groq(audio_path: Path, language: str) -> str:
     transcription = await asyncio.wait_for(
         client.audio.transcriptions.create(
             file=audio_file,  # Required audio file
-            model="whisper-large-v3-turbo",  # Required model to use for transcription
+            model=STT_PROVIDER_MODELS["groq"],  # Required model to use for transcription
             response_format="text",  # Optional
             language=lang_code,  # Optional
             temperature=0.0,  # Optional
@@ -381,7 +382,7 @@ async def transcribe_google(audio_path: Path, language: str) -> str:
         model = "chirp_2"
         region = "asia-southeast1"
     else:
-        model = "chirp_3"
+        model = STT_PROVIDER_MODELS["google"]
         region = "us"
 
     result = await asyncio.wait_for(
@@ -479,7 +480,7 @@ async def transcribe_cartesia(audio_path: Path, language: str) -> str:
     try:
         # Create websocket connection with voice activity detection
         ws = await client.stt.websocket(
-            model="ink-whisper",  # Model (required)
+            model=STT_PROVIDER_MODELS["cartesia"],  # Model (required)
             language=lang_code,  # Language of your audio (required)
             encoding="pcm_s16le",  # Audio encoding format (required)
             sample_rate=16000,  # Audio sample rate (required)
@@ -558,7 +559,7 @@ async def transcribe_smallest_streaming(audio_path: Path, language: str) -> str:
     lang_code = get_stt_language_code(language, "smallest")
     endpoint = "wss://api.smallest.ai/waves/v1/stt/live"
     params = {
-        "model": "pulse",
+        "model": STT_PROVIDER_MODELS["smallest"],
         "language": lang_code,
         "encoding": "linear16",
         "sample_rate": "16000",
@@ -695,7 +696,7 @@ async def transcribe_elevenlabs_streaming(audio_path: Path, language: str) -> st
     client = ElevenLabs(api_key=api_key)
     connection = await client.speech_to_text.realtime.connect(
         RealtimeAudioOptions(
-            model_id="scribe_v2_realtime",
+            model_id=STT_PROVIDER_MODELS["elevenlabs"],
             audio_format=AudioFormat.PCM_16000,
             sample_rate=16000,
             commit_strategy=CommitStrategy.MANUAL,

--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -426,7 +426,7 @@ async def transcribe_sarvam(audio_path: Path, language: str) -> str:
 
     async with client.speech_to_text_streaming.connect(
         language_code=lang_code,
-        model="saaras:v3",
+        model=STT_PROVIDER_MODELS["sarvam"],
         mode="transcribe",
         flush_signal=True,
     ) as ws:

--- a/calibrate/tts/eval.py
+++ b/calibrate/tts/eval.py
@@ -29,6 +29,8 @@ from calibrate.utils import (
     provider_log as _log,
     provider_log_file as _current_log_file,
     TTS_PROVIDER_MODELS,
+    TTS_PROVIDER_VOICES,
+    GOOGLE_TTS_VOICE_FAMILY,
 )
 from calibrate.tts.metrics import get_tts_llm_judge_score
 from calibrate.llm._metrics_utils import _latency_percentiles
@@ -110,7 +112,7 @@ async def synthesize_openai(text: str, language: str, audio_path: str) -> Dict:
     with open(audio_path, "wb") as f:
         async with client.audio.speech.with_streaming_response.create(
             model=TTS_PROVIDER_MODELS["openai"],
-            voice="coral",
+            voice=TTS_PROVIDER_VOICES["openai"],
             input=text,
             response_format="wav",
         ) as response:
@@ -166,7 +168,7 @@ async def synthesize_google(text: str, language: str, audio_path: str) -> Dict:
     )
 
     voice_params = texttospeech.VoiceSelectionParams(
-        name=f"{lang_code}-Chirp3-HD-Charon",
+        name=f"{lang_code}-{GOOGLE_TTS_VOICE_FAMILY}",
         language_code=lang_code,
     )
 
@@ -219,7 +221,7 @@ async def synthesize_elevenlabs(text: str, language: str, audio_path: str) -> Di
 
     elevenlabs = AsyncElevenLabs(api_key=api_key)
 
-    voice_id = "m5qndnI7u4OAdXhH0Mr5"
+    voice_id = TTS_PROVIDER_VOICES["elevenlabs"]
     output_format = "mp3_24000_48"
 
     if language.lower() == "sindhi":
@@ -286,7 +288,7 @@ async def synthesize_cartesia(text: str, language: str, audio_path: str) -> Dict
             transcript=text,
             voice={
                 "mode": "id",
-                "id": "faf0731e-dfb9-4cfc-8119-259a79b27e12",  # riya
+                "id": TTS_PROVIDER_VOICES["cartesia"],  # riya
             },
             language=lang_code,
             output_format={
@@ -314,7 +316,7 @@ async def synthesize_groq(text: str, language: str, audio_path: str) -> Dict:
     client = AsyncGroq(api_key=api_key)
 
     model = TTS_PROVIDER_MODELS["groq"]
-    voice = "troy"
+    voice = TTS_PROVIDER_VOICES["groq"]
     response_format = "wav"
 
     response = await client.audio.speech.create(
@@ -347,7 +349,7 @@ async def synthesize_sarvam(text: str, language: str, audio_path: str) -> Dict:
     ) as ws:
         await ws.configure(
             target_language_code=lang_code,
-            speaker="aditya",
+            speaker=TTS_PROVIDER_VOICES["sarvam"],
             output_audio_codec="mp3",
             speech_sample_rate=22050,
             enable_preprocessing=True,
@@ -409,7 +411,7 @@ async def synthesize_smallest(text: str, language: str, audio_path: str) -> Dict
     ws_url = "wss://waves-api.smallest.ai/api/v1/lightning-v3.1/get_speech/stream"
     payload = {
         "text": text,
-        "voice_id": "aditi",
+        "voice_id": TTS_PROVIDER_VOICES["smallest"],
         "language": lang_code,
         "sample_rate": 24000,
         "speed": 1.0,

--- a/calibrate/tts/eval.py
+++ b/calibrate/tts/eval.py
@@ -28,6 +28,7 @@ from calibrate.utils import (
     validate_tts_language,
     provider_log as _log,
     provider_log_file as _current_log_file,
+    TTS_PROVIDER_MODELS,
 )
 from calibrate.tts.metrics import get_tts_llm_judge_score
 from calibrate.llm._metrics_utils import _latency_percentiles
@@ -108,7 +109,7 @@ async def synthesize_openai(text: str, language: str, audio_path: str) -> Dict:
     # Stream directly to file
     with open(audio_path, "wb") as f:
         async with client.audio.speech.with_streaming_response.create(
-            model="gpt-4o-mini-tts",
+            model=TTS_PROVIDER_MODELS["openai"],
             voice="coral",
             input=text,
             response_format="wav",
@@ -234,7 +235,7 @@ async def synthesize_elevenlabs(text: str, language: str, audio_path: str) -> Di
         )
 
     else:
-        model_id = "eleven_multilingual_v2"
+        model_id = TTS_PROVIDER_MODELS["elevenlabs"]
 
         response = elevenlabs.text_to_speech.stream(
             voice_id=voice_id,  # Krishna pre-made voice
@@ -281,7 +282,7 @@ async def synthesize_cartesia(text: str, language: str, audio_path: str) -> Dict
         ttfb = None
 
         bytes_iter = client.tts.bytes(
-            model_id="sonic-3.5",
+            model_id=TTS_PROVIDER_MODELS["cartesia"],
             transcript=text,
             voice={
                 "mode": "id",
@@ -312,7 +313,7 @@ async def synthesize_groq(text: str, language: str, audio_path: str) -> Dict:
 
     client = AsyncGroq(api_key=api_key)
 
-    model = "canopylabs/orpheus-v1-english"
+    model = TTS_PROVIDER_MODELS["groq"]
     voice = "troy"
     response_format = "wav"
 
@@ -342,7 +343,7 @@ async def synthesize_sarvam(text: str, language: str, audio_path: str) -> Dict:
     ttfb = None
 
     async with client.text_to_speech_streaming.connect(
-        model="bulbul:v3", send_completion_event=True
+        model=TTS_PROVIDER_MODELS["sarvam"], send_completion_event=True
     ) as ws:
         await ws.configure(
             target_language_code=lang_code,

--- a/calibrate/tts/eval.py
+++ b/calibrate/tts/eval.py
@@ -29,8 +29,7 @@ from calibrate.utils import (
     provider_log as _log,
     provider_log_file as _current_log_file,
     TTS_PROVIDER_MODELS,
-    TTS_PROVIDER_VOICES,
-    GOOGLE_TTS_VOICE_FAMILY,
+    get_tts_voice,
 )
 from calibrate.tts.metrics import get_tts_llm_judge_score
 from calibrate.llm._metrics_utils import _latency_percentiles
@@ -112,7 +111,7 @@ async def synthesize_openai(text: str, language: str, audio_path: str) -> Dict:
     with open(audio_path, "wb") as f:
         async with client.audio.speech.with_streaming_response.create(
             model=TTS_PROVIDER_MODELS["openai"],
-            voice=TTS_PROVIDER_VOICES["openai"],
+            voice=get_tts_voice("openai", language),
             input=text,
             response_format="wav",
         ) as response:
@@ -168,7 +167,7 @@ async def synthesize_google(text: str, language: str, audio_path: str) -> Dict:
     )
 
     voice_params = texttospeech.VoiceSelectionParams(
-        name=f"{lang_code}-{GOOGLE_TTS_VOICE_FAMILY}",
+        name=get_tts_voice("google", language),
         language_code=lang_code,
     )
 
@@ -221,7 +220,7 @@ async def synthesize_elevenlabs(text: str, language: str, audio_path: str) -> Di
 
     elevenlabs = AsyncElevenLabs(api_key=api_key)
 
-    voice_id = TTS_PROVIDER_VOICES["elevenlabs"]
+    voice_id = get_tts_voice("elevenlabs", language)
     output_format = "mp3_24000_48"
 
     if language.lower() == "sindhi":
@@ -240,7 +239,7 @@ async def synthesize_elevenlabs(text: str, language: str, audio_path: str) -> Di
         model_id = TTS_PROVIDER_MODELS["elevenlabs"]
 
         response = elevenlabs.text_to_speech.stream(
-            voice_id=voice_id,  # Krishna pre-made voice
+            voice_id=voice_id,
             output_format=output_format,
             text=text,
             model_id=model_id,
@@ -288,7 +287,7 @@ async def synthesize_cartesia(text: str, language: str, audio_path: str) -> Dict
             transcript=text,
             voice={
                 "mode": "id",
-                "id": TTS_PROVIDER_VOICES["cartesia"],  # riya
+                "id": get_tts_voice("cartesia", language),
             },
             language=lang_code,
             output_format={
@@ -316,7 +315,7 @@ async def synthesize_groq(text: str, language: str, audio_path: str) -> Dict:
     client = AsyncGroq(api_key=api_key)
 
     model = TTS_PROVIDER_MODELS["groq"]
-    voice = TTS_PROVIDER_VOICES["groq"]
+    voice = get_tts_voice("groq", language)
     response_format = "wav"
 
     response = await client.audio.speech.create(
@@ -349,7 +348,7 @@ async def synthesize_sarvam(text: str, language: str, audio_path: str) -> Dict:
     ) as ws:
         await ws.configure(
             target_language_code=lang_code,
-            speaker=TTS_PROVIDER_VOICES["sarvam"],
+            speaker=get_tts_voice("sarvam", language),
             output_audio_codec="mp3",
             speech_sample_rate=22050,
             enable_preprocessing=True,
@@ -411,7 +410,7 @@ async def synthesize_smallest(text: str, language: str, audio_path: str) -> Dict
     ws_url = "wss://waves-api.smallest.ai/api/v1/lightning-v3.1/get_speech/stream"
     payload = {
         "text": text,
-        "voice_id": TTS_PROVIDER_VOICES["smallest"],
+        "voice_id": get_tts_voice("smallest", language),
         "language": lang_code,
         "sample_rate": 24000,
         "speed": 1.0,

--- a/calibrate/utils.py
+++ b/calibrate/utils.py
@@ -1677,26 +1677,69 @@ def get_tts_language(
         return Language.EN
 
 
-# Single source of truth for per-provider default TTS voices, shared by the live
-# agent (create_tts_service) and the benchmark (calibrate/tts/eval.py) so a
-# leaderboard reflects the exact voice the agent deploys. One voice per provider,
-# language-agnostic (the same voice serves english/hindi/kannada). Guarded by
-# tests/test_utils_factories.py. Google is the exception — its voice name embeds
-# the language code, so both sides build it from GOOGLE_TTS_VOICE_FAMILY below.
-# Deepgram TTS isn't benchmarked, so its voice stays inline in create_tts_service.
+# Per-provider DEFAULT TTS voice, used when a language has no entry in
+# TTS_PROVIDER_VOICES_BY_LANGUAGE below. Shared by the live agent
+# (create_tts_service) and the benchmark (calibrate/tts/eval.py) through
+# get_tts_voice() so a leaderboard reflects the exact voice the agent deploys.
+# Guarded by tests/test_utils_factories.py. Google's default embeds the language
+# code, built from GOOGLE_TTS_VOICE_FAMILY. Deepgram TTS isn't benchmarked, so
+# its voice stays inline in create_tts_service.
 TTS_PROVIDER_VOICES = {
-    "cartesia": "faf0731e-dfb9-4cfc-8119-259a79b27e12",
+    "cartesia": "faf0731e-dfb9-4cfc-8119-259a79b27e12",  # riya
     "openai": "coral",
     "groq": "troy",
-    "elevenlabs": "m5qndnI7u4OAdXhH0Mr5",
+    "elevenlabs": "m5qndnI7u4OAdXhH0Mr5",  # Krishna (pre-made voice)
     "sarvam": "aditya",
     "smallest": "aditi",
 }
 
-# Google TTS voice family; the full voice name is "{lang_code}-{family}"
-# (e.g. en-US-Chirp3-HD-Charon), built identically in create_tts_service and
-# calibrate/tts/eval.py's synthesize_google.
+# Google TTS default voice family; the full name is "{lang_code}-{family}"
+# (e.g. en-US-Chirp3-HD-Charon), used when a language has no override below.
 GOOGLE_TTS_VOICE_FAMILY = "Chirp3-HD-Charon"
+
+# Per-language voice OVERRIDES. A (provider, language) entry here wins over the
+# provider's TTS_PROVIDER_VOICES default; languages without an entry fall back to
+# it. This restores the per-language voices the live agent shipped before voices
+# were single-sourced. Read by both sides through get_tts_voice(), so the live
+# agent and benchmark still can't drift.
+TTS_PROVIDER_VOICES_BY_LANGUAGE = {
+    "cartesia": {
+        "english": "66c6b81c-ddb7-4892-bdd5-19b5a7be38e7",
+        "hindi": "28ca2041-5dda-42df-8123-f58ea9c3da00",
+        "kannada": "7c6219d2-e8d2-462c-89d8-7ecba7c75d65",
+    },
+    "google": {
+        "english": "en-US-Chirp3-HD-Achernar",
+        "hindi": "hi-IN-Chirp3-HD-Achernar",
+        "kannada": "kn-IN-Chirp3-HD-Achernar",
+    },
+    "elevenlabs": {
+        "english": "90ipbRoKi4CpHXvKVtl0",
+        "hindi": "jUjRbhZWoMK4aDciW36V",
+        "kannada": "90ipbRoKi4CpHXvKVtl0",  # falls back to the english voice
+    },
+    "smallest": {
+        "english": "aarushi",
+        "hindi": "aarushi",
+        "kannada": "vijay",
+    },
+}
+
+
+def get_tts_voice(provider: str, language: str) -> str:
+    """Return the default TTS voice for a provider + language.
+
+    A per-language override in TTS_PROVIDER_VOICES_BY_LANGUAGE wins; otherwise the
+    provider's language-agnostic default (Google builds
+    "{lang_code}-{GOOGLE_TTS_VOICE_FAMILY}"). Shared by create_tts_service and
+    calibrate/tts/eval.py so the live agent and benchmark pick the same voice.
+    """
+    override = TTS_PROVIDER_VOICES_BY_LANGUAGE.get(provider, {}).get(language)
+    if override is not None:
+        return override
+    if provider == "google":
+        return f"{get_tts_language_code(language, 'google')}-{GOOGLE_TTS_VOICE_FAMILY}"
+    return TTS_PROVIDER_VOICES[provider]
 
 
 # Single source of truth for per-provider default model names. The live agent
@@ -1872,7 +1915,7 @@ def create_tts_service(
             settings=CartesiaTTSService.Settings(
                 language=tts_language,
                 model=model or TTS_PROVIDER_MODELS["cartesia"],
-                voice=voice_id or TTS_PROVIDER_VOICES["cartesia"],
+                voice=voice_id or get_tts_voice("cartesia", language),
             ),
         )
     elif provider == "openai":
@@ -1880,7 +1923,7 @@ def create_tts_service(
             api_key=os.getenv("OPENAI_API_KEY"),
             settings=OpenAITTSService.Settings(
                 model=model or TTS_PROVIDER_MODELS["openai"],
-                voice=voice_id or TTS_PROVIDER_VOICES["openai"],
+                voice=voice_id or get_tts_voice("openai", language),
                 instructions=instructions,
             ),
         )
@@ -1889,15 +1932,14 @@ def create_tts_service(
             api_key=os.getenv("GROQ_API_KEY"),
             settings=GroqTTSService.Settings(
                 model=model or TTS_PROVIDER_MODELS["groq"],
-                voice=voice_id or TTS_PROVIDER_VOICES["groq"],
+                voice=voice_id or get_tts_voice("groq", language),
             ),
         )
     elif provider == "google":
         return GoogleTTSService(
             settings=GoogleTTSService.Settings(
                 language=tts_language,
-                voice=voice_id
-                or f"{get_tts_language_code(language, 'google')}-{GOOGLE_TTS_VOICE_FAMILY}",
+                voice=voice_id or get_tts_voice("google", language),
             ),
             credentials_path=os.getenv("GOOGLE_APPLICATION_CREDENTIALS"),
         )
@@ -1907,7 +1949,7 @@ def create_tts_service(
             settings=ElevenLabsTTSService.Settings(
                 language=tts_language,
                 model=TTS_PROVIDER_MODELS["elevenlabs"],
-                voice=voice_id or TTS_PROVIDER_VOICES["elevenlabs"],
+                voice=voice_id or get_tts_voice("elevenlabs", language),
             ),
         )
     elif provider == "sarvam":
@@ -1916,7 +1958,7 @@ def create_tts_service(
             settings=SarvamTTSService.Settings(
                 language=tts_language,
                 model=model or TTS_PROVIDER_MODELS["sarvam"],
-                voice=voice_id or TTS_PROVIDER_VOICES["sarvam"],
+                voice=voice_id or get_tts_voice("sarvam", language),
             ),
         )
     elif provider == "deepgram":
@@ -1928,7 +1970,7 @@ def create_tts_service(
         return SmallestTTSService(
             api_key=os.getenv("SMALLEST_API_KEY"),
             settings=SmallestTTSService.Settings(
-                voice=voice_id or TTS_PROVIDER_VOICES["smallest"],
+                voice=voice_id or get_tts_voice("smallest", language),
                 language=tts_language,
             ),
         )

--- a/calibrate/utils.py
+++ b/calibrate/utils.py
@@ -1693,9 +1693,11 @@ TTS_PROVIDER_VOICES = {
     "smallest": "aditi",
 }
 
-# Google TTS default voice family; the full name is "{lang_code}-{family}"
-# (e.g. en-US-Chirp3-HD-Charon), used when a language has no override below.
-GOOGLE_TTS_VOICE_FAMILY = "Chirp3-HD-Charon"
+# Google TTS voice family; the full name is "{lang_code}-{family}" (e.g.
+# en-US-Chirp3-HD-Achernar), built per language in get_tts_voice. Google needs no
+# TTS_PROVIDER_VOICES_BY_LANGUAGE entry — the language code in the name already
+# makes it per-language, so this family IS the single source for every language.
+GOOGLE_TTS_VOICE_FAMILY = "Chirp3-HD-Achernar"
 
 # Per-language voice OVERRIDES. A (provider, language) entry here wins over the
 # provider's TTS_PROVIDER_VOICES default; languages without an entry fall back to
@@ -1707,11 +1709,6 @@ TTS_PROVIDER_VOICES_BY_LANGUAGE = {
         "english": "66c6b81c-ddb7-4892-bdd5-19b5a7be38e7",
         "hindi": "28ca2041-5dda-42df-8123-f58ea9c3da00",
         "kannada": "7c6219d2-e8d2-462c-89d8-7ecba7c75d65",
-    },
-    "google": {
-        "english": "en-US-Chirp3-HD-Achernar",
-        "hindi": "hi-IN-Chirp3-HD-Achernar",
-        "kannada": "kn-IN-Chirp3-HD-Achernar",
     },
     "elevenlabs": {
         "english": "90ipbRoKi4CpHXvKVtl0",

--- a/calibrate/utils.py
+++ b/calibrate/utils.py
@@ -1677,33 +1677,26 @@ def get_tts_language(
         return Language.EN
 
 
-# Voice ID mappings for TTS providers by language
-# Kept in sync with the TTS benchmark defaults in calibrate/tts/eval.py so a
-# leaderboard reflects the exact voice the live agent deploys. The benchmark
-# uses one voice per provider regardless of language, so these entries match
-# across languages (Google keeps the Chirp3-HD-Charon family per language).
-TTS_VOICE_IDS = {
-    "cartesia": {
-        "english": "faf0731e-dfb9-4cfc-8119-259a79b27e12",
-        "hindi": "faf0731e-dfb9-4cfc-8119-259a79b27e12",
-        "kannada": "faf0731e-dfb9-4cfc-8119-259a79b27e12",
-    },
-    "google": {
-        "english": "en-US-Chirp3-HD-Charon",
-        "hindi": "hi-IN-Chirp3-HD-Charon",
-        "kannada": "kn-IN-Chirp3-HD-Charon",
-    },
-    "elevenlabs": {
-        "english": "m5qndnI7u4OAdXhH0Mr5",
-        "hindi": "m5qndnI7u4OAdXhH0Mr5",
-        "kannada": "m5qndnI7u4OAdXhH0Mr5",
-    },
-    "smallest": {
-        "english": "aditi",
-        "hindi": "aditi",
-        "kannada": "aditi",
-    },
+# Single source of truth for per-provider default TTS voices, shared by the live
+# agent (create_tts_service) and the benchmark (calibrate/tts/eval.py) so a
+# leaderboard reflects the exact voice the agent deploys. One voice per provider,
+# language-agnostic (the same voice serves english/hindi/kannada). Guarded by
+# tests/test_utils_factories.py. Google is the exception — its voice name embeds
+# the language code, so both sides build it from GOOGLE_TTS_VOICE_FAMILY below.
+# Deepgram TTS isn't benchmarked, so its voice stays inline in create_tts_service.
+TTS_PROVIDER_VOICES = {
+    "cartesia": "faf0731e-dfb9-4cfc-8119-259a79b27e12",
+    "openai": "coral",
+    "groq": "troy",
+    "elevenlabs": "m5qndnI7u4OAdXhH0Mr5",
+    "sarvam": "aditya",
+    "smallest": "aditi",
 }
+
+# Google TTS voice family; the full voice name is "{lang_code}-{family}"
+# (e.g. en-US-Chirp3-HD-Charon), built identically in create_tts_service and
+# calibrate/tts/eval.py's synthesize_google.
+GOOGLE_TTS_VOICE_FAMILY = "Chirp3-HD-Charon"
 
 
 # Single source of truth for per-provider default model names. The live agent
@@ -1873,17 +1866,13 @@ def create_tts_service(
 
     tts_language = get_tts_language(language, provider)
 
-    # Get default voice ID if not provided
-    if voice_id is None and provider in TTS_VOICE_IDS:
-        voice_id = TTS_VOICE_IDS[provider].get(language)
-
     if provider == "cartesia":
         return CartesiaTTSService(
             api_key=os.getenv("CARTESIA_API_KEY"),
             settings=CartesiaTTSService.Settings(
                 language=tts_language,
                 model=model or TTS_PROVIDER_MODELS["cartesia"],
-                voice=voice_id or "faf0731e-dfb9-4cfc-8119-259a79b27e12",
+                voice=voice_id or TTS_PROVIDER_VOICES["cartesia"],
             ),
         )
     elif provider == "openai":
@@ -1891,7 +1880,7 @@ def create_tts_service(
             api_key=os.getenv("OPENAI_API_KEY"),
             settings=OpenAITTSService.Settings(
                 model=model or TTS_PROVIDER_MODELS["openai"],
-                voice=voice_id or "coral",
+                voice=voice_id or TTS_PROVIDER_VOICES["openai"],
                 instructions=instructions,
             ),
         )
@@ -1900,7 +1889,7 @@ def create_tts_service(
             api_key=os.getenv("GROQ_API_KEY"),
             settings=GroqTTSService.Settings(
                 model=model or TTS_PROVIDER_MODELS["groq"],
-                voice=voice_id or "troy",
+                voice=voice_id or TTS_PROVIDER_VOICES["groq"],
             ),
         )
     elif provider == "google":
@@ -1908,7 +1897,7 @@ def create_tts_service(
             settings=GoogleTTSService.Settings(
                 language=tts_language,
                 voice=voice_id
-                or TTS_VOICE_IDS["google"].get(language, "en-US-Chirp3-HD-Charon"),
+                or f"{get_tts_language_code(language, 'google')}-{GOOGLE_TTS_VOICE_FAMILY}",
             ),
             credentials_path=os.getenv("GOOGLE_APPLICATION_CREDENTIALS"),
         )
@@ -1918,8 +1907,7 @@ def create_tts_service(
             settings=ElevenLabsTTSService.Settings(
                 language=tts_language,
                 model=TTS_PROVIDER_MODELS["elevenlabs"],
-                voice=voice_id
-                or TTS_VOICE_IDS["elevenlabs"].get(language, "m5qndnI7u4OAdXhH0Mr5"),
+                voice=voice_id or TTS_PROVIDER_VOICES["elevenlabs"],
             ),
         )
     elif provider == "sarvam":
@@ -1928,7 +1916,7 @@ def create_tts_service(
             settings=SarvamTTSService.Settings(
                 language=tts_language,
                 model=model or TTS_PROVIDER_MODELS["sarvam"],
-                voice=voice_id or "aditya",
+                voice=voice_id or TTS_PROVIDER_VOICES["sarvam"],
             ),
         )
     elif provider == "deepgram":
@@ -1940,7 +1928,7 @@ def create_tts_service(
         return SmallestTTSService(
             api_key=os.getenv("SMALLEST_API_KEY"),
             settings=SmallestTTSService.Settings(
-                voice=voice_id or TTS_VOICE_IDS["smallest"].get(language, "aditi"),
+                voice=voice_id or TTS_PROVIDER_VOICES["smallest"],
                 language=tts_language,
             ),
         )

--- a/calibrate/utils.py
+++ b/calibrate/utils.py
@@ -1711,14 +1711,14 @@ TTS_VOICE_IDS = {
 # (calibrate/stt/eval.py, calibrate/tts/eval.py) both read these, so a change in
 # one place applies to both and a leaderboard always reflects the deployed
 # config. See CLAUDE.md ("Keeping live-agent and eval defaults in sync"); the
-# parity is guarded by tests/test_utils_factories.py. Sarvam is intentionally
-# excluded from STT only — the live agent stays on pipecat's default and its STT
-# model is tracked separately (a parked decision: pipecat 0.0.98 couldn't
-# reproduce the benchmark's saaras:v3 transcribe path, and pipecat 1.0.0 now
-# exposes mode="transcribe" but this hasn't been wired in yet). Sarvam TTS has no
-# such history and is included below. Providers absent here have no shared model
-# string (e.g. Google/Smallest/Deepgram TTS carry the model in the voice name or
-# set no model at all).
+# parity is guarded by tests/test_utils_factories.py. Sarvam STT uses saaras:v3
+# with mode="transcribe" — under pipecat 1.0.0 that routes to the plain STT
+# streaming endpoint (use_translate_endpoint=False), matching the benchmark's
+# transcribe_sarvam. (Under pipecat 0.0.98 this wasn't possible — its wrapper
+# forced saaras onto the translate endpoint with no mode param — which is why it
+# was previously excluded.) Providers absent here have no shared model string
+# (e.g. Google/Smallest/Deepgram TTS carry the model in the voice name or set no
+# model at all).
 STT_PROVIDER_MODELS = {
     "deepgram": "nova-3",
     "openai": "gpt-4o-transcribe",
@@ -1727,6 +1727,7 @@ STT_PROVIDER_MODELS = {
     "cartesia": "ink-whisper",
     "elevenlabs": "scribe_v2_realtime",
     "smallest": "pulse",
+    "sarvam": "saaras:v3",
 }
 
 TTS_PROVIDER_MODELS = {
@@ -1780,7 +1781,11 @@ def create_stt_service(
     elif provider == "sarvam":
         return SarvamSTTService(
             api_key=os.getenv("SARVAM_API_KEY"),
-            settings=SarvamSTTService.Settings(language=stt_language),
+            mode="transcribe",
+            settings=SarvamSTTService.Settings(
+                language=stt_language,
+                model=STT_PROVIDER_MODELS["sarvam"],
+            ),
         )
     elif provider == "elevenlabs":
         return ElevenLabsRealtimeSTTService(

--- a/calibrate/utils.py
+++ b/calibrate/utils.py
@@ -1678,27 +1678,63 @@ def get_tts_language(
 
 
 # Voice ID mappings for TTS providers by language
+# Kept in sync with the TTS benchmark defaults in calibrate/tts/eval.py so a
+# leaderboard reflects the exact voice the live agent deploys. The benchmark
+# uses one voice per provider regardless of language, so these entries match
+# across languages (Google keeps the Chirp3-HD-Charon family per language).
 TTS_VOICE_IDS = {
     "cartesia": {
-        "english": "66c6b81c-ddb7-4892-bdd5-19b5a7be38e7",
-        "hindi": "28ca2041-5dda-42df-8123-f58ea9c3da00",
-        "kannada": "7c6219d2-e8d2-462c-89d8-7ecba7c75d65",
+        "english": "faf0731e-dfb9-4cfc-8119-259a79b27e12",
+        "hindi": "faf0731e-dfb9-4cfc-8119-259a79b27e12",
+        "kannada": "faf0731e-dfb9-4cfc-8119-259a79b27e12",
     },
     "google": {
-        "english": "en-US-Chirp3-HD-Achernar",
-        "hindi": "hi-IN-Chirp3-HD-Achernar",
-        "kannada": "kn-IN-Chirp3-HD-Achernar",
+        "english": "en-US-Chirp3-HD-Charon",
+        "hindi": "hi-IN-Chirp3-HD-Charon",
+        "kannada": "kn-IN-Chirp3-HD-Charon",
     },
     "elevenlabs": {
-        "english": "90ipbRoKi4CpHXvKVtl0",
-        "hindi": "jUjRbhZWoMK4aDciW36V",
-        "kannada": "90ipbRoKi4CpHXvKVtl0",  # fallback to english
+        "english": "m5qndnI7u4OAdXhH0Mr5",
+        "hindi": "m5qndnI7u4OAdXhH0Mr5",
+        "kannada": "m5qndnI7u4OAdXhH0Mr5",
     },
     "smallest": {
-        "english": "aarushi",
-        "hindi": "aarushi",
-        "kannada": "vijay",
+        "english": "aditi",
+        "hindi": "aditi",
+        "kannada": "aditi",
     },
+}
+
+
+# Single source of truth for per-provider default model names. The live agent
+# (create_stt_service / create_tts_service below) AND the benchmarks
+# (calibrate/stt/eval.py, calibrate/tts/eval.py) both read these, so a change in
+# one place applies to both and a leaderboard always reflects the deployed
+# config. See CLAUDE.md ("Keeping live-agent and eval defaults in sync"); the
+# parity is guarded by tests/test_utils_factories.py. Sarvam is intentionally
+# excluded from STT only — the live agent stays on pipecat's default and its STT
+# model is tracked separately (a parked decision: pipecat 0.0.98 couldn't
+# reproduce the benchmark's saaras:v3 transcribe path, and pipecat 1.0.0 now
+# exposes mode="transcribe" but this hasn't been wired in yet). Sarvam TTS has no
+# such history and is included below. Providers absent here have no shared model
+# string (e.g. Google/Smallest/Deepgram TTS carry the model in the voice name or
+# set no model at all).
+STT_PROVIDER_MODELS = {
+    "deepgram": "nova-3",
+    "openai": "gpt-4o-transcribe",
+    "groq": "whisper-large-v3-turbo",
+    "google": "chirp_3",
+    "cartesia": "ink-whisper",
+    "elevenlabs": "scribe_v2_realtime",
+    "smallest": "pulse",
+}
+
+TTS_PROVIDER_MODELS = {
+    "cartesia": "sonic-3.5",
+    "openai": "gpt-4o-mini-tts",
+    "groq": "canopylabs/orpheus-v1-english",
+    "elevenlabs": "eleven_multilingual_v2",
+    "sarvam": "bulbul:v3",
 }
 
 
@@ -1736,7 +1772,10 @@ def create_stt_service(
         return DeepgramSTTService(
             api_key=os.getenv("DEEPGRAM_API_KEY"),
             encoding="linear16",
-            settings=DeepgramSTTService.Settings(language=stt_language),
+            settings=DeepgramSTTService.Settings(
+                language=stt_language,
+                model=STT_PROVIDER_MODELS["deepgram"],
+            ),
         )
     elif provider == "sarvam":
         return SarvamSTTService(
@@ -1746,30 +1785,39 @@ def create_stt_service(
     elif provider == "elevenlabs":
         return ElevenLabsRealtimeSTTService(
             api_key=os.getenv("ELEVENLABS_API_KEY"),
-            settings=ElevenLabsRealtimeSTTService.Settings(language=stt_language),
+            settings=ElevenLabsRealtimeSTTService.Settings(
+                language=stt_language,
+                model=STT_PROVIDER_MODELS["elevenlabs"],
+            ),
         )
     elif provider == "openai":
         return OpenAISTTService(
             api_key=os.getenv("OPENAI_API_KEY"),
             settings=OpenAISTTService.Settings(
-                language=stt_language, model=model or "gpt-4o-transcribe"
+                language=stt_language, model=model or STT_PROVIDER_MODELS["openai"]
             ),
         )
     elif provider == "cartesia":
         return CartesiaSTTService(
             api_key=os.getenv("CARTESIA_API_KEY"),
-            settings=CartesiaSTTService.Settings(language=stt_language),
+            settings=CartesiaSTTService.Settings(
+                language=stt_language,
+                model=STT_PROVIDER_MODELS["cartesia"],
+            ),
         )
     elif provider == "smallest":
         return SmallestSTTService(
             api_key=os.getenv("SMALLEST_API_KEY"),
-            settings=SmallestSTTService.Settings(language=stt_language),
+            settings=SmallestSTTService.Settings(
+                language=stt_language,
+                model=STT_PROVIDER_MODELS["smallest"],
+            ),
         )
     elif provider == "groq":
         return GroqSTTService(
             api_key=os.getenv("GROQ_API_KEY"),
             settings=GroqSTTService.Settings(
-                language=stt_language, model=model or "whisper-large-v3"
+                language=stt_language, model=model or STT_PROVIDER_MODELS["groq"]
             ),
         )
     elif provider == "google":
@@ -1778,7 +1826,7 @@ def create_stt_service(
             location="us",
             settings=GoogleSTTService.Settings(
                 languages=[stt_language],
-                model=model or "chirp_3",
+                model=model or STT_PROVIDER_MODELS["google"],
             ),
             credentials_path=os.getenv("GOOGLE_APPLICATION_CREDENTIALS"),
         )
@@ -1829,15 +1877,16 @@ def create_tts_service(
             api_key=os.getenv("CARTESIA_API_KEY"),
             settings=CartesiaTTSService.Settings(
                 language=tts_language,
-                model=model or "sonic-3",
-                voice=voice_id or "95d51f79-c397-46f9-b49a-23763d3eaa2d",
+                model=model or TTS_PROVIDER_MODELS["cartesia"],
+                voice=voice_id or "faf0731e-dfb9-4cfc-8119-259a79b27e12",
             ),
         )
     elif provider == "openai":
         return OpenAITTSService(
             api_key=os.getenv("OPENAI_API_KEY"),
             settings=OpenAITTSService.Settings(
-                voice=voice_id or "fable",
+                model=model or TTS_PROVIDER_MODELS["openai"],
+                voice=voice_id or "coral",
                 instructions=instructions,
             ),
         )
@@ -1845,8 +1894,8 @@ def create_tts_service(
         return GroqTTSService(
             api_key=os.getenv("GROQ_API_KEY"),
             settings=GroqTTSService.Settings(
-                model=model or "canopylabs/orpheus-v1-english",
-                voice=voice_id or "autumn",
+                model=model or TTS_PROVIDER_MODELS["groq"],
+                voice=voice_id or "troy",
             ),
         )
     elif provider == "google":
@@ -1863,9 +1912,9 @@ def create_tts_service(
             api_key=os.getenv("ELEVENLABS_API_KEY"),
             settings=ElevenLabsTTSService.Settings(
                 language=tts_language,
-                model="eleven_multilingual_v2",
+                model=TTS_PROVIDER_MODELS["elevenlabs"],
                 voice=voice_id
-                or TTS_VOICE_IDS["elevenlabs"].get(language, "90ipbRoKi4CpHXvKVtl0"),
+                or TTS_VOICE_IDS["elevenlabs"].get(language, "m5qndnI7u4OAdXhH0Mr5"),
             ),
         )
     elif provider == "sarvam":
@@ -1873,8 +1922,8 @@ def create_tts_service(
             api_key=os.getenv("SARVAM_API_KEY"),
             settings=SarvamTTSService.Settings(
                 language=tts_language,
-                model=model or "bulbul:v2",
-                voice=voice_id or "abhilash",
+                model=model or TTS_PROVIDER_MODELS["sarvam"],
+                voice=voice_id or "aditya",
             ),
         )
     elif provider == "deepgram":
@@ -1886,7 +1935,7 @@ def create_tts_service(
         return SmallestTTSService(
             api_key=os.getenv("SMALLEST_API_KEY"),
             settings=SmallestTTSService.Settings(
-                voice=voice_id or TTS_VOICE_IDS["smallest"].get(language, "aarushi"),
+                voice=voice_id or TTS_VOICE_IDS["smallest"].get(language, "aditi"),
                 language=tts_language,
             ),
         )

--- a/calibrate/utils.py
+++ b/calibrate/utils.py
@@ -1811,7 +1811,7 @@ def create_stt_service(
             encoding="linear16",
             settings=DeepgramSTTService.Settings(
                 language=stt_language,
-                model=STT_PROVIDER_MODELS["deepgram"],
+                model=STT_PROVIDER_MODELS[provider],
             ),
         )
     elif provider == "sarvam":
@@ -1820,7 +1820,7 @@ def create_stt_service(
             mode="transcribe",
             settings=SarvamSTTService.Settings(
                 language=stt_language,
-                model=STT_PROVIDER_MODELS["sarvam"],
+                model=STT_PROVIDER_MODELS[provider],
             ),
         )
     elif provider == "elevenlabs":
@@ -1828,14 +1828,14 @@ def create_stt_service(
             api_key=os.getenv("ELEVENLABS_API_KEY"),
             settings=ElevenLabsRealtimeSTTService.Settings(
                 language=stt_language,
-                model=STT_PROVIDER_MODELS["elevenlabs"],
+                model=STT_PROVIDER_MODELS[provider],
             ),
         )
     elif provider == "openai":
         return OpenAISTTService(
             api_key=os.getenv("OPENAI_API_KEY"),
             settings=OpenAISTTService.Settings(
-                language=stt_language, model=model or STT_PROVIDER_MODELS["openai"]
+                language=stt_language, model=model or STT_PROVIDER_MODELS[provider]
             ),
         )
     elif provider == "cartesia":
@@ -1843,7 +1843,7 @@ def create_stt_service(
             api_key=os.getenv("CARTESIA_API_KEY"),
             settings=CartesiaSTTService.Settings(
                 language=stt_language,
-                model=STT_PROVIDER_MODELS["cartesia"],
+                model=STT_PROVIDER_MODELS[provider],
             ),
         )
     elif provider == "smallest":
@@ -1851,14 +1851,14 @@ def create_stt_service(
             api_key=os.getenv("SMALLEST_API_KEY"),
             settings=SmallestSTTService.Settings(
                 language=stt_language,
-                model=STT_PROVIDER_MODELS["smallest"],
+                model=STT_PROVIDER_MODELS[provider],
             ),
         )
     elif provider == "groq":
         return GroqSTTService(
             api_key=os.getenv("GROQ_API_KEY"),
             settings=GroqSTTService.Settings(
-                language=stt_language, model=model or STT_PROVIDER_MODELS["groq"]
+                language=stt_language, model=model or STT_PROVIDER_MODELS[provider]
             ),
         )
     elif provider == "google":
@@ -1867,7 +1867,7 @@ def create_stt_service(
             location="us",
             settings=GoogleSTTService.Settings(
                 languages=[stt_language],
-                model=model or STT_PROVIDER_MODELS["google"],
+                model=model or STT_PROVIDER_MODELS[provider],
             ),
             credentials_path=os.getenv("GOOGLE_APPLICATION_CREDENTIALS"),
         )
@@ -1914,16 +1914,16 @@ def create_tts_service(
             api_key=os.getenv("CARTESIA_API_KEY"),
             settings=CartesiaTTSService.Settings(
                 language=tts_language,
-                model=model or TTS_PROVIDER_MODELS["cartesia"],
-                voice=voice_id or get_tts_voice("cartesia", language),
+                model=model or TTS_PROVIDER_MODELS[provider],
+                voice=voice_id or get_tts_voice(provider, language),
             ),
         )
     elif provider == "openai":
         return OpenAITTSService(
             api_key=os.getenv("OPENAI_API_KEY"),
             settings=OpenAITTSService.Settings(
-                model=model or TTS_PROVIDER_MODELS["openai"],
-                voice=voice_id or get_tts_voice("openai", language),
+                model=model or TTS_PROVIDER_MODELS[provider],
+                voice=voice_id or get_tts_voice(provider, language),
                 instructions=instructions,
             ),
         )
@@ -1931,15 +1931,15 @@ def create_tts_service(
         return GroqTTSService(
             api_key=os.getenv("GROQ_API_KEY"),
             settings=GroqTTSService.Settings(
-                model=model or TTS_PROVIDER_MODELS["groq"],
-                voice=voice_id or get_tts_voice("groq", language),
+                model=model or TTS_PROVIDER_MODELS[provider],
+                voice=voice_id or get_tts_voice(provider, language),
             ),
         )
     elif provider == "google":
         return GoogleTTSService(
             settings=GoogleTTSService.Settings(
                 language=tts_language,
-                voice=voice_id or get_tts_voice("google", language),
+                voice=voice_id or get_tts_voice(provider, language),
             ),
             credentials_path=os.getenv("GOOGLE_APPLICATION_CREDENTIALS"),
         )
@@ -1948,8 +1948,8 @@ def create_tts_service(
             api_key=os.getenv("ELEVENLABS_API_KEY"),
             settings=ElevenLabsTTSService.Settings(
                 language=tts_language,
-                model=TTS_PROVIDER_MODELS["elevenlabs"],
-                voice=voice_id or get_tts_voice("elevenlabs", language),
+                model=TTS_PROVIDER_MODELS[provider],
+                voice=voice_id or get_tts_voice(provider, language),
             ),
         )
     elif provider == "sarvam":
@@ -1957,8 +1957,8 @@ def create_tts_service(
             api_key=os.getenv("SARVAM_API_KEY"),
             settings=SarvamTTSService.Settings(
                 language=tts_language,
-                model=model or TTS_PROVIDER_MODELS["sarvam"],
-                voice=voice_id or get_tts_voice("sarvam", language),
+                model=model or TTS_PROVIDER_MODELS[provider],
+                voice=voice_id or get_tts_voice(provider, language),
             ),
         )
     elif provider == "deepgram":
@@ -1970,7 +1970,7 @@ def create_tts_service(
         return SmallestTTSService(
             api_key=os.getenv("SMALLEST_API_KEY"),
             settings=SmallestTTSService.Settings(
-                voice=voice_id or get_tts_voice("smallest", language),
+                voice=voice_id or get_tts_voice(provider, language),
                 language=tts_language,
             ),
         )

--- a/tests/test_utils_factories.py
+++ b/tests/test_utils_factories.py
@@ -102,23 +102,36 @@ class TestCreateTTSService(unittest.TestCase):
 
     def test_defaults_match_tts_eval(self):
         """The live-agent TTS defaults must stay in sync with the benchmark
-        defaults in calibrate/tts/eval.py. Model names come from the shared
-        utils.TTS_PROVIDER_MODELS (which tts/eval.py also reads), so those can't
-        drift; voices are asserted against the eval literals directly. In pipecat
-        1.0.0 both are passed via <Service>.Settings(model=..., voice=...)."""
-        from calibrate.utils import create_tts_service, TTS_PROVIDER_MODELS
+        defaults in calibrate/tts/eval.py. Both models and voices come from the
+        shared utils.TTS_PROVIDER_MODELS / TTS_PROVIDER_VOICES (which tts/eval.py
+        also reads), so neither can drift. In pipecat 1.0.0 both are passed via
+        <Service>.Settings(model=..., voice=...)."""
+        from calibrate.utils import (
+            create_tts_service,
+            TTS_PROVIDER_MODELS,
+            TTS_PROVIDER_VOICES,
+            GOOGLE_TTS_VOICE_FAMILY,
+        )
 
         # provider -> (expected model or None, expected voice) for english.
         expected = {
-            "cartesia": (TTS_PROVIDER_MODELS["cartesia"],
-                         "faf0731e-dfb9-4cfc-8119-259a79b27e12"),
-            "openai": (TTS_PROVIDER_MODELS["openai"], "coral"),
-            "groq": (TTS_PROVIDER_MODELS["groq"], "troy"),
-            "google": (None, "en-US-Chirp3-HD-Charon"),
-            "elevenlabs": (TTS_PROVIDER_MODELS["elevenlabs"], "m5qndnI7u4OAdXhH0Mr5"),
-            "sarvam": (TTS_PROVIDER_MODELS["sarvam"], "aditya"),
-            "smallest": (None, "aditi"),
+            "cartesia": (TTS_PROVIDER_MODELS["cartesia"], TTS_PROVIDER_VOICES["cartesia"]),
+            "openai": (TTS_PROVIDER_MODELS["openai"], TTS_PROVIDER_VOICES["openai"]),
+            "groq": (TTS_PROVIDER_MODELS["groq"], TTS_PROVIDER_VOICES["groq"]),
+            "google": (None, f"en-US-{GOOGLE_TTS_VOICE_FAMILY}"),
+            "elevenlabs": (TTS_PROVIDER_MODELS["elevenlabs"], TTS_PROVIDER_VOICES["elevenlabs"]),
+            "sarvam": (TTS_PROVIDER_MODELS["sarvam"], TTS_PROVIDER_VOICES["sarvam"]),
+            "smallest": (None, TTS_PROVIDER_VOICES["smallest"]),
         }
+
+        # Completeness guard: `expected` must cover every single-sourced TTS
+        # provider (both dicts, plus Google which is single-sourced via
+        # GOOGLE_TTS_VOICE_FAMILY). Adding a provider to a constant without a
+        # parity row here fails the test until it's covered too.
+        self.assertEqual(
+            set(expected),
+            set(TTS_PROVIDER_MODELS) | set(TTS_PROVIDER_VOICES) | {"google"},
+        )
 
         for prov, (model_val, voice_val) in expected.items():
             with patch.dict(os.environ, ALL_KEYS), \

--- a/tests/test_utils_factories.py
+++ b/tests/test_utils_factories.py
@@ -55,9 +55,7 @@ class TestCreateSTTService(unittest.TestCase):
     def test_stt_models_come_from_shared_constant(self):
         """Every provider's model in create_stt_service must come from
         utils.STT_PROVIDER_MODELS — the SAME dict calibrate/stt/eval.py reads —
-        so the live agent and the benchmark can't drift apart. Sarvam is excluded
-        (pipecat routes saaras to the translate endpoint, so it can't reproduce
-        eval's saaras:v3 transcribe path)."""
+        so the live agent and the benchmark can't drift apart."""
         from calibrate.utils import create_stt_service, STT_PROVIDER_MODELS
 
         for prov, expected in STT_PROVIDER_MODELS.items():
@@ -73,8 +71,24 @@ class TestCreateSTTService(unittest.TestCase):
         # parity coverage here.
         self.assertEqual(
             set(STT_PROVIDER_MODELS),
-            {"deepgram", "openai", "groq", "google", "cartesia", "elevenlabs", "smallest"},
+            {"deepgram", "openai", "groq", "google", "cartesia",
+             "elevenlabs", "smallest", "sarvam"},
         )
+
+    def test_sarvam_stt_transcribes(self):
+        """Sarvam STT must use saaras:v3 with mode="transcribe" so pipecat routes
+        it to the plain STT streaming endpoint (not translate), matching
+        stt/eval.py's transcribe_sarvam."""
+        from calibrate.utils import create_stt_service, STT_PROVIDER_MODELS
+
+        with patch.dict(os.environ, ALL_KEYS), \
+                patch(STT_SERVICE_TARGETS["sarvam"]) as svc:
+            create_stt_service("sarvam", "english")
+            self.assertEqual(svc.call_args.kwargs["mode"], "transcribe")
+            self.assertEqual(
+                svc.Settings.call_args.kwargs["model"], STT_PROVIDER_MODELS["sarvam"]
+            )
+            self.assertEqual(STT_PROVIDER_MODELS["sarvam"], "saaras:v3")
 
 
 class TestCreateTTSService(unittest.TestCase):

--- a/tests/test_utils_factories.py
+++ b/tests/test_utils_factories.py
@@ -122,13 +122,14 @@ class TestCreateTTSService(unittest.TestCase):
         benchmarked = set(TTS_SERVICE_TARGETS) - {"deepgram"}
 
         # Completeness guard: every provider carrying a shared model or voice
-        # (default or per-language override) must be exercised below. Adding one
-        # to a constant without covering it here fails the test.
+        # (default, per-language override, or Google's family) must be exercised
+        # below. Adding one to a constant without covering it here fails the test.
         self.assertEqual(
             benchmarked,
             set(TTS_PROVIDER_MODELS)
             | set(TTS_PROVIDER_VOICES)
-            | set(TTS_PROVIDER_VOICES_BY_LANGUAGE),
+            | set(TTS_PROVIDER_VOICES_BY_LANGUAGE)
+            | {"google"},
         )
 
         for prov in benchmarked:

--- a/tests/test_utils_factories.py
+++ b/tests/test_utils_factories.py
@@ -100,53 +100,61 @@ class TestCreateTTSService(unittest.TestCase):
             with patch.dict(os.environ, ALL_KEYS), patch(target):
                 create_tts_service(prov, "english")
 
+    # Providers whose model create_tts_service passes explicitly (the rest carry
+    # no shared TTS model — Google/Smallest set none, Deepgram isn't benchmarked).
+    _TTS_MODEL_PROVIDERS = {"cartesia", "openai", "groq", "elevenlabs", "sarvam"}
+
     def test_defaults_match_tts_eval(self):
-        """The live-agent TTS defaults must stay in sync with the benchmark
-        defaults in calibrate/tts/eval.py. Both models and voices come from the
-        shared utils.TTS_PROVIDER_MODELS / TTS_PROVIDER_VOICES (which tts/eval.py
-        also reads), so neither can drift. In pipecat 1.0.0 both are passed via
+        """create_tts_service must pick the same model (TTS_PROVIDER_MODELS) and
+        voice (get_tts_voice) that calibrate/tts/eval.py uses — for every provider
+        and every language — so the live agent and benchmark can't drift. Voices
+        are per-language: overrides in TTS_PROVIDER_VOICES_BY_LANGUAGE, else the
+        default. In pipecat 1.0.0 both are passed via
         <Service>.Settings(model=..., voice=...)."""
         from calibrate.utils import (
             create_tts_service,
             TTS_PROVIDER_MODELS,
             TTS_PROVIDER_VOICES,
-            GOOGLE_TTS_VOICE_FAMILY,
+            TTS_PROVIDER_VOICES_BY_LANGUAGE,
+            get_tts_voice,
         )
 
-        # provider -> (expected model or None, expected voice) for english.
-        expected = {
-            "cartesia": (TTS_PROVIDER_MODELS["cartesia"], TTS_PROVIDER_VOICES["cartesia"]),
-            "openai": (TTS_PROVIDER_MODELS["openai"], TTS_PROVIDER_VOICES["openai"]),
-            "groq": (TTS_PROVIDER_MODELS["groq"], TTS_PROVIDER_VOICES["groq"]),
-            "google": (None, f"en-US-{GOOGLE_TTS_VOICE_FAMILY}"),
-            "elevenlabs": (TTS_PROVIDER_MODELS["elevenlabs"], TTS_PROVIDER_VOICES["elevenlabs"]),
-            "sarvam": (TTS_PROVIDER_MODELS["sarvam"], TTS_PROVIDER_VOICES["sarvam"]),
-            "smallest": (None, TTS_PROVIDER_VOICES["smallest"]),
-        }
+        benchmarked = set(TTS_SERVICE_TARGETS) - {"deepgram"}
 
-        # Completeness guard: `expected` must cover every single-sourced TTS
-        # provider (both dicts, plus Google which is single-sourced via
-        # GOOGLE_TTS_VOICE_FAMILY). Adding a provider to a constant without a
-        # parity row here fails the test until it's covered too.
+        # Completeness guard: every provider carrying a shared model or voice
+        # (default or per-language override) must be exercised below. Adding one
+        # to a constant without covering it here fails the test.
         self.assertEqual(
-            set(expected),
-            set(TTS_PROVIDER_MODELS) | set(TTS_PROVIDER_VOICES) | {"google"},
+            benchmarked,
+            set(TTS_PROVIDER_MODELS)
+            | set(TTS_PROVIDER_VOICES)
+            | set(TTS_PROVIDER_VOICES_BY_LANGUAGE),
         )
 
-        for prov, (model_val, voice_val) in expected.items():
-            with patch.dict(os.environ, ALL_KEYS), \
-                    patch(TTS_SERVICE_TARGETS[prov]) as svc:
-                create_tts_service(prov, "english")
-                kwargs = svc.Settings.call_args.kwargs
-                if model_val is not None:
+        for prov in benchmarked:
+            for language in ("english", "hindi", "kannada"):
+                with patch.dict(os.environ, ALL_KEYS), \
+                        patch(TTS_SERVICE_TARGETS[prov]) as svc:
+                    create_tts_service(prov, language)
+                    kwargs = svc.Settings.call_args.kwargs
                     self.assertEqual(
-                        kwargs["model"], model_val,
-                        f"{prov}: TTS model drifted from tts/eval.py",
+                        kwargs["voice"], get_tts_voice(prov, language),
+                        f"{prov}/{language}: TTS voice drifted from get_tts_voice",
                     )
-                self.assertEqual(
-                    kwargs["voice"], voice_val,
-                    f"{prov}: TTS voice drifted from tts/eval.py",
-                )
+                    if prov in self._TTS_MODEL_PROVIDERS:
+                        self.assertEqual(
+                            kwargs["model"], TTS_PROVIDER_MODELS[prov],
+                            f"{prov}: TTS model drifted from TTS_PROVIDER_MODELS",
+                        )
+
+        # The per-language overrides must actually be distinct — i.e. not silently
+        # collapsed back to one voice per provider.
+        self.assertNotEqual(
+            get_tts_voice("cartesia", "hindi"), get_tts_voice("cartesia", "english")
+        )
+        self.assertNotEqual(
+            get_tts_voice("smallest", "kannada"), get_tts_voice("smallest", "english")
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_utils_factories.py
+++ b/tests/test_utils_factories.py
@@ -1,103 +1,125 @@
-"""Cover create_stt_service / create_tts_service provider branches."""
+"""Cover create_stt_service / create_tts_service provider branches.
+
+pipecat 1.0.0 passes per-provider config through ``<Service>.Settings(...)``, so
+these tests patch the service class and inspect the recorded ``.Settings`` call.
+"""
 
 import os
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
+
+
+STT_SERVICE_TARGETS = {
+    "deepgram": "pipecat.services.deepgram.stt.DeepgramSTTService",
+    "openai": "pipecat.services.openai.stt.OpenAISTTService",
+    "groq": "pipecat.services.groq.stt.GroqSTTService",
+    "google": "pipecat.services.google.stt.GoogleSTTService",
+    "cartesia": "pipecat.services.cartesia.stt.CartesiaSTTService",
+    "elevenlabs": "pipecat.services.elevenlabs.stt.ElevenLabsRealtimeSTTService",
+    "smallest": "pipecat.services.smallest.stt.SmallestSTTService",
+    "sarvam": "pipecat.services.sarvam.stt.SarvamSTTService",
+}
+
+TTS_SERVICE_TARGETS = {
+    "cartesia": "pipecat.services.cartesia.tts.CartesiaTTSService",
+    "openai": "pipecat.services.openai.tts.OpenAITTSService",
+    "groq": "pipecat.services.groq.tts.GroqTTSService",
+    "google": "pipecat.services.google.tts.GoogleTTSService",
+    "elevenlabs": "pipecat.services.elevenlabs.tts.ElevenLabsTTSService",
+    "sarvam": "pipecat.services.sarvam.tts.SarvamTTSService",
+    "deepgram": "pipecat.services.deepgram.tts.DeepgramTTSService",
+    "smallest": "pipecat.services.smallest.tts.SmallestTTSService",
+}
+
+ALL_KEYS = {
+    "DEEPGRAM_API_KEY": "k",
+    "SARVAM_API_KEY": "k",
+    "OPENAI_API_KEY": "k",
+    "GROQ_API_KEY": "k",
+    "CARTESIA_API_KEY": "k",
+    "ELEVENLABS_API_KEY": "k",
+    "SMALLEST_API_KEY": "k",
+    "GOOGLE_APPLICATION_CREDENTIALS": "/creds.json",
+}
 
 
 class TestCreateSTTService(unittest.TestCase):
-    """Each provider branch — patch the imported pipecat service classes."""
-
-    def _patch_imports(self):
-        """Patch all pipecat services imported lazily in create_stt_service."""
-        patches = [
-            patch("pipecat.services.deepgram.stt.DeepgramSTTService"),
-            patch("pipecat.services.deepgram.stt.LiveOptions"),
-            patch("pipecat.services.openai.stt.OpenAISTTService"),
-            patch("pipecat.services.google.stt.GoogleSTTService"),
-            patch("pipecat.services.cartesia.stt.CartesiaSTTService"),
-            patch("pipecat.services.cartesia.stt.CartesiaLiveOptions"),
-            patch("pipecat.services.groq.stt.GroqSTTService"),
-            patch("pipecat.services.sarvam.stt.SarvamSTTService"),
-            patch("pipecat.services.elevenlabs.stt.ElevenLabsRealtimeSTTService"),
-            patch("pipecat.services.smallest.stt.SmallestSTTService"),
-        ]
-        return patches
-
-    def test_deepgram(self):
-        from calibrate.utils import create_stt_service
-
-        with patch.dict(os.environ, {"DEEPGRAM_API_KEY": "k"}):
-            for p in self._patch_imports():
-                p.start()
-            try:
-                create_stt_service("deepgram", "english")
-            finally:
-                for p in self._patch_imports():
-                    p.stop()
-
     def test_each_provider(self):
+        """Every provider branch constructs (pipecat service patched)."""
         from calibrate.utils import create_stt_service
 
-        envs = {
-            "DEEPGRAM_API_KEY": "k",
-            "SARVAM_API_KEY": "k",
-            "OPENAI_API_KEY": "k",
-            "GROQ_API_KEY": "k",
-            "CARTESIA_API_KEY": "k",
-            "ELEVENLABS_API_KEY": "k",
-            "SMALLEST_API_KEY": "k",
-            "GOOGLE_APPLICATION_CREDENTIALS": "/creds.json",
-        }
-        with patch.dict(os.environ, envs):
-            patches = self._patch_imports()
-            started = [p.start() for p in patches]
-            try:
-                for prov in ["deepgram", "sarvam", "elevenlabs", "openai",
-                             "cartesia", "smallest", "groq", "google"]:
-                    create_stt_service(prov, "english")
-            finally:
-                for p in patches:
-                    p.stop()
+        for prov, target in STT_SERVICE_TARGETS.items():
+            with patch.dict(os.environ, ALL_KEYS), patch(target):
+                create_stt_service(prov, "english")
+
+    def test_stt_models_come_from_shared_constant(self):
+        """Every provider's model in create_stt_service must come from
+        utils.STT_PROVIDER_MODELS — the SAME dict calibrate/stt/eval.py reads —
+        so the live agent and the benchmark can't drift apart. Sarvam is excluded
+        (pipecat routes saaras to the translate endpoint, so it can't reproduce
+        eval's saaras:v3 transcribe path)."""
+        from calibrate.utils import create_stt_service, STT_PROVIDER_MODELS
+
+        for prov, expected in STT_PROVIDER_MODELS.items():
+            with patch.dict(os.environ, ALL_KEYS), \
+                    patch(STT_SERVICE_TARGETS[prov]) as svc:
+                create_stt_service(prov, "english")
+                self.assertEqual(
+                    svc.Settings.call_args.kwargs["model"], expected,
+                    f"{prov}: STT model default drifted from STT_PROVIDER_MODELS",
+                )
+
+        # Guard against a new provider entering the constant without matching
+        # parity coverage here.
+        self.assertEqual(
+            set(STT_PROVIDER_MODELS),
+            {"deepgram", "openai", "groq", "google", "cartesia", "elevenlabs", "smallest"},
+        )
 
 
 class TestCreateTTSService(unittest.TestCase):
-    def _patch_imports(self):
-        return [
-            patch("pipecat.services.cartesia.tts.CartesiaTTSService"),
-            patch("pipecat.services.openai.tts.OpenAITTSService"),
-            patch("pipecat.services.groq.tts.GroqTTSService"),
-            patch("pipecat.services.google.tts.GoogleTTSService"),
-            patch("pipecat.services.elevenlabs.tts.ElevenLabsTTSService"),
-            patch("pipecat.services.sarvam.tts.SarvamTTSService"),
-            patch("pipecat.services.deepgram.tts.DeepgramTTSService"),
-            patch("pipecat.services.smallest.tts.SmallestTTSService"),
-        ]
-
     def test_each_provider(self):
+        """Every provider branch constructs (pipecat service patched)."""
         from calibrate.utils import create_tts_service
 
-        envs = {
-            "OPENAI_API_KEY": "k",
-            "GROQ_API_KEY": "k",
-            "CARTESIA_API_KEY": "k",
-            "ELEVENLABS_API_KEY": "k",
-            "SARVAM_API_KEY": "k",
-            "DEEPGRAM_API_KEY": "k",
-            "SMALLEST_API_KEY": "k",
-            "GOOGLE_APPLICATION_CREDENTIALS": "/creds.json",
+        for prov, target in TTS_SERVICE_TARGETS.items():
+            with patch.dict(os.environ, ALL_KEYS), patch(target):
+                create_tts_service(prov, "english")
+
+    def test_defaults_match_tts_eval(self):
+        """The live-agent TTS defaults must stay in sync with the benchmark
+        defaults in calibrate/tts/eval.py. Model names come from the shared
+        utils.TTS_PROVIDER_MODELS (which tts/eval.py also reads), so those can't
+        drift; voices are asserted against the eval literals directly. In pipecat
+        1.0.0 both are passed via <Service>.Settings(model=..., voice=...)."""
+        from calibrate.utils import create_tts_service, TTS_PROVIDER_MODELS
+
+        # provider -> (expected model or None, expected voice) for english.
+        expected = {
+            "cartesia": (TTS_PROVIDER_MODELS["cartesia"],
+                         "faf0731e-dfb9-4cfc-8119-259a79b27e12"),
+            "openai": (TTS_PROVIDER_MODELS["openai"], "coral"),
+            "groq": (TTS_PROVIDER_MODELS["groq"], "troy"),
+            "google": (None, "en-US-Chirp3-HD-Charon"),
+            "elevenlabs": (TTS_PROVIDER_MODELS["elevenlabs"], "m5qndnI7u4OAdXhH0Mr5"),
+            "sarvam": (TTS_PROVIDER_MODELS["sarvam"], "aditya"),
+            "smallest": (None, "aditi"),
         }
-        with patch.dict(os.environ, envs):
-            patches = self._patch_imports()
-            for p in patches:
-                p.start()
-            try:
-                for prov in ["cartesia", "openai", "groq", "google", "elevenlabs",
-                             "sarvam", "deepgram", "smallest"]:
-                    create_tts_service(prov, "english")
-            finally:
-                for p in patches:
-                    p.stop()
+
+        for prov, (model_val, voice_val) in expected.items():
+            with patch.dict(os.environ, ALL_KEYS), \
+                    patch(TTS_SERVICE_TARGETS[prov]) as svc:
+                create_tts_service(prov, "english")
+                kwargs = svc.Settings.call_args.kwargs
+                if model_val is not None:
+                    self.assertEqual(
+                        kwargs["model"], model_val,
+                        f"{prov}: TTS model drifted from tts/eval.py",
+                    )
+                self.assertEqual(
+                    kwargs["voice"], voice_val,
+                    f"{prov}: TTS voice drifted from tts/eval.py",
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
- `create_*_service` (live agent) and `stt/eval.py` / `tts/eval.py` (benchmarks) each hardcoded their own per-provider model/voice defaults, which had drifted — a leaderboard could measure a different config than the agent ships.
- Add `STT_PROVIDER_MODELS` / `TTS_PROVIDER_MODELS` in `utils.py` as the single source both sides read, reconcile the drifted defaults (models + voices), and guard parity in `tests/test_utils_factories.py`.
- Sarvam STT now uses `saaras:v3` with `mode="transcribe"`, so no provider is excluded from single-sourcing.

## Notes
- Built on main's pipecat 1.0.0 migration; `create_*_service` uses the `.Settings` API.
- Sarvam STT changes from pipecat's `saarika:v2.5` default to `saaras:v3` (a behavior change that now matches the benchmark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)