### PR TITLE
Fix Smallest TTS (lightning-v2 retired) and cover STT in status check

### DIFF
--- a/calibrate/status.py
+++ b/calibrate/status.py
@@ -12,6 +12,7 @@ import asyncio
 import json
 import time
 import struct
+from urllib.parse import urlencode
 
 import httpx
 
@@ -288,28 +289,99 @@ async def _check_cartesia(client: httpx.AsyncClient) -> str:
     return "tts"
 
 
-async def _check_smallest(client: httpx.AsyncClient) -> str:
-    """TTS: synthesize 'hi' via Smallest streaming TTS."""
+# Smallest retired lightning-v2 (the standalone smallestai SDK's hard-coded
+# model), so it now returns HTTP 410 Gone. lightning-v3.1 is the current model
+# and matches what pipecat's SmallestTTSService uses in the real TTS/agent path
+# (see calibrate/utils.py:create_tts_service).
+_SMALLEST_TTS_WS_URL = (
+    "wss://waves-api.smallest.ai/api/v1/lightning-v3.1/get_speech/stream"
+)
+
+
+_SMALLEST_STT_WS_URL = "wss://api.smallest.ai/waves/v1/stt/live"
+
+
+async def _check_smallest_tts() -> str:
+    """TTS: synthesize 'hi' via Smallest lightning-v3.1 streaming TTS."""
+    from websockets.asyncio.client import connect as websocket_connect
+
     api_key = os.getenv("SMALLEST_API_KEY")
+    payload = {
+        "text": "hi",
+        "voice_id": "sophia",
+        "language": "en",
+        "sample_rate": 24000,
+    }
+    headers = {"Authorization": f"Bearer {api_key}"}
 
-    def _sync_check():
-        from smallestai.waves import TTSConfig, WavesStreamingTTS
+    async with websocket_connect(
+        _SMALLEST_TTS_WS_URL, additional_headers=headers
+    ) as ws:
+        await ws.send(json.dumps(payload))
+        async for message in ws:
+            msg = json.loads(message)
+            status = msg.get("status")
+            if status == "chunk" and msg.get("data", {}).get("audio"):
+                return "tts"  # Got audio — TTS works
+            if status == "error":
+                raise RuntimeError(msg.get("error") or msg.get("message") or msg)
+            if status == "complete":
+                break
+    raise ValueError("No audio generated")
 
-        config = TTSConfig(
-            voice_id="aditi",
-            language="en",
-            api_key=api_key,
-            sample_rate=24000,
-        )
-        tts = WavesStreamingTTS(config)
-        for chunk in tts.synthesize("hi"):
-            if chunk:
-                return  # Got audio — TTS works
-        raise ValueError("No audio generated")
 
-    loop = asyncio.get_running_loop()
-    await loop.run_in_executor(None, _sync_check)
-    return "tts"
+async def _check_smallest_stt() -> str:
+    """STT: stream silence through Smallest's Pulse STT WebSocket."""
+    from websockets.asyncio.client import connect as websocket_connect
+    from websockets.exceptions import ConnectionClosed
+
+    api_key = os.getenv("SMALLEST_API_KEY")
+    params = {
+        "model": "pulse",
+        "language": "en",
+        "encoding": "linear16",
+        "sample_rate": "16000",
+        "word_timestamps": "false",
+    }
+    ws_url = f"{_SMALLEST_STT_WS_URL}?{urlencode(params)}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    silence = b"\x00\x00" * 8000  # 0.5s @ 16 kHz, 16-bit mono PCM
+
+    async with websocket_connect(ws_url, additional_headers=headers) as ws:
+        await ws.send(silence)
+        await ws.send(json.dumps({"type": "close_stream"}))
+        while True:
+            try:
+                message = await asyncio.wait_for(ws.recv(), timeout=5.0)
+            except (asyncio.TimeoutError, ConnectionClosed):
+                break  # Handshake + stream accepted, no error surfaced
+            try:
+                output = json.loads(message)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if isinstance(output, dict) and (
+                output.get("type") == "error" or output.get("error")
+            ):
+                error = output.get("message") or output.get("error") or output
+                raise RuntimeError(f"Smallest STT error: {error}")
+            break  # Got a valid response — STT pipeline is live
+    return "stt"
+
+
+async def _check_smallest(client: httpx.AsyncClient) -> str:
+    """Verify both of Smallest's declared capabilities: STT and TTS."""
+
+    async def _labeled(coro, label):
+        try:
+            return await coro
+        except Exception as e:
+            raise RuntimeError(f"{label} {e}") from e
+
+    await asyncio.gather(
+        _labeled(_check_smallest_tts(), "TTS:"),
+        _labeled(_check_smallest_stt(), "STT:"),
+    )
+    return "stt,tts"
 
 
 async def _check_deepgram(client: httpx.AsyncClient) -> str:

