### PR TITLE
Add Mintlify API reference from public OpenAPI spec

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ CALIBRATE_SIMULATION_PARALLEL=2
 ENVIRONMENT=development # langfuse tracing environment
 ENABLE_TRACING=true
 
+# Calibrate Public API (docs sync + generated API reference pages)
+PUBLIC_API_BASE_URL=https://pense-backend.artpark.ai
+
 # OTLP endpoint (defaults to localhost:4317 if not set)
 # OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel" # 🇪🇺 EU data region
 # OTEL_EXPORTER_OTLP_ENDPOINT="https://us.cloud.langfuse.com/api/public/otel" # 🇺🇸 US data region

--- a/.github/workflows/sync-api-spec.yml
+++ b/.github/workflows/sync-api-spec.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - ".github/workflows/sync-api-spec.yml"
       - "scripts/fetch_public_openapi.py"
+      - "docs/templates/**"
   schedule:
     # Refresh weekly so docs track backend deploys even without agentloop changes.
     - cron: "0 6 * * 1"
@@ -27,19 +28,21 @@ jobs:
           python-version: "3.12"
 
       - name: Fetch and normalize public OpenAPI spec
+        env:
+          PUBLIC_API_BASE_URL: ${{ secrets.PUBLIC_API_BASE_URL }}
         run: python scripts/fetch_public_openapi.py
 
-      - name: Commit spec if changed
+      - name: Commit generated docs if changed
         run: |
-          if git diff --quiet docs/api-reference/openapi.json; then
-            echo "OpenAPI spec unchanged"
+          git add docs/api-reference/openapi.json docs/api-reference/introduction.mdx
+          if git diff --cached --quiet; then
+            echo "Generated API docs unchanged"
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add docs/api-reference/openapi.json
           git commit -m "$(cat <<'EOF'
-Sync public OpenAPI spec for API reference docs.
+Sync public OpenAPI spec and API URL docs from PUBLIC_API_BASE_URL.
 
 EOF
 )"

--- a/.github/workflows/sync-api-spec.yml
+++ b/.github/workflows/sync-api-spec.yml
@@ -1,0 +1,46 @@
+name: Sync API spec
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/sync-api-spec.yml"
+      - "scripts/fetch_public_openapi.py"
+  schedule:
+    # Refresh weekly so docs track backend deploys even without agentloop changes.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Fetch and normalize public OpenAPI spec
+        run: python scripts/fetch_public_openapi.py
+
+      - name: Commit spec if changed
+        run: |
+          if git diff --quiet docs/api-reference/openapi.json; then
+            echo "OpenAPI spec unchanged"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/api-reference/openapi.json
+          git commit -m "$(cat <<'EOF'
+Sync public OpenAPI spec for API reference docs.
+
+EOF
+)"
+          git push

--- a/.github/workflows/sync-api-spec.yml
+++ b/.github/workflows/sync-api-spec.yml
@@ -11,6 +11,8 @@ on:
     # Refresh weekly so docs track backend deploys even without agentloop changes.
     - cron: "0 6 * * 1"
   workflow_dispatch:
+  repository_dispatch:
+    types: [sync-api-spec]
 
 permissions:
   contents: write

--- a/.github/workflows/sync-api-spec.yml
+++ b/.github/workflows/sync-api-spec.yml
@@ -41,9 +41,5 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "$(cat <<'EOF'
-Sync public OpenAPI spec and API URL docs from PUBLIC_API_BASE_URL.
-
-EOF
-)"
+          git commit -m "Sync public OpenAPI spec and API URL docs from PUBLIC_API_BASE_URL."
           git push

--- a/.github/workflows/sync-api-spec.yml
+++ b/.github/workflows/sync-api-spec.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Commit generated docs if changed
         run: |
-          git add docs/api-reference/openapi.json docs/api-reference/introduction.mdx
+          git add docs/api-reference/openapi.json docs/api-reference/introduction.mdx docs/reference/api-keys.mdx docs/reference/github-actions.mdx
           if git diff --cached --quiet; then
             echo "Generated API docs unchanged"
             exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,21 @@ examples/                  # Example datasets + scripts users can run
 
 ## Conventions in this codebase
 
+### Docs (Mintlify) writing style
+The docs under `docs/` use **sentence case** for all headings (`##`/`###`),
+`Card`/`Step` titles, and frontmatter `title` fields — capitalize only the first
+word, e.g. `## Next steps`, `## Get started`, `### Launch run`. Do **not** use
+Title Case (`## Next Steps`). The only words that stay capitalized mid-heading
+are acronyms (API, LLM, STT, TTS, WER, TTFB, PR, HTML, URL) and proper nouns
+(Calibrate, GitHub, Mintlify, Markdown). Match this when adding or editing any
+`.mdx` page.
+
+Some pages are **generated** from templates in `docs/templates/` by
+`scripts/fetch_public_openapi.py` (which single-sources the backend host from
+`PUBLIC_API_BASE_URL` — never hardcode it). Edit the template, not the generated
+output, then re-run the script. Currently templated: `api-reference/introduction.mdx`,
+`reference/api-keys.mdx`, `reference/github-actions.mdx`.
+
 ### Evaluator dicts everywhere
 Every LLM/audio judge in the codebase takes a list of **evaluator** dicts of
 this shape:

--- a/docs/api-reference/endpoint/create.mdx
+++ b/docs/api-reference/endpoint/create.mdx
@@ -1,4 +1,0 @@
----
-title: 'Create Plant'
-openapi: 'POST /plants'
----

--- a/docs/api-reference/endpoint/delete.mdx
+++ b/docs/api-reference/endpoint/delete.mdx
@@ -1,4 +1,0 @@
----
-title: 'Delete Plant'
-openapi: 'DELETE /plants/{id}'
----

--- a/docs/api-reference/endpoint/get.mdx
+++ b/docs/api-reference/endpoint/get.mdx
@@ -1,4 +1,0 @@
----
-title: 'Get Plants'
-openapi: 'GET /plants'
----

--- a/docs/api-reference/endpoint/webhook.mdx
+++ b/docs/api-reference/endpoint/webhook.mdx
@@ -1,4 +1,0 @@
----
-title: 'New Plant'
-openapi: 'WEBHOOK /plant/webhook'
----

--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -26,7 +26,7 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
 
 <Steps>
   <Step title="Get your API key">
