### PR TITLE
Pass language to OpenAI STT during eval

### DIFF
--- a/calibrate/stt/eval.py
+++ b/calibrate/stt/eval.py
@@ -222,12 +222,20 @@ async def transcribe_openai_streaming(audio_path: Path, language: str) -> str:
     if not api_key:
         raise ValueError("OPENAI_API_KEY environment variable not set")
 
+    lang_code = get_stt_language_code(language, "openai")
+
     client = AsyncOpenAI()
 
     audio_file = load_audio(audio_path, as_file=True)
 
+    # Supplying the input language (ISO-639-1) improves accuracy and latency
+    # per the OpenAI transcription docs.
     stream = await client.audio.transcriptions.create(
-        model="gpt-4o-transcribe", file=audio_file, response_format="text", stream=True
+        model="gpt-4o-transcribe",
+        file=audio_file,
+        language=lang_code,
+        response_format="text",
+        stream=True,
     )
 
     transcript = ""

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -600,5 +600,38 @@ class TestTranscribeSarvam(unittest.IsolatedAsyncioTestCase):
                 p.stop()
 
 
+class TestTranscribeOpenAIStreaming(unittest.IsolatedAsyncioTestCase):
+    async def test_passes_language_code_to_api(self):
+        from calibrate.stt import eval as stt_eval
+
+        done_event = SimpleNamespace(type="transcript.text.done", text="hello world")
+
+        async def _fake_stream():
+            yield done_event
+
+        create = AsyncMock(return_value=_fake_stream())
+        fake_client = MagicMock()
+        fake_client.audio.transcriptions.create = create
+
+        patches = (
+            patch.dict("os.environ", {"OPENAI_API_KEY": "sk-fake"}),
+            patch.object(stt_eval, "AsyncOpenAI", return_value=fake_client),
+            patch.object(stt_eval, "load_audio", return_value=SimpleNamespace()),
+        )
+        for p in patches:
+            p.start()
+        try:
+            result = await stt_eval.transcribe_openai_streaming(
+                Path("/tmp/x.wav"), "hindi"
+            )
+        finally:
+            for p in patches:
+                p.stop()
+
+        self.assertEqual(result["transcript"], "hello world")
+        # OpenAI STT expects an ISO-639-1 code — "hi" for hindi.
+        self.assertEqual(create.await_args.kwargs["language"], "hi")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What
- OpenAI STT (`gpt-4o-transcribe`) now sends the ISO-639-1 `language` code, which OpenAI's docs say improves accuracy and latency.
- Added a scoped unit test asserting the language reaches the API.