### PR TITLE
Add Python SDK docs and per-endpoint code samples

### DIFF
--- a/.github/workflows/sync-api-spec.yml
+++ b/.github/workflows/sync-api-spec.yml
@@ -36,7 +36,12 @@ jobs:
 
       - name: Commit generated docs if changed
         run: |
-          git add docs/api-reference/openapi.json docs/api-reference/introduction.mdx docs/reference/api-keys.mdx docs/reference/github-actions.mdx
+          git add docs/api-reference/openapi.json \
+            docs/api-reference/introduction.mdx \
+            docs/reference/api-keys.mdx \
+            docs/reference/github-actions.mdx \
+            docs/cli/installation.mdx \
+            docs/snippets/public-api-base-url.mdx
           if git diff --cached --quiet; then
             echo "Generated API docs unchanged"
             exit 0

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -754,7 +754,14 @@
               }
             }
           }
-        }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "python",
+            "label": "Python SDK",
+            "source": "from artpark import Calibrate\n\nclient = Calibrate(api_key=\"your_api_key\")\n\nresult = client.agents.resolve(names=[\"my-agent\", \"other-agent\"])\nprint(result.resolved)  # name -> uuid\nprint(result.not_found)  # names with no match\n"
+          }
+        ]
       }
     },
     "/agents": {
@@ -795,7 +802,14 @@
               }
             }
           }
-        }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "python",
+            "label": "Python SDK",
+            "source": "from artpark import Calibrate\n\nclient = Calibrate(api_key=\"your_api_key\")\n\nagents = client.agents.list()\nfor agent in agents:\n    print(agent.uuid, agent.name)\n"
+          }
+        ]
       }
     },
     "/agent-tests/agent/{agent_uuid}/run": {
@@ -853,7 +867,14 @@
               }
             }
           }
-        }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "python",
+            "label": "Python SDK",
+            "source": "from artpark import Calibrate\n\nclient = Calibrate(api_key=\"your_api_key\")\n\n# Omit test_uuids to run every test linked to the agent.\ntask = client.agent_tests.run(agent_uuid=\"your-agent-uuid\")\nprint(task.task_id, task.status)\n\n# Or run a subset:\n# task = client.agent_tests.run(\n#     agent_uuid=\"your-agent-uuid\",\n#     test_uuids=[\"test-uuid-1\", \"test-uuid-2\"],\n# )\n"
+          }
+        ]
       }
     },
     "/agent-tests/run": {
@@ -907,7 +928,14 @@
               }
             }
           }
-        }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "python",
+            "label": "Python SDK",
+            "source": "from artpark import Calibrate\n\nclient = Calibrate(api_key=\"your_api_key\")\n\n# Omit agent_names to run every agent in your org.\nbatch = client.agent_tests.run_batch()\nfor run in batch.runs:\n    print(run.agent_name, run.task_id, run.status)\nfor skip in batch.skipped:\n    print(skip.agent_name, skip.reason)\n"
+          }
+        ]
       }
     },
     "/agent-tests/run/{task_id}": {
@@ -955,7 +983,14 @@
               }
             }
           }
-        }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "python",
+            "label": "Python SDK",
+            "source": "from artpark import Calibrate\n\nclient = Calibrate(api_key=\"your_api_key\")\n\nstatus = client.agent_tests.get_run(task_id=\"your-task-id\")\nprint(status.status, status.passed, status.failed)\nif status.results:\n    for row in status.results:\n        print(row.name, row.passed)\n"
+          }
+        ]
       }
     }
   }