-    Go to [Workspace settings → API keys](https://calibrate.artpark.ai/workspace-settings?tab=api-keys), click **Create key**, and copy the full key when it is shown — you cannot view it again after closing the dialog.
+    Obtain your API key from the [Calibrate dashboard](https://calibrate.artpark.ai/workspace-settings?tab=api-keys). See the [API keys guide](/reference/api-keys) for detailed setup instructions.
   </Step>
   <Step title="Authenticate your requests">
     Pass your key in the `X-API-Key` header on every request:
@@ -47,16 +47,31 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
 
   </Step>
   <Step title="Run tests">
-    Launch a test run for an agent, then poll the returned `task_id`:
+    Launch a test run for an agent:
 
     ```bash
-    # Start a run (all linked tests when test_uuids is omitted)
     curl -X POST "https://pense-backend.artpark.ai/agent-tests/agent/{agent_uuid}/run" \
       -H "X-API-Key: your_api_key" \
       -H "Content-Type: application/json" \
       -d '{}'
+    ```
 
-    # Poll status + results
+    Since no `test_uuids` were passed, all linked tests for the agent will be run. The response returns a `task_id`:
+
+    ```json
+    {
+      "task_id": "abc123",
+      "status": "queued",
+      "dataset_id": null,
+      "dataset_name": null
+    }
+    ```
+
+  </Step>
+  <Step title="Poll results">
+    Poll the returned `task_id` for status and results:
+
+    ```bash
     curl "https://pense-backend.artpark.ai/agent-tests/run/{task_id}" \
       -H "X-API-Key: your_api_key"
     ```
@@ -66,29 +81,19 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
 
 ## Base URL
 
-```
+```bash
 https://pense-backend.artpark.ai
 ```
 
 ## OpenAPI specification
 
-The public API schema is published at an unauthenticated endpoint and synced into this docs site on every deploy.
+The public API schema is published at an unauthenticated endpoint.
 
 ```bash
 # Fetch the live spec (JSON)
 curl -s https://pense-backend.artpark.ai/public-api/openapi.json
 ```
 
-<Card
-  title="OpenAPI specification"
-  icon="brackets-curly"
-  href="https://pense-backend.artpark.ai/public-api/openapi.json"
->
-  View the machine-readable spec
-</Card>
-
 ## Authentication
 
-All API requests require an `X-API-Key` header. Keys grant access to the public API routes for your workspace.
-
-JWT bearer tokens (used by the Calibrate web UI) also work at the HTTP layer, but programmatic clients should use API keys exclusively.
+All API requests require an `X-API-Key` header.

--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -5,7 +5,7 @@ description: "Authenticate and call the Calibrate Public API programmatically"
 
 {/* Generated from docs/templates/api-reference/introduction.mdx — do not edit directly. */}
 
-The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launch LLM test runs, and poll results — all from CI or automation scripts.
+The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launch LLM test runs, and poll results.
 
 ## Most used
 
@@ -32,7 +32,7 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
     Pass your key in the `X-API-Key` header on every request:
 
     ```bash
-    curl http://localhost:8000/agents \
+    curl https://pense-backend.artpark.ai/agents \
       -H "X-API-Key: your_api_key"
     ```
 
@@ -41,7 +41,7 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
     Enumerate every agent in your org:
 
     ```bash
-    curl http://localhost:8000/agents \
+    curl https://pense-backend.artpark.ai/agents \
       -H "X-API-Key: your_api_key"
     ```
 
@@ -51,13 +51,13 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
 
     ```bash
     # Start a run (all linked tests when test_uuids is omitted)
-    curl -X POST "http://localhost:8000/agent-tests/agent/{agent_uuid}/run" \
+    curl -X POST "https://pense-backend.artpark.ai/agent-tests/agent/{agent_uuid}/run" \
       -H "X-API-Key: your_api_key" \
       -H "Content-Type: application/json" \
       -d '{}'
 
     # Poll status + results
-    curl "http://localhost:8000/agent-tests/run/{task_id}" \
+    curl "https://pense-backend.artpark.ai/agent-tests/run/{task_id}" \
       -H "X-API-Key: your_api_key"
     ```
 
@@ -67,7 +67,7 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
 ## Base URL
 
 ```
-http://localhost:8000
+https://pense-backend.artpark.ai
 ```
 
 ## OpenAPI specification
@@ -76,13 +76,13 @@ The public API schema is published at an unauthenticated endpoint and synced int
 
 ```bash
 # Fetch the live spec (JSON)
-curl -s http://localhost:8000/public-api/openapi.json
+curl -s https://pense-backend.artpark.ai/public-api/openapi.json
 ```
 
 <Card
   title="OpenAPI specification"
   icon="brackets-curly"
-  href="http://localhost:8000/public-api/openapi.json"
+  href="https://pense-backend.artpark.ai/public-api/openapi.json"
 >
   View the machine-readable spec
 </Card>

--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Introduction'
-description: 'Authenticate and call the Calibrate Public API programmatically'
+title: "Introduction"
+description: "Authenticate and call the Calibrate Public API programmatically"
 ---
 
 {/* Generated from docs/templates/api-reference/introduction.mdx — do not edit directly. */}
@@ -13,7 +13,11 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
   <Card title="Agents" icon="robot" href="/api-reference/agents/list-agents">
     List agents and resolve human-friendly names to UUIDs
   </Card>
-  <Card title="Agent tests" icon="play" href="/api-reference/agent-tests/run-agent-test">
+  <Card
+    title="Agent tests"
+    icon="play"
+    href="/api-reference/agent-tests/run-agent-test"
+  >
     Launch test runs and poll for results
   </Card>
 </CardGroup>
@@ -22,45 +26,48 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
 
 <Steps>
   <Step title="Get your API key">
-    Sign in to [Calibrate](https://calibrate.artpark.ai), open **Settings → API keys**, and create an org-scoped key. The raw `sk_…` value is shown once — store it securely.
+    Go to [Workspace settings → API keys](https://calibrate.artpark.ai/workspace-settings?tab=api-keys), click **Create key**, and copy the full key when it is shown — you cannot view it again after closing the dialog.
   </Step>
   <Step title="Authenticate your requests">
     Pass your key in the `X-API-Key` header on every request:
 
     ```bash
-    curl https://pense-backend.artpark.ai/agents \
-      -H "X-API-Key: sk_your_api_key"
+    curl http://localhost:8000/agents \
+      -H "X-API-Key: your_api_key"
     ```
+
   </Step>
   <Step title="List agents">
     Enumerate every agent in your org:
 
     ```bash
-    curl https://pense-backend.artpark.ai/agents \
-      -H "X-API-Key: sk_your_api_key"
+    curl http://localhost:8000/agents \
+      -H "X-API-Key: your_api_key"
     ```
+
   </Step>
   <Step title="Run tests">
     Launch a test run for an agent, then poll the returned `task_id`:
 
     ```bash
     # Start a run (all linked tests when test_uuids is omitted)
-    curl -X POST "https://pense-backend.artpark.ai/agent-tests/agent/{agent_uuid}/run" \
-      -H "X-API-Key: sk_your_api_key" \
+    curl -X POST "http://localhost:8000/agent-tests/agent/{agent_uuid}/run" \
+      -H "X-API-Key: your_api_key" \
       -H "Content-Type: application/json" \
       -d '{}'
 
     # Poll status + results
-    curl "https://pense-backend.artpark.ai/agent-tests/run/{task_id}" \
-      -H "X-API-Key: sk_your_api_key"
+    curl "http://localhost:8000/agent-tests/run/{task_id}" \
+      -H "X-API-Key: your_api_key"
     ```
+
   </Step>
 </Steps>
 
 ## Base URL
 
 ```
-https://pense-backend.artpark.ai
+http://localhost:8000
 ```
 
 ## OpenAPI specification
@@ -69,19 +76,19 @@ The public API schema is published at an unauthenticated endpoint and synced int
 
 ```bash
 # Fetch the live spec (JSON)
-curl -s https://pense-backend.artpark.ai/public-api/openapi.json
+curl -s http://localhost:8000/public-api/openapi.json
 ```
 
 <Card
   title="OpenAPI specification"
   icon="brackets-curly"
-  href="https://pense-backend.artpark.ai/public-api/openapi.json"
+  href="http://localhost:8000/public-api/openapi.json"
 >
   View the machine-readable spec
 </Card>
 
 ## Authentication
 
-All API requests require an `X-API-Key` header. Keys are scoped to one organization and grant owner-level access to that org's public API routes.
+All API requests require an `X-API-Key` header. Keys grant access to the public API routes for your workspace.
 
 JWT bearer tokens (used by the Calibrate web UI) also work at the HTTP layer, but programmatic clients should use API keys exclusively.

--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -1,33 +1,85 @@
 ---
 title: 'Introduction'
-description: 'Example section for showcasing API endpoints'
+description: 'Authenticate and call the Calibrate Public API programmatically'
 ---
 
-<Note>
-  If you're not looking to build API reference documentation, you can delete
-  this section by removing the api-reference folder.
-</Note>
+The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launch LLM test runs, and poll results — all from CI or automation scripts.
 
-## Welcome
+## Most used
 
-There are two ways to build API documentation: [OpenAPI](https://mintlify.com/docs/api-playground/openapi/setup) and [MDX components](https://mintlify.com/docs/api-playground/mdx/configuration). For the starter kit, we are using the following OpenAPI specification.
+<CardGroup cols={2}>
+  <Card title="Agents" icon="robot" href="/api-reference/agents/list-agents">
+    List agents and resolve human-friendly names to UUIDs
+  </Card>
+  <Card title="Agent tests" icon="play" href="/api-reference/agent-tests/run-agent-test">
+    Launch test runs and poll for results
+  </Card>
+</CardGroup>
+
+## Getting started
+
+<Steps>
+  <Step title="Get your API key">
+    Sign in to [Calibrate](https://calibrate.artpark.ai), open **Settings → API keys**, and create an org-scoped key. The raw `sk_…` value is shown once — store it securely.
+  </Step>
+  <Step title="Authenticate your requests">
+    Pass your key in the `X-API-Key` header on every request:
+
+    ```bash
+    curl https://pense-backend.artpark.ai/agents \
+      -H "X-API-Key: sk_your_api_key"
+    ```
+  </Step>
+  <Step title="List agents">
+    Enumerate every agent in your org:
+
+    ```bash
+    curl https://pense-backend.artpark.ai/agents \
+      -H "X-API-Key: sk_your_api_key"
+    ```
+  </Step>
+  <Step title="Run tests">
+    Launch a test run for an agent, then poll the returned `task_id`:
+
+    ```bash
+    # Start a run (all linked tests when test_uuids is omitted)
+    curl -X POST "https://pense-backend.artpark.ai/agent-tests/agent/{agent_uuid}/run" \
+      -H "X-API-Key: sk_your_api_key" \
+      -H "Content-Type: application/json" \
+      -d '{}'
+
+    # Poll status + results
+    curl "https://pense-backend.artpark.ai/agent-tests/run/{task_id}" \
+      -H "X-API-Key: sk_your_api_key"
+    ```
+  </Step>
+</Steps>
+
+## Base URL
+
+```
+https://pense-backend.artpark.ai
+```
+
+## OpenAPI specification
+
+The public API schema is published at an unauthenticated endpoint and synced into this docs site on every deploy.
+
+```bash
+# Fetch the live spec (JSON)
+curl -s https://pense-backend.artpark.ai/public-api/openapi.json
+```
 
 <Card
-  title="Plant Store Endpoints"
-  icon="leaf"
-  href="https://github.com/mintlify/starter/blob/main/api-reference/openapi.json"
+  title="OpenAPI specification"
+  icon="brackets-curly"
+  href="https://pense-backend.artpark.ai/public-api/openapi.json"
 >
-  View the OpenAPI specification file
+  View the machine-readable spec
 </Card>
 
 ## Authentication
 
-All API endpoints are authenticated using Bearer tokens and picked up from the specification file.
+All API requests require an `X-API-Key` header. Keys are scoped to one organization and grant owner-level access to that org's public API routes.
 
-```json
-"security": [
-  {
-    "bearerAuth": []
-  }
-]
-```
+JWT bearer tokens (used by the Calibrate web UI) also work at the HTTP layer, but programmatic clients should use API keys exclusively.

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:8000",
+      "url": "https://pense-backend.artpark.ai",
       "description": "Production"
     }
   ],

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://pense-backend.artpark.ai",
+      "url": "http://localhost:8000",
       "description": "Production"
     }
   ],
@@ -705,7 +705,7 @@
         "type": "apiKey",
         "in": "header",
         "name": "X-API-Key",
-        "description": "Org-scoped API key. Create one in Calibrate under Settings \u2192 API keys. Prefix: `sk_\u2026`."
+        "description": "API key. Create one under Workspace settings \u2192 API keys (https://calibrate.artpark.ai/workspace-settings?tab=api-keys). Prefix: `sk_\u2026`."
       }
     }
   },

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -3,8 +3,14 @@
   "info": {
     "title": "Calibrate Public API",
     "version": "0.1.0",
-    "description": "Programmatic API for CI/automation, authenticated with an org-scoped API key. Pass your key as `X-API-Key: sk_\u2026` or `Authorization: Bearer sk_\u2026`."
+    "description": "Programmatic API for CI/automation, authenticated with an org-scoped API key. Pass your key in the `X-API-Key: sk_\u2026` header."
   },
+  "servers": [
+    {
+      "url": "https://pense-backend.artpark.ai",
+      "description": "Production"
+    }
+  ],
   "components": {
     "schemas": {
       "BatchRunRequest": {
@@ -952,11 +958,5 @@
         }
       }
     }
-  },
-  "servers": [
-    {
-      "url": "https://pense-backend.artpark.ai",
-      "description": "Production"
-    }
-  ]
+  }
 }

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -1,94 +1,790 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "OpenAPI Plant Store",
-    "description": "A sample API that uses a plant store as an example to demonstrate features in the OpenAPI specification",
-    "license": {
-      "name": "MIT"
-    },
-    "version": "1.0.0"
+    "title": "Calibrate Public API",
+    "version": "0.1.0",
+    "description": "Programmatic API for CI/automation, authenticated with an org-scoped API key. Pass your key as `X-API-Key: sk_\u2026` or `Authorization: Bearer sk_\u2026`."
   },
-  "servers": [
-    {
-      "url": "http://sandbox.mintlify.com"
+  "components": {
+    "schemas": {
+      "BatchRunRequest": {
+        "properties": {
+          "agent_names": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Names"
+          }
+        },
+        "type": "object",
+        "title": "BatchRunRequest"
+      },
+      "BatchTestRun": {
+        "properties": {
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
+          "agent_uuid": {
+            "type": "string",
+            "title": "Agent Uuid"
+          },
+          "task_id": {
+            "type": "string",
+            "title": "Task Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "agent_name",
+          "agent_uuid",
+          "task_id",
+          "status"
+        ],
+        "title": "BatchTestRun"
+      },
+      "BatchTestRunResponse": {
+        "properties": {
+          "runs": {
+            "items": {
+              "$ref": "#/components/schemas/BatchTestRun"
+            },
+            "type": "array",
+            "title": "Runs"
+          },
+          "skipped": {
+            "items": {
+              "$ref": "#/components/schemas/BatchTestSkip"
+            },
+            "type": "array",
+            "title": "Skipped",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "runs"
+        ],
+        "title": "BatchTestRunResponse"
+      },
+      "BatchTestSkip": {
+        "properties": {
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
+          "agent_uuid": {
+            "type": "string",
+            "title": "Agent Uuid"
+          },
+          "reason": {
+            "type": "string",
+            "title": "Reason"
+          }
+        },
+        "type": "object",
+        "required": [
+          "agent_name",
+          "agent_uuid",
+          "reason"
+        ],
+        "title": "BatchTestSkip"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "JudgeResult": {
+        "properties": {
+          "evaluator_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluator Uuid"
+          },
+          "reasoning": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasoning"
+          },
+          "match": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Match"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score"
+          },
+          "value_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Name"
+          },
+          "variable_values": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Variable Values"
+          }
+        },
+        "type": "object",
+        "title": "JudgeResult",
+        "description": "One evaluator's verdict for a response-type test case.\n\nPer-row data only \u2014 anything constant across rows for the same evaluator\n(name, description, output_type, output_config, scale_min/max) lives on\nthe response-level `evaluators[]` block; look it up by `evaluator_uuid`.\n\n`evaluator_uuid` is None for legacy runs that pre-date the evaluator-\nsnapshot capture or when the evaluator can't be resolved from the\nsnapshot.\n\nExactly one of `match` (binary) / `score` (rating) is set per entry;\nboth are None for tool-call tests, but tool-call tests don't carry\n`judge_results`.\n\n`variable_values` are the {{var}} substitutions used for this evaluator\non this test case, frozen from `test_evaluators.variable_values` at\nsubmission time \u2014 stays on the row because it varies per test case.\n\n`value_name` is the human-readable label for `match`/`score` resolved\nagainst the rubric the run actually used (snapshot's\n`output_config.scale.name`). Falls back to `Correct`/`Wrong` for binary\nor the stringified score for rating when the snapshot lacks named\nscale entries (e.g. legacy runs captured before the rubric was\nsnapshotted)."
+      },
+      "ResolveAgentNamesRequest": {
+        "properties": {
+          "names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Names"
+          }
+        },
+        "type": "object",
+        "required": [
+          "names"
+        ],
+        "title": "ResolveAgentNamesRequest"
+      },
+      "ResolveAgentNamesResponse": {
+        "properties": {
+          "resolved": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Resolved"
+          },
+          "not_found": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Not Found"
+          }
+        },
+        "type": "object",
+        "required": [
+          "resolved",
+          "not_found"
+        ],
+        "title": "ResolveAgentNamesResponse"
+      },
+      "RunTestRequest": {
+        "properties": {
+          "test_uuids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Test Uuids"
+          }
+        },
+        "type": "object",
+        "title": "RunTestRequest"
+      },
+      "TaskCreateResponse": {
+        "properties": {
+          "task_id": {
+            "type": "string",
+            "title": "Task Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "dataset_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dataset Id"
+          },
+          "dataset_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dataset Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "task_id",
+          "status"
+        ],
+        "title": "TaskCreateResponse"
+      },
+      "TestCaseResult": {
+        "properties": {
+          "test_case_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Test Case Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "passed": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Passed"
+          },
+          "reasoning": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasoning"
+          },
+          "output": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TestOutput"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "test_case": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Test Case"
+          },
+          "judge_results": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/JudgeResult"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Judge Results"
+          },
+          "latency_ms": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latency Ms"
+          },
+          "cost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost"
+          }
+        },
+        "type": "object",
+        "title": "TestCaseResult",
+        "description": "Result for a single test case matching calibrate results.json structure"
+      },
+      "TestOutput": {
+        "properties": {
+          "response": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Response"
+          },
+          "tool_calls": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ToolCallOutput"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Calls"
+          }
+        },
+        "type": "object",
+        "title": "TestOutput"
+      },
+      "TestRunStatusResponse": {
+        "properties": {
+          "task_id": {
+            "type": "string",
+            "title": "Task Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "total_tests": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Tests"
+          },
+          "passed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Passed"
+          },
+          "failed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Failed"
+          },
+          "latency_ms": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latency Ms"
+          },
+          "cost": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost"
+          },
+          "total_tokens": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Tokens"
+          },
+          "evaluators": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluators"
+          },
+          "results": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/TestCaseResult"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Results"
+          },
+          "results_s3_prefix": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Results S3 Prefix"
+          },
+          "error": {
+            "type": "boolean",
+            "title": "Error",
+            "default": false
+          },
+          "is_public": {
+            "type": "boolean",
+            "title": "Is Public",
+            "default": false
+          },
+          "share_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Share Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "task_id",
+          "status"
+        ],
+        "title": "TestRunStatusResponse"
+      },
+      "ToolCallOutput": {
+        "properties": {
+          "tool": {
+            "type": "string",
+            "title": "Tool"
+          },
+          "arguments": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Arguments"
+          },
+          "output": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tool"
+        ],
+        "title": "ToolCallOutput"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "routers__agent_tools__AgentResponse": {
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "title": "Uuid"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "agent",
+              "connection"
+            ],
+            "title": "Type"
+          },
+          "config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Config"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "uuid",
+          "name",
+          "type",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "AgentResponse"
+      }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key",
+        "description": "Org-scoped API key. Create one in Calibrate under Settings \u2192 API keys. Prefix: `sk_\u2026`."
+      }
     }
-  ],
-  "security": [
-    {
-      "bearerAuth": []
-    }
-  ],
+  },
   "paths": {
-    "/plants": {
-      "get": {
-        "description": "Returns all plants from the system that the user has access to",
-        "parameters": [
+    "/agents/resolve": {
+      "post": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "Resolve Agent Names",
+        "description": "Resolve a list of agent names to their UUIDs within the caller's org.\n\nAuth accepts either a JWT (frontend) or an `sk_` API key (programmatic\nclients) via `get_org_jwt_or_api_key`, so CI tooling can map human-friendly\nagent names to the UUIDs the run/poll endpoints expect. Agent names are\nunique per org, so each name resolves to at most one agent. Names with no\nmatching (non-deleted) agent in the org are returned under `not_found`.",
+        "operationId": "resolve_agent_names_agents_resolve_post",
+        "security": [
           {
-            "name": "limit",
-            "in": "query",
-            "description": "The maximum number of results to return",
-            "schema": {
-              "type": "integer",
-              "format": "int32"
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResolveAgentNamesRequest"
+              }
             }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResolveAgentNamesResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents": {
+      "get": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "List Agents",
+        "description": "List all agents for the caller's current org.\n\nAuth accepts either a JWT (frontend) or an `sk_` API key (programmatic\nclients) via `get_org_jwt_or_api_key`, so CI tooling can enumerate every\nagent UUID in the org without knowing names up front (the run/poll and\n`/resolve` endpoints accept the same key).",
+        "operationId": "list_agents_agents_get",
+        "security": [
+          {
+            "ApiKeyAuth": []
           }
         ],
         "responses": {
           "200": {
-            "description": "Plant response",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Plant"
-                  }
+                    "$ref": "#/components/schemas/routers__agent_tools__AgentResponse"
+                  },
+                  "title": "Response List Agents Agents Get"
                 }
               }
             }
           },
-          "400": {
-            "description": "Unexpected error",
+          "422": {
+            "description": "Validation Error",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "description": "Creates a new plant in the store",
-        "requestBody": {
-          "description": "Plant to add to the store",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NewPlant"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "plant response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Plant"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -96,32 +792,159 @@
         }
       }
     },
-    "/plants/{id}": {
-      "delete": {
-        "description": "Deletes a single plant based on the ID supplied",
+    "/agent-tests/agent/{agent_uuid}/run": {
+      "post": {
+        "tags": [
+          "agent-tests"
+        ],
+        "summary": "Run Agent Test",
+        "description": "Run one or more tests for an agent.\n\nThis starts a background task that runs the calibrate LLM tests command\nwith the agent's config and the combined test cases from all specified tests.\n\nReturns a task ID that can be used to poll for status and results.\n\nAuth: requires either a JWT (frontend) or an `sk_` API key. The agent\nmust belong to the caller's org or this 404s.",
+        "operationId": "run_agent_test_agent_tests_agent__agent_uuid__run_post",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
-            "name": "id",
+            "name": "agent_uuid",
             "in": "path",
-            "description": "ID of plant to delete",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string",
+              "title": "Agent Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RunTestRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskCreateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agent-tests/run": {
+      "post": {
+        "tags": [
+          "agent-tests"
+        ],
+        "summary": "Run Tests Batch",
+        "description": "Run every linked test for a set of agents, one ``llm-unit-test`` job per agent.\n\nScope is driven by the optional ``agent_names`` payload:\n\n- **Provided (non-empty)** \u2014 run only those agents. Names are unique per org\n  and **all are validated up front**: if any doesn't resolve to a\n  (non-deleted) agent in the caller's org, the call 404s with the offending\n  names and NO jobs are created.\n- **Omitted / null / empty** \u2014 run every agent in the caller's org.\n\nFor each selected agent, its linked tests are launched as one job. Agents\nwith no linked tests or an unverified connection are reported under\n``skipped`` instead of failing the batch. Subject to the normal per-org\nconcurrency queue, so over-limit jobs come back ``queued``.\n\nAuth accepts a JWT (frontend) or an `sk_` API key (programmatic clients).\nReturns one ``runs`` entry per launched agent with ``agent_name``,\n``agent_uuid``, ``task_id``, and ``status``.",
+        "operationId": "run_tests_batch_agent_tests_run_post",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/BatchRunRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchTestRunResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agent-tests/run/{task_id}": {
+      "get": {
+        "tags": [
+          "agent-tests"
+        ],
+        "summary": "Get Agent Test Run Status",
+        "description": "Get the status of an agent test run.\n\nRequires either a JWT (frontend) or an `sk_` API key, plus org\nownership of the run. Unauthenticated access to a completed run is only\npossible once it is made public, via the share-token endpoint in the public\nrouter.\n\nReturns the current status and, if done, the test results.",
+        "operationId": "get_agent_test_run_status_agent_tests_run__task_id__get",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "task_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Task Id"
             }
           }
         ],
         "responses": {
-          "204": {
-            "description": "Plant deleted",
-            "content": {}
-          },
-          "400": {
-            "description": "unexpected error",
+          "200": {
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/TestRunStatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -130,88 +953,10 @@
       }
     }
   },
-  "webhooks": {
-    "/plant/webhook": {
-      "post": {
-        "description": "Information about a new plant added to the store",
-        "requestBody": {
-          "description": "Plant added to the store",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NewPlant"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Return a 200 status to indicate that the data was received successfully"
-          }
-        }
-      }
+  "servers": [
+    {
+      "url": "https://pense-backend.artpark.ai",
+      "description": "Production"
     }
-  },
-  "components": {
-    "schemas": {
-      "Plant": {
-        "required": [
-          "name"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "description": "The name of the plant",
-            "type": "string"
-          },
-          "tag": {
-            "description": "Tag to specify the type",
-            "type": "string"
-          }
-        }
-      },
-      "NewPlant": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Plant"
-          },
-          {
-            "required": [
-              "id"
-            ],
-            "type": "object",
-            "properties": {
-              "id": {
-                "description": "Identification number of the plant",
-                "type": "integer",
-                "format": "int64"
-              }
-            }
-          }
-        ]
-      },
-      "Error": {
-        "required": [
-          "error",
-          "message"
-        ],
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "securitySchemes": {
-      "bearerAuth": {
-        "type": "http",
-        "scheme": "bearer"
-      }
-    }
-  }
+  ]
 }

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -29,7 +29,7 @@ Launches the interactive main menu where you can select from all available optio
 | `calibrate-agent llm`         | Interactive LLM evaluation — test agent responses |
 | `calibrate-agent simulations` | Interactive text or voice simulations             |
 
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
   <Card title="Speech to Text" icon="microphone" href="/cli/speech-to-text">

--- a/docs/core-concepts/agent-connections.mdx
+++ b/docs/core-concepts/agent-connections.mdx
@@ -163,7 +163,7 @@ Depending on the provider you have selected, the format of the `model` field wil
 
 3. When running a benchmark via **Compare models**, Calibrate will verify the connection for each selected model before starting the evaluation. See [this](/quickstart/text-to-text#verifying-agent-connection) for details.
 
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
   <Card title="Run LLM Tests" icon="list-check" href="/quickstart/text-to-text">

--- a/docs/core-concepts/agents.mdx
+++ b/docs/core-concepts/agents.mdx
@@ -17,7 +17,7 @@ An agent is a core building block of Calibrate. Agents can:
 
 ## Quickstart
 
-### Navigate to Agents
+### Navigate to agents
 
 From the sidebar, click **Agents** to view your existing agents or create a new one.
 
@@ -132,7 +132,7 @@ Set the maximum number of assistant turns before ending the call.
 
 Click **Save** in the top right to save your configuration.
 
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
   <Card

--- a/docs/core-concepts/personas.mdx
+++ b/docs/core-concepts/personas.mdx
@@ -74,11 +74,11 @@ Real users often interrupt agents mid-sentence. Configure how likely this person
 | **Medium** | 50% chance of interrupting |
 | **High**   | 80% chance of interrupting |
 
-### Save the Persona
+### Save the persona
 
 Click **Add persona** to create the persona.
 
-## Best Practices
+## Best practices
 
 ### Creating realistic personas
 
@@ -87,7 +87,7 @@ Click **Add persona** to create the persona.
 3. **Include limitations**: Language proficiency, technical knowledge, etc.
 4. **Add emotional traits**: Patient, impatient, friendly, formal
 
-### Personas vs Scenarios
+### Personas vs scenarios
 
 | Aspect  | Persona                                  | Scenario                               |
 | ------- | ---------------------------------------- | -------------------------------------- |
@@ -95,7 +95,7 @@ Click **Add persona** to create the persona.
 | Content | Demographics, behavior                   | Task, goal, situation                  |
 | Example | "A 45-year-old farmer who speaks slowly" | "Call to inquire about crop insurance" |
 
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
   <Card title="Create Scenarios" icon="file-lines" href="/guides/scenarios">

--- a/docs/core-concepts/scenarios.mdx
+++ b/docs/core-concepts/scenarios.mdx
@@ -33,16 +33,16 @@ Give a meaningful label to the scenario (e.g. `crop insurance inquiry`) and defi
 
 Click **Add scenario** to create the scenario.
 
-## Best Practices
+## Best practices
 
-### Writing Effective Scenarios
+### Writing effective scenarios
 
 1. **Be specific**: Include concrete details (order numbers, dates, amounts)
 2. **Set clear objectives**: What should the user aim to achieve?
 3. **Include conversation flow hints**: What questions should they ask?
 4. **Add realistic context**: Why is the user calling?
 
-### Scenarios vs Personas
+### Scenarios vs personas
 
 | Aspect  | Scenario                              | Persona                                  |
 | ------- | ------------------------------------- | ---------------------------------------- |
@@ -50,7 +50,7 @@ Click **Add scenario** to create the scenario.
 | Content | Task, goal, situation                 | Demographics, behavior                   |
 | Example | "Call to get a refund for order #123" | "A busy professional who speaks quickly" |
 
-### Scenario Complexity Levels
+### Scenario complexity levels
 
 | Level       | Description                      | Example                                             |
 | ----------- | -------------------------------- | --------------------------------------------------- |
@@ -58,7 +58,7 @@ Click **Add scenario** to create the scenario.
 | **Medium**  | Multiple questions, some details | "Inquire about insurance and ask about eligibility" |
 | **Complex** | Edge cases, negotiations         | "Dispute a charge and escalate if unsatisfied"      |
 
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
   <Card title="Create Personas" icon="user" href="/guides/personas">

--- a/docs/core-concepts/speech-to-text.mdx
+++ b/docs/core-concepts/speech-to-text.mdx
@@ -5,7 +5,7 @@ description: "Understand the concepts for evaluating Speech To Text providers"
 
 ## Metrics
 
-### Word Error Rate (WER)
+### Word error rate (WER)
 
 Measures the edit distance between the predicted and reference transcripts at the word level. It calculates the minimum number of word insertions, deletions, and substitutions needed to transform the prediction into the reference, divided by the number of words in the reference.
 
@@ -20,7 +20,7 @@ Measures the edit distance between the predicted and reference transcripts at th
 | "Hello world"   | "Hello there" | 0.5 |
 | "one two three" | "1 2 3"       | 1.0 |
 
-### String Similarity
+### String similarity
 
 Computes the ratio of matching characters between the normalized reference and prediction.
 
@@ -35,7 +35,7 @@ Computes the ratio of matching characters between the normalized reference and p
 | "Geeta"   | "Gita"     | 0.8               |
 | "Geeta"   | "John"     | 0.2               |
 
-### LLM Judge Score
+### LLM judge score
 
 The LLM Judge uses a powerful LLM to semantically evaluate whether the transcription matches the source text. Unlike WER, it understands context and meaning.
 
@@ -114,7 +114,7 @@ From the **Datasets** tab, click the delete button next to a dataset to remove i
 
 Once your dataset has samples, click the **New evaluation** button on the dataset page. This pre-selects the dataset and takes you to the evaluation settings where you choose the language and providers to compare.
 
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="play" href="/quickstart/speech-to-text">

--- a/docs/core-concepts/text-to-speech.mdx
+++ b/docs/core-concepts/text-to-speech.mdx
@@ -5,7 +5,7 @@ description: "Understand the concepts for evaluating Text to Speech providers"
 
 ## Metrics
 
-### LLM Judge Score
+### LLM judge score
 
 An audio LLM Judge (`gpt-audio`) listens to the generated audio and evaluates whether the pronunciation matches the input text.
 
@@ -36,7 +36,7 @@ What the LLM Judge evaluates:
 | "Call 1-800-555-0123" | <audio controls src="/core-concepts/audios/phone_number.wav" /> | True      | The phone number is pronounced correctly.                        |
 | "Dr. Smith"           | <audio controls src="/core-concepts/audios/dr_smith.wav" />     | False     | "Dr." was pronounced as "dur" instead of "doctor".               |
 
-### Time to First Byte (TTFB)
+### Time to first byte (TTFB)
 
 Measures the time (in seconds) from when the request is made to the provider until the first audio chunk is received. It is critical for real-time voice agents where responsiveness matters.
 
@@ -90,7 +90,7 @@ From the **Datasets** tab, click the delete button next to a dataset to remove i
 
 Once your dataset has samples, click the **New evaluation** button on the dataset page. This pre-selects the dataset and takes you to the evaluation settings where you choose the language and providers to compare.
 
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="play" href="/quickstart/text-to-speech">

--- a/docs/core-concepts/tools.mdx
+++ b/docs/core-concepts/tools.mdx
@@ -8,7 +8,7 @@ Tools extend your agents' capabilities by enabling them to perform actions and p
 - **Webhook tools** — Call external APIs or services to perform actions
 - **Structured output tools** — Extract information from conversations in a defined format
 
-## Navigate to Tools
+## Navigate to tools
 
 From the sidebar, click **Tools** to view and manage your tools.
 
@@ -16,11 +16,11 @@ From the sidebar, click **Tools** to view and manage your tools.
   <img src="./images/tools-1.png" alt="Tools page" />
 </Frame>
 
-## Webhook Tools
+## Webhook tools
 
 Webhook tools allow agents to call external APIs or services to perform actions like sending notifications or querying databases.
 
-### Create a Webhook Tool
+### Create a webhook tool
 
 Click **Add webhook tool** to open the configuration panel.
 
@@ -28,7 +28,7 @@ Click **Add webhook tool** to open the configuration panel.
   <img src="./images/tools-webhook-1.png" alt="Add webhook tool" />
 </Frame>
 
-### Configure the Tool
+### Configure the tool
 
 Provide the following details:
 
@@ -60,11 +60,11 @@ Define the request body structure with a description and properties the LLM shou
 
 Click **Add tool** to save.
 
-## Structured Output Tools
+## Structured output tools
 
 Structured output tools enable agents to extract information from conversations in a defined format, such as user names or order details.
 
-### Create a Structured Output Tool
+### Create a structured output tool
 
 Click **Add structured output tool** to open the configuration panel.
 
@@ -72,7 +72,7 @@ Click **Add structured output tool** to open the configuration panel.
   <img src="./images/tools-structured-1.png" alt="Add structured output tool" />
 </Frame>
 
-### Configure the Tool
+### Configure the tool
 
 Provide the following details:
 
@@ -97,7 +97,7 @@ For each parameter, specify:
 
 Click **Add param** to add more parameters. Click **Add tool** to save.
 
-## Inbuilt Tools
+## Inbuilt tools
 
 Some tools are built into the platform and enabled by default:
 
@@ -105,7 +105,7 @@ Some tools are built into the platform and enabled by default:
 | -------------------- | -------------------------------- |
 | **End conversation** | Allows the agent to end the call |
 
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
   <Card title="Configure Agents" icon="robot" href="/core-concepts/agents">

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -93,6 +93,29 @@
             "pages": ["examples/overview"]
           }
         ]
+      },
+      {
+        "tab": "API Reference",
+        "groups": [
+          {
+            "group": "Getting started",
+            "pages": ["api-reference/introduction"]
+          },
+          {
+            "group": "Agents",
+            "openapi": "api-reference/openapi.json",
+            "pages": ["GET /agents", "POST /agents/resolve"]
+          },
+          {
+            "group": "Agent tests",
+            "openapi": "api-reference/openapi.json",
+            "pages": [
+              "POST /agent-tests/agent/{agent_uuid}/run",
+              "POST /agent-tests/run",
+              "GET /agent-tests/run/{task_id}"
+            ]
+          }
+        ]
       }
     ],
     "global": {
@@ -130,6 +153,16 @@
       "type": "button",
       "label": "Get Started",
       "href": "https://calibrate.artpark.ai"
+    }
+  },
+  "api": {
+    "openapi": "api-reference/openapi.json",
+    "playground": {
+      "display": "interactive"
+    },
+    "examples": {
+      "languages": ["curl", "python"],
+      "defaults": "required"
     }
   },
   "contextual": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -11,7 +11,7 @@
   "navigation": {
     "tabs": [
       {
-        "tab": "Getting started",
+        "tab": "Home",
         "groups": [
           {
             "group": "Get Started",
@@ -39,19 +39,10 @@
               "core-concepts/scenarios",
               "core-concepts/metrics"
             ]
-          }
-        ]
-      },
-      {
-        "tab": "Integrations",
-        "groups": [
+          },
           {
-            "group": "Providers",
-            "pages": [
-              "integrations/stt",
-              "integrations/llm",
-              "integrations/tts"
-            ]
+            "group": "Reference",
+            "pages": ["reference/api-keys", "reference/github-actions"]
           }
         ]
       },
@@ -86,19 +77,10 @@
         ]
       },
       {
-        "tab": "Use cases",
+        "tab": "API reference",
         "groups": [
           {
-            "group": "Browse use cases",
-            "pages": ["examples/overview"]
-          }
-        ]
-      },
-      {
-        "tab": "API Reference",
-        "groups": [
-          {
-            "group": "Getting started",
+            "group": "API",
             "pages": ["api-reference/introduction"]
           },
           {
@@ -114,6 +96,28 @@
               "POST /agent-tests/run",
               "GET /agent-tests/run/{task_id}"
             ]
+          }
+        ]
+      },
+      {
+        "tab": "Integrations",
+        "groups": [
+          {
+            "group": "Providers",
+            "pages": [
+              "integrations/stt",
+              "integrations/llm",
+              "integrations/tts"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Use cases",
+        "groups": [
+          {
+            "group": "Browse use cases",
+            "pages": ["examples/overview"]
           }
         ]
       }

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -38,7 +38,7 @@ Calibrate solves this problem by letting you evaluate your entire voice agent st
 
 Calibrate helps you continuously improve your agent, ensure a bug never repeats itself and deploy your agent with confidence.
 
-## Get Started
+## Get started
 
 <CardGroup cols={2}>
   <Card
@@ -63,7 +63,7 @@ Calibrate helps you continuously improve your agent, ensure a bug never repeats 
   </Card>
 </CardGroup>
 
-## Learn More
+## Learn more
 
 <CardGroup cols={2}>
   <Card title="Core Concepts" icon="book" href="/core-concepts/speech-to-text">

--- a/docs/integrations/llm.mdx
+++ b/docs/integrations/llm.mdx
@@ -20,7 +20,7 @@ export OPENAI_API_KEY=your_key
 export OPENROUTER_API_KEY=your_key
 ```
 
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="/quickstart/text-to-text">

--- a/docs/integrations/stt.mdx
+++ b/docs/integrations/stt.mdx
@@ -25,7 +25,7 @@ Some providers use different models for specific languages:
   This is handled automatically by Calibrate.
 </Note>
 
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="/quickstart/speech-to-text">

--- a/docs/integrations/tts.mdx
+++ b/docs/integrations/tts.mdx
@@ -47,7 +47,7 @@ export GROQ_API_KEY=your_key
 export SMALLEST_API_KEY=your_key
 ```
 
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="/quickstart/text-to-speech">

--- a/docs/quickstart/speech-to-text.mdx
+++ b/docs/quickstart/speech-to-text.mdx
@@ -147,7 +147,7 @@ This toggles the evaluation to **Public** and generates a shareable link. Anyone
 
 Click the **Public** button again to make the evaluation private.
 
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
   <Card

--- a/docs/quickstart/text-to-speech.mdx
+++ b/docs/quickstart/text-to-speech.mdx
@@ -131,7 +131,7 @@ This toggles the evaluation to **Public** and generates a shareable link. Anyone
 
 Click the **Public** button again to make the evaluation private.
 
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
   <Card

--- a/docs/quickstart/text-to-text.mdx
+++ b/docs/quickstart/text-to-text.mdx
@@ -306,7 +306,7 @@ If you have many test cases, you can upload them all at once via CSV. Click **Bu
 
 Once you confirm, the tests will be uploaded (if they are in the right format) and attached to the selected agents.
 
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
   <Card

--- a/docs/reference/api-keys.mdx
+++ b/docs/reference/api-keys.mdx
@@ -1,0 +1,82 @@
+---
+title: "API keys"
+description: "Create and manage API keys to authenticate with the Calibrate API"
+---
+
+{/* Generated from docs/templates/reference/api-keys.mdx — do not edit directly. */}
+
+API keys authenticate Calibrate in the [GitHub Action](/reference/github-actions) or the [REST API](/api-reference/introduction). You can create multiple keys per workspace.
+
+## Creating an API key
+
+<Steps>
+  <Step title="Open Workspace settings">
+    Go to [Workspace settings → API
+    keys](https://calibrate.artpark.ai/workspace-settings?tab=api-keys) and
+    select the **API keys** tab.
+  </Step>
+  <Step title="Click Create key">
+    Click **Create key** in the top right of the API keys section.
+  </Step>
+  <Step title="Name your key">
+    Enter a **Name** for the key — for example, `Form bharo` or `GitHub Action
+    CI`.
+  </Step>
+  <Step title="Copy your key">
+    Copy the full key immediately when it is shown. After you close the dialog,
+    only a masked value (for example, `sk_....NsYs`) appears in the table and
+    the full key cannot be viewed again.
+  </Step>
+</Steps>
+
+## Managing keys
+
+The API keys table lists every key with three columns:
+
+| Column        | Description                                          |
+| ------------- | ---------------------------------------------------- |
+| **Name**      | The label you gave the key when creating it          |
+| **Value**     | The masked key prefix (for example, `sk_....NsYs`)   |
+| **Last used** | When the key was last used to authenticate a request |
+
+To permanently disable a key, click **Revoke** on its row. Any integration using that key will immediately lose access.
+
+## Using your API key
+
+Include the key in the `X-API-Key` header with every request:
+
+```bash
+curl http://localhost:8000/agents \
+  -H "X-API-Key: your_api_key"
+```
+
+For CI, store the key as a GitHub secret named `CALIBRATE_API_KEY` and pass it to the [Calibrate GitHub Action](/reference/github-actions).
+
+## Best practices
+
+### Use descriptive names
+
+Name keys after their purpose (for example, `GitHub Action CI` or `Staging automation`) so you can identify them in the table later.
+
+### Rotate keys regularly
+
+Create a new key, update your integrations, then **Revoke** the old one — especially for production CI pipelines.
+
+### Revoke unused keys
+
+Promptly revoke keys that are no longer in use.
+
+### Store keys as secrets
+
+Never commit API keys to version control. Use GitHub secrets, environment variables, or your team's secret manager.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="API reference" icon="book" href="/api-reference/introduction">
+    Explore the full API documentation
+  </Card>
+  <Card title="GitHub Action" icon="github" href="/reference/github-actions">
+    Use API keys in your CI/CD pipeline
+  </Card>
+</CardGroup>

--- a/docs/reference/api-keys.mdx
+++ b/docs/reference/api-keys.mdx
@@ -19,8 +19,7 @@ API keys authenticate Calibrate in the [GitHub Action](/reference/github-actions
     Click **Create key** in the top right of the API keys section.
   </Step>
   <Step title="Name your key">
-    Enter a **Name** for the key — for example, `Form bharo` or `GitHub Action
-    CI`.
+    Enter a **Name** for the key (for example, `GitHub Action CI`).
   </Step>
   <Step title="Save your key">
     Click **Create key**. Your API key will be displayed once.
@@ -64,7 +63,7 @@ Name keys after their purpose (for example, `GitHub Action CI` or `Staging autom
 
 ### Rotate keys regularly
 
-Create a new key, update your integrations, then **Revoke** the old one, especially for production CI pipelines.
+Create a new key, update your integrations, then **Revoke** the old one — especially for production CI pipelines.
 
 ### Revoke unused keys
 

--- a/docs/reference/api-keys.mdx
+++ b/docs/reference/api-keys.mdx
@@ -22,12 +22,27 @@ API keys authenticate Calibrate in the [GitHub Action](/reference/github-actions
     Enter a **Name** for the key — for example, `Form bharo` or `GitHub Action
     CI`.
   </Step>
-  <Step title="Copy your key">
-    Copy the full key immediately when it is shown. After you close the dialog,
-    only a masked value (for example, `sk_....NsYs`) appears in the table and
-    the full key cannot be viewed again.
+  <Step title="Save your key">
+    Click **Create key**. Your API key will be displayed once.
+
+    <Warning>
+      Copy the key immediately. You will not be able to view the full key again
+      after closing the dialog.
+    </Warning>
+
   </Step>
 </Steps>
+
+## Using your API key
+
+Include the key in the `X-API-Key` header with every request:
+
+```bash
+curl https://pense-backend.artpark.ai/agents \
+  -H "X-API-Key: your_api_key"
+```
+
+For using it with the [Calibrate GitHub Action](/reference/github-actions), store the key as a GitHub secret named `CALIBRATE_API_KEY`.
 
 ## Managing keys
 
@@ -36,21 +51,10 @@ The API keys table lists every key with three columns:
 | Column        | Description                                          |
 | ------------- | ---------------------------------------------------- |
 | **Name**      | The label you gave the key when creating it          |
-| **Value**     | The masked key prefix (for example, `sk_....NsYs`)   |
+| **Value**     | The masked key prefix                                |
 | **Last used** | When the key was last used to authenticate a request |
 
-To permanently disable a key, click **Revoke** on its row. Any integration using that key will immediately lose access.
-
-## Using your API key
-
-Include the key in the `X-API-Key` header with every request:
-
-```bash
-curl http://localhost:8000/agents \
-  -H "X-API-Key: your_api_key"
-```
-
-For CI, store the key as a GitHub secret named `CALIBRATE_API_KEY` and pass it to the [Calibrate GitHub Action](/reference/github-actions).
+To permanently disable a key, click **Revoke**. Any integration using that key will immediately lose access.
 
 ## Best practices
 
@@ -60,7 +64,7 @@ Name keys after their purpose (for example, `GitHub Action CI` or `Staging autom
 
 ### Rotate keys regularly
 
-Create a new key, update your integrations, then **Revoke** the old one — especially for production CI pipelines.
+Create a new key, update your integrations, then **Revoke** the old one, especially for production CI pipelines.
 
 ### Revoke unused keys
 

--- a/docs/reference/github-actions.mdx
+++ b/docs/reference/github-actions.mdx
@@ -1,0 +1,381 @@
+---
+title: "GitHub Action"
+description: "Launch Calibrate agent test runs from GitHub Actions"
+---
+
+{/* Generated from docs/templates/reference/github-actions.mdx — do not edit directly. */}
+
+The [Calibrate GitHub Action](https://github.com/ARTPARK-SAHAI-ORG/calibrate-github-action) runs your agent tests automatically in CI.
+During deployment, you can choose what happens when a test fails:
+
+- **gate** (default) — Prevent merging the changes. This is the recommended mode for production CI pipelines to prevent deploying broken agents.
+- **report** — Report evaluation results without blocking merges. You may be aware of the mistakes but still want to merge the changes.
+
+On pull requests, the action posts a comment with the evaluation results.
+
+## Prerequisites
+
+<Steps>
+  <Step title="Get your API key">
+    Navigate to your [Calibrate dashboard](https://calibrate.artpark.ai/workspace-settings?tab=api-keys) and generate an API key. See the [API keys guide](/reference/api-keys) for detailed instructions.
+
+  </Step>
+  <Step title="Add GitHub Secret">
+    1. Go to your repository **Settings > Secrets and variables > Actions**
+    2. Click **New repository secret**
+    3. Name: `CALIBRATE_API_KEY`
+    4. Value: Your Calibrate API key
+  </Step>
+  <Step title="Link tests to your agents">
+    The agents in Calibrate you want to evaluate must have tests linked to them. By default, the action runs all the tests for every agent in your workspace. 
+    
+    Optionally, if you want to restrict evaluation to a few specific agents, you can set that too. Gather the agent names from the [Agents](https://calibrate.artpark.ai/agents) page (for example, `checkout-bot`, `support-agent`).
+
+  </Step>
+</Steps>
+
+## Quick start
+
+### Automatic PR checks
+
+Create `.github/workflows/calibrate.yml`:
+
+```yaml
+name: Calibrate automatic evaluation
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  evaluate-agent:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Calibrate Evaluation
+        uses: ARTPARK-SAHAI-ORG/calibrate-github-action@v1
+        with:
+          api-key: ${{ secrets.CALIBRATE_API_KEY }}
+          # Omit this field to run on all agents
+          agents: checkout-bot, support-agent
+```
+
+### Manual workflow dispatch
+
+Create `.github/workflows/manual-eval.yml`:
+
+```yaml
+name: Calibrate manual evaluation
+
+on:
+  workflow_dispatch:
+    inputs:
+      agents:
+        description: "Agent names (comma-separated)"
+        required: true
+        type: string
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Evaluation
+        uses: ARTPARK-SAHAI-ORG/calibrate-github-action@v1
+        with:
+          api-key: ${{ secrets.CALIBRATE_API_KEY }}
+          agents: ${{ inputs.agents }}
+```
+
+To trigger:
+
+1. Navigate to **Actions** tab
+2. Select **Manual Evaluation**
+3. Click **Run workflow**
+4. Enter your agent names and click **Run workflow**
+
+## Advanced configuration
+
+### Custom options
+
+```yaml
+- name: Advanced Evaluation
+  uses: ARTPARK-SAHAI-ORG/calibrate-github-action@v1
+  with:
+    api-key: ${{ secrets.CALIBRATE_API_KEY }}
+    agents: checkout-bot, support-agent
+    # Fail the job on any test failure (default)
+    mode: gate
+    # Seconds between status polls
+    poll-interval: 5
+    # Max seconds to wait for runs to finish
+    timeout: 1800
+```
+
+### Using outputs
+
+```yaml
+- name: Run Evaluation
+  id: calibrate
+  uses: ARTPARK-SAHAI-ORG/calibrate-github-action@v1
+  with:
+    api-key: ${{ secrets.CALIBRATE_API_KEY }}
+    agents: checkout-bot
+
+- name: Post Results
+  run: |
+    echo "Total:  ${{ steps.calibrate.outputs.total }}"
+    echo "Passed: ${{ steps.calibrate.outputs.passed }}"
+    echo "Failed: ${{ steps.calibrate.outputs.failed }}"
+```
+
+## Configuration reference
+
+### Inputs
+
+| Parameter       | Type    | Required | Default                            | Description                                                                                                                             |
+| --------------- | ------- | -------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `api-key`       | string  | Yes      | —                                  | Calibrate API key (`sk_…`). Store as a secret.                                                                                          |
+| `agents`        | string  | No       | All agents                         | Agent names, comma- or newline-separated. Runs all linked tests for each. Omit to run every agent in the account linked to the API key. |
+| `base-url`      | string  | No       | `http://localhost:8000` | Backend API URL. Override only for self-hosted.                                                                                         |
+| `app-url`       | string  | No       | `https://calibrate.artpark.ai`     | Web UI base URL for view links in the report.                                                                                           |
+| `mode`          | string  | No       | `gate`                             | `gate` fails the job on any failure; `report` always succeeds.                                                                          |
+| `poll-interval` | integer | No       | `5`                                | Seconds between status polls.                                                                                                           |
+| `timeout`       | integer | No       | `1800`                             | Max seconds to wait for all runs to finish.                                                                                             |
+| `github-token`  | string  | No       | `${{ github.token }}`              | Token for PR comments. Requires `pull-requests: write`.                                                                                 |
+
+### Outputs
+
+| Output   | Type   | Description                                  |
+| -------- | ------ | -------------------------------------------- |
+| `total`  | string | Total test cases across all agents evaluated |
+| `passed` | string | Total test cases passed                      |
+| `failed` | string | Total test cases failed                      |
+
+### Environment variables
+
+| Variable            | Required | Description            |
+| ------------------- | -------- | ---------------------- |
+| `CALIBRATE_API_KEY` | Yes      | Your Calibrate API key |
+
+## API details
+
+The action talks to the Calibrate Public API with your API key. For each invocation it runs three steps.
+
+### Resolve agents
+
+When `agents` is set, it resolves the names to UUIDs:
+
+**Endpoint:** `POST http://localhost:8000/agents/resolve`
+
+**Request:**
+
+```json
+{
+  "names": ["checkout-bot", "support-agent"]
+}
+```
+
+**Response:**
+
+```json
+{
+  "resolved": {
+    "checkout-bot": "8f3c...",
+    "support-agent": "a91d..."
+  },
+  "not_found": []
+}
+```
+
+When `agents` is omitted, it lists every agent in the account instead:
+
+**Endpoint:** `GET http://localhost:8000/agents`
+
+**Response:**
+
+```json
+[{ "uuid": "8f3c...", "name": "checkout-bot" }]
+```
+
+### Launch run
+
+For each agent, it triggers all linked tests. The agent is selected by UUID in the URL path and the body is empty:
+
+**Endpoint:** `POST http://localhost:8000/agent-tests/agent/{agent_uuid}/run`
+
+**Request:**
+
+```json
+{}
+```
+
+**Response:**
+
+```json
+{
+  "task_id": "abc123"
+}
+```
+
+### Monitor run
+
+It polls each task until it finishes:
+
+**Endpoint:** `GET http://localhost:8000/agent-tests/run/{task_id}`
+
+**Response:**
+
+```json
+{
+  "status": "done",
+  "total_tests": 10,
+  "passed": 9,
+  "failed": 1
+}
+```
+
+### Run statuses
+
+| Status        | Description            |
+| ------------- | ---------------------- |
+| `queued`      | Waiting to start       |
+| `in_progress` | Running test cases     |
+| `done`        | Successfully completed |
+| `failed`      | Run failed             |
+| `cancelled`   | Run was cancelled      |
+
+## Examples
+
+### Environment-based testing
+
+```yaml
+name: Multi-Environment Testing
+
+on:
+  push:
+    branches: [main, staging, dev]
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Environment
+        id: env
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "agents=checkout-bot" >> $GITHUB_OUTPUT
+            echo "env=production" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref }}" == "refs/heads/staging" ]]; then
+            echo "agents=staging-bot" >> $GITHUB_OUTPUT
+            echo "env=staging" >> $GITHUB_OUTPUT
+          else
+            echo "agents=dev-bot" >> $GITHUB_OUTPUT
+            echo "env=development" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Evaluate
+        uses: ARTPARK-SAHAI-ORG/calibrate-github-action@v1
+        with:
+          api-key: ${{ secrets.CALIBRATE_API_KEY }}
+          agents: ${{ steps.env.outputs.agents }}
+```
+
+### Parallel agent testing
+
+```yaml
+name: Multi-Agent Testing
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        agent:
+          - { name: "checkout-bot" }
+          - { name: "support-agent" }
+          - { name: "returns-bot" }
+    steps:
+      - name: Test ${{ matrix.agent.name }}
+        uses: ARTPARK-SAHAI-ORG/calibrate-github-action@v1
+        with:
+          api-key: ${{ secrets.CALIBRATE_API_KEY }}
+          agents: ${{ matrix.agent.name }}
+```
+
+### Scheduled regression testing
+
+```yaml
+name: Nightly Regression
+
+on:
+  schedule:
+    - cron: "0 2 * * *" # 2 AM daily
+
+jobs:
+  regression:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Tests
+        uses: ARTPARK-SAHAI-ORG/calibrate-github-action@v1
+        with:
+          api-key: ${{ secrets.CALIBRATE_API_KEY }}
+          timeout: 1800
+```
+
+## Troubleshooting
+
+### Invalid API key
+
+```
+authentication failed (HTTP 401) — check the api-key input
+```
+
+**Solution:** Verify `CALIBRATE_API_KEY` is set correctly in GitHub Secrets.
+
+### Invalid agent name
+
+```
+agent "my-agent": no agent with that name in this org
+```
+
+**Solution:** Confirm the agent name matches exactly and exists in your workspace.
+
+### Agent cannot run
+
+```
+agent my-agent: cannot run (HTTP 400): connection not verified
+```
+
+**Solution:** Open the agent in Calibrate, verify its connection, and ensure at least one test is linked.
+
+### Timeout
+
+**Solution:** Increase `timeout` for larger test suites or check the Calibrate dashboard for run status.
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card
+    title="API keys"
+    icon="key"
+    href="https://calibrate.artpark.ai/workspace-settings?tab=api-keys"
+  >
+    Create and manage your API keys
+  </Card>
+  <Card title="API reference" icon="book" href="/api-reference/introduction">
+    Full REST API documentation
+  </Card>
+  <Card
+    title="GitHub Action repository"
+    icon="github"
+    href="https://github.com/ARTPARK-SAHAI-ORG/calibrate-github-action"
+  >
+    Source, releases, and issue tracker
+  </Card>
+</CardGroup>

--- a/docs/reference/github-actions.mdx
+++ b/docs/reference/github-actions.mdx
@@ -139,7 +139,7 @@ To trigger:
 | --------------- | ------- | -------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `api-key`       | string  | Yes      | —                                  | Calibrate API key (`sk_…`). Store as a secret.                                                                                          |
 | `agents`        | string  | No       | All agents                         | Agent names, comma- or newline-separated. Runs all linked tests for each. Omit to run every agent in the account linked to the API key. |
-| `base-url`      | string  | No       | `http://localhost:8000` | Backend API URL. Override only for self-hosted.                                                                                         |
+| `base-url`      | string  | No       | `https://pense-backend.artpark.ai` | Backend API URL. Override only for self-hosted.                                                                                         |
 | `app-url`       | string  | No       | `https://calibrate.artpark.ai`     | Web UI base URL for view links in the report.                                                                                           |
 | `mode`          | string  | No       | `gate`                             | `gate` fails the job on any failure; `report` always succeeds.                                                                          |
 | `poll-interval` | integer | No       | `5`                                | Seconds between status polls.                                                                                                           |
@@ -168,7 +168,7 @@ The action talks to the Calibrate Public API with your API key. For each invocat
 
 When `agents` is set, it resolves the names to UUIDs:
 
-**Endpoint:** `POST http://localhost:8000/agents/resolve`
+**Endpoint:** `POST https://pense-backend.artpark.ai/agents/resolve`
 
 **Request:**
 
@@ -192,7 +192,7 @@ When `agents` is set, it resolves the names to UUIDs:
 
 When `agents` is omitted, it lists every agent in the account instead:
 
-**Endpoint:** `GET http://localhost:8000/agents`
+**Endpoint:** `GET https://pense-backend.artpark.ai/agents`
 
 **Response:**
 
@@ -204,7 +204,7 @@ When `agents` is omitted, it lists every agent in the account instead:
 
 For each agent, it triggers all linked tests. The agent is selected by UUID in the URL path and the body is empty:
 
-**Endpoint:** `POST http://localhost:8000/agent-tests/agent/{agent_uuid}/run`
+**Endpoint:** `POST https://pense-backend.artpark.ai/agent-tests/agent/{agent_uuid}/run`
 
 **Request:**
 
@@ -224,7 +224,7 @@ For each agent, it triggers all linked tests. The agent is selected by UUID in t
 
 It polls each task until it finishes:
 
-**Endpoint:** `GET http://localhost:8000/agent-tests/run/{task_id}`
+**Endpoint:** `GET https://pense-backend.artpark.ai/agent-tests/run/{task_id}`
 
 **Response:**
 

--- a/docs/templates/api-reference/introduction.mdx
+++ b/docs/templates/api-reference/introduction.mdx
@@ -28,7 +28,7 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
     Pass your key in the `X-API-Key` header on every request:
 
     ```bash
-    curl https://pense-backend.artpark.ai/agents \
+    curl __PUBLIC_API_BASE_URL__/agents \
       -H "X-API-Key: sk_your_api_key"
     ```
   </Step>
@@ -36,7 +36,7 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
     Enumerate every agent in your org:
 
     ```bash
-    curl https://pense-backend.artpark.ai/agents \
+    curl __PUBLIC_API_BASE_URL__/agents \
       -H "X-API-Key: sk_your_api_key"
     ```
   </Step>
@@ -45,13 +45,13 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
 
     ```bash
     # Start a run (all linked tests when test_uuids is omitted)
-    curl -X POST "https://pense-backend.artpark.ai/agent-tests/agent/{agent_uuid}/run" \
+    curl -X POST "__PUBLIC_API_BASE_URL__/agent-tests/agent/{agent_uuid}/run" \
       -H "X-API-Key: sk_your_api_key" \
       -H "Content-Type: application/json" \
       -d '{}'
 
     # Poll status + results
-    curl "https://pense-backend.artpark.ai/agent-tests/run/{task_id}" \
+    curl "__PUBLIC_API_BASE_URL__/agent-tests/run/{task_id}" \
       -H "X-API-Key: sk_your_api_key"
     ```
   </Step>
@@ -60,7 +60,7 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
 ## Base URL
 
 ```
-https://pense-backend.artpark.ai
+__PUBLIC_API_BASE_URL__
 ```
 
 ## OpenAPI specification
@@ -69,13 +69,13 @@ The public API schema is published at an unauthenticated endpoint and synced int
 
 ```bash
 # Fetch the live spec (JSON)
-curl -s https://pense-backend.artpark.ai/public-api/openapi.json
+curl -s __PUBLIC_OPENAPI_SPEC_URL__
 ```
 
 <Card
   title="OpenAPI specification"
   icon="brackets-curly"
-  href="https://pense-backend.artpark.ai/public-api/openapi.json"
+  href="__PUBLIC_OPENAPI_SPEC_URL__"
 >
   View the machine-readable spec
 </Card>

--- a/docs/templates/api-reference/introduction.mdx
+++ b/docs/templates/api-reference/introduction.mdx
@@ -5,7 +5,7 @@ description: "Authenticate and call the Calibrate Public API programmatically"
 
 {/* Generated from docs/templates/api-reference/introduction.mdx — do not edit directly. */}
 
-The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launch LLM test runs, and poll results — all from CI or automation scripts.
+The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launch LLM test runs, and poll results.
 
 ## Most used
 
@@ -26,7 +26,7 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
 
 <Steps>
   <Step title="Get your API key">
-    Go to [Workspace settings → API keys](https://calibrate.artpark.ai/workspace-settings?tab=api-keys), click **Create key**, and copy the full key when it is shown — you cannot view it again after closing the dialog.
+    Obtain your API key from the [Calibrate dashboard](https://calibrate.artpark.ai/workspace-settings?tab=api-keys). See the [API keys guide](/reference/api-keys) for detailed setup instructions.
   </Step>
   <Step title="Authenticate your requests">
     Pass your key in the `X-API-Key` header on every request:
@@ -47,16 +47,31 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
 
   </Step>
   <Step title="Run tests">
-    Launch a test run for an agent, then poll the returned `task_id`:
+    Launch a test run for an agent:
 
     ```bash
-    # Start a run (all linked tests when test_uuids is omitted)
     curl -X POST "__PUBLIC_API_BASE_URL__/agent-tests/agent/{agent_uuid}/run" \
       -H "X-API-Key: your_api_key" \
       -H "Content-Type: application/json" \
       -d '{}'
+    ```
 
-    # Poll status + results
+    Since no `test_uuids` were passed, all linked tests for the agent will be run. The response returns a `task_id`:
+
+    ```json
+    {
+      "task_id": "abc123",
+      "status": "queued",
+      "dataset_id": null,
+      "dataset_name": null
+    }
+    ```
+
+  </Step>
+  <Step title="Poll results">
+    Poll the returned `task_id` for status and results:
+
+    ```bash
     curl "__PUBLIC_API_BASE_URL__/agent-tests/run/{task_id}" \
       -H "X-API-Key: your_api_key"
     ```
@@ -66,29 +81,19 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
 
 ## Base URL
 
-```
+```bash
 __PUBLIC_API_BASE_URL__
 ```
 
 ## OpenAPI specification
 
-The public API schema is published at an unauthenticated endpoint and synced into this docs site on every deploy.
+The public API schema is published at an unauthenticated endpoint.
 
 ```bash
 # Fetch the live spec (JSON)
 curl -s __PUBLIC_OPENAPI_SPEC_URL__
 ```
 
-<Card
-  title="OpenAPI specification"
-  icon="brackets-curly"
-  href="__PUBLIC_OPENAPI_SPEC_URL__"
->
-  View the machine-readable spec
-</Card>
-
 ## Authentication
 
-All API requests require an `X-API-Key` header. Keys grant access to the public API routes for your workspace.
-
-JWT bearer tokens (used by the Calibrate web UI) also work at the HTTP layer, but programmatic clients should use API keys exclusively.
+All API requests require an `X-API-Key` header.

--- a/docs/templates/api-reference/introduction.mdx
+++ b/docs/templates/api-reference/introduction.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Introduction'
-description: 'Authenticate and call the Calibrate Public API programmatically'
+title: "Introduction"
+description: "Authenticate and call the Calibrate Public API programmatically"
 ---
 
 {/* Generated from docs/templates/api-reference/introduction.mdx — do not edit directly. */}
@@ -13,7 +13,11 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
   <Card title="Agents" icon="robot" href="/api-reference/agents/list-agents">
     List agents and resolve human-friendly names to UUIDs
   </Card>
-  <Card title="Agent tests" icon="play" href="/api-reference/agent-tests/run-agent-test">
+  <Card
+    title="Agent tests"
+    icon="play"
+    href="/api-reference/agent-tests/run-agent-test"
+  >
     Launch test runs and poll for results
   </Card>
 </CardGroup>
@@ -22,23 +26,25 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
 
 <Steps>
   <Step title="Get your API key">
-    Sign in to [Calibrate](https://calibrate.artpark.ai), open **Settings → API keys**, and create an org-scoped key. The raw `sk_…` value is shown once — store it securely.
+    Go to [Workspace settings → API keys](https://calibrate.artpark.ai/workspace-settings?tab=api-keys), click **Create key**, and copy the full key when it is shown — you cannot view it again after closing the dialog.
   </Step>
   <Step title="Authenticate your requests">
     Pass your key in the `X-API-Key` header on every request:
 
     ```bash
     curl __PUBLIC_API_BASE_URL__/agents \
-      -H "X-API-Key: sk_your_api_key"
+      -H "X-API-Key: your_api_key"
     ```
+
   </Step>
   <Step title="List agents">
     Enumerate every agent in your org:
 
     ```bash
     curl __PUBLIC_API_BASE_URL__/agents \
-      -H "X-API-Key: sk_your_api_key"
+      -H "X-API-Key: your_api_key"
     ```
+
   </Step>
   <Step title="Run tests">
     Launch a test run for an agent, then poll the returned `task_id`:
@@ -46,14 +52,15 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
     ```bash
     # Start a run (all linked tests when test_uuids is omitted)
     curl -X POST "__PUBLIC_API_BASE_URL__/agent-tests/agent/{agent_uuid}/run" \
-      -H "X-API-Key: sk_your_api_key" \
+      -H "X-API-Key: your_api_key" \
       -H "Content-Type: application/json" \
       -d '{}'
 
     # Poll status + results
     curl "__PUBLIC_API_BASE_URL__/agent-tests/run/{task_id}" \
-      -H "X-API-Key: sk_your_api_key"
+      -H "X-API-Key: your_api_key"
     ```
+
   </Step>
 </Steps>
 
@@ -82,6 +89,6 @@ curl -s __PUBLIC_OPENAPI_SPEC_URL__
 
 ## Authentication
 
-All API requests require an `X-API-Key` header. Keys are scoped to one organization and grant owner-level access to that org's public API routes.
+All API requests require an `X-API-Key` header. Keys grant access to the public API routes for your workspace.
 
 JWT bearer tokens (used by the Calibrate web UI) also work at the HTTP layer, but programmatic clients should use API keys exclusively.

--- a/docs/templates/reference/api-keys.mdx
+++ b/docs/templates/reference/api-keys.mdx
@@ -22,12 +22,26 @@ API keys authenticate Calibrate in the [GitHub Action](/reference/github-actions
     Enter a **Name** for the key — for example, `Form bharo` or `GitHub Action
     CI`.
   </Step>
-  <Step title="Copy your key">
-    Copy the full key immediately when it is shown. After you close the dialog,
-    only a masked value (for example, `sk_....NsYs`) appears in the table and
-    the full key cannot be viewed again.
+  <Step title="Save your key">
+    Click **Create key**. Your API key will be displayed once.
+
+    <Warning>
+      Copy the key immediately. You will not be able to view the full key again
+      after closing the dialog.
+    </Warning>
   </Step>
 </Steps>
+
+## Using your API key
+
+Include the key in the `X-API-Key` header with every request:
+
+```bash
+curl __PUBLIC_API_BASE_URL__/agents \
+  -H "X-API-Key: your_api_key"
+```
+
+For CI, store the key as a GitHub secret named `CALIBRATE_API_KEY` and pass it to the [Calibrate GitHub Action](/reference/github-actions).
 
 ## Managing keys
 
@@ -40,17 +54,6 @@ The API keys table lists every key with three columns:
 | **Last used** | When the key was last used to authenticate a request |
 
 To permanently disable a key, click **Revoke** on its row. Any integration using that key will immediately lose access.
-
-## Using your API key
-
-Include the key in the `X-API-Key` header with every request:
-
-```bash
-curl __PUBLIC_API_BASE_URL__/agents \
-  -H "X-API-Key: your_api_key"
-```
-
-For CI, store the key as a GitHub secret named `CALIBRATE_API_KEY` and pass it to the [Calibrate GitHub Action](/reference/github-actions).
 
 ## Best practices
 

--- a/docs/templates/reference/api-keys.mdx
+++ b/docs/templates/reference/api-keys.mdx
@@ -19,8 +19,7 @@ API keys authenticate Calibrate in the [GitHub Action](/reference/github-actions
     Click **Create key** in the top right of the API keys section.
   </Step>
   <Step title="Name your key">
-    Enter a **Name** for the key — for example, `Form bharo` or `GitHub Action
-    CI`.
+    Enter a **Name** for the key (for example, `GitHub Action CI`).
   </Step>
   <Step title="Save your key">
     Click **Create key**. Your API key will be displayed once.
@@ -29,6 +28,7 @@ API keys authenticate Calibrate in the [GitHub Action](/reference/github-actions
       Copy the key immediately. You will not be able to view the full key again
       after closing the dialog.
     </Warning>
+
   </Step>
 </Steps>
 
@@ -41,7 +41,7 @@ curl __PUBLIC_API_BASE_URL__/agents \
   -H "X-API-Key: your_api_key"
 ```
 
-For CI, store the key as a GitHub secret named `CALIBRATE_API_KEY` and pass it to the [Calibrate GitHub Action](/reference/github-actions).
+For using it with the [Calibrate GitHub Action](/reference/github-actions), store the key as a GitHub secret named `CALIBRATE_API_KEY`.
 
 ## Managing keys
 
@@ -50,10 +50,10 @@ The API keys table lists every key with three columns:
 | Column        | Description                                          |
 | ------------- | ---------------------------------------------------- |
 | **Name**      | The label you gave the key when creating it          |
-| **Value**     | The masked key prefix (for example, `sk_....NsYs`)   |
+| **Value**     | The masked key prefix                                |
 | **Last used** | When the key was last used to authenticate a request |
 
-To permanently disable a key, click **Revoke** on its row. Any integration using that key will immediately lose access.
+To permanently disable a key, click **Revoke**. Any integration using that key will immediately lose access.
 
 ## Best practices
 

--- a/docs/templates/reference/api-keys.mdx
+++ b/docs/templates/reference/api-keys.mdx
@@ -1,0 +1,82 @@
+---
+title: "API keys"
+description: "Create and manage API keys to authenticate with the Calibrate API"
+---
+
+{/* Generated from docs/templates/reference/api-keys.mdx — do not edit directly. */}
+
+API keys authenticate Calibrate in the [GitHub Action](/reference/github-actions) or the [REST API](/api-reference/introduction). You can create multiple keys per workspace.
+
+## Creating an API key
+
+<Steps>
+  <Step title="Open Workspace settings">
+    Go to [Workspace settings → API
+    keys](https://calibrate.artpark.ai/workspace-settings?tab=api-keys) and
+    select the **API keys** tab.
+  </Step>
+  <Step title="Click Create key">
+    Click **Create key** in the top right of the API keys section.
+  </Step>
+  <Step title="Name your key">
+    Enter a **Name** for the key — for example, `Form bharo` or `GitHub Action
+    CI`.
+  </Step>
+  <Step title="Copy your key">
+    Copy the full key immediately when it is shown. After you close the dialog,
+    only a masked value (for example, `sk_....NsYs`) appears in the table and
+    the full key cannot be viewed again.
+  </Step>
+</Steps>
+
+## Managing keys
+
+The API keys table lists every key with three columns:
+
+| Column        | Description                                          |
+| ------------- | ---------------------------------------------------- |
+| **Name**      | The label you gave the key when creating it          |
+| **Value**     | The masked key prefix (for example, `sk_....NsYs`)   |
+| **Last used** | When the key was last used to authenticate a request |
+
+To permanently disable a key, click **Revoke** on its row. Any integration using that key will immediately lose access.
+
+## Using your API key
+
+Include the key in the `X-API-Key` header with every request:
+
+```bash
+curl __PUBLIC_API_BASE_URL__/agents \
+  -H "X-API-Key: your_api_key"
+```
+
+For CI, store the key as a GitHub secret named `CALIBRATE_API_KEY` and pass it to the [Calibrate GitHub Action](/reference/github-actions).
+
+## Best practices
+
+### Use descriptive names
+
+Name keys after their purpose (for example, `GitHub Action CI` or `Staging automation`) so you can identify them in the table later.
+
+### Rotate keys regularly
+
+Create a new key, update your integrations, then **Revoke** the old one — especially for production CI pipelines.
+
+### Revoke unused keys
+
+Promptly revoke keys that are no longer in use.
+
+### Store keys as secrets
+
+Never commit API keys to version control. Use GitHub secrets, environment variables, or your team's secret manager.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="API reference" icon="book" href="/api-reference/introduction">
+    Explore the full API documentation
+  </Card>
+  <Card title="GitHub Action" icon="github" href="/reference/github-actions">
+    Use API keys in your CI/CD pipeline
+  </Card>
+</CardGroup>

--- a/docs/templates/reference/github-actions.mdx
+++ b/docs/templates/reference/github-actions.mdx
@@ -1,0 +1,381 @@
+---
+title: "GitHub Action"
+description: "Launch Calibrate agent test runs from GitHub Actions"
+---
+
+{/* Generated from docs/templates/reference/github-actions.mdx — do not edit directly. */}
+
+The [Calibrate GitHub Action](https://github.com/ARTPARK-SAHAI-ORG/calibrate-github-action) runs your agent tests automatically in CI.
+During deployment, you can choose what happens when a test fails:
+
+- **gate** (default) — Prevent merging the changes. This is the recommended mode for production CI pipelines to prevent deploying broken agents.
+- **report** — Report evaluation results without blocking merges. You may be aware of the mistakes but still want to merge the changes.
+
+On pull requests, the action posts a comment with the evaluation results.
+
+## Prerequisites
+
+<Steps>
+  <Step title="Get your API key">
+    Navigate to your [Calibrate dashboard](https://calibrate.artpark.ai/workspace-settings?tab=api-keys) and generate an API key. See the [API keys guide](/reference/api-keys) for detailed instructions.
+
+  </Step>
+  <Step title="Add GitHub Secret">
+    1. Go to your repository **Settings > Secrets and variables > Actions**
+    2. Click **New repository secret**
+    3. Name: `CALIBRATE_API_KEY`
+    4. Value: Your Calibrate API key
+  </Step>
+  <Step title="Link tests to your agents">
+    The agents in Calibrate you want to evaluate must have tests linked to them. By default, the action runs all the tests for every agent in your workspace. 
+    
+    Optionally, if you want to restrict evaluation to a few specific agents, you can set that too. Gather the agent names from the [Agents](https://calibrate.artpark.ai/agents) page (for example, `checkout-bot`, `support-agent`).
+
+  </Step>
+</Steps>
+
+## Quick start
+
+### Automatic PR checks
+
+Create `.github/workflows/calibrate.yml`:
+
+```yaml
+name: Calibrate automatic evaluation
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  evaluate-agent:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Calibrate Evaluation
+        uses: ARTPARK-SAHAI-ORG/calibrate-github-action@v1
+        with:
+          api-key: ${{ secrets.CALIBRATE_API_KEY }}
+          # Omit this field to run on all agents
+          agents: checkout-bot, support-agent
+```
+
+### Manual workflow dispatch
+
+Create `.github/workflows/manual-eval.yml`:
+
+```yaml
+name: Calibrate manual evaluation
+
+on:
+  workflow_dispatch:
+    inputs:
+      agents:
+        description: "Agent names (comma-separated)"
+        required: true
+        type: string
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Evaluation
+        uses: ARTPARK-SAHAI-ORG/calibrate-github-action@v1
+        with:
+          api-key: ${{ secrets.CALIBRATE_API_KEY }}
+          agents: ${{ inputs.agents }}
+```
+
+To trigger:
+
+1. Navigate to **Actions** tab
+2. Select **Manual Evaluation**
+3. Click **Run workflow**
+4. Enter your agent names and click **Run workflow**
+
+## Advanced configuration
+
+### Custom options
+
+```yaml
+- name: Advanced Evaluation
+  uses: ARTPARK-SAHAI-ORG/calibrate-github-action@v1
+  with:
+    api-key: ${{ secrets.CALIBRATE_API_KEY }}
+    agents: checkout-bot, support-agent
+    # Fail the job on any test failure (default)
+    mode: gate
+    # Seconds between status polls
+    poll-interval: 5
+    # Max seconds to wait for runs to finish
+    timeout: 1800
+```
+
+### Using outputs
+
+```yaml
+- name: Run Evaluation
+  id: calibrate
+  uses: ARTPARK-SAHAI-ORG/calibrate-github-action@v1
+  with:
+    api-key: ${{ secrets.CALIBRATE_API_KEY }}
+    agents: checkout-bot
+
+- name: Post Results
+  run: |
+    echo "Total:  ${{ steps.calibrate.outputs.total }}"
+    echo "Passed: ${{ steps.calibrate.outputs.passed }}"
+    echo "Failed: ${{ steps.calibrate.outputs.failed }}"
+```
+
+## Configuration reference
+
+### Inputs
+
+| Parameter       | Type    | Required | Default                            | Description                                                                                                                             |
+| --------------- | ------- | -------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `api-key`       | string  | Yes      | —                                  | Calibrate API key (`sk_…`). Store as a secret.                                                                                          |
+| `agents`        | string  | No       | All agents                         | Agent names, comma- or newline-separated. Runs all linked tests for each. Omit to run every agent in the account linked to the API key. |
+| `base-url`      | string  | No       | `__PUBLIC_API_BASE_URL__` | Backend API URL. Override only for self-hosted.                                                                                         |
+| `app-url`       | string  | No       | `https://calibrate.artpark.ai`     | Web UI base URL for view links in the report.                                                                                           |
+| `mode`          | string  | No       | `gate`                             | `gate` fails the job on any failure; `report` always succeeds.                                                                          |
+| `poll-interval` | integer | No       | `5`                                | Seconds between status polls.                                                                                                           |
+| `timeout`       | integer | No       | `1800`                             | Max seconds to wait for all runs to finish.                                                                                             |
+| `github-token`  | string  | No       | `${{ github.token }}`              | Token for PR comments. Requires `pull-requests: write`.                                                                                 |
+
+### Outputs
+
+| Output   | Type   | Description                                  |
+| -------- | ------ | -------------------------------------------- |
+| `total`  | string | Total test cases across all agents evaluated |
+| `passed` | string | Total test cases passed                      |
+| `failed` | string | Total test cases failed                      |
+
+### Environment variables
+
+| Variable            | Required | Description            |
+| ------------------- | -------- | ---------------------- |
+| `CALIBRATE_API_KEY` | Yes      | Your Calibrate API key |
+
+## API details
+
+The action talks to the Calibrate Public API with your API key. For each invocation it runs three steps.
+
+### Resolve agents
+
+When `agents` is set, it resolves the names to UUIDs:
+
+**Endpoint:** `POST __PUBLIC_API_BASE_URL__/agents/resolve`
+
+**Request:**
+
+```json
+{
+  "names": ["checkout-bot", "support-agent"]
+}
+```
+
+**Response:**
+
+```json
+{
+  "resolved": {
+    "checkout-bot": "8f3c...",
+    "support-agent": "a91d..."
+  },
+  "not_found": []
+}
+```
+
+When `agents` is omitted, it lists every agent in the account instead:
+
+**Endpoint:** `GET __PUBLIC_API_BASE_URL__/agents`
+
+**Response:**
+
+```json
+[{ "uuid": "8f3c...", "name": "checkout-bot" }]
+```
+
+### Launch run
+
+For each agent, it triggers all linked tests. The agent is selected by UUID in the URL path and the body is empty:
+
+**Endpoint:** `POST __PUBLIC_API_BASE_URL__/agent-tests/agent/{agent_uuid}/run`
+
+**Request:**
+
+```json
+{}
+```
+
+**Response:**
+
+```json
+{
+  "task_id": "abc123"
+}
+```
+
+### Monitor run
+
+It polls each task until it finishes:
+
+**Endpoint:** `GET __PUBLIC_API_BASE_URL__/agent-tests/run/{task_id}`
+
+**Response:**
+
+```json
+{
+  "status": "done",
+  "total_tests": 10,
+  "passed": 9,
+  "failed": 1
+}
+```
+
+### Run statuses
+
+| Status        | Description            |
+| ------------- | ---------------------- |
+| `queued`      | Waiting to start       |
+| `in_progress` | Running test cases     |
+| `done`        | Successfully completed |
+| `failed`      | Run failed             |
+| `cancelled`   | Run was cancelled      |
+
+## Examples
+
+### Environment-based testing
+
+```yaml
+name: Multi-Environment Testing
+
+on:
+  push:
+    branches: [main, staging, dev]
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Environment
+        id: env
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "agents=checkout-bot" >> $GITHUB_OUTPUT
+            echo "env=production" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref }}" == "refs/heads/staging" ]]; then
+            echo "agents=staging-bot" >> $GITHUB_OUTPUT
+            echo "env=staging" >> $GITHUB_OUTPUT
+          else
+            echo "agents=dev-bot" >> $GITHUB_OUTPUT
+            echo "env=development" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Evaluate
+        uses: ARTPARK-SAHAI-ORG/calibrate-github-action@v1
+        with:
+          api-key: ${{ secrets.CALIBRATE_API_KEY }}
+          agents: ${{ steps.env.outputs.agents }}
+```
+
+### Parallel agent testing
+
+```yaml
+name: Multi-Agent Testing
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        agent:
+          - { name: "checkout-bot" }
+          - { name: "support-agent" }
+          - { name: "returns-bot" }
+    steps:
+      - name: Test ${{ matrix.agent.name }}
+        uses: ARTPARK-SAHAI-ORG/calibrate-github-action@v1
+        with:
+          api-key: ${{ secrets.CALIBRATE_API_KEY }}
+          agents: ${{ matrix.agent.name }}
+```
+
+### Scheduled regression testing
+
+```yaml
+name: Nightly Regression
+
+on:
+  schedule:
+    - cron: "0 2 * * *" # 2 AM daily
+
+jobs:
+  regression:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Tests
+        uses: ARTPARK-SAHAI-ORG/calibrate-github-action@v1
+        with:
+          api-key: ${{ secrets.CALIBRATE_API_KEY }}
+          timeout: 1800
+```
+
+## Troubleshooting
+
+### Invalid API key
+
+```
+authentication failed (HTTP 401) — check the api-key input
+```
+
+**Solution:** Verify `CALIBRATE_API_KEY` is set correctly in GitHub Secrets.
+
+### Invalid agent name
+
+```
+agent "my-agent": no agent with that name in this org
+```
+
+**Solution:** Confirm the agent name matches exactly and exists in your workspace.
+
+### Agent cannot run
+
+```
+agent my-agent: cannot run (HTTP 400): connection not verified
+```
+
+**Solution:** Open the agent in Calibrate, verify its connection, and ensure at least one test is linked.
+
+### Timeout
+
+**Solution:** Increase `timeout` for larger test suites or check the Calibrate dashboard for run status.
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card
+    title="API keys"
+    icon="key"
+    href="https://calibrate.artpark.ai/workspace-settings?tab=api-keys"
+  >
+    Create and manage your API keys
+  </Card>
+  <Card title="API reference" icon="book" href="/api-reference/introduction">
+    Full REST API documentation
+  </Card>
+  <Card
+    title="GitHub Action repository"
+    icon="github"
+    href="https://github.com/ARTPARK-SAHAI-ORG/calibrate-github-action"
+  >
+    Source, releases, and issue tracker
+  </Card>
+</CardGroup>

--- a/scripts/fetch_public_openapi.py
+++ b/scripts/fetch_public_openapi.py
@@ -4,32 +4,65 @@
 Downloads from the live backend, then patches the spec so Mintlify's API
 playground and auth UI advertise X-API-Key (the public API's real auth path)
 and include a production server URL.
+
+Requires ``PUBLIC_API_BASE_URL`` (see ``.env.example``). Loads ``.env`` from
+the repo root when present.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import sys
 import urllib.request
 from pathlib import Path
 from typing import Any
 
-DEFAULT_URL = "https://pense-backend.artpark.ai/public-api/openapi.json"
-DEFAULT_OUT = Path(__file__).resolve().parents[1] / "docs" / "api-reference" / "openapi.json"
-PRODUCTION_SERVER = "https://pense-backend.artpark.ai"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUT = REPO_ROOT / "docs" / "api-reference" / "openapi.json"
 API_KEY_SCHEME = "ApiKeyAuth"
 
+INTRO_TEMPLATE = REPO_ROOT / "docs/templates/api-reference/introduction.mdx"
+INTRO_OUTPUT = REPO_ROOT / "docs/api-reference/introduction.mdx"
 
-def _normalize_for_docs(spec: dict[str, Any]) -> dict[str, Any]:
+
+def _load_dotenv() -> None:
+    env_file = REPO_ROOT / ".env"
+    if not env_file.is_file():
+        return
+    for line in env_file.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, sep, value = line.partition("=")
+        if not sep:
+            continue
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+def public_api_base_url() -> str:
+    _load_dotenv()
+    url = os.getenv("PUBLIC_API_BASE_URL", "").strip().rstrip("/")
+    if not url:
+        raise SystemExit(
+            "PUBLIC_API_BASE_URL is required (set in .env or the environment). "
+            "See .env.example."
+        )
+    return url
+
+
+def public_openapi_spec_url(base_url: str | None = None) -> str:
+    return f"{base_url or public_api_base_url()}/public-api/openapi.json"
+
+
+def _normalize_for_docs(spec: dict[str, Any], base_url: str) -> dict[str, Any]:
     """Ensure servers + API-key auth match what Mintlify expects."""
     spec = json.loads(json.dumps(spec))  # deep copy
 
-    spec["servers"] = [
-        {
-            "url": PRODUCTION_SERVER,
-            "description": "Production",
-        }
-    ]
+    spec["servers"] = [{"url": base_url, "description": "Production"}]
 
     components = spec.setdefault("components", {})
     components["securitySchemes"] = {
@@ -51,8 +84,6 @@ def _normalize_for_docs(spec: dict[str, Any]) -> dict[str, Any]:
             if not isinstance(op, dict):
                 continue
             op["security"] = [{API_KEY_SCHEME: []}]
-            # Drop FastAPI's optional X-API-Key header param — it's the auth
-            # scheme, not a separate optional field.
             params = op.get("parameters")
             if params:
                 op["parameters"] = [
@@ -76,21 +107,31 @@ def _normalize_for_docs(spec: dict[str, Any]) -> dict[str, Any]:
     return spec
 
 
-def fetch(url: str = DEFAULT_URL) -> dict[str, Any]:
+def render_intro_template(base_url: str) -> None:
+    spec_url = public_openapi_spec_url(base_url)
+    text = INTRO_TEMPLATE.read_text(encoding="utf-8")
+    text = text.replace("__PUBLIC_API_BASE_URL__", base_url)
+    text = text.replace("__PUBLIC_OPENAPI_SPEC_URL__", spec_url)
+    INTRO_OUTPUT.write_text(text, encoding="utf-8")
+
+
+def fetch(url: str) -> dict[str, Any]:
     with urllib.request.urlopen(url, timeout=30) as resp:
         return json.loads(resp.read().decode())
 
 
 def main(argv: list[str] | None = None) -> int:
     argv = argv if argv is not None else sys.argv[1:]
-    url = argv[0] if argv else DEFAULT_URL
+    base_url = public_api_base_url()
+    url = argv[0] if argv else public_openapi_spec_url(base_url)
     out = Path(argv[1]) if len(argv) > 1 else DEFAULT_OUT
 
-    spec = _normalize_for_docs(fetch(url))
+    spec = _normalize_for_docs(fetch(url), base_url)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
+    render_intro_template(base_url)
     print(f"Wrote {out} ({len(spec.get('paths', {}))} paths)")
-    return 0
+    print(f"Wrote {INTRO_OUTPUT}")
 
 
 if __name__ == "__main__":

--- a/scripts/fetch_public_openapi.py
+++ b/scripts/fetch_public_openapi.py
@@ -25,6 +25,20 @@ API_KEY_SCHEME = "ApiKeyAuth"
 INTRO_TEMPLATE = REPO_ROOT / "docs/templates/api-reference/introduction.mdx"
 INTRO_OUTPUT = REPO_ROOT / "docs/api-reference/introduction.mdx"
 
+# (template, output) pairs whose base-URL placeholders are single-sourced from
+# PUBLIC_API_BASE_URL. Keeps every docs page off a hardcoded backend host.
+TEMPLATED_PAGES = [
+    (INTRO_TEMPLATE, INTRO_OUTPUT),
+    (
+        REPO_ROOT / "docs/templates/reference/api-keys.mdx",
+        REPO_ROOT / "docs/reference/api-keys.mdx",
+    ),
+    (
+        REPO_ROOT / "docs/templates/reference/github-actions.mdx",
+        REPO_ROOT / "docs/reference/github-actions.mdx",
+    ),
+]
+
 
 def _load_dotenv() -> None:
     env_file = REPO_ROOT / ".env"
@@ -71,8 +85,9 @@ def _normalize_for_docs(spec: dict[str, Any], base_url: str) -> dict[str, Any]:
             "in": "header",
             "name": "X-API-Key",
             "description": (
-                "Org-scoped API key. Create one in Calibrate under "
-                "Settings → API keys. Prefix: `sk_…`."
+                "API key. Create one under Workspace settings → API keys "
+                "(https://calibrate.artpark.ai/workspace-settings?tab=api-keys). "
+                "Prefix: `sk_…`."
             ),
         }
     }
@@ -101,18 +116,20 @@ def _normalize_for_docs(spec: dict[str, Any], base_url: str) -> dict[str, Any]:
     info = spec.setdefault("info", {})
     info.setdefault(
         "description",
-        "Programmatic API for CI/automation, authenticated with an org-scoped API key.",
+        "Programmatic API for CI/automation, authenticated with an API key.",
     )
 
     return spec
 
 
-def render_intro_template(base_url: str) -> None:
+def render_templates(base_url: str) -> None:
     spec_url = public_openapi_spec_url(base_url)
-    text = INTRO_TEMPLATE.read_text(encoding="utf-8")
-    text = text.replace("__PUBLIC_API_BASE_URL__", base_url)
-    text = text.replace("__PUBLIC_OPENAPI_SPEC_URL__", spec_url)
-    INTRO_OUTPUT.write_text(text, encoding="utf-8")
+    for template, output in TEMPLATED_PAGES:
+        text = template.read_text(encoding="utf-8")
+        text = text.replace("__PUBLIC_API_BASE_URL__", base_url)
+        text = text.replace("__PUBLIC_OPENAPI_SPEC_URL__", spec_url)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(text, encoding="utf-8")
 
 
 def fetch(url: str) -> dict[str, Any]:
@@ -129,9 +146,10 @@ def main(argv: list[str] | None = None) -> int:
     spec = _normalize_for_docs(fetch(url), base_url)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
-    render_intro_template(base_url)
+    render_templates(base_url)
     print(f"Wrote {out} ({len(spec.get('paths', {}))} paths)")
-    print(f"Wrote {INTRO_OUTPUT}")
+    for _, output in TEMPLATED_PAGES:
+        print(f"Wrote {output}")
 
 
 if __name__ == "__main__":

--- a/scripts/fetch_public_openapi.py
+++ b/scripts/fetch_public_openapi.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Fetch Calibrate's public OpenAPI spec and normalize it for Mintlify docs.
+
+Downloads from the live backend, then patches the spec so Mintlify's API
+playground and auth UI advertise X-API-Key (the public API's real auth path)
+and include a production server URL.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+DEFAULT_URL = "https://pense-backend.artpark.ai/public-api/openapi.json"
+DEFAULT_OUT = Path(__file__).resolve().parents[1] / "docs" / "api-reference" / "openapi.json"
+PRODUCTION_SERVER = "https://pense-backend.artpark.ai"
+API_KEY_SCHEME = "ApiKeyAuth"
+
+
+def _normalize_for_docs(spec: dict[str, Any]) -> dict[str, Any]:
+    """Ensure servers + API-key auth match what Mintlify expects."""
+    spec = json.loads(json.dumps(spec))  # deep copy
+
+    spec["servers"] = [
+        {
+            "url": PRODUCTION_SERVER,
+            "description": "Production",
+        }
+    ]
+
+    components = spec.setdefault("components", {})
+    components["securitySchemes"] = {
+        API_KEY_SCHEME: {
+            "type": "apiKey",
+            "in": "header",
+            "name": "X-API-Key",
+            "description": (
+                "Org-scoped API key. Create one in Calibrate under "
+                "Settings → API keys. Prefix: `sk_…`."
+            ),
+        }
+    }
+
+    for ops in spec.get("paths", {}).values():
+        if not isinstance(ops, dict):
+            continue
+        for op in ops.values():
+            if not isinstance(op, dict):
+                continue
+            op["security"] = [{API_KEY_SCHEME: []}]
+            # Drop FastAPI's optional X-API-Key header param — it's the auth
+            # scheme, not a separate optional field.
+            params = op.get("parameters")
+            if params:
+                op["parameters"] = [
+                    p
+                    for p in params
+                    if not (
+                        isinstance(p, dict)
+                        and p.get("in") == "header"
+                        and p.get("name") in ("X-API-Key", "X-Org-UUID")
+                    )
+                ]
+                if not op["parameters"]:
+                    op.pop("parameters", None)
+
+    info = spec.setdefault("info", {})
+    info.setdefault(
+        "description",
+        "Programmatic API for CI/automation, authenticated with an org-scoped API key.",
+    )
+
+    return spec
+
+
+def fetch(url: str = DEFAULT_URL) -> dict[str, Any]:
+    with urllib.request.urlopen(url, timeout=30) as resp:
+        return json.loads(resp.read().decode())
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    url = argv[0] if argv else DEFAULT_URL
+    out = Path(argv[1]) if len(argv) > 1 else DEFAULT_OUT
+
+    spec = _normalize_for_docs(fetch(url))
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {out} ({len(spec.get('paths', {}))} paths)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_fetch_public_openapi.py
+++ b/tests/test_fetch_public_openapi.py
@@ -11,7 +11,19 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
-from fetch_public_openapi import _normalize_for_docs  # noqa: E402
+from fetch_public_openapi import (  # noqa: E402
+    _normalize_for_docs,
+    public_api_base_url,
+    public_openapi_spec_url,
+    render_intro_template,
+)
+
+TEST_BASE_URL = "https://api.example.test"
+
+
+@pytest.fixture(autouse=True)
+def api_base_url_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PUBLIC_API_BASE_URL", TEST_BASE_URL)
 
 
 @pytest.fixture
@@ -39,11 +51,20 @@ def minimal_spec() -> dict:
     }
 
 
+def test_public_api_base_url_from_env() -> None:
+    assert public_api_base_url() == TEST_BASE_URL
+    assert public_openapi_spec_url() == f"{TEST_BASE_URL}/public-api/openapi.json"
+
+
+def test_public_api_base_url_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PUBLIC_API_BASE_URL", raising=False)
+    with pytest.raises(SystemExit):
+        public_api_base_url()
+
+
 def test_normalize_adds_servers_and_api_key_auth(minimal_spec: dict) -> None:
-    out = _normalize_for_docs(minimal_spec)
-    assert out["servers"] == [
-        {"url": "https://pense-backend.artpark.ai", "description": "Production"}
-    ]
+    out = _normalize_for_docs(minimal_spec, TEST_BASE_URL)
+    assert out["servers"] == [{"url": TEST_BASE_URL, "description": "Production"}]
     assert set(out["components"]["securitySchemes"]) == {"ApiKeyAuth"}
     assert out["paths"]["/agents"]["get"]["security"] == [{"ApiKeyAuth": []}]
     assert "parameters" not in out["paths"]["/agents"]["get"]
@@ -51,5 +72,21 @@ def test_normalize_adds_servers_and_api_key_auth(minimal_spec: dict) -> None:
 
 def test_normalize_does_not_mutate_input(minimal_spec: dict) -> None:
     before = json.dumps(minimal_spec)
-    _normalize_for_docs(minimal_spec)
+    _normalize_for_docs(minimal_spec, TEST_BASE_URL)
     assert json.dumps(minimal_spec) == before
+
+
+def test_render_intro_template_substitutes_base_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    template = tmp_path / "intro.mdx"
+    template.write_text("curl __PUBLIC_API_BASE_URL__/agents\nspec __PUBLIC_OPENAPI_SPEC_URL__\n")
+    output = tmp_path / "out.mdx"
+
+    import fetch_public_openapi as mod
+
+    monkeypatch.setattr(mod, "INTRO_TEMPLATE", template)
+    monkeypatch.setattr(mod, "INTRO_OUTPUT", output)
+    render_intro_template(TEST_BASE_URL)
+
+    text = output.read_text()
+    assert TEST_BASE_URL in text
+    assert f"{TEST_BASE_URL}/public-api/openapi.json" in text

--- a/tests/test_fetch_public_openapi.py
+++ b/tests/test_fetch_public_openapi.py
@@ -15,7 +15,7 @@ from fetch_public_openapi import (  # noqa: E402
     _normalize_for_docs,
     public_api_base_url,
     public_openapi_spec_url,
-    render_intro_template,
+    render_templates,
 )
 
 TEST_BASE_URL = "https://api.example.test"
@@ -57,7 +57,10 @@ def test_public_api_base_url_from_env() -> None:
 
 
 def test_public_api_base_url_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    import fetch_public_openapi as mod
+
     monkeypatch.delenv("PUBLIC_API_BASE_URL", raising=False)
+    monkeypatch.setattr(mod, "_load_dotenv", lambda: None)
     with pytest.raises(SystemExit):
         public_api_base_url()
 
@@ -76,17 +79,26 @@ def test_normalize_does_not_mutate_input(minimal_spec: dict) -> None:
     assert json.dumps(minimal_spec) == before
 
 
-def test_render_intro_template_substitutes_base_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    template = tmp_path / "intro.mdx"
-    template.write_text("curl __PUBLIC_API_BASE_URL__/agents\nspec __PUBLIC_OPENAPI_SPEC_URL__\n")
-    output = tmp_path / "out.mdx"
+def test_render_templates_substitutes_base_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    template_a = tmp_path / "intro.mdx"
+    template_a.write_text("curl __PUBLIC_API_BASE_URL__/agents\nspec __PUBLIC_OPENAPI_SPEC_URL__\n")
+    output_a = tmp_path / "out" / "intro.mdx"
+
+    template_b = tmp_path / "keys.mdx"
+    template_b.write_text("base __PUBLIC_API_BASE_URL__\n")
+    output_b = tmp_path / "out" / "keys.mdx"
 
     import fetch_public_openapi as mod
 
-    monkeypatch.setattr(mod, "INTRO_TEMPLATE", template)
-    monkeypatch.setattr(mod, "INTRO_OUTPUT", output)
-    render_intro_template(TEST_BASE_URL)
+    monkeypatch.setattr(
+        mod,
+        "TEMPLATED_PAGES",
+        [(template_a, output_a), (template_b, output_b)],
+    )
+    render_templates(TEST_BASE_URL)
 
-    text = output.read_text()
-    assert TEST_BASE_URL in text
-    assert f"{TEST_BASE_URL}/public-api/openapi.json" in text
+    text_a = output_a.read_text()
+    assert TEST_BASE_URL in text_a
+    assert f"{TEST_BASE_URL}/public-api/openapi.json" in text_a
+
+    assert output_b.read_text() == f"base {TEST_BASE_URL}\n"

--- a/tests/test_fetch_public_openapi.py
+++ b/tests/test_fetch_public_openapi.py
@@ -1,0 +1,55 @@
+"""Tests for scripts/fetch_public_openapi.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from fetch_public_openapi import _normalize_for_docs  # noqa: E402
+
+
+@pytest.fixture
+def minimal_spec() -> dict:
+    return {
+        "openapi": "3.1.0",
+        "info": {"title": "Test", "version": "0.0.1"},
+        "paths": {
+            "/agents": {
+                "get": {
+                    "tags": ["agents"],
+                    "security": [{"HTTPBearer": []}],
+                    "parameters": [
+                        {"in": "header", "name": "X-API-Key", "schema": {"type": "string"}}
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            },
+        },
+        "components": {
+            "securitySchemes": {
+                "HTTPBearer": {"type": "http", "scheme": "bearer"},
+            }
+        },
+    }
+
+
+def test_normalize_adds_servers_and_api_key_auth(minimal_spec: dict) -> None:
+    out = _normalize_for_docs(minimal_spec)
+    assert out["servers"] == [
+        {"url": "https://pense-backend.artpark.ai", "description": "Production"}
+    ]
+    assert set(out["components"]["securitySchemes"]) == {"ApiKeyAuth"}
+    assert out["paths"]["/agents"]["get"]["security"] == [{"ApiKeyAuth": []}]
+    assert "parameters" not in out["paths"]["/agents"]["get"]
+
+
+def test_normalize_does_not_mutate_input(minimal_spec: dict) -> None:
+    before = json.dumps(minimal_spec)
+    _normalize_for_docs(minimal_spec)
+    assert json.dumps(minimal_spec) == before


### PR DESCRIPTION
## Summary

- Syncs the public OpenAPI spec from `pense-backend` into `docs/api-reference/openapi.json` via CI (`sync-api-spec.yml`, weekly + manual).
- Adds an **API Reference** Mintlify tab with interactive playground, `ApiKeyAuth` normalization, and a getting-started intro (curl only).
- Removes placeholder Mintlify starter endpoint pages.

SDK docs (overview page + per-endpoint Python snippets) are in a follow-up PR: #111.

## Test plan

- [x] `uv run pytest tests/test_fetch_public_openapi.py -q`
- [ ] `cd docs && mint dev` — verify API Reference tab and playground auth