--- a/calibrate/tts/eval.py
+++ b/calibrate/tts/eval.py
@@ -17,7 +17,6 @@ from groq import AsyncGroq
 from cartesia import AsyncCartesia
 from sarvamai import AsyncSarvamAI, AudioOutput, EventResponse
 from google.cloud import texttospeech
-from smallestai.waves import TTSConfig, WavesStreamingTTS
 
 import numpy as np
 import pandas as pd
@@ -393,32 +392,51 @@ async def synthesize_sarvam(text: str, language: str, audio_path: str) -> Dict:
 
 
 async def synthesize_smallest(text: str, language: str, audio_path: str) -> Dict:
-    """Synthesize speech using Smallest AI's TTS API and save to file."""
+    """Synthesize speech using Smallest AI's lightning-v3.1 streaming TTS.
+
+    lightning-v2 (the standalone smallestai SDK's hard-coded model) was retired
+    and now returns HTTP 410, so this talks to the current lightning-v3.1
+    WebSocket directly — the same endpoint pipecat's SmallestTTSService uses.
+    """
+    from websockets.asyncio.client import connect as websocket_connect
+
     api_key = os.getenv("SMALLEST_API_KEY")
     if not api_key:
         raise ValueError("SMALLEST_API_KEY environment variable not set")
 
     lang_code = get_tts_language_code(language, "smallest")
-
-    config = TTSConfig(
-        voice_id="aditi",
-        language=lang_code,
-        api_key=api_key,
-        sample_rate=24000,
-        speed=1.0,
-        max_buffer_flush_ms=100,
-    )
-
-    streaming_tts = WavesStreamingTTS(config)
+    ws_url = "wss://waves-api.smallest.ai/api/v1/lightning-v3.1/get_speech/stream"
+    payload = {
+        "text": text,
+        "voice_id": "aditi",
+        "language": lang_code,
+        "sample_rate": 24000,
+        "speed": 1.0,
+    }
+    headers = {"Authorization": f"Bearer {api_key}"}
 
     start_time = time.time()
     ttfb = None
+    audio_chunks: List[bytes] = []
 
-    for chunk in streaming_tts.synthesize(text):
-        if ttfb is None:
-            ttfb = time.time() - start_time
+    async with websocket_connect(ws_url, additional_headers=headers) as ws:
+        await ws.send(json.dumps(payload))
+        async for message in ws:
+            msg = json.loads(message)
+            status = msg.get("status")
+            if status == "chunk":
+                audio_b64 = msg.get("data", {}).get("audio")
+                if audio_b64:
+                    if ttfb is None:
+                        ttfb = time.time() - start_time
+                    audio_chunks.append(base64.b64decode(audio_b64))
+            elif status == "error":
+                error = msg.get("error") or msg.get("message") or msg
+                raise RuntimeError(f"Smallest TTS error: {error}")
+            elif status == "complete":
+                break
 
-        save_audio(chunk, audio_path, 24000)
+    save_audio(b"".join(audio_chunks), audio_path, sample_rate=24000)
 
     return {"ttfb": ttfb}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "python-dotenv>=1.2.1",
     "sarvamai>=0.1.21",
     "simpleaudio>=1.0.4",
-    "smallestai>=4.0.1",
     "sounddevice>=0.5.3",
     "uvicorn>=0.38.0",
     "whisper-normalizer>=0.1.12",