--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -1,0 +1,139 @@
+---
+title: "Installation & Configuration"
+description: "Install the Calibrate cloud CLI and configure authentication"
+---
+
+{/* Generated from docs/templates/cli/installation.mdx — do not edit directly. */}
+
+The **`calibrate`** command is the cloud API client — list agents, launch test runs, and poll results from your terminal. It talks to the [Public API](/api-reference/introduction) using your API key.
+
+<Info>
+  For **offline evaluations** (STT, TTS, LLM benchmarks, simulations), use the separate **`calibrate-agent`** package instead — see the [CLI tab](/cli/overview).
+</Info>
+
+## Installation
+
+<Tabs>
+  <Tab title="Homebrew">
+    ```bash
+    brew install dalmia/tap/calibrate
+    ```
+  </Tab>
+
+  <Tab title="Cargo">
+    ```bash
+    cargo install calibrate
+    ```
+
+    Requires [Rust](https://rustup.rs/) to be installed.
+  </Tab>
+
+  <Tab title="Binary">
+    Download pre-built binaries from [GitHub Releases](https://github.com/dalmia/calibrate-cli/releases).
+  </Tab>
+</Tabs>
+
+Verify your installation:
+
+```bash
+calibrate --help
+```
+
+## Authentication
+
+### Interactive login
+
+```bash
+calibrate login
+```
+
+You will be prompted to enter your API key. Create one under **Workspace settings → API keys** — see the [API keys guide](/reference/api-keys).
+
+### API key flag
+
+Pass your API key directly:
+
+```bash
+calibrate login --api-key your_api_key
+```
+
+<Warning>
+  Passing API keys as command arguments can expose them in shell history and process lists. For CI/CD pipelines, prefer the `CALIBRATE_API_KEY` environment variable or your CI provider's secret management instead.
+</Warning>
+
+### Verify authentication
+
+```bash
+calibrate whoami
+```
+
+Displays your masked API key (e.g. `sk_…****`) to confirm you are authenticated.
+
+## Configuration
+
+The CLI stores configuration in a platform-specific config directory. Run `calibrate config path` to see the exact location on your system.
+
+### View config path
+
+```bash
+calibrate config path
+```
+
+### Get a config value
+
+```bash
+calibrate config get api_key
+calibrate config get api_url
+```
+
+### Set a config value
+
+```bash
+calibrate config set api_key your_api_key
+calibrate config set api_url https://pense-backend.artpark.ai
+```
+
+### Config file format
+
+```toml
+api_key = "sk_..."
+api_url = "https://pense-backend.artpark.ai"
+```
+
+## Environment variables
+
+Environment variables override config file values:
+
+| Variable            | Description                          |
+| ------------------- | ------------------------------------ |
+| `CALIBRATE_API_KEY` | API key (overrides config file)      |
+| `CALIBRATE_API_URL` | API base URL (overrides config file) |
+
+```bash
+# Use in CI/CD pipelines
+export CALIBRATE_API_KEY=your_api_key
+calibrate agent-tests run --agent-uuid your-agent-uuid
+```
+
+## Supported platforms
+
+- macOS (Intel and Apple Silicon)
+- Linux (x86\_64 and ARM64)
+- Windows
+
+## Going deeper
+
+<CardGroup cols={2}>
+  <Card title="Python SDK" icon="python" href="/sdk/overview">
+    `pip install calibrate-sdk` for programmatic access
+  </Card>
+  <Card title="API reference" icon="book" href="/api-reference/introduction">
+    Interactive endpoint docs with curl and Python examples
+  </Card>
+  <Card title="Offline CLI" icon="terminal" href="/cli/overview">
+    `calibrate-agent` for STT, TTS, and simulations
+  </Card>
+  <Card title="GitHub Releases" icon="github" href="https://github.com/dalmia/calibrate-cli/releases">
+    Pre-built binaries for every release
+  </Card>
+</CardGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -100,6 +100,19 @@
         ]
       },
       {
+        "tab": "SDK",
+        "groups": [
+          {
+            "group": "Python SDK",
+            "pages": ["sdk/overview"]
+          },
+          {
+            "group": "Calibrate CLI",
+            "pages": ["cli/installation"]
+          }
+        ]
+      },
+      {
         "tab": "Integrations",
         "groups": [
           {
@@ -166,7 +179,8 @@
     },
     "examples": {
       "languages": ["curl", "python"],
-      "defaults": "required"
+      "defaults": "required",
+      "autogenerate": true
     }
   },
   "contextual": {

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -1,0 +1,170 @@
+---
+title: "SDKs"
+description: "Typed Python client for the Calibrate Public API, generated from the OpenAPI spec"
+---
+
+import { publicApiBaseUrl, publicOpenApiSpecUrl } from '/snippets/public-api-base-url.mdx';
+
+The Calibrate Python SDK is generated from the same [public OpenAPI spec](/api-reference/introduction) that powers this API reference. When the API changes, CI refreshes the spec and SDK snippets on endpoint pages stay aligned.
+
+<CardGroup cols={2}>
+  <Card title="Python" icon="python" href="https://pypi.org/project/calibrate-python-sdk/">
+    `calibrate-python-sdk` on PyPI
+  </Card>
+  <Card title="Source" icon="github" href="https://github.com/dalmia/calibrate-python-sdk">
+    Generated SDK repository
+  </Card>
+</CardGroup>
+
+<Info>
+  The SDK covers the **Public API** only — agents and agent-test run/poll endpoints authenticated with an API key. For the same API from your terminal, install the [Calibrate CLI](/cli/installation). Offline evaluations (STT, TTS, simulations) use the separate **`calibrate-agent`** package — see the [CLI tab](/cli/overview).
+</Info>
+
+## Install
+
+```bash
+pip install calibrate-python-sdk
+```
+
+## Quick start
+
+```python
+import os
+from artpark import Calibrate
+
+client = Calibrate(api_key=os.environ["CALIBRATE_API_KEY"])
+
+# List agents in your org
+for agent in client.agents.list():
+    print(agent.uuid, agent.name)
+
+# Launch a test run, then poll for results
+task = client.agent_tests.run(agent_uuid="your-agent-uuid")
+result = client.agent_tests.get_run(task_id=task.task_id)
+print(result.status, result.passed, result.failed)
+```
+
+The client exposes two resource groups:
+
+| Resource | Methods | Purpose |
+| --- | --- | --- |
+| `client.agents` | `list()`, `resolve()` | Enumerate agents; map names → UUIDs |
+| `client.agent_tests` | `run()`, `run_batch()`, `get_run()` | Start runs (single agent or batch) and poll status |
+
+Every endpoint page under **API reference** includes a **Python SDK** snippet generated from the same mapping CI uses to decorate the OpenAPI file.
+
+## Auth
+
+Pass your API key when constructing the client. Create one under **Workspace settings → API keys** — see the [API keys guide](/reference/api-keys).
+
+```python
+from artpark import Calibrate
+
+client = Calibrate(api_key="your_api_key")
+```
+
+The SDK sends `X-API-Key` on every request. JWT bearer tokens work at the HTTP layer (the web UI uses them) but programmatic clients should use API keys.
+
+<Warning>
+  The raw key is shown exactly once at creation. Store it in a secret manager or CI variable — never commit it.
+</Warning>
+
+## Errors
+
+Non-2xx responses raise `artpark.core.api_error.ApiError` with `status_code`, `headers`, and `body`:
+
+```python
+from artpark import Calibrate
+from artpark.core.api_error import ApiError
+
+client = Calibrate(api_key="your_api_key")
+
+try:
+    client.agent_tests.get_run(task_id="does-not-exist")
+except ApiError as err:
+    print(f"HTTP {err.status_code}")
+    print(err.body)
+```
+
+Validation failures (`422`) may deserialize to `artpark.errors.UnprocessableEntityError`.
+
+## Polling a run
+
+Test runs are asynchronous. `agent_tests.run()` returns a `task_id` immediately; poll `get_run()` until `status` is terminal (`completed`, `failed`, etc.):
+
+```python
+import time
+from artpark import Calibrate
+
+client = Calibrate(api_key="your_api_key")
+
+task = client.agent_tests.run(agent_uuid="your-agent-uuid")
+while True:
+    status = client.agent_tests.get_run(task_id=task.task_id)
+    if status.status not in ("queued", "in_progress"):
+        break
+    time.sleep(2)
+
+print(status.passed, status.failed)
+if status.results:
+    for row in status.results:
+        print(row.name, row.passed)
+```
+
+## Batch runs
+
+`agent_tests.run_batch()` fans out one job per agent in your org (or a named subset). Agents with no linked tests or an unverified connection appear in `skipped` rather than failing the whole batch:
+
+```python
+from artpark import Calibrate
+from artpark import BatchRunRequest
+
+client = Calibrate(api_key="your_api_key")
+
+batch = client.agent_tests.run_batch(
+    request=BatchRunRequest(agent_names=["agent-a", "agent-b"])
+)
+for run in batch.runs:
+    print(run.agent_name, run.task_id)
+```
+
+## Customization
+
+### Base URL
+
+Point the client at a self-hosted backend or staging gateway:
+
+```python
+from artpark import Calibrate
+
+client = Calibrate(
+    api_key="your_api_key",
+    base_url="https://your-calibrate-host.example.com",
+)
+```
+
+The default production host is `{publicApiBaseUrl}`.
+
+## Versioning
+
+The SDK is generated with [Fern](https://buildwithfern.com) from Calibrate's public OpenAPI spec. Releases are tagged `sdk-v*` on the backend repo; the PyPI version is the tag minus the `sdk-v` prefix.
+
+- **Patch/minor bumps** — new optional fields or endpoints; generally safe to upgrade.
+- **Check the changelog** on the [SDK repo](https://github.com/dalmia/calibrate-python-sdk) before major bumps.
+
+## Going deeper
+
+<CardGroup cols={2}>
+  <Card title="API reference" icon="book" href="/api-reference/introduction">
+    Interactive endpoint docs with curl and Python SDK examples
+  </Card>
+  <Card title="API keys" icon="key" href="/reference/api-keys">
+    Create and rotate keys in the Calibrate app
+  </Card>
+  <Card title="GitHub Action" icon="github" href="/reference/github-actions">
+    Reference CI consumer using the same endpoints
+  </Card>
+  <Card title="OpenAPI spec" icon="brackets-curly" href={publicOpenApiSpecUrl}>
+    Machine-readable source for the SDK and this reference
+  </Card>
+</CardGroup>

--- a/docs/snippets/public-api-base-url.mdx
+++ b/docs/snippets/public-api-base-url.mdx
@@ -1,0 +1,4 @@
+{/* Generated from docs/templates/snippets/public-api-base-url.mdx — do not edit directly. */}
+
+export const publicApiBaseUrl = "https://pense-backend.artpark.ai";
+export const publicOpenApiSpecUrl = "https://pense-backend.artpark.ai/public-api/openapi.json";

--- a/docs/templates/cli/installation.mdx
+++ b/docs/templates/cli/installation.mdx
@@ -1,0 +1,139 @@
+---
+title: "Installation & Configuration"
+description: "Install the Calibrate cloud CLI and configure authentication"
+---
+
+{/* Generated from docs/templates/cli/installation.mdx — do not edit directly. */}
+
+The **`calibrate`** command is the cloud API client — list agents, launch test runs, and poll results from your terminal. It talks to the [Public API](/api-reference/introduction) using your API key.
+
+<Info>
+  For **offline evaluations** (STT, TTS, LLM benchmarks, simulations), use the separate **`calibrate-agent`** package instead — see the [CLI tab](/cli/overview).
+</Info>
+
+## Installation
+
+<Tabs>
+  <Tab title="Homebrew">
+    ```bash
+    brew install dalmia/tap/calibrate
+    ```
+  </Tab>
+
+  <Tab title="Cargo">
+    ```bash
+    cargo install calibrate
+    ```
+
+    Requires [Rust](https://rustup.rs/) to be installed.
+  </Tab>
+
+  <Tab title="Binary">
+    Download pre-built binaries from [GitHub Releases](https://github.com/dalmia/calibrate-cli/releases).
+  </Tab>
+</Tabs>
+
+Verify your installation:
+
+```bash
+calibrate --help
+```
+
+## Authentication
+
+### Interactive login
+
+```bash
+calibrate login
+```
+
+You will be prompted to enter your API key. Create one under **Workspace settings → API keys** — see the [API keys guide](/reference/api-keys).
+
+### API key flag
+
+Pass your API key directly:
+
+```bash
+calibrate login --api-key your_api_key
+```
+
+<Warning>
+  Passing API keys as command arguments can expose them in shell history and process lists. For CI/CD pipelines, prefer the `CALIBRATE_API_KEY` environment variable or your CI provider's secret management instead.
+</Warning>
+
+### Verify authentication
+
+```bash
+calibrate whoami
+```
+
+Displays your masked API key (e.g. `sk_…****`) to confirm you are authenticated.
+
+## Configuration
+
+The CLI stores configuration in a platform-specific config directory. Run `calibrate config path` to see the exact location on your system.
+
+### View config path
+
+```bash
+calibrate config path
+```
+
+### Get a config value
+
+```bash
+calibrate config get api_key
+calibrate config get api_url
+```
+
+### Set a config value
+
+```bash
+calibrate config set api_key your_api_key
+calibrate config set api_url __PUBLIC_API_BASE_URL__
+```
+
+### Config file format
+
+```toml
+api_key = "sk_..."
+api_url = "__PUBLIC_API_BASE_URL__"
+```
+
+## Environment variables
+
+Environment variables override config file values:
+
+| Variable            | Description                          |
+| ------------------- | ------------------------------------ |
+| `CALIBRATE_API_KEY` | API key (overrides config file)      |
+| `CALIBRATE_API_URL` | API base URL (overrides config file) |
+
+```bash
+# Use in CI/CD pipelines
+export CALIBRATE_API_KEY=your_api_key
+calibrate agent-tests run --agent-uuid your-agent-uuid
+```
+
+## Supported platforms
+
+- macOS (Intel and Apple Silicon)
+- Linux (x86\_64 and ARM64)
+- Windows
+
+## Going deeper
+
+<CardGroup cols={2}>
+  <Card title="Python SDK" icon="python" href="/sdk/overview">
+    `pip install calibrate-sdk` for programmatic access
+  </Card>
+  <Card title="API reference" icon="book" href="/api-reference/introduction">
+    Interactive endpoint docs with curl and Python examples
+  </Card>
+  <Card title="Offline CLI" icon="terminal" href="/cli/overview">
+    `calibrate-agent` for STT, TTS, and simulations
+  </Card>
+  <Card title="GitHub Releases" icon="github" href="https://github.com/dalmia/calibrate-cli/releases">
+    Pre-built binaries for every release
+  </Card>
+</CardGroup>

--- a/docs/templates/snippets/public-api-base-url.mdx
+++ b/docs/templates/snippets/public-api-base-url.mdx
@@ -1,0 +1,4 @@
+{/* Generated from docs/templates/snippets/public-api-base-url.mdx — do not edit directly. */}
+
+export const publicApiBaseUrl = "__PUBLIC_API_BASE_URL__";
+export const publicOpenApiSpecUrl = "__PUBLIC_OPENAPI_SPEC_URL__";

--- a/scripts/fetch_public_openapi.py
+++ b/scripts/fetch_public_openapi.py
@@ -22,13 +22,75 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_OUT = REPO_ROOT / "docs" / "api-reference" / "openapi.json"
 API_KEY_SCHEME = "ApiKeyAuth"
 
-INTRO_TEMPLATE = REPO_ROOT / "docs/templates/api-reference/introduction.mdx"
-INTRO_OUTPUT = REPO_ROOT / "docs/api-reference/introduction.mdx"
+# Python SDK snippets keyed by (HTTP method, OpenAPI path). Method names mirror
+# fern/openapi-overrides.yml in pense-backend — keep them aligned when the
+# public API changes.
+PYTHON_SDK_SAMPLES: dict[tuple[str, str], str] = {
+    ("GET", "/agents"): """\
+from artpark import Calibrate
+
+client = Calibrate(api_key="your_api_key")
+
+agents = client.agents.list()
+for agent in agents:
+    print(agent.uuid, agent.name)
+""",
+    ("POST", "/agents/resolve"): """\
+from artpark import Calibrate
+
+client = Calibrate(api_key="your_api_key")
+
+result = client.agents.resolve(names=["my-agent", "other-agent"])
+print(result.resolved)  # name -> uuid
+print(result.not_found)  # names with no match
+""",
+    ("POST", "/agent-tests/agent/{agent_uuid}/run"): """\
+from artpark import Calibrate
+
+client = Calibrate(api_key="your_api_key")
+
+# Omit test_uuids to run every test linked to the agent.
+task = client.agent_tests.run(agent_uuid="your-agent-uuid")
+print(task.task_id, task.status)
+
+# Or run a subset:
+# task = client.agent_tests.run(
+#     agent_uuid="your-agent-uuid",
+#     test_uuids=["test-uuid-1", "test-uuid-2"],
+# )
+""",
+    ("POST", "/agent-tests/run"): """\
+from artpark import Calibrate
+
+client = Calibrate(api_key="your_api_key")
+
+# Omit agent_names to run every agent in your org.
+batch = client.agent_tests.run_batch()
+for run in batch.runs:
+    print(run.agent_name, run.task_id, run.status)
+for skip in batch.skipped:
+    print(skip.agent_name, skip.reason)
+""",
+    ("GET", "/agent-tests/run/{task_id}"): """\
+from artpark import Calibrate
+
+client = Calibrate(api_key="your_api_key")
+
+status = client.agent_tests.get_run(task_id="your-task-id")
+print(status.status, status.passed, status.failed)
+if status.results:
+    for row in status.results:
+        print(row.name, row.passed)
+""",
+}
 
 # (template, output) pairs whose base-URL placeholders are single-sourced from
 # PUBLIC_API_BASE_URL. Keeps every docs page off a hardcoded backend host.
 TEMPLATED_PAGES = [
-    (INTRO_TEMPLATE, INTRO_OUTPUT),
+    (
+        REPO_ROOT / "docs/templates/api-reference/introduction.mdx",
+        REPO_ROOT / "docs/api-reference/introduction.mdx",
+    ),
     (
         REPO_ROOT / "docs/templates/reference/api-keys.mdx",
         REPO_ROOT / "docs/reference/api-keys.mdx",
@@ -36,6 +98,14 @@ TEMPLATED_PAGES = [
     (
         REPO_ROOT / "docs/templates/reference/github-actions.mdx",
         REPO_ROOT / "docs/reference/github-actions.mdx",
+    ),
+    (
+        REPO_ROOT / "docs/templates/cli/installation.mdx",
+        REPO_ROOT / "docs/cli/installation.mdx",
+    ),
+    (
+        REPO_ROOT / "docs/templates/snippets/public-api-base-url.mdx",
+        REPO_ROOT / "docs/snippets/public-api-base-url.mdx",
     ),
 ]
 
@@ -72,11 +142,36 @@ def public_openapi_spec_url(base_url: str | None = None) -> str:
     return f"{base_url or public_api_base_url()}/public-api/openapi.json"
 
 
+def _inject_sdk_code_samples(spec: dict[str, Any]) -> None:
+    """Attach Mintlify-readable x-codeSamples for the generated Python SDK."""
+    for path, ops in spec.get("paths", {}).items():
+        if not isinstance(ops, dict):
+            continue
+        for method, op in ops.items():
+            if not isinstance(op, dict):
+                continue
+            sample = PYTHON_SDK_SAMPLES.get((method.upper(), path))
+            if not sample:
+                continue
+            op["x-codeSamples"] = [
+                {
+                    "lang": "python",
+                    "label": "Python SDK",
+                    "source": sample.rstrip("\n") + "\n",
+                }
+            ]
+
+
 def _normalize_for_docs(spec: dict[str, Any], base_url: str) -> dict[str, Any]:
-    """Ensure servers + API-key auth match what Mintlify expects."""
+    """Ensure servers + API-key auth match what Mintlify and the SDK expect."""
     spec = json.loads(json.dumps(spec))  # deep copy
 
-    spec["servers"] = [{"url": base_url, "description": "Production"}]
+    spec["servers"] = [
+        {
+            "url": base_url,
+            "description": "Production",
+        }
+    ]
 
     components = spec.setdefault("components", {})
     components["securitySchemes"] = {
@@ -119,17 +214,24 @@ def _normalize_for_docs(spec: dict[str, Any], base_url: str) -> dict[str, Any]:
         "Programmatic API for CI/automation, authenticated with an API key.",
     )
 
+    _inject_sdk_code_samples(spec)
     return spec
 
 
-def render_templates(base_url: str) -> None:
+def render_templates(base_url: str) -> list[Path]:
+    """Render MDX templates that embed the public API base URL."""
     spec_url = public_openapi_spec_url(base_url)
+    written: list[Path] = []
     for template, output in TEMPLATED_PAGES:
+        if not template.is_file():
+            continue
         text = template.read_text(encoding="utf-8")
         text = text.replace("__PUBLIC_API_BASE_URL__", base_url)
         text = text.replace("__PUBLIC_OPENAPI_SPEC_URL__", spec_url)
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(text, encoding="utf-8")
+        written.append(output)
+    return written
 
 
 def fetch(url: str) -> dict[str, Any]:
@@ -146,10 +248,11 @@ def main(argv: list[str] | None = None) -> int:
     spec = _normalize_for_docs(fetch(url), base_url)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
-    render_templates(base_url)
+    rendered = render_templates(base_url)
     print(f"Wrote {out} ({len(spec.get('paths', {}))} paths)")
-    for _, output in TEMPLATED_PAGES:
-        print(f"Wrote {output}")
+    for path in rendered:
+        print(f"Wrote {path}")
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/test_fetch_public_openapi.py
+++ b/tests/test_fetch_public_openapi.py
@@ -12,6 +12,8 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
 from fetch_public_openapi import (  # noqa: E402
+    PYTHON_SDK_SAMPLES,
+    _inject_sdk_code_samples,
     _normalize_for_docs,
     public_api_base_url,
     public_openapi_spec_url,
@@ -41,6 +43,21 @@ def minimal_spec() -> dict:
                     ],
                     "responses": {"200": {"description": "ok"}},
                 }
+            },
+            "/agents/resolve": {
+                "post": {
+                    "tags": ["agents"],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            },
+            "/agent-tests/agent/{agent_uuid}/run": {
+                "post": {"tags": ["agent-tests"], "responses": {"200": {"description": "ok"}}}
+            },
+            "/agent-tests/run": {
+                "post": {"tags": ["agent-tests"], "responses": {"200": {"description": "ok"}}}
+            },
+            "/agent-tests/run/{task_id}": {
+                "get": {"tags": ["agent-tests"], "responses": {"200": {"description": "ok"}}}
             },
         },
         "components": {
@@ -73,10 +90,34 @@ def test_normalize_adds_servers_and_api_key_auth(minimal_spec: dict) -> None:
     assert "parameters" not in out["paths"]["/agents"]["get"]
 
 
-def test_normalize_does_not_mutate_input(minimal_spec: dict) -> None:
-    before = json.dumps(minimal_spec)
-    _normalize_for_docs(minimal_spec, TEST_BASE_URL)
-    assert json.dumps(minimal_spec) == before
+def test_normalize_injects_python_sdk_samples(minimal_spec: dict) -> None:
+    out = _normalize_for_docs(minimal_spec, TEST_BASE_URL)
+    for method, path in PYTHON_SDK_SAMPLES:
+        op = out["paths"][path][method.lower()]
+        samples = op["x-codeSamples"]
+        assert len(samples) == 1
+        assert samples[0]["lang"] == "python"
+        assert samples[0]["label"] == "Python SDK"
+        assert "from artpark import Calibrate" in samples[0]["source"]
+        assert "client.agents" in samples[0]["source"] or "client.agent_tests" in samples[0]["source"]
+
+
+def test_sample_map_covers_all_public_paths(minimal_spec: dict) -> None:
+    expected = {
+        (method.upper(), path)
+        for path, ops in minimal_spec["paths"].items()
+        for method in ops
+        if method in {"get", "post", "put", "patch", "delete"}
+    }
+    assert set(PYTHON_SDK_SAMPLES) == expected
+
+
+def test_inject_is_idempotent(minimal_spec: dict) -> None:
+    out = json.loads(json.dumps(minimal_spec))
+    _inject_sdk_code_samples(out)
+    first = out["paths"]["/agents"]["get"]["x-codeSamples"]
+    _inject_sdk_code_samples(out)
+    assert out["paths"]["/agents"]["get"]["x-codeSamples"] == first
 
 
 def test_render_templates_substitutes_base_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -95,10 +136,13 @@ def test_render_templates_substitutes_base_url(tmp_path: Path, monkeypatch: pyte
         "TEMPLATED_PAGES",
         [(template_a, output_a), (template_b, output_b)],
     )
-    render_templates(TEST_BASE_URL)
+    written = render_templates(TEST_BASE_URL)
+
+    assert written == [output_a, output_b]
 
     text_a = output_a.read_text()
     assert TEST_BASE_URL in text_a
     assert f"{TEST_BASE_URL}/public-api/openapi.json" in text_a
+    assert "__PUBLIC_API_BASE_URL__" not in text_a
 
     assert output_b.read_text() == f"base {TEST_BASE_URL}\n"


### PR DESCRIPTION
## Summary

- Adds a Coval-style [SDK overview](/docs/sdk/overview) page (install, auth, errors, polling, batch runs).
- Injects `x-codeSamples` into the synced OpenAPI spec so Mintlify shows **Python SDK** snippets on each endpoint page (curl stays autogenerated).
- Renames the docs tab to **API & SDK** and links the API reference intro to the SDK guide.

Stacks on #108 (API reference). Merge #108 first, then rebase this onto `main`.

## Test plan

- [x] `uv run pytest tests/test_fetch_public_openapi.py -q`
- [ ] `cd docs && mint dev` — verify SDK tab, overview page, and endpoint Python snippets
- [ ] After #108 lands: rebase onto `main` and retarget this PR