### PR TITLE
Fix agent turn handling in external voice simulations

### DIFF
--- a/calibrate/agent/run_simulation.py
+++ b/calibrate/agent/run_simulation.py
@@ -124,11 +124,9 @@ from pipecat.frames.frames import (
     EndFrame,
     BotSpeakingFrame,
     UserSpeakingFrame,
-    EndTaskFrame,
     LLMContextFrame,
     StopFrame,
     CancelFrame,
-    EndFrame,
     InterimTranscriptionFrame,
     LLMRunFrame,
     TTSTextFrame,
@@ -754,9 +752,6 @@ class RTVIMessageFrameAdapter(FrameProcessor):
 
                 if msg_type == "bot-started-speaking":
                     self._audio_buffer._reset_all_audio_buffers()
-                    agent_turns_so_far = count_agent_message_turns(
-                        self._context.get_messages()
-                    )
                     if self._is_external and self._is_bot_interrupt_triggered:
                         # External interrupt in progress: the sim user has the floor.
                         # Ignore the agent's attempt to speak — keep its output blocked
@@ -766,13 +761,11 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                         log_and_print(
                             f"{PARTIAL_AGENT_MESSAGE_COLOR_IGNORED}Agent tried to speak during user interrupt — blocked{RESET_COLOR}"
                         )
-                    elif agent_turns_so_far >= self._max_turns:
-                        log_and_print(
-                            f"{INTERRUPTION_COLOR}Max turns ({self._max_turns}) reached, ending conversation{RESET_COLOR}"
-                        )
-                        self._ended_due_to_max_turns = True
-                        await self.push_frame(EndTaskFrame(), FrameDirection.UPSTREAM)
                     else:
+                        # max_turns is enforced when the agent's turn *commits*
+                        # (on_user_turn_stopped) so the conversation always ends on
+                        # the agent's turn with its final message captured — see
+                        # _run_simulation_inner.
                         self._awaiting_first_bot_audio_chunk = True
                         self._pending_user_turn = True
                         # A new bot utterance starts with a clean interrupt slate.
@@ -1651,6 +1644,21 @@ async def _run_simulation_inner(
         log_and_print(
             f"{AGENT_MESSAGE_COLOR}[Agent]{RESET_COLOR}: {message.content}{RESET_COLOR}"
         )
+
+        # Enforce max_turns here, when the agent's turn has committed, rather than
+        # when its next turn starts. Ending on the next bot-started dropped that
+        # message and left the transcript ending on a user turn or an assistant
+        # turn depending on whether the sim user happened to reply first. Ending on
+        # commit is deterministic: the conversation always ends right after the
+        # agent's max_turns-th turn, with its final message captured.
+        if not rtvi_message_adapter._ended_due_to_max_turns:
+            agent_turns = count_agent_message_turns(context.get_messages())
+            if agent_turns >= max_turns:
+                rtvi_message_adapter._ended_due_to_max_turns = True
+                log_and_print(
+                    f"{INTERRUPTION_COLOR}Max turns ({max_turns}) reached, ending conversation{RESET_COLOR}"
+                )
+                await task.queue_frame(EndFrame())
 
     @context_aggregator.assistant().event_handler("on_assistant_turn_stopped")
     async def on_assistant_turn_stopped(aggregator, message):

--- a/calibrate/agent/run_simulation.py
+++ b/calibrate/agent/run_simulation.py
@@ -62,16 +62,11 @@ DEFAULT_MAX_TURNS = 10
 DEFAULT_PORT = 8765
 DEFAULT_AGENT_SPEAKS_FIRST = True
 
-# A remote agent often speaks one conversational turn as several back-to-back TTS
-# utterances (each its own bot-started/stopped cycle), e.g. a greeting immediately
-# followed by the first question. Those should form ONE simulated-user turn so the
-# sim user replies after the agent yields the floor, not after the first utterance.
-# We therefore debounce the end-of-turn signal: the turn only ends once the agent
-# has been silent for this long. Measured inter-utterance gaps for the tested
-# agents run ~1.0-1.3s, while the agent waits several seconds for the user between
-# turns — so 2.0s cleanly separates "pausing between sentences" from "yielded the
-# floor" without making the simulated user feel unresponsive.
-AGENT_TURN_YIELD_DEBOUNCE_SECS = 2.0
+# Fallback for when the smart-turn analyzer can't decide the agent has yielded the
+# floor. Smart-turn v3 is trained on human prosody and often reads synthesized TTS
+# audio as "not turn-final", stalling until this fires; 2.0s keeps recovery quick
+# (vs pipecat's 5s default) without cutting off a genuinely mid-turn agent.
+SIM_USER_TURN_STOP_TIMEOUT_SECS = 2.0
 
 # Pipecat logs Google STT gRPC 409 (idle stream) at ERROR while reconnecting; that is
 # recoverable and must not trigger our error sink (which cancels the eval pipeline).
@@ -133,7 +128,6 @@ from pipecat.frames.frames import (
     TranscriptionFrame,
     BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
-    UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
     InputAudioRawFrame,
     OutputAudioRawFrame,
@@ -158,7 +152,8 @@ from pipecat.processors.aggregators.llm_response_universal import (
     LLMContextAggregatorPair,
     LLMUserAggregatorParams,
 )
-from pipecat.turns.user_turn_strategies import ExternalUserTurnStrategies
+from pipecat.turns.user_turn_strategies import UserTurnStrategies
+from pipecat.turns.user_stop import TurnAnalyzerUserTurnStopStrategy
 from pipecat.observers.loggers.llm_log_observer import LLMLogObserver
 from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
@@ -209,22 +204,40 @@ def resolve_serializer(name: str) -> FrameSerializer:
 
 
 def build_user_context_aggregator(context: LLMContext) -> LLMContextAggregatorPair:
-    """Build the simulation context aggregator pair with external turn control.
+    """Build the simulation context aggregator pair.
 
-    The simulator drives user-turn boundaries explicitly: ``RTVIMessageFrameAdapter``
-    emits ``UserStartedSpeakingFrame`` / ``UserStoppedSpeakingFrame`` around each
-    agent utterance (the agent under test is the "user" of this pipeline). Pipecat's
-    default turn strategies (VAD + smart-turn analyzer) ignore those frames and
-    instead segment turns from audio, which mis-segments the agent's speech and
-    drops the first utterance of a multi-utterance turn (e.g. a greeting spoken just
-    before the first question never lands in the transcript). ``ExternalUserTurnStrategies``
-    makes the aggregator honor the explicit UserStarted/UserStopped frames so every
-    agent utterance is committed as its own turn.
+    In this pipeline the agent under test is the "user": the agent's audio and its
+    RTVI ``bot-output`` transcriptions are the user input, and turn-taking is driven
+    by the agent's audio (mirroring the internal ``bot.py`` config):
+
+    - Start: the default audio-driven start strategies (VAD on the agent's audio +
+      transcription). We deliberately do NOT use a manual
+      ``ExternalUserTurnStartStrategy`` — a manually emitted ``UserStartedSpeakingFrame``
+      gets swallowed when a follow-on utterance arrives while the turn is still open,
+      leaving the next turn without a smart-turn re-arm so it stalls to the timeout.
+      Keeping start audio-driven keeps it consistent with the audio-driven stop.
+    - Stop: ``TurnAnalyzerUserTurnStopStrategy`` (smart-turn v3) decides when the
+      agent has actually *yielded the floor* from the audio prosody. A greeting spoken
+      with turn-final intonation ends its own turn (a real user would respond), while
+      a run-on acknowledgement ("okay, and...") is coalesced with what follows — no
+      fixed debounce. ``SIM_USER_TURN_STOP_TIMEOUT_SECS`` bounds the wait for the
+      cases where smart-turn stalls on synthesized TTS audio.
+
+    The ``vad_analyzer`` feeds the smart-turn model the speech/silence boundaries it
+    needs (same as ``bot.py``).
     """
     return LLMContextAggregatorPair(
         context,
         user_params=LLMUserAggregatorParams(
-            user_turn_strategies=ExternalUserTurnStrategies()
+            vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
+            user_turn_stop_timeout=SIM_USER_TURN_STOP_TIMEOUT_SECS,
+            user_turn_strategies=UserTurnStrategies(
+                stop=[
+                    TurnAnalyzerUserTurnStopStrategy(
+                        turn_analyzer=LocalSmartTurnAnalyzerV3()
+                    ),
+                ],
+            ),
         ),
     )
 
@@ -412,21 +425,6 @@ class RTVIMessageFrameAdapter(FrameProcessor):
         # Avoids allocating an index for sim-user turns that get interrupted before
         # any audio actually flows.
         self._sim_user_turn_pending = False
-        # Whether the agent currently holds the conversational floor. Set True when
-        # the agent starts an utterance and reset to False when the simulated user
-        # begins its own LLM turn (SimulatedUserTurnIndexHook). Gates the
-        # InterruptionTaskFrame in ``bot-started-speaking`` so that consecutive
-        # agent utterances (e.g. a greeting immediately followed by the first
-        # question) don't interrupt — and drop — one another.
-        self._agent_has_floor = False
-        # Whether a simulated-user turn is currently open on the agent's behalf
-        # (UserStartedSpeakingFrame emitted, matching UserStoppedSpeakingFrame not
-        # yet emitted). Consecutive agent utterances reuse the same open turn so
-        # they coalesce into one sim-user turn; see _schedule_agent_turn_stop.
-        self._agent_turn_active = False
-        # Debounce task that emits the coalesced UserStoppedSpeakingFrame once the
-        # agent has been silent for AGENT_TURN_YIELD_DEBOUNCE_SECS.
-        self._agent_turn_stop_task = None
         # Inbound bot audio frames that arrive after ``bot-started-speaking`` but
         # before the first ``spoken=True`` RTVI confirmation. TTS audio commonly
         # streams ~1s ahead of its ``spoken`` event, so the first sentence's
@@ -483,35 +481,6 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                 audio_save_path, frame.audio, frame.sample_rate, frame.num_channels
             )
         self._pending_bot_audio_frames = []
-
-    def _schedule_agent_turn_stop(self) -> None:
-        """Arm the debounce that ends the coalesced sim-user turn.
-
-        Called on every ``bot-stopped-speaking``. If the agent starts another
-        utterance before the debounce elapses, ``_cancel_agent_turn_stop`` (from
-        the next ``bot-started-speaking``) cancels this, so both utterances share
-        one sim-user turn. Otherwise the debounce fires and emits the single
-        ``UserStoppedSpeakingFrame`` that closes the turn and lets the sim user
-        respond to everything the agent said.
-        """
-        self._agent_turn_stop_task = self.create_task(
-            self._end_agent_turn_after_debounce()
-        )
-
-    async def _cancel_agent_turn_stop(self) -> None:
-        task = self._agent_turn_stop_task
-        self._agent_turn_stop_task = None
-        if task is not None:
-            await self.cancel_task(task)
-
-    async def _end_agent_turn_after_debounce(self) -> None:
-        try:
-            await asyncio.sleep(AGENT_TURN_YIELD_DEBOUNCE_SECS)
-        except asyncio.CancelledError:
-            return
-        self._agent_turn_stop_task = None
-        self._agent_turn_active = False
-        await self.push_frame(UserStoppedSpeakingFrame(), FrameDirection.DOWNSTREAM)
 
     def _assign_next_transcript_audio_line(self, role: str) -> int:
         """Next 1-based transcript line for ``{N}_bot`` / ``{N}_user`` chunk files.
@@ -724,9 +693,6 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                         self._ended_due_to_max_turns = True
                         await self.push_frame(EndTaskFrame(), FrameDirection.UPSTREAM)
                     else:
-                        # The agent is (still) speaking: hold off ending the
-                        # coalesced sim-user turn until it goes quiet.
-                        await self._cancel_agent_turn_stop()
                         self._awaiting_first_bot_audio_chunk = True
                         self._pending_user_turn = True
                         # A new bot utterance starts with a clean interrupt slate.
@@ -740,33 +706,16 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                         self._is_bot_interrupt_decided = False
                         self._is_bot_interrupt_triggered = False
                         self._spoken_text_buffer = ""
-                        # Cancel any pending sim-user line allocation: bot has
-                        # the floor and any in-flight sim-user TTS will be
-                        # killed by the InterruptionTaskFrame below (when sent).
                         self._sim_user_turn_pending = False
-                        # Only interrupt when the agent is actually taking the floor
-                        # back from the simulated user. The InterruptionTaskFrame
-                        # broadcasts a StartInterruptionFrame that cancels the user
-                        # context aggregator's process queue; if fired on every
-                        # utterance it discards the PREVIOUS agent utterance's
-                        # not-yet-committed transcription. That drops the first line
-                        # whenever an agent speaks a turn as multiple back-to-back
-                        # utterances (e.g. a greeting followed by its first question).
-                        # ``_agent_has_floor`` is reset to False when the sim user
-                        # begins its LLM turn, so the interrupt still fires the first
-                        # time the agent takes back the floor to stop the sim user's
-                        # in-flight TTS and flush its assistant aggregator.
-                        if not self._agent_has_floor:
-                            await self.push_frame(
-                                InterruptionTaskFrame(), FrameDirection.UPSTREAM
-                            )
-                        self._agent_has_floor = True
-                        # Open a sim-user turn only if one isn't already open. A
-                        # follow-on utterance in the same agent turn keeps the
-                        # existing turn so both utterances land in one sim-user turn.
-                        if not self._agent_turn_active:
-                            self._agent_turn_active = True
-                            generated_frames.append(UserStartedSpeakingFrame())
+                        # Natural full-duplex: any agent utterance interrupts the sim
+                        # user (cut its in-flight TTS, flush its aggregation). The sim
+                        # user only keeps a reply once the agent has actually stopped.
+                        # Turn START is left to the aggregator's audio/transcription
+                        # start strategies (not a manual UserStartedSpeakingFrame),
+                        # so start and the smart-turn stop stay audio-consistent.
+                        await self.push_frame(
+                            InterruptionTaskFrame(), FrameDirection.UPSTREAM
+                        )
                 elif msg_type == "bot-stopped-speaking" and self._pending_user_turn:
                     if self._awaiting_first_bot_audio_chunk:
                         # Tool-only turn: no ``spoken=True`` ever fired, so any
@@ -774,13 +723,10 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                         self._pending_bot_audio_frames = []
                     self._awaiting_first_bot_audio_chunk = False
                     self._pending_user_turn = False
-                    # Commit this utterance's transcription into the open sim-user
-                    # turn, but debounce the UserStoppedSpeakingFrame: if the agent
-                    # speaks another utterance shortly after, it joins this turn;
-                    # only once the agent stays quiet does the turn end (and the sim
-                    # user respond). Emitting UserStopped here instead would end the
-                    # turn per utterance, so the sim user's LLM fires on the greeting
-                    # before it has heard the question.
+                    # Emit this utterance's transcription (content). We do NOT emit
+                    # UserStoppedSpeakingFrame here: the smart-turn analyzer decides
+                    # when the agent has yielded the floor, coalescing consecutive
+                    # utterances into one sim-user turn.
                     generated_frames.append(
                         TranscriptionFrame(
                             # Strip the buffer's leading space: the aggregator adds
@@ -793,7 +739,6 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                         )
                     )
                     await self._reset_buffers()
-                    self._schedule_agent_turn_stop()
 
                 elif msg_type == "user-stopped-speaking":
                     # once the simulated user stops speaking, mark the bot as not
@@ -854,11 +799,10 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                                         FrameDirection.DOWNSTREAM,
                                     )
 
-                                    # The sim user cut in: this hard-ends the agent
-                                    # turn now, so drop any pending debounce and
-                                    # close the coalesced turn immediately.
-                                    await self._cancel_agent_turn_stop()
-                                    self._agent_turn_active = False
+                                    # The sim user cut in (only reachable when
+                                    # interruption_sensitivity > none): commit the
+                                    # agent's partial speech and signal it stopped. The
+                                    # turn itself ends on the next smart-turn/timeout.
                                     generated_frames.extend(
                                         [
                                             TranscriptionFrame(
@@ -1060,11 +1004,6 @@ class SimulatedUserTurnIndexHook(FrameProcessor):
             # Just signal intent — actual line allocation happens lazily in
             # SilencePadder when the first audio frame arrives.
             self._rtvi_adapter._sim_user_turn_pending = True
-            # The simulated user is taking a turn, so the next time the agent
-            # starts speaking it is genuinely taking the floor back and should
-            # interrupt. (Reset here rather than on audio so it's set before any
-            # sim-user TTS can race with the agent's next utterance.)
-            self._rtvi_adapter._agent_has_floor = False
 
         await self.push_frame(frame, direction)
 

--- a/calibrate/agent/run_simulation.py
+++ b/calibrate/agent/run_simulation.py
@@ -68,6 +68,13 @@ DEFAULT_AGENT_SPEAKS_FIRST = True
 # (vs pipecat's 5s default) without cutting off a genuinely mid-turn agent.
 SIM_USER_TURN_STOP_TIMEOUT_SECS = 2.0
 
+# Normal agent turns are ended by smart-turn. ExternalUserTurnStopStrategy is kept
+# in the stop list ONLY so an explicit interrupt (the sim user cutting in emits a
+# UserStoppedSpeakingFrame) hard-stops the turn immediately. Its built-in
+# transcription auto-timeout would otherwise fire on every turn and pre-empt
+# smart-turn, so we set it high enough to never fire in practice.
+_INTERRUPT_ONLY_STOP_TIMEOUT_SECS = 86400.0
+
 # Pipecat logs Google STT gRPC 409 (idle stream) at ERROR while reconnecting; that is
 # recoverable and must not trigger our error sink (which cancels the eval pipeline).
 _BENIGN_GOOGLE_STT_IDLE_TIMEOUT = (
@@ -154,6 +161,9 @@ from pipecat.processors.aggregators.llm_response_universal import (
 )
 from pipecat.turns.user_turn_strategies import UserTurnStrategies
 from pipecat.turns.user_stop import TurnAnalyzerUserTurnStopStrategy
+from pipecat.turns.user_stop.external_user_turn_stop_strategy import (
+    ExternalUserTurnStopStrategy,
+)
 from pipecat.observers.loggers.llm_log_observer import LLMLogObserver
 from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
@@ -225,6 +235,11 @@ def build_user_context_aggregator(context: LLMContext) -> LLMContextAggregatorPa
 
     The ``vad_analyzer`` feeds the smart-turn model the speech/silence boundaries it
     needs (same as ``bot.py``).
+
+    ``ExternalUserTurnStopStrategy`` is included with its auto-timeout effectively
+    disabled: it does nothing for normal turns but lets a simulated-user interrupt
+    (which emits an explicit ``UserStoppedSpeakingFrame``) hard-stop the agent's turn
+    immediately, for both internal (word-level) and external (block) interrupts.
     """
     return LLMContextAggregatorPair(
         context,
@@ -233,6 +248,9 @@ def build_user_context_aggregator(context: LLMContext) -> LLMContextAggregatorPa
             user_turn_stop_timeout=SIM_USER_TURN_STOP_TIMEOUT_SECS,
             user_turn_strategies=UserTurnStrategies(
                 stop=[
+                    ExternalUserTurnStopStrategy(
+                        timeout=_INTERRUPT_ONLY_STOP_TIMEOUT_SECS
+                    ),
                     TurnAnalyzerUserTurnStopStrategy(
                         turn_analyzer=LocalSmartTurnAnalyzerV3()
                     ),
@@ -375,11 +393,17 @@ class RTVIMessageFrameAdapter(FrameProcessor):
         agent_speaks_first: bool = True,
         max_turns: int = DEFAULT_MAX_TURNS,
         latency_tracker: Optional["EndToEndLatencyTracker"] = None,
+        is_external: bool = False,
     ):
         super().__init__(enable_direct_mode=True, name="RTVIMessageFrameAdapter")
         self._context = context
         self._audio_buffer = audio_buffer
         self._latency_tracker = latency_tracker
+        # Whether the agent under test is an external WS agent. External agents give
+        # no word-level control, so an interrupt cuts the agent off wholesale and
+        # blocks its output until the sim user finishes, rather than the internal
+        # path's stream-vs-spoken word matching.
+        self._is_external = is_external
         self._agent_speaks_first = agent_speaks_first
         self._max_turns = max_turns
         self._interrupt_probability = interrupt_probability
@@ -481,6 +505,46 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                 audio_save_path, frame.audio, frame.sample_rate, frame.num_channels
             )
         self._pending_bot_audio_frames = []
+
+    async def _commit_user_interrupt(
+        self, generated_frames: list, user_id: str, timestamp: str
+    ) -> None:
+        """Execute a simulated-user interrupt of the agent.
+
+        Tells the agent to stop (RTVI ``interrupt``), commits ``_text_buffer`` (what
+        the sim user heard up to the cut-in point) as the agent's partial turn, and
+        marks the interrupt triggered so further agent output stays blocked until the
+        sim user finishes (the block is cleared on ``user-stopped-speaking``). The
+        emitted ``UserStoppedSpeakingFrame`` hard-stops the turn via
+        ``ExternalUserTurnStopStrategy``, immediately handing the floor to the sim
+        user. Shared by the internal word-level path and the external block path.
+        """
+        self._is_bot_interrupt_triggered = True
+        self._pending_user_turn = False
+        self._awaiting_first_bot_audio_chunk = False
+        await self.push_frame(
+            OutputTransportMessageUrgentFrame(
+                message={
+                    "label": "rtvi-ai",
+                    "type": "client-message",
+                    "id": str(uuid4()),
+                    "data": {"t": "interrupt"},
+                }
+            ),
+            FrameDirection.DOWNSTREAM,
+        )
+        generated_frames.extend(
+            [
+                TranscriptionFrame(
+                    text=self._text_buffer.strip(),
+                    user_id=user_id,
+                    timestamp=timestamp,
+                    result={},
+                ),
+                UserStoppedSpeakingFrame(),
+            ]
+        )
+        await self._reset_buffers()
 
     def _assign_next_transcript_audio_line(self, role: str) -> int:
         """Next 1-based transcript line for ``{N}_bot`` / ``{N}_user`` chunk files.
@@ -646,6 +710,13 @@ class RTVIMessageFrameAdapter(FrameProcessor):
             # don't forward bot audio frames after the interruption has been triggered
             return
         elif isinstance(frame, InputAudioRawFrame):
+            if self._is_external and self._is_bot_interrupt_triggered:
+                # External interrupt in progress: block the agent's inbound audio so
+                # it never reaches the aggregator's VAD. Otherwise the agent's
+                # continued speech starts a phantom user turn and broadcasts an
+                # interruption that cancels the sim user's own reply mid-word. Drop
+                # it entirely (no latency mark, no save) until the block is lifted.
+                return
             # Inbound audio from the agent under test — the first such frame after
             # the simulated user stopped speaking marks the end-to-end response
             # latency (works identically for internal and external agents).
@@ -686,7 +757,16 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                     agent_turns_so_far = count_agent_message_turns(
                         self._context.get_messages()
                     )
-                    if agent_turns_so_far >= self._max_turns:
+                    if self._is_external and self._is_bot_interrupt_triggered:
+                        # External interrupt in progress: the sim user has the floor.
+                        # Ignore the agent's attempt to speak — keep its output blocked
+                        # and do NOT interrupt the sim user's TTS or reset the interrupt
+                        # slate. The block is lifted on ``user-stopped-speaking`` once
+                        # the sim user is done, and the agent may speak again.
+                        log_and_print(
+                            f"{PARTIAL_AGENT_MESSAGE_COLOR_IGNORED}Agent tried to speak during user interrupt — blocked{RESET_COLOR}"
+                        )
+                    elif agent_turns_so_far >= self._max_turns:
                         log_and_print(
                             f"{INTERRUPTION_COLOR}Max turns ({self._max_turns}) reached, ending conversation{RESET_COLOR}"
                         )
@@ -741,8 +821,9 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                     await self._reset_buffers()
 
                 elif msg_type == "user-stopped-speaking":
-                    # once the simulated user stops speaking, mark the bot as not
-                    # interrupted anymore and spoken text buffer as not complete anymore
+                    # The simulated user has finished. Clear the interrupt slate,
+                    # which also lifts an external-interrupt block so the agent may
+                    # speak again.
                     self._is_bot_interrupt_decided = False
                     self._is_bot_interrupt_triggered = False
                     await self._save_intermediate_state(
@@ -778,44 +859,13 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                                 # the bot by the user has been made
                                 self._spoken_text_buffer += " " + text
 
-                                # once the spoken text buffer matches the text buffer, mark the spoken
-                                # text buffer as complete and interrupt the bot by the simulated user
+                                # Internal (word-level) path: once the spoken text has
+                                # caught up to the point the user decided to cut in,
+                                # execute the interrupt.
                                 if self._spoken_text_buffer == self._text_buffer:
-                                    self._is_bot_interrupt_triggered = True
-                                    self._pending_user_turn = False
-                                    self._awaiting_first_bot_audio_chunk = False
-
-                                    await self.push_frame(
-                                        OutputTransportMessageUrgentFrame(
-                                            message={
-                                                "label": "rtvi-ai",
-                                                "type": "client-message",
-                                                "id": str(uuid4()),
-                                                "data": {
-                                                    "t": "interrupt",
-                                                },
-                                            }
-                                        ),
-                                        FrameDirection.DOWNSTREAM,
+                                    await self._commit_user_interrupt(
+                                        generated_frames, user_id, timestamp
                                     )
-
-                                    # The sim user cut in (only reachable when
-                                    # interruption_sensitivity > none): commit the
-                                    # agent's partial speech and signal it stopped. The
-                                    # turn itself ends on the next smart-turn/timeout.
-                                    generated_frames.extend(
-                                        [
-                                            TranscriptionFrame(
-                                                text=self._text_buffer.strip(),
-                                                user_id=user_id,
-                                                timestamp=timestamp,
-                                                result={},
-                                            ),
-                                            UserStoppedSpeakingFrame(),
-                                        ]
-                                    )
-
-                                    await self._reset_buffers()
                             elif not spoken and not self._is_bot_interrupt_decided:
                                 # Received stream only (not yet spoken): track for interrupt
                                 # completion matching but do not feed STT — the simulated user
@@ -841,15 +891,27 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                                     self._is_bot_interrupt_decided = True
                                     # Align interrupt target with heard text only (received may run ahead of TTS).
                                     self._text_buffer = self._heard_text_buffer
+                                    if self._is_external:
+                                        # No word-level control over an external agent:
+                                        # cut it off immediately and block its output
+                                        # until the sim user finishes speaking.
+                                        await self._commit_user_interrupt(
+                                            generated_frames, user_id, timestamp
+                                        )
 
-                                generated_frames.append(
-                                    InterimTranscriptionFrame(
-                                        text=self._heard_text_buffer,
-                                        user_id=user_id,
-                                        timestamp=timestamp,
-                                        result=result_payload,
+                                # Feed what the sim user heard so far — unless we just
+                                # cut the agent off (external interrupt), in which case
+                                # the partial is already committed and the sim user
+                                # should not "hear" anything more.
+                                if not self._is_bot_interrupt_triggered:
+                                    generated_frames.append(
+                                        InterimTranscriptionFrame(
+                                            text=self._heard_text_buffer,
+                                            user_id=user_id,
+                                            timestamp=timestamp,
+                                            result=result_payload,
+                                        )
                                     )
-                                )
 
                         else:
                             if not spoken:
@@ -1466,6 +1528,7 @@ async def _run_simulation_inner(
         agent_speaks_first=agent_speaks_first,
         max_turns=max_turns,
         latency_tracker=latency_tracker,
+        is_external=bool(agent_uri),
     )
 
     simulated_user_turn_index_hook = SimulatedUserTurnIndexHook(rtvi_message_adapter)

--- a/calibrate/agent/run_simulation.py
+++ b/calibrate/agent/run_simulation.py
@@ -68,13 +68,6 @@ DEFAULT_AGENT_SPEAKS_FIRST = True
 # (vs pipecat's 5s default) without cutting off a genuinely mid-turn agent.
 SIM_USER_TURN_STOP_TIMEOUT_SECS = 2.0
 
-# Normal agent turns are ended by smart-turn. ExternalUserTurnStopStrategy is kept
-# in the stop list ONLY so an explicit interrupt (the sim user cutting in emits a
-# UserStoppedSpeakingFrame) hard-stops the turn immediately. Its built-in
-# transcription auto-timeout would otherwise fire on every turn and pre-empt
-# smart-turn, so we set it high enough to never fire in practice.
-_INTERRUPT_ONLY_STOP_TIMEOUT_SECS = 86400.0
-
 # Pipecat logs Google STT gRPC 409 (idle stream) at ERROR while reconnecting; that is
 # recoverable and must not trigger our error sink (which cancels the eval pipeline).
 _BENIGN_GOOGLE_STT_IDLE_TIMEOUT = (
@@ -234,10 +227,13 @@ def build_user_context_aggregator(context: LLMContext) -> LLMContextAggregatorPa
     The ``vad_analyzer`` feeds the smart-turn model the speech/silence boundaries it
     needs (same as ``bot.py``).
 
-    ``ExternalUserTurnStopStrategy`` is included with its auto-timeout effectively
-    disabled: it does nothing for normal turns but lets a simulated-user interrupt
-    (which emits an explicit ``UserStoppedSpeakingFrame``) hard-stop the agent's turn
-    immediately, for both internal (word-level) and external (block) interrupts.
+    ``ExternalUserTurnStopStrategy(timeout=None)`` is included only so a
+    simulated-user interrupt (which emits an explicit ``UserStoppedSpeakingFrame``)
+    hard-stops the agent's turn immediately — for both internal (word-level) and
+    external (block) interrupts. ``timeout=None`` disables that strategy's built-in
+    transcription auto-timeout (which would otherwise pre-empt smart-turn on every
+    turn); it keeps the strategy's ``UserStoppedSpeakingFrame`` handling and its
+    transcription guards intact, so normal turn-ends are still decided by smart-turn.
     """
     return LLMContextAggregatorPair(
         context,
@@ -246,9 +242,7 @@ def build_user_context_aggregator(context: LLMContext) -> LLMContextAggregatorPa
             user_turn_stop_timeout=SIM_USER_TURN_STOP_TIMEOUT_SECS,
             user_turn_strategies=UserTurnStrategies(
                 stop=[
-                    ExternalUserTurnStopStrategy(
-                        timeout=_INTERRUPT_ONLY_STOP_TIMEOUT_SECS
-                    ),
+                    ExternalUserTurnStopStrategy(timeout=None),
                     TurnAnalyzerUserTurnStopStrategy(
                         turn_analyzer=LocalSmartTurnAnalyzerV3()
                     ),

--- a/calibrate/agent/run_simulation.py
+++ b/calibrate/agent/run_simulation.py
@@ -62,6 +62,17 @@ DEFAULT_MAX_TURNS = 10
 DEFAULT_PORT = 8765
 DEFAULT_AGENT_SPEAKS_FIRST = True
 
+# A remote agent often speaks one conversational turn as several back-to-back TTS
+# utterances (each its own bot-started/stopped cycle), e.g. a greeting immediately
+# followed by the first question. Those should form ONE simulated-user turn so the
+# sim user replies after the agent yields the floor, not after the first utterance.
+# We therefore debounce the end-of-turn signal: the turn only ends once the agent
+# has been silent for this long. Measured inter-utterance gaps for the tested
+# agents run ~1.0-1.3s, while the agent waits several seconds for the user between
+# turns — so 2.0s cleanly separates "pausing between sentences" from "yielded the
+# floor" without making the simulated user feel unresponsive.
+AGENT_TURN_YIELD_DEBOUNCE_SECS = 2.0
+
 # Pipecat logs Google STT gRPC 409 (idle stream) at ERROR while reconnecting; that is
 # recoverable and must not trigger our error sink (which cancels the eval pipeline).
 _BENIGN_GOOGLE_STT_IDLE_TIMEOUT = (
@@ -145,7 +156,9 @@ from pipecat.pipeline.task import PipelineParams, PipelineTask
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.aggregators.llm_response_universal import (
     LLMContextAggregatorPair,
+    LLMUserAggregatorParams,
 )
+from pipecat.turns.user_turn_strategies import ExternalUserTurnStrategies
 from pipecat.observers.loggers.llm_log_observer import LLMLogObserver
 from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
@@ -193,6 +206,27 @@ def resolve_serializer(name: str) -> FrameSerializer:
             f"Available: {sorted(SERIALIZER_REGISTRY)}"
         )
     return factory()
+
+
+def build_user_context_aggregator(context: LLMContext) -> LLMContextAggregatorPair:
+    """Build the simulation context aggregator pair with external turn control.
+
+    The simulator drives user-turn boundaries explicitly: ``RTVIMessageFrameAdapter``
+    emits ``UserStartedSpeakingFrame`` / ``UserStoppedSpeakingFrame`` around each
+    agent utterance (the agent under test is the "user" of this pipeline). Pipecat's
+    default turn strategies (VAD + smart-turn analyzer) ignore those frames and
+    instead segment turns from audio, which mis-segments the agent's speech and
+    drops the first utterance of a multi-utterance turn (e.g. a greeting spoken just
+    before the first question never lands in the transcript). ``ExternalUserTurnStrategies``
+    makes the aggregator honor the explicit UserStarted/UserStopped frames so every
+    agent utterance is committed as its own turn.
+    """
+    return LLMContextAggregatorPair(
+        context,
+        user_params=LLMUserAggregatorParams(
+            user_turn_strategies=ExternalUserTurnStrategies()
+        ),
+    )
 
 
 def is_external_ws_agent(config: dict) -> bool:
@@ -378,6 +412,21 @@ class RTVIMessageFrameAdapter(FrameProcessor):
         # Avoids allocating an index for sim-user turns that get interrupted before
         # any audio actually flows.
         self._sim_user_turn_pending = False
+        # Whether the agent currently holds the conversational floor. Set True when
+        # the agent starts an utterance and reset to False when the simulated user
+        # begins its own LLM turn (SimulatedUserTurnIndexHook). Gates the
+        # InterruptionTaskFrame in ``bot-started-speaking`` so that consecutive
+        # agent utterances (e.g. a greeting immediately followed by the first
+        # question) don't interrupt — and drop — one another.
+        self._agent_has_floor = False
+        # Whether a simulated-user turn is currently open on the agent's behalf
+        # (UserStartedSpeakingFrame emitted, matching UserStoppedSpeakingFrame not
+        # yet emitted). Consecutive agent utterances reuse the same open turn so
+        # they coalesce into one sim-user turn; see _schedule_agent_turn_stop.
+        self._agent_turn_active = False
+        # Debounce task that emits the coalesced UserStoppedSpeakingFrame once the
+        # agent has been silent for AGENT_TURN_YIELD_DEBOUNCE_SECS.
+        self._agent_turn_stop_task = None
         # Inbound bot audio frames that arrive after ``bot-started-speaking`` but
         # before the first ``spoken=True`` RTVI confirmation. TTS audio commonly
         # streams ~1s ahead of its ``spoken`` event, so the first sentence's
@@ -434,6 +483,35 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                 audio_save_path, frame.audio, frame.sample_rate, frame.num_channels
             )
         self._pending_bot_audio_frames = []
+
+    def _schedule_agent_turn_stop(self) -> None:
+        """Arm the debounce that ends the coalesced sim-user turn.
+
+        Called on every ``bot-stopped-speaking``. If the agent starts another
+        utterance before the debounce elapses, ``_cancel_agent_turn_stop`` (from
+        the next ``bot-started-speaking``) cancels this, so both utterances share
+        one sim-user turn. Otherwise the debounce fires and emits the single
+        ``UserStoppedSpeakingFrame`` that closes the turn and lets the sim user
+        respond to everything the agent said.
+        """
+        self._agent_turn_stop_task = self.create_task(
+            self._end_agent_turn_after_debounce()
+        )
+
+    async def _cancel_agent_turn_stop(self) -> None:
+        task = self._agent_turn_stop_task
+        self._agent_turn_stop_task = None
+        if task is not None:
+            await self.cancel_task(task)
+
+    async def _end_agent_turn_after_debounce(self) -> None:
+        try:
+            await asyncio.sleep(AGENT_TURN_YIELD_DEBOUNCE_SECS)
+        except asyncio.CancelledError:
+            return
+        self._agent_turn_stop_task = None
+        self._agent_turn_active = False
+        await self.push_frame(UserStoppedSpeakingFrame(), FrameDirection.DOWNSTREAM)
 
     def _assign_next_transcript_audio_line(self, role: str) -> int:
         """Next 1-based transcript line for ``{N}_bot`` / ``{N}_user`` chunk files.
@@ -646,6 +724,9 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                         self._ended_due_to_max_turns = True
                         await self.push_frame(EndTaskFrame(), FrameDirection.UPSTREAM)
                     else:
+                        # The agent is (still) speaking: hold off ending the
+                        # coalesced sim-user turn until it goes quiet.
+                        await self._cancel_agent_turn_stop()
                         self._awaiting_first_bot_audio_chunk = True
                         self._pending_user_turn = True
                         # A new bot utterance starts with a clean interrupt slate.
@@ -661,15 +742,31 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                         self._spoken_text_buffer = ""
                         # Cancel any pending sim-user line allocation: bot has
                         # the floor and any in-flight sim-user TTS will be
-                        # killed by the upcoming InterruptionTaskFrame.
+                        # killed by the InterruptionTaskFrame below (when sent).
                         self._sim_user_turn_pending = False
-                        # The bot has the floor: stop the sim user's in-flight TTS
-                        # and flush its assistant aggregator so anything spoken so
-                        # far is committed as its own turn.
-                        await self.push_frame(
-                            InterruptionTaskFrame(), FrameDirection.UPSTREAM
-                        )
-                        generated_frames.append(UserStartedSpeakingFrame())
+                        # Only interrupt when the agent is actually taking the floor
+                        # back from the simulated user. The InterruptionTaskFrame
+                        # broadcasts a StartInterruptionFrame that cancels the user
+                        # context aggregator's process queue; if fired on every
+                        # utterance it discards the PREVIOUS agent utterance's
+                        # not-yet-committed transcription. That drops the first line
+                        # whenever an agent speaks a turn as multiple back-to-back
+                        # utterances (e.g. a greeting followed by its first question).
+                        # ``_agent_has_floor`` is reset to False when the sim user
+                        # begins its LLM turn, so the interrupt still fires the first
+                        # time the agent takes back the floor to stop the sim user's
+                        # in-flight TTS and flush its assistant aggregator.
+                        if not self._agent_has_floor:
+                            await self.push_frame(
+                                InterruptionTaskFrame(), FrameDirection.UPSTREAM
+                            )
+                        self._agent_has_floor = True
+                        # Open a sim-user turn only if one isn't already open. A
+                        # follow-on utterance in the same agent turn keeps the
+                        # existing turn so both utterances land in one sim-user turn.
+                        if not self._agent_turn_active:
+                            self._agent_turn_active = True
+                            generated_frames.append(UserStartedSpeakingFrame())
                 elif msg_type == "bot-stopped-speaking" and self._pending_user_turn:
                     if self._awaiting_first_bot_audio_chunk:
                         # Tool-only turn: no ``spoken=True`` ever fired, so any
@@ -677,18 +774,26 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                         self._pending_bot_audio_frames = []
                     self._awaiting_first_bot_audio_chunk = False
                     self._pending_user_turn = False
-                    generated_frames.extend(
-                        [
-                            TranscriptionFrame(
-                                text=self._heard_text_buffer,
-                                user_id=user_id,
-                                timestamp=timestamp,
-                                result={},
-                            ),
-                            UserStoppedSpeakingFrame(),
-                        ]
+                    # Commit this utterance's transcription into the open sim-user
+                    # turn, but debounce the UserStoppedSpeakingFrame: if the agent
+                    # speaks another utterance shortly after, it joins this turn;
+                    # only once the agent stays quiet does the turn end (and the sim
+                    # user respond). Emitting UserStopped here instead would end the
+                    # turn per utterance, so the sim user's LLM fires on the greeting
+                    # before it has heard the question.
+                    generated_frames.append(
+                        TranscriptionFrame(
+                            # Strip the buffer's leading space: the aggregator adds
+                            # its own separator between utterances, so a leading
+                            # space here would double up (``greeting  question``).
+                            text=self._heard_text_buffer.strip(),
+                            user_id=user_id,
+                            timestamp=timestamp,
+                            result={},
+                        )
                     )
                     await self._reset_buffers()
+                    self._schedule_agent_turn_stop()
 
                 elif msg_type == "user-stopped-speaking":
                     # once the simulated user stops speaking, mark the bot as not
@@ -749,10 +854,15 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                                         FrameDirection.DOWNSTREAM,
                                     )
 
+                                    # The sim user cut in: this hard-ends the agent
+                                    # turn now, so drop any pending debounce and
+                                    # close the coalesced turn immediately.
+                                    await self._cancel_agent_turn_stop()
+                                    self._agent_turn_active = False
                                     generated_frames.extend(
                                         [
                                             TranscriptionFrame(
-                                                text=self._text_buffer,
+                                                text=self._text_buffer.strip(),
                                                 user_id=user_id,
                                                 timestamp=timestamp,
                                                 result={},
@@ -950,6 +1060,11 @@ class SimulatedUserTurnIndexHook(FrameProcessor):
             # Just signal intent — actual line allocation happens lazily in
             # SilencePadder when the first audio frame arrives.
             self._rtvi_adapter._sim_user_turn_pending = True
+            # The simulated user is taking a turn, so the next time the agent
+            # starts speaking it is genuinely taking the floor back and should
+            # interrupt. (Reset here rather than on audio so it's set before any
+            # sim-user TTS can race with the agent's next utterance.)
+            self._rtvi_adapter._agent_has_floor = False
 
         await self.push_frame(frame, direction)
 
@@ -1390,7 +1505,7 @@ async def _run_simulation_inner(
     ]
 
     context = LLMContext(messages)
-    context_aggregator = LLMContextAggregatorPair(context)
+    context_aggregator = build_user_context_aggregator(context)
 
     audio_buffer = AudioBufferProcessor(enable_turn_audio=True)
 

--- a/tests/agent/test_rtvi_adapter.py
+++ b/tests/agent/test_rtvi_adapter.py
@@ -301,5 +301,109 @@ class TestNaturalInterrupt(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(_count_frames(pushed, UserStoppedSpeakingFrame), 0)
 
 
+def _bot_output_frame(text, spoken):
+    from pipecat.frames.frames import InputTransportMessageFrame
+
+    return InputTransportMessageFrame(
+        message={
+            "label": "rtvi-ai",
+            "type": "bot-output",
+            "data": {"text": text, "spoken": spoken},
+        }
+    )
+
+
+async def _drive_frame(adapter, frame, pushed=None):
+    from pipecat.processors.frame_processor import FrameDirection
+
+    if pushed is None:
+        pushed = []
+
+    async def _capture(f, direction):
+        pushed.append((f, direction))
+
+    adapter.push_frame = _capture
+    await adapter.process_frame(frame, FrameDirection.DOWNSTREAM)
+    return pushed
+
+
+def _count_interrupt_messages(pushed):
+    from pipecat.frames.frames import OutputTransportMessageUrgentFrame
+
+    return sum(
+        1
+        for f, _ in pushed
+        if isinstance(f, OutputTransportMessageUrgentFrame)
+        and (getattr(f, "message", {}) or {}).get("data", {}).get("t") == "interrupt"
+    )
+
+
+class TestExternalAgentInterrupt(unittest.IsolatedAsyncioTestCase):
+    """External agents get the block model: a decided interrupt cuts the agent off
+    at once and blocks its output until the sim user finishes. Internal agents keep
+    the word-level path (decision only; trigger later on stream/spoken match)."""
+
+    async def test_external_interrupt_executes_immediately(self):
+        from pipecat.frames.frames import (
+            TranscriptionFrame,
+            UserStoppedSpeakingFrame,
+            InterimTranscriptionFrame,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = _make_adapter(
+                output_dir=tmp, interrupt_probability=1.0, is_external=True
+            )
+            pushed = await _drive_frame(adapter, _bot_output_frame("नमस्ते!", True))
+
+        self.assertTrue(adapter._is_bot_interrupt_triggered)
+        # Tells the agent to stop, commits the partial, ends the turn.
+        self.assertEqual(_count_interrupt_messages(pushed), 1)
+        self.assertEqual(_count_frames(pushed, TranscriptionFrame), 1)
+        self.assertEqual(_count_frames(pushed, UserStoppedSpeakingFrame), 1)
+        # Nothing more is fed to the sim user (no interim after cutting in).
+        self.assertEqual(_count_frames(pushed, InterimTranscriptionFrame), 0)
+
+    async def test_internal_interrupt_only_decides(self):
+        from pipecat.frames.frames import (
+            UserStoppedSpeakingFrame,
+            InterimTranscriptionFrame,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = _make_adapter(
+                output_dir=tmp, interrupt_probability=1.0, is_external=False
+            )
+            pushed = await _drive_frame(adapter, _bot_output_frame("नमस्ते!", True))
+
+        # Internal: decision is made but the interrupt is NOT executed yet; it waits
+        # for the spoken text to catch up (word-level control).
+        self.assertTrue(adapter._is_bot_interrupt_decided)
+        self.assertFalse(adapter._is_bot_interrupt_triggered)
+        self.assertEqual(_count_interrupt_messages(pushed), 0)
+        self.assertEqual(_count_frames(pushed, UserStoppedSpeakingFrame), 0)
+        # Internal still feeds what was heard up to the cut-in point.
+        self.assertEqual(_count_frames(pushed, InterimTranscriptionFrame), 1)
+
+    async def test_bot_started_blocked_while_external_interrupt_active(self):
+        adapter = _make_adapter(is_external=True)
+        adapter._is_bot_interrupt_triggered = True
+        pushed = await _drive_bot_started(adapter)
+        # Agent's attempt to speak is ignored: no interrupt of the sim user's turn.
+        self.assertEqual(_count_interruptions(pushed), 0)
+
+    async def test_agent_audio_dropped_while_external_interrupt_active(self):
+        from pipecat.frames.frames import InputAudioRawFrame
+
+        adapter = _make_adapter(is_external=True)
+        adapter._is_bot_interrupt_triggered = True
+        frame = InputAudioRawFrame(
+            audio=b"\x00\x00", sample_rate=16000, num_channels=1
+        )
+        pushed = await _drive_frame(adapter, frame)
+        # Dropped, not forwarded to the aggregator's VAD (would cancel the sim user).
+        self.assertEqual(_count_frames(pushed, InputAudioRawFrame), 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/agent/test_rtvi_adapter.py
+++ b/tests/agent/test_rtvi_adapter.py
@@ -217,5 +217,163 @@ class TestResetBuffers(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(adapter._spoken_text_buffer, "")
 
 
+def _rtvi_frame(msg_type):
+    from pipecat.frames.frames import InputTransportMessageFrame
+
+    return InputTransportMessageFrame(
+        message={"label": "rtvi-ai", "type": msg_type}
+    )
+
+
+def _stub_tasks(adapter):
+    """Replace the pipecat task-manager hooks so no real event loop tasks run.
+
+    ``_schedule_agent_turn_stop`` calls ``create_task`` (needs a running task
+    manager the unit-test adapter doesn't have); the coalescing tests drive the
+    debounce coroutine directly instead.
+    """
+    def _fake_create_task(coro, name=None):
+        coro.close()  # avoid "coroutine was never awaited" warnings
+        return MagicMock()
+
+    adapter.create_task = _fake_create_task
+    adapter.cancel_task = AsyncMock()
+
+
+async def _drive_bot_started(adapter, pushed=None):
+    """Push a ``bot-started-speaking`` RTVI frame through the adapter.
+
+    Captures every ``push_frame`` call and returns the pushed (frame, direction)
+    pairs so tests can assert whether an InterruptionTaskFrame was emitted.
+    """
+    return await _drive_rtvi(adapter, "bot-started-speaking", pushed)
+
+
+async def _drive_rtvi(adapter, msg_type, pushed=None):
+    from pipecat.processors.frame_processor import FrameDirection
+
+    if pushed is None:
+        pushed = []
+
+    async def _capture(frame, direction):
+        pushed.append((frame, direction))
+
+    _stub_tasks(adapter)
+    adapter.push_frame = _capture
+    await adapter.process_frame(_rtvi_frame(msg_type), FrameDirection.DOWNSTREAM)
+    return pushed
+
+
+def _count_frames(pushed, frame_cls):
+    return sum(1 for frame, _ in pushed if isinstance(frame, frame_cls))
+
+
+def _count_interruptions(pushed):
+    from pipecat.frames.frames import InterruptionTaskFrame
+
+    return _count_frames(pushed, InterruptionTaskFrame)
+
+
+class TestAgentFloorInterruptGating(unittest.IsolatedAsyncioTestCase):
+    """Consecutive agent utterances must not interrupt (and drop) one another.
+
+    Regression test for the bug where an external agent that speaks its opening
+    as two back-to-back utterances (e.g. a greeting then the first question) had
+    the greeting erased: the second utterance's InterruptionTaskFrame cancelled
+    the user context aggregator's queue before the greeting was committed.
+    """
+
+    async def test_first_utterance_interrupts(self):
+        adapter = _make_adapter()
+        self.assertFalse(adapter._agent_has_floor)
+        pushed = await _drive_bot_started(adapter)
+        self.assertEqual(_count_interruptions(pushed), 1)
+        self.assertTrue(adapter._agent_has_floor)
+
+    async def test_consecutive_utterance_does_not_interrupt(self):
+        adapter = _make_adapter()
+        await _drive_bot_started(adapter)  # first utterance takes the floor
+        pushed = await _drive_bot_started(adapter)  # second utterance, same turn
+        self.assertEqual(_count_interruptions(pushed), 0)
+        self.assertTrue(adapter._agent_has_floor)
+
+    async def test_interrupts_again_after_sim_user_turn(self):
+        from pipecat.frames.frames import LLMFullResponseStartFrame
+        from pipecat.processors.frame_processor import FrameDirection
+        from calibrate.agent.run_simulation import SimulatedUserTurnIndexHook
+
+        adapter = _make_adapter()
+        await _drive_bot_started(adapter)  # agent takes the floor
+
+        # Simulated user starts its own turn -> agent no longer holds the floor.
+        hook = SimulatedUserTurnIndexHook(adapter)
+        hook.push_frame = AsyncMock()
+        await hook.process_frame(
+            LLMFullResponseStartFrame(), FrameDirection.DOWNSTREAM
+        )
+        self.assertFalse(adapter._agent_has_floor)
+
+        # Agent taking the floor back should interrupt the sim user again.
+        pushed = await _drive_bot_started(adapter)
+        self.assertEqual(_count_interruptions(pushed), 1)
+        self.assertTrue(adapter._agent_has_floor)
+
+
+class TestAgentTurnCoalescing(unittest.IsolatedAsyncioTestCase):
+    """Consecutive agent utterances coalesce into one simulated-user turn.
+
+    Regression test for the follow-on bug: with per-utterance UserStopped frames,
+    the sim user's LLM fired on the greeting before it heard the first question,
+    so only sometimes did both land in the same turn. Now UserStopped is debounced
+    so a multi-utterance agent turn (greeting + question) forms one sim-user turn.
+    """
+
+    async def test_single_user_started_across_consecutive_utterances(self):
+        from pipecat.frames.frames import UserStartedSpeakingFrame
+
+        adapter = _make_adapter()
+        pushed = []
+        await _drive_bot_started(adapter, pushed)  # first utterance opens the turn
+        await _drive_bot_started(adapter, pushed)  # follow-on utterance, same turn
+        self.assertTrue(adapter._agent_turn_active)
+        # Only one turn opened, so exactly one UserStartedSpeakingFrame.
+        self.assertEqual(_count_frames(pushed, UserStartedSpeakingFrame), 1)
+
+    async def test_bot_stopped_defers_user_stop(self):
+        from pipecat.frames.frames import (
+            TranscriptionFrame,
+            UserStoppedSpeakingFrame,
+        )
+
+        adapter = _make_adapter()
+        adapter._heard_text_buffer = " नमस्ते!"
+        await _drive_bot_started(adapter)
+        pushed = await _drive_rtvi(adapter, "bot-stopped-speaking")
+        # The utterance's transcription is emitted immediately...
+        self.assertEqual(_count_frames(pushed, TranscriptionFrame), 1)
+        # ...but the turn-ending UserStopped is deferred to the debounce.
+        self.assertEqual(_count_frames(pushed, UserStoppedSpeakingFrame), 0)
+        self.assertTrue(adapter._agent_turn_active)
+
+    async def test_debounce_emits_user_stop(self):
+        from unittest.mock import patch
+        from pipecat.frames.frames import UserStoppedSpeakingFrame
+        from pipecat.processors.frame_processor import FrameDirection
+
+        adapter = _make_adapter()
+        adapter._agent_turn_active = True
+        pushed = []
+
+        async def _capture(frame, direction):
+            pushed.append((frame, direction))
+
+        adapter.push_frame = _capture
+        with patch("calibrate.agent.run_simulation.asyncio.sleep", AsyncMock()):
+            await adapter._end_agent_turn_after_debounce()
+
+        self.assertEqual(_count_frames(pushed, UserStoppedSpeakingFrame), 1)
+        self.assertFalse(adapter._agent_turn_active)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/agent/test_rtvi_adapter.py
+++ b/tests/agent/test_rtvi_adapter.py
@@ -225,31 +225,13 @@ def _rtvi_frame(msg_type):
     )
 
 
-def _stub_tasks(adapter):
-    """Replace the pipecat task-manager hooks so no real event loop tasks run.
-
-    ``_schedule_agent_turn_stop`` calls ``create_task`` (needs a running task
-    manager the unit-test adapter doesn't have); the coalescing tests drive the
-    debounce coroutine directly instead.
-    """
-    def _fake_create_task(coro, name=None):
-        coro.close()  # avoid "coroutine was never awaited" warnings
-        return MagicMock()
-
-    adapter.create_task = _fake_create_task
-    adapter.cancel_task = AsyncMock()
-
-
 async def _drive_bot_started(adapter, pushed=None):
-    """Push a ``bot-started-speaking`` RTVI frame through the adapter.
-
-    Captures every ``push_frame`` call and returns the pushed (frame, direction)
-    pairs so tests can assert whether an InterruptionTaskFrame was emitted.
-    """
+    """Push a ``bot-started-speaking`` RTVI frame through the adapter."""
     return await _drive_rtvi(adapter, "bot-started-speaking", pushed)
 
 
 async def _drive_rtvi(adapter, msg_type, pushed=None):
+    """Push one RTVI message through the adapter, capturing pushed frames."""
     from pipecat.processors.frame_processor import FrameDirection
 
     if pushed is None:
@@ -258,7 +240,6 @@ async def _drive_rtvi(adapter, msg_type, pushed=None):
     async def _capture(frame, direction):
         pushed.append((frame, direction))
 
-    _stub_tasks(adapter)
     adapter.push_frame = _capture
     await adapter.process_frame(_rtvi_frame(msg_type), FrameDirection.DOWNSTREAM)
     return pushed
@@ -274,105 +255,50 @@ def _count_interruptions(pushed):
     return _count_frames(pushed, InterruptionTaskFrame)
 
 
-class TestAgentFloorInterruptGating(unittest.IsolatedAsyncioTestCase):
-    """Consecutive agent utterances must not interrupt (and drop) one another.
+class TestNaturalInterrupt(unittest.IsolatedAsyncioTestCase):
+    """Every agent utterance interrupts the simulated user (natural full-duplex).
 
-    Regression test for the bug where an external agent that speaks its opening
-    as two back-to-back utterances (e.g. a greeting then the first question) had
-    the greeting erased: the second utterance's InterruptionTaskFrame cancelled
-    the user context aggregator's queue before the greeting was committed.
+    Turn boundaries are driven by the aggregator's audio strategies, so the adapter
+    no longer emits UserStarted/UserStopped — it just fires the interrupt and the
+    utterance transcription.
     """
 
-    async def test_first_utterance_interrupts(self):
-        adapter = _make_adapter()
-        self.assertFalse(adapter._agent_has_floor)
-        pushed = await _drive_bot_started(adapter)
-        self.assertEqual(_count_interruptions(pushed), 1)
-        self.assertTrue(adapter._agent_has_floor)
-
-    async def test_consecutive_utterance_does_not_interrupt(self):
-        adapter = _make_adapter()
-        await _drive_bot_started(adapter)  # first utterance takes the floor
-        pushed = await _drive_bot_started(adapter)  # second utterance, same turn
-        self.assertEqual(_count_interruptions(pushed), 0)
-        self.assertTrue(adapter._agent_has_floor)
-
-    async def test_interrupts_again_after_sim_user_turn(self):
-        from pipecat.frames.frames import LLMFullResponseStartFrame
-        from pipecat.processors.frame_processor import FrameDirection
-        from calibrate.agent.run_simulation import SimulatedUserTurnIndexHook
-
-        adapter = _make_adapter()
-        await _drive_bot_started(adapter)  # agent takes the floor
-
-        # Simulated user starts its own turn -> agent no longer holds the floor.
-        hook = SimulatedUserTurnIndexHook(adapter)
-        hook.push_frame = AsyncMock()
-        await hook.process_frame(
-            LLMFullResponseStartFrame(), FrameDirection.DOWNSTREAM
-        )
-        self.assertFalse(adapter._agent_has_floor)
-
-        # Agent taking the floor back should interrupt the sim user again.
-        pushed = await _drive_bot_started(adapter)
-        self.assertEqual(_count_interruptions(pushed), 1)
-        self.assertTrue(adapter._agent_has_floor)
-
-
-class TestAgentTurnCoalescing(unittest.IsolatedAsyncioTestCase):
-    """Consecutive agent utterances coalesce into one simulated-user turn.
-
-    Regression test for the follow-on bug: with per-utterance UserStopped frames,
-    the sim user's LLM fired on the greeting before it heard the first question,
-    so only sometimes did both land in the same turn. Now UserStopped is debounced
-    so a multi-utterance agent turn (greeting + question) forms one sim-user turn.
-    """
-
-    async def test_single_user_started_across_consecutive_utterances(self):
+    async def test_bot_started_interrupts_without_manual_userstarted(self):
         from pipecat.frames.frames import UserStartedSpeakingFrame
 
         adapter = _make_adapter()
-        pushed = []
-        await _drive_bot_started(adapter, pushed)  # first utterance opens the turn
-        await _drive_bot_started(adapter, pushed)  # follow-on utterance, same turn
-        self.assertTrue(adapter._agent_turn_active)
-        # Only one turn opened, so exactly one UserStartedSpeakingFrame.
-        self.assertEqual(_count_frames(pushed, UserStartedSpeakingFrame), 1)
+        pushed = await _drive_bot_started(adapter)
+        # Fires the interrupt to cut the sim user's in-flight TTS...
+        self.assertEqual(_count_interruptions(pushed), 1)
+        # ...but does NOT manually open the turn (audio strategies do that).
+        self.assertEqual(_count_frames(pushed, UserStartedSpeakingFrame), 0)
 
-    async def test_bot_stopped_defers_user_stop(self):
+    async def test_every_consecutive_utterance_interrupts(self):
+        adapter = _make_adapter()
+        pushed = []
+        await _drive_bot_started(adapter, pushed)
+        await _drive_bot_started(adapter, pushed)
+        # Unlike the old gated behavior, a follow-on utterance still interrupts.
+        self.assertEqual(_count_interruptions(pushed), 2)
+
+    async def test_bot_stopped_emits_stripped_transcription_no_userstopped(self):
         from pipecat.frames.frames import (
             TranscriptionFrame,
             UserStoppedSpeakingFrame,
         )
 
-        adapter = _make_adapter()
-        adapter._heard_text_buffer = " नमस्ते!"
-        await _drive_bot_started(adapter)
-        pushed = await _drive_rtvi(adapter, "bot-stopped-speaking")
-        # The utterance's transcription is emitted immediately...
-        self.assertEqual(_count_frames(pushed, TranscriptionFrame), 1)
-        # ...but the turn-ending UserStopped is deferred to the debounce.
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = _make_adapter(output_dir=tmp)
+            adapter._pending_user_turn = True
+            adapter._heard_text_buffer = " नमस्ते!"
+            pushed = await _drive_rtvi(adapter, "bot-stopped-speaking")
+
+        transcriptions = [f for f, _ in pushed if isinstance(f, TranscriptionFrame)]
+        self.assertEqual(len(transcriptions), 1)
+        # Leading space stripped so coalesced turns don't double-space.
+        self.assertEqual(transcriptions[0].text, "नमस्ते!")
+        # Turn-end is decided by smart-turn, not a manual UserStopped.
         self.assertEqual(_count_frames(pushed, UserStoppedSpeakingFrame), 0)
-        self.assertTrue(adapter._agent_turn_active)
-
-    async def test_debounce_emits_user_stop(self):
-        from unittest.mock import patch
-        from pipecat.frames.frames import UserStoppedSpeakingFrame
-        from pipecat.processors.frame_processor import FrameDirection
-
-        adapter = _make_adapter()
-        adapter._agent_turn_active = True
-        pushed = []
-
-        async def _capture(frame, direction):
-            pushed.append((frame, direction))
-
-        adapter.push_frame = _capture
-        with patch("calibrate.agent.run_simulation.asyncio.sleep", AsyncMock()):
-            await adapter._end_agent_turn_after_debounce()
-
-        self.assertEqual(_count_frames(pushed, UserStoppedSpeakingFrame), 1)
-        self.assertFalse(adapter._agent_turn_active)
 
 
 if __name__ == "__main__":

--- a/tests/agent/test_run_simulation_helpers.py
+++ b/tests/agent/test_run_simulation_helpers.py
@@ -435,16 +435,6 @@ class TestBotStartedResetsInterruptState(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(adapter._is_bot_interrupt_triggered)
         self.assertEqual(adapter._spoken_text_buffer, "")
 
-    async def test_max_turns_branch_does_not_reset(self):
-        # When max turns is reached the adapter ends the run instead of starting a
-        # fresh utterance; the reset must not fire on that path.
-        adapter = self._make_adapter(max_turns=0)
-        adapter._is_bot_interrupt_decided = True
-
-        await self._send_bot_started(adapter)
-
-        self.assertTrue(adapter._is_bot_interrupt_decided)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/agent/test_run_simulation_helpers.py
+++ b/tests/agent/test_run_simulation_helpers.py
@@ -158,6 +158,7 @@ class TestSimulatedUserTurnIndexHook(unittest.IsolatedAsyncioTestCase):
 
         adapter = MagicMock()
         adapter._sim_user_turn_pending = False
+        adapter._agent_has_floor = True
         hook = SimulatedUserTurnIndexHook(adapter)
         frame = MagicMock(spec=LLMFullResponseStartFrame)
 
@@ -165,6 +166,39 @@ class TestSimulatedUserTurnIndexHook(unittest.IsolatedAsyncioTestCase):
              patch.object(SimulatedUserTurnIndexHook, "push_frame", AsyncMock()):
             await hook.process_frame(frame, FrameDirection.DOWNSTREAM)
         self.assertTrue(adapter._sim_user_turn_pending)
+        # Sim user taking a turn releases the agent's floor so the agent's next
+        # utterance is treated as taking the floor back (and interrupts).
+        self.assertFalse(adapter._agent_has_floor)
+
+
+class TestBuildUserContextAggregator(unittest.TestCase):
+    """The sim aggregator must honor the explicit UserStarted/UserStopped frames.
+
+    Regression test: pipecat's default turn strategies (VAD + smart-turn) ignore
+    those frames and drop the first utterance of a multi-utterance agent turn
+    (e.g. a greeting spoken before the first question). The aggregator must be
+    built with ExternalUserTurnStrategies instead.
+    """
+
+    def test_uses_external_turn_strategies(self):
+        from calibrate.agent.run_simulation import build_user_context_aggregator
+        from pipecat.processors.aggregators.llm_context import LLMContext
+        from pipecat.turns.user_start.external_user_turn_start_strategy import (
+            ExternalUserTurnStartStrategy,
+        )
+        from pipecat.turns.user_stop.external_user_turn_stop_strategy import (
+            ExternalUserTurnStopStrategy,
+        )
+
+        ctx = LLMContext([{"role": "system", "content": "x"}])
+        pair = build_user_context_aggregator(ctx)
+        strategies = pair.user()._user_turn_controller._user_turn_strategies
+        self.assertTrue(
+            any(isinstance(s, ExternalUserTurnStartStrategy) for s in strategies.start)
+        )
+        self.assertTrue(
+            any(isinstance(s, ExternalUserTurnStopStrategy) for s in strategies.stop)
+        )
 
 
 class TestSTTLogger(unittest.IsolatedAsyncioTestCase):

--- a/tests/agent/test_run_simulation_helpers.py
+++ b/tests/agent/test_run_simulation_helpers.py
@@ -180,9 +180,13 @@ class TestBuildUserContextAggregator(unittest.TestCase):
         from calibrate.agent.run_simulation import (
             build_user_context_aggregator,
             SIM_USER_TURN_STOP_TIMEOUT_SECS,
+            _INTERRUPT_ONLY_STOP_TIMEOUT_SECS,
         )
         from pipecat.processors.aggregators.llm_context import LLMContext
         from pipecat.turns.user_stop import TurnAnalyzerUserTurnStopStrategy
+        from pipecat.turns.user_stop.external_user_turn_stop_strategy import (
+            ExternalUserTurnStopStrategy,
+        )
         from pipecat.turns.user_start.external_user_turn_start_strategy import (
             ExternalUserTurnStartStrategy,
         )
@@ -191,9 +195,19 @@ class TestBuildUserContextAggregator(unittest.TestCase):
         pair = build_user_context_aggregator(ctx)
         controller = pair.user()._user_turn_controller
         strategies = controller._user_turn_strategies
-        # Smart-turn decides turn-end.
+        # Smart-turn decides turn-end for normal turns.
         self.assertTrue(
             any(isinstance(s, TurnAnalyzerUserTurnStopStrategy) for s in strategies.stop)
+        )
+        # ExternalUserTurnStopStrategy is present ONLY to hard-stop the turn on an
+        # explicit interrupt UserStopped; its auto-timeout is disabled so it never
+        # pre-empts smart-turn on normal turns.
+        external_stops = [
+            s for s in strategies.stop if isinstance(s, ExternalUserTurnStopStrategy)
+        ]
+        self.assertEqual(len(external_stops), 1)
+        self.assertEqual(
+            external_stops[0]._timeout, _INTERRUPT_ONLY_STOP_TIMEOUT_SECS
         )
         # Turn-start is audio-driven (default strategies), NOT manual/external.
         self.assertFalse(

--- a/tests/agent/test_run_simulation_helpers.py
+++ b/tests/agent/test_run_simulation_helpers.py
@@ -158,7 +158,6 @@ class TestSimulatedUserTurnIndexHook(unittest.IsolatedAsyncioTestCase):
 
         adapter = MagicMock()
         adapter._sim_user_turn_pending = False
-        adapter._agent_has_floor = True
         hook = SimulatedUserTurnIndexHook(adapter)
         frame = MagicMock(spec=LLMFullResponseStartFrame)
 
@@ -166,38 +165,43 @@ class TestSimulatedUserTurnIndexHook(unittest.IsolatedAsyncioTestCase):
              patch.object(SimulatedUserTurnIndexHook, "push_frame", AsyncMock()):
             await hook.process_frame(frame, FrameDirection.DOWNSTREAM)
         self.assertTrue(adapter._sim_user_turn_pending)
-        # Sim user taking a turn releases the agent's floor so the agent's next
-        # utterance is treated as taking the floor back (and interrupts).
-        self.assertFalse(adapter._agent_has_floor)
 
 
 class TestBuildUserContextAggregator(unittest.TestCase):
-    """The sim aggregator must honor the explicit UserStarted/UserStopped frames.
+    """Turn-taking must be audio-driven: smart-turn stop + a bounded fallback.
 
-    Regression test: pipecat's default turn strategies (VAD + smart-turn) ignore
-    those frames and drop the first utterance of a multi-utterance agent turn
-    (e.g. a greeting spoken before the first question). The aggregator must be
-    built with ExternalUserTurnStrategies instead.
+    The agent under test is the "user"; turn boundaries come from its audio, not
+    manual UserStarted/UserStopped frames. Turn-end is decided by the smart-turn
+    analyzer, with a short user_turn_stop_timeout fallback for when it stalls on
+    synthesized TTS audio.
     """
 
-    def test_uses_external_turn_strategies(self):
-        from calibrate.agent.run_simulation import build_user_context_aggregator
+    def test_uses_smart_turn_stop_and_bounded_timeout(self):
+        from calibrate.agent.run_simulation import (
+            build_user_context_aggregator,
+            SIM_USER_TURN_STOP_TIMEOUT_SECS,
+        )
         from pipecat.processors.aggregators.llm_context import LLMContext
+        from pipecat.turns.user_stop import TurnAnalyzerUserTurnStopStrategy
         from pipecat.turns.user_start.external_user_turn_start_strategy import (
             ExternalUserTurnStartStrategy,
-        )
-        from pipecat.turns.user_stop.external_user_turn_stop_strategy import (
-            ExternalUserTurnStopStrategy,
         )
 
         ctx = LLMContext([{"role": "system", "content": "x"}])
         pair = build_user_context_aggregator(ctx)
-        strategies = pair.user()._user_turn_controller._user_turn_strategies
+        controller = pair.user()._user_turn_controller
+        strategies = controller._user_turn_strategies
+        # Smart-turn decides turn-end.
         self.assertTrue(
+            any(isinstance(s, TurnAnalyzerUserTurnStopStrategy) for s in strategies.stop)
+        )
+        # Turn-start is audio-driven (default strategies), NOT manual/external.
+        self.assertFalse(
             any(isinstance(s, ExternalUserTurnStartStrategy) for s in strategies.start)
         )
-        self.assertTrue(
-            any(isinstance(s, ExternalUserTurnStopStrategy) for s in strategies.stop)
+        # Bounded fallback for smart-turn stalls on TTS audio.
+        self.assertEqual(
+            controller._user_turn_stop_timeout, SIM_USER_TURN_STOP_TIMEOUT_SECS
         )
 
 

--- a/tests/agent/test_run_simulation_helpers.py
+++ b/tests/agent/test_run_simulation_helpers.py
@@ -180,7 +180,6 @@ class TestBuildUserContextAggregator(unittest.TestCase):
         from calibrate.agent.run_simulation import (
             build_user_context_aggregator,
             SIM_USER_TURN_STOP_TIMEOUT_SECS,
-            _INTERRUPT_ONLY_STOP_TIMEOUT_SECS,
         )
         from pipecat.processors.aggregators.llm_context import LLMContext
         from pipecat.turns.user_stop import TurnAnalyzerUserTurnStopStrategy
@@ -200,15 +199,13 @@ class TestBuildUserContextAggregator(unittest.TestCase):
             any(isinstance(s, TurnAnalyzerUserTurnStopStrategy) for s in strategies.stop)
         )
         # ExternalUserTurnStopStrategy is present ONLY to hard-stop the turn on an
-        # explicit interrupt UserStopped; its auto-timeout is disabled so it never
-        # pre-empts smart-turn on normal turns.
+        # explicit interrupt UserStopped; timeout=None disables its auto-timeout so
+        # it never pre-empts smart-turn on normal turns.
         external_stops = [
             s for s in strategies.stop if isinstance(s, ExternalUserTurnStopStrategy)
         ]
         self.assertEqual(len(external_stops), 1)
-        self.assertEqual(
-            external_stops[0]._timeout, _INTERRUPT_ONLY_STOP_TIMEOUT_SECS
-        )
+        self.assertIsNone(external_stops[0]._timeout)
         # Turn-start is audio-driven (default strategies), NOT manual/external.
         self.assertFalse(
             any(isinstance(s, ExternalUserTurnStartStrategy) for s in strategies.start)


### PR DESCRIPTION
## What
- Fix the external-agent voice sim dropping/mis-segmenting agent turns: the aggregator was using pipecat's default VAD/smart-turn strategies with no VAD enabled, so the agent's explicit turn frames were ignored and the first utterance of a multi-utterance turn (e.g. a greeting before the first question) was lost.
- Drive turn boundaries from the agent's audio instead: VAD + smart-turn v3 stop strategy decides when the agent yields the floor; the adapter fires a natural interrupt on every agent utterance and no longer emits manual UserStarted/UserStopped.
- Add a bounded 2s `user_turn_stop_timeout` fallback for when smart-turn stalls on synthesized TTS audio.

## Notes
- Turn-taking is intentionally realistic and non-deterministic: greeting+question may merge into one turn or split, and the sim user may greet back before answering. Nothing is dropped.
- The sim-user-interrupts-agent path (`interruption_sensitivity > none`) no longer hard-stops the turn on its explicit UserStopped; it commits on the next smart-turn/timeout. Untested since current configs use `none`.
- `bot.py` (the agent side) is unchanged.