--- a/tests/test_misc_extra.py
+++ b/tests/test_misc_extra.py
@@ -101,28 +101,8 @@ class TestStatusSarvamCheck(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, "tts")
 
 
-class TestStatusSmallestCheck(unittest.IsolatedAsyncioTestCase):
-    async def test_smallest_check(self):
-        from calibrate.status import _check_smallest
-
-        fake_tts = MagicMock()
-        fake_tts.synthesize = MagicMock(return_value=iter([b"audio"]))
-
-        with patch.dict(os.environ, {"SMALLEST_API_KEY": "k"}), \
-             patch("smallestai.waves.WavesStreamingTTS", return_value=fake_tts):
-            result = await _check_smallest(MagicMock())
-        self.assertEqual(result, "tts")
-
-    async def test_smallest_check_no_audio(self):
-        from calibrate.status import _check_smallest
-
-        fake_tts = MagicMock()
-        fake_tts.synthesize = MagicMock(return_value=iter([]))
-
-        with patch.dict(os.environ, {"SMALLEST_API_KEY": "k"}), \
-             patch("smallestai.waves.WavesStreamingTTS", return_value=fake_tts):
-            with self.assertRaises(ValueError):
-                await _check_smallest(MagicMock())
+# Smallest status-check coverage lives in tests/test_status.py
+# (TestCheckProviders.test_check_smallest_*), alongside the STT/TTS sub-checks.
 
 
 # ── stt/eval - run_eval_only invalid dataset path ------------------------

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -30,6 +30,63 @@ def _mk_client(post_resp=None):
     return client
 
 
+class _FakeWS:
+    """Websocket stand-in supporting both async iteration (TTS check) and
+    recv() (STT check)."""
+
+    def __init__(self, messages, recv_end=None):
+        self._messages = list(messages)
+        self.sent = []
+        self._recv_end = recv_end or asyncio.TimeoutError()
+
+    async def send(self, data):
+        self.sent.append(data)
+
+    def __aiter__(self):
+        self._it = iter(list(self._messages))
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration
+
+    async def recv(self):
+        if self._messages:
+            return self._messages.pop(0)
+        raise self._recv_end
+
+
+class _FakeConnect:
+    def __init__(self, ws):
+        self._ws = ws
+
+    async def __aenter__(self):
+        return self._ws
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _patch_ws(messages, recv_end=None):
+    """Patch the websockets connect used by the Smallest checks to yield messages."""
+    ws = _FakeWS(messages, recv_end=recv_end)
+    return patch(
+        "websockets.asyncio.client.connect",
+        MagicMock(return_value=_FakeConnect(ws)),
+    ), ws
+
+
+def _patch_smallest_both(tts_ws, stt_ws):
+    """Route connect() to the right fake by URL for the combined check."""
+
+    def _connect(url, *a, **k):
+        return _FakeConnect(stt_ws if "stt/live" in url else tts_ws)
+
+    return patch("websockets.asyncio.client.connect", MagicMock(side_effect=_connect))
+
+
 class TestSilenceWav(unittest.TestCase):
     def test_generate_silence(self):
         from calibrate.status import _generate_silence_wav
@@ -155,6 +212,90 @@ class TestCheckProviders(unittest.IsolatedAsyncioTestCase):
         with patch.dict(os.environ, {"DEEPGRAM_API_KEY": "k"}):
             result = await _check_deepgram(client)
         self.assertEqual(result, "stt")
