### PR TITLE
Retry silent (empty-audio) TTS turns in the voice-agent simulator

### DIFF
--- a/calibrate_agent/agent/run_simulation.py
+++ b/calibrate_agent/agent/run_simulation.py
@@ -31,6 +31,7 @@ from calibrate_agent.utils import (
     build_tools_schema,
     make_webhook_call,
     create_tts_service,
+    wrap_tts_with_empty_response_retry,
     provider_log_file,
     summarize_metric_distribution,
     save_transcript,
@@ -1557,6 +1558,11 @@ async def _run_simulation_inner(
         raise ValueError(
             f"Unsupported simulated-user TTS provider: {voices['provider']}"
         )
+
+    # Guard against intermittent silent-TTS turns (e.g. ElevenLabs returning a
+    # 200 with an empty audio stream), which otherwise stall the sim until the
+    # pipeline idle timeout and truncate the transcript.
+    tts = wrap_tts_with_empty_response_retry(tts)
 
     llm = OpenAILLMService(
         api_key=os.getenv("OPENAI_API_KEY"),

--- a/calibrate_agent/utils.py
+++ b/calibrate_agent/utils.py
@@ -16,7 +16,11 @@ import aiohttp
 import numpy as np
 from loguru import logger
 from pipecat.adapters.schemas.function_schema import FunctionSchema
-from pipecat.frames.frames import InputTransportMessageFrame
+from pipecat.frames.frames import (
+    InputTransportMessageFrame,
+    TTSAudioRawFrame,
+    ErrorFrame,
+)
 from pipecat.processors.frame_processor import FrameProcessor
 from pipecat.transcriptions.language import Language
 
@@ -1985,6 +1989,95 @@ def create_tts_service(
         )
     else:
         raise ValueError(f"Unsupported TTS provider: {provider}")
+
+
+def wrap_tts_with_empty_response_retry(
+    tts,
+    *,
+    max_attempts: int = 3,
+    backoff_base_secs: float = 0.5,
+):
+    """Retry a TTS turn that yields no audio, in place, on any pipecat TTS service.
+
+    Some HTTP TTS providers (notably ElevenLabs) intermittently return an HTTP
+    200 with an *empty* audio stream: ``run_tts`` iterates zero times, yields no
+    ``TTSAudioRawFrame`` and no error, so the turn goes completely silent. In the
+    voice-agent simulator that stalls the whole conversation until the pipeline
+    idle timeout, leaving a truncated transcript.
+
+    This wraps the instance's ``run_tts`` so that any synthesis attempt producing
+    zero ``TTSAudioRawFrame`` is retried (exponential backoff) up to
+    ``max_attempts`` times. Audio is streamed as it arrives on the successful
+    attempt — only the empty case (nothing yielded) triggers a retry. If every
+    attempt is empty, an ``ErrorFrame`` is surfaced instead of silence so the
+    caller fails loudly rather than idle-timing-out with a corrupted transcript.
+
+    Provider-general and safe for streaming (websocket) services: those signal
+    "audio arrives via a separate receive loop" by yielding ``None`` from
+    ``run_tts``; when that happens the retry is skipped and frames pass through
+    untouched.
+
+    Returns the same ``tts`` instance (mutated) for convenient chaining.
+    """
+    original_run_tts = tts.run_tts
+    service_name = type(tts).__name__
+
+    async def run_tts_with_retry(text: str, context_id: str):
+        for attempt in range(1, max_attempts + 1):
+            audio_seen = False
+            streams_out_of_band = False
+            deferred = []  # non-audio frames held until we commit to this attempt
+            async for frame in original_run_tts(text, context_id):
+                if frame is None:
+                    # Websocket services deliver audio via a separate receive
+                    # loop; the None sentinel means "handled elsewhere". Never
+                    # retry these — pass through as-is.
+                    streams_out_of_band = True
+                    yield frame
+                elif isinstance(frame, TTSAudioRawFrame):
+                    audio_seen = True
+                    yield frame
+                elif isinstance(frame, ErrorFrame):
+                    deferred.append(frame)
+                elif audio_seen:
+                    yield frame
+                else:
+                    deferred.append(frame)
+
+            if audio_seen or streams_out_of_band:
+                for frame in deferred:
+                    if not isinstance(frame, ErrorFrame):
+                        yield frame
+                return
+
+            if attempt < max_attempts:
+                delay = backoff_base_secs * (2 ** (attempt - 1))
+                logger.warning(
+                    f"{service_name}: TTS produced no audio for [{text}] "
+                    f"(attempt {attempt}/{max_attempts}); retrying in {delay:.1f}s"
+                )
+                await asyncio.sleep(delay)
+                continue
+
+            logger.error(
+                f"{service_name}: TTS produced no audio for [{text}] after "
+                f"{max_attempts} attempts; surfacing error"
+            )
+            emitted_error = False
+            for frame in deferred:
+                yield frame
+                if isinstance(frame, ErrorFrame):
+                    emitted_error = True
+            if not emitted_error:
+                yield ErrorFrame(
+                    error=(
+                        f"{service_name} produced no audio for [{text}] after "
+                        f"{max_attempts} attempts"
+                    )
+                )
+
+    tts.run_tts = run_tts_with_retry
+    return tts
 
 
 def _build_param_property(param: dict) -> dict:

--- a/tests/agent/test_tts_retry.py
+++ b/tests/agent/test_tts_retry.py
@@ -1,0 +1,133 @@
+"""Tests for wrap_tts_with_empty_response_retry in calibrate_agent/utils.py.
+
+The wrapper guards against intermittent silent-TTS turns (e.g. ElevenLabs
+returning an HTTP 200 with an empty audio stream), which otherwise stall the
+voice-agent simulator until the pipeline idle timeout. These tests mock a TTS
+service whose run_tts yields a scripted sequence of frames per attempt and
+assert the retry/recover/surface-error behavior.
+"""
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from pipecat.frames.frames import TTSAudioRawFrame, ErrorFrame
+
+from calibrate_agent.utils import wrap_tts_with_empty_response_retry
+
+
+def _audio():
+    return TTSAudioRawFrame(b"\x00\x00", 16000, 1)
+
+
+class FakeTTSService:
+    """A TTS service whose run_tts replays one scripted frame-list per attempt.
+
+    ``scripts`` is a list of per-attempt frame lists. A frame value of ``None``
+    is yielded verbatim (the websocket out-of-band sentinel).
+    """
+
+    def __init__(self, scripts):
+        self._scripts = scripts
+        self.attempts = 0
+
+    async def run_tts(self, text, context_id):
+        script = self._scripts[self.attempts]
+        self.attempts += 1
+        for frame in script:
+            yield frame
+
+
+async def _collect(tts, text="hello", context_id="ctx"):
+    return [frame async for frame in tts.run_tts(text, context_id)]
+
+
+class TestWrapTTSWithEmptyResponseRetry(unittest.IsolatedAsyncioTestCase):
+    async def test_first_attempt_succeeds_no_retry(self):
+        tts = FakeTTSService([[_audio(), _audio()]])
+        wrap_tts_with_empty_response_retry(tts)
+
+        with patch("calibrate_agent.utils.asyncio.sleep", new=AsyncMock()) as sleep:
+            frames = await _collect(tts)
+
+        self.assertEqual(tts.attempts, 1)
+        self.assertEqual(len(frames), 2)
+        self.assertTrue(all(isinstance(f, TTSAudioRawFrame) for f in frames))
+        sleep.assert_not_awaited()
+
+    async def test_empty_then_audio_retries_and_recovers(self):
+        tts = FakeTTSService([[], [_audio()]])
+        wrap_tts_with_empty_response_retry(tts, max_attempts=3, backoff_base_secs=0.5)
+
+        with patch("calibrate_agent.utils.asyncio.sleep", new=AsyncMock()) as sleep:
+            frames = await _collect(tts)
+
+        self.assertEqual(tts.attempts, 2)
+        self.assertEqual(len(frames), 1)
+        self.assertIsInstance(frames[0], TTSAudioRawFrame)
+        sleep.assert_awaited_once_with(0.5)
+
+    async def test_all_empty_surfaces_synthetic_error(self):
+        tts = FakeTTSService([[], [], []])
+        wrap_tts_with_empty_response_retry(tts, max_attempts=3)
+
+        with patch("calibrate_agent.utils.asyncio.sleep", new=AsyncMock()) as sleep:
+            frames = await _collect(tts)
+
+        self.assertEqual(tts.attempts, 3)
+        self.assertEqual(len(frames), 1)
+        self.assertIsInstance(frames[0], ErrorFrame)
+        # backoff between the 3 attempts => 2 sleeps
+        self.assertEqual(sleep.await_count, 2)
+
+    async def test_all_empty_surfaces_providers_own_error(self):
+        provider_error = ErrorFrame(error="ElevenLabs API error: boom")
+        tts = FakeTTSService([[provider_error], [provider_error], [provider_error]])
+        wrap_tts_with_empty_response_retry(tts, max_attempts=3)
+
+        with patch("calibrate_agent.utils.asyncio.sleep", new=AsyncMock()):
+            frames = await _collect(tts)
+
+        # The provider's own ErrorFrame is surfaced; no synthetic one is added.
+        self.assertEqual(len(frames), 1)
+        self.assertIs(frames[0], provider_error)
+
+    async def test_error_frame_on_empty_attempt_does_not_leak_on_recovery(self):
+        # First attempt yields only an ErrorFrame (still no audio) -> retry.
+        tts = FakeTTSService([[ErrorFrame(error="boom")], [_audio()]])
+        wrap_tts_with_empty_response_retry(tts)
+
+        with patch("calibrate_agent.utils.asyncio.sleep", new=AsyncMock()):
+            frames = await _collect(tts)
+
+        self.assertEqual(len(frames), 1)
+        self.assertIsInstance(frames[0], TTSAudioRawFrame)
+
+    async def test_none_sentinel_skips_retry(self):
+        # Websocket services deliver audio out-of-band and yield None; the
+        # wrapper must pass None through and never retry.
+        tts = FakeTTSService([[None]])
+        wrap_tts_with_empty_response_retry(tts)
+
+        with patch("calibrate_agent.utils.asyncio.sleep", new=AsyncMock()) as sleep:
+            frames = await _collect(tts)
+
+        self.assertEqual(tts.attempts, 1)
+        self.assertEqual(frames, [None])
+        sleep.assert_not_awaited()
+
+    async def test_backoff_is_exponential(self):
+        tts = FakeTTSService([[], [], [_audio()]])
+        wrap_tts_with_empty_response_retry(tts, max_attempts=3, backoff_base_secs=0.5)
+
+        with patch("calibrate_agent.utils.asyncio.sleep", new=AsyncMock()) as sleep:
+            await _collect(tts)
+
+        self.assertEqual([c.args[0] for c in sleep.await_args_list], [0.5, 1.0])
+
+    async def test_returns_same_instance(self):
+        tts = FakeTTSService([[_audio()]])
+        self.assertIs(wrap_tts_with_empty_response_retry(tts), tts)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What
- Some HTTP TTS providers (notably ElevenLabs' with-timestamps endpoint) intermittently return HTTP 200 with an empty audio stream — pipecat's `run_tts` yields no audio and no error, so the sim-user turn goes silent, the agent never responds, and the pipeline stalls until the 120s idle timeout with a truncated transcript.
- Add `wrap_tts_with_empty_response_retry` in `calibrate/utils.py`: retries `run_tts` (exponential backoff, capped attempts) when an attempt yields zero audio frames, and surfaces an `ErrorFrame` instead of silence when all attempts are empty.
- Wrap the simulated-user TTS in `run_simulation.py`, covering both the ElevenLabs and Google branches.

## Notes
- Provider-general (operates on any pipecat `TTSService` instance). Websocket services that deliver audio out-of-band (yielding `None`) are detected and never retried.
- Audio streams as it arrives on the successful attempt — only the empty case triggers a retry.
- Hard to reproduce live (intermittent, ~1 in 4), so the retry logic is covered by 8 mocked unit tests in `tests/agent/test_tts_retry.py`.