+
+    async def test_check_smallest_tts_ok(self):
+        import json
+        from calibrate.status import _check_smallest_tts
+
+        chunk = json.dumps({"status": "chunk", "data": {"audio": "YWJj"}})
+        patcher, ws = _patch_ws([chunk])
+        with patch.dict(os.environ, {"SMALLEST_API_KEY": "k"}), patcher:
+            result = await _check_smallest_tts()
+        self.assertEqual(result, "tts")
+        self.assertEqual(len(ws.sent), 1)
+
+    async def test_check_smallest_tts_server_error(self):
+        import json
+        from calibrate.status import _check_smallest_tts
+
+        err = json.dumps({"status": "error", "error": "MODEL_DEPRECATED"})
+        patcher, _ = _patch_ws([err])
+        with patch.dict(os.environ, {"SMALLEST_API_KEY": "k"}), patcher:
+            with self.assertRaises(RuntimeError):
+                await _check_smallest_tts()
+
+    async def test_check_smallest_tts_no_audio(self):
+        import json
+        from calibrate.status import _check_smallest_tts
+
+        done = json.dumps({"status": "complete"})
+        patcher, _ = _patch_ws([done])
+        with patch.dict(os.environ, {"SMALLEST_API_KEY": "k"}), patcher:
+            with self.assertRaises(ValueError):
+                await _check_smallest_tts()
+
+    async def test_check_smallest_stt_ok(self):
+        import json
+        from calibrate.status import _check_smallest_stt
+
+        msg = json.dumps({"type": "transcription", "transcript": "", "is_last": True})
+        patcher, ws = _patch_ws([msg])
+        with patch.dict(os.environ, {"SMALLEST_API_KEY": "k"}), patcher:
+            result = await _check_smallest_stt()
+        self.assertEqual(result, "stt")
+        # Sent the silence buffer and a close_stream control message.
+        self.assertEqual(len(ws.sent), 2)
+
+    async def test_check_smallest_stt_idle_closes_ok(self):
+        # No messages -> recv() raises the end sentinel -> treated as success.
+        from calibrate.status import _check_smallest_stt
+
+        patcher, _ = _patch_ws([])
+        with patch.dict(os.environ, {"SMALLEST_API_KEY": "k"}), patcher:
+            result = await _check_smallest_stt()
+        self.assertEqual(result, "stt")
+
+    async def test_check_smallest_stt_server_error(self):
+        import json
+        from calibrate.status import _check_smallest_stt
+
+        err = json.dumps({"type": "error", "message": "bad audio"})
+        patcher, _ = _patch_ws([err])
+        with patch.dict(os.environ, {"SMALLEST_API_KEY": "k"}), patcher:
+            with self.assertRaises(RuntimeError):
+                await _check_smallest_stt()
+
+    async def test_check_smallest_both_ok(self):
+        import json
+        from calibrate.status import _check_smallest
+
+        tts_ws = _FakeWS([json.dumps({"status": "chunk", "data": {"audio": "YWJj"}})])
+        stt_ws = _FakeWS([json.dumps({"type": "transcription", "is_last": True})])
+        with patch.dict(os.environ, {"SMALLEST_API_KEY": "k"}), \
+                _patch_smallest_both(tts_ws, stt_ws):
+            result = await _check_smallest(_mk_client())
+        self.assertEqual(result, "stt,tts")
+
+    async def test_check_smallest_fails_if_stt_down(self):
+        import json
+        from calibrate.status import _check_smallest
+
+        tts_ws = _FakeWS([json.dumps({"status": "chunk", "data": {"audio": "YWJj"}})])
+        stt_ws = _FakeWS([json.dumps({"type": "error", "message": "down"})])
+        with patch.dict(os.environ, {"SMALLEST_API_KEY": "k"}), \
+                _patch_smallest_both(tts_ws, stt_ws):
+            with self.assertRaises(RuntimeError):
+                await _check_smallest(_mk_client())
 
 
 class TestCheckSingleProvider(unittest.IsolatedAsyncioTestCase):

--- a/tests/tts/test_eval_providers.py
+++ b/tests/tts/test_eval_providers.py
@@ -157,19 +157,72 @@ class TestSynthesizeSarvam(unittest.IsolatedAsyncioTestCase):
         self.assertIsNotNone(result.get("ttfb"))
 
 
+class _FakeSmallestWS:
+    def __init__(self, messages):
+        self._messages = messages
+        self.sent = []
+
+    async def send(self, data):
+        self.sent.append(data)
+
+    def __aiter__(self):
+        self._it = iter(self._messages)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class _FakeSmallestConnect:
+    def __init__(self, ws):
+        self._ws = ws
+
+    async def __aenter__(self):
+        return self._ws
+
+    async def __aexit__(self, *exc):
+        return False
+
+
 class TestSynthesizeSmallest(unittest.IsolatedAsyncioTestCase):
     async def test_smallest_happy(self):
+        import base64
+        import json
         from calibrate.tts import eval as E
 
-        fake_streamer = MagicMock()
-        fake_streamer.synthesize = MagicMock(return_value=iter([b"RIFF" + b"\x00" * 100]))
+        audio_b64 = base64.b64encode(b"\x01\x02" * 100).decode()
+        messages = [
+            json.dumps({"status": "chunk", "data": {"audio": audio_b64}}),
+            json.dumps({"status": "chunk", "data": {"audio": audio_b64}}),
+            json.dumps({"status": "complete"}),
+        ]
+        ws = _FakeSmallestWS(messages)
 
         with tempfile.TemporaryDirectory() as tmp, \
              patch.dict(os.environ, {"SMALLEST_API_KEY": "k"}), \
-             patch.object(E, "WavesStreamingTTS", return_value=fake_streamer):
+             patch("websockets.asyncio.client.connect",
+                   MagicMock(return_value=_FakeSmallestConnect(ws))):
             path = Path(tmp) / "x.wav"
             result = await E.synthesize_smallest("hi", "english", str(path))
-        self.assertIsNotNone(result.get("ttfb"))
+            self.assertIsNotNone(result.get("ttfb"))
+            self.assertTrue(path.exists())
+            self.assertEqual(len(ws.sent), 1)  # one JSON synthesis request
+
+    async def test_smallest_server_error(self):
+        import json
+        from calibrate.tts import eval as E
+
+        ws = _FakeSmallestWS([json.dumps({"status": "error", "error": "boom"})])
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch.dict(os.environ, {"SMALLEST_API_KEY": "k"}), \
+             patch("websockets.asyncio.client.connect",
+                   MagicMock(return_value=_FakeSmallestConnect(ws))):
+            path = Path(tmp) / "x.wav"
+            with self.assertRaises(RuntimeError):
+                await E.synthesize_smallest("hi", "english", str(path))
 
 
 class TestSynthesizeGoogle(unittest.IsolatedAsyncioTestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -365,7 +365,6 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "sarvamai" },
     { name = "simpleaudio" },
-    { name = "smallestai" },
     { name = "sounddevice" },
     { name = "uvicorn" },
     { name = "whisper-normalizer" },
@@ -409,7 +408,6 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "sarvamai", specifier = ">=0.1.21" },
     { name = "simpleaudio", specifier = ">=1.0.4" },
-    { name = "smallestai", specifier = ">=4.0.1" },
     { name = "sounddevice", specifier = ">=0.5.3" },
     { name = "uvicorn", specifier = ">=0.38.0" },
     { name = "whisper-normalizer", specifier = ">=0.1.12" },
@@ -4288,27 +4286,6 @@ wheels = [
 ]
 
 [[package]]
-name = "smallestai"
-version = "4.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiofiles" },
-    { name = "aiohttp" },
-    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
-    { name = "pydantic" },
-    { name = "pydub" },
-    { name = "python-dateutil" },
-    { name = "requests" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-    { name = "websocket-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/43/4c0348c4a0c4ceb965b6b11e0dbb121a6a9063e144918eeac681beeceb74/smallestai-4.0.1.tar.gz", hash = "sha256:ecf736c7fe4fb6566abb0403bc9c6df30a55efd97503ea5a1d1b1912e74e4664", size = 79017, upload-time = "2025-07-29T10:44:32.783Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/a4/8c5d5537ff03705df60da56108ba312af5cf3a22457131efef7f744c79a0/smallestai-4.0.1-py3-none-any.whl", hash = "sha256:6b385965f664a50fb5a742bb4bf89a9f99e17f15d89ae9240a1896ed728a4ef5", size = 232520, upload-time = "2025-07-29T10:44:31.596Z" },
-]
-
-[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5018,15 +4995,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/30/6b0809f4510673dc723187aeaf24c7f5459922d01e2f794277a3dfb90345/wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605", size = 102293, upload-time = "2025-09-22T16:29:53.023Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/b5/123f13c975e9f27ab9c0770f514345bd406d0e8d3b7a0723af9d43f710af/wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1", size = 37286, upload-time = "2025-09-22T16:29:51.641Z" },
-]
-
-[[package]]
-name = "websocket-client"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
- Smallest retired `lightning-v2` (HTTP 410 Gone), breaking both the status check and TTS eval — both used the standalone `smallestai` SDK pinned to that model. Moved them to the current `lightning-v3.1` WebSocket (the endpoint pipecat's `SmallestTTSService` uses).
- `_check_smallest` now probes both STT (Pulse) and TTS, covering the provider's declared `stt`+`tts` types instead of TTS only.
- `synthesize_smallest` now accumulates chunks before saving (was overwriting per-chunk, keeping only the last); dropped the now-unused `smallestai` dependency.

## Notes
- The Smallest STT WebSocket was never actually down — the only outage was the TTS model retirement surfacing as a generic connect error.
- `synthesize_smallest` still hard-codes `voice_id="aditi"` (pre-existing); not changed here.