### PR TITLE
Update voice simulation default LLMs to gpt-5.4-mini

### DIFF
--- a/calibrate/agent/__init__.py
+++ b/calibrate/agent/__init__.py
@@ -25,6 +25,11 @@ import asyncio
 from collections import defaultdict
 import pandas as pd
 
+from calibrate.agent.bot import (
+    DEFAULT_TEST_AGENT_LLM_MODEL,
+    DEFAULT_SIMULATED_USER_LLM_MODEL,
+)
+
 
 @dataclass
 class STTConfig:
@@ -55,7 +60,7 @@ class LLMConfig:
     """Configuration for LLM service."""
 
     provider: str = "openrouter"
-    model: str = "openai/gpt-5.4-mini"
+    model: str = DEFAULT_TEST_AGENT_LLM_MODEL
 
     def to_dict(self) -> dict:
         return {"provider": self.provider, "model": self.model}
@@ -91,7 +96,7 @@ class _Simulation:
             output_dir: Path to output directory for results (default: ./out)
             stt: STT configuration (default: Google)
             tts: TTS configuration (default: Google)
-            llm: LLM configuration (default: OpenRouter with gpt-5.4-mini)
+            llm: LLM configuration (default: OpenRouter with ``DEFAULT_TEST_AGENT_LLM_MODEL``)
             agent_speaks_first: Whether the agent initiates the conversation (default: True)
             max_turns: Maximum number of assistant turns (default: 50)
             port: Base WebSocket port for simulations (default: 8765)
@@ -116,7 +121,7 @@ class _Simulation:
             ...     output_dir="./out",
             ...     stt=STTConfig(provider="google"),
             ...     tts=TTSConfig(provider="google"),
-            ...     llm=LLMConfig(provider="openrouter", model="openai/gpt-4.1"),
+            ...     llm=LLMConfig(provider="openrouter", model=DEFAULT_TEST_AGENT_LLM_MODEL),
             ... ))
         """
         from calibrate.judges import require_simulation_evaluators, write_evaluator_config
@@ -338,4 +343,11 @@ class _Simulation:
 simulation = _Simulation()
 
 # Re-export config classes
-__all__ = ["simulation", "STTConfig", "TTSConfig", "LLMConfig"]
+__all__ = [
+    "simulation",
+    "STTConfig",
+    "TTSConfig",
+    "LLMConfig",
+    "DEFAULT_TEST_AGENT_LLM_MODEL",
+    "DEFAULT_SIMULATED_USER_LLM_MODEL",
+]

--- a/calibrate/agent/__init__.py
+++ b/calibrate/agent/__init__.py
@@ -55,7 +55,7 @@ class LLMConfig:
     """Configuration for LLM service."""
 
     provider: str = "openrouter"
-    model: str = "openai/gpt-4.1"
+    model: str = "openai/gpt-5.4-mini"
 
     def to_dict(self) -> dict:
         return {"provider": self.provider, "model": self.model}
@@ -91,7 +91,7 @@ class _Simulation:
             output_dir: Path to output directory for results (default: ./out)
             stt: STT configuration (default: Google)
             tts: TTS configuration (default: Google)
-            llm: LLM configuration (default: OpenRouter with gpt-4.1)
+            llm: LLM configuration (default: OpenRouter with gpt-5.4-mini)
             agent_speaks_first: Whether the agent initiates the conversation (default: True)
             max_turns: Maximum number of assistant turns (default: 50)
             port: Base WebSocket port for simulations (default: 8765)

--- a/calibrate/agent/bot.py
+++ b/calibrate/agent/bot.py
@@ -125,7 +125,7 @@ class TTSConfig(BaseModel):
 
 class LLMConfig(BaseModel):
     provider: Literal["openai", "openrouter"] = "openrouter"
-    model: str = "openai/gpt-4.1"
+    model: str = "openai/gpt-5.4-mini"
 
 
 async def run_bot(

--- a/calibrate/agent/bot.py
+++ b/calibrate/agent/bot.py
@@ -123,9 +123,13 @@ class TTSConfig(BaseModel):
     instructions: str = None
 
 
+DEFAULT_TEST_AGENT_LLM_MODEL = "openai/gpt-5.4-mini"
+DEFAULT_SIMULATED_USER_LLM_MODEL = "gpt-5.4-mini"
+
+
 class LLMConfig(BaseModel):
     provider: Literal["openai", "openrouter"] = "openrouter"
-    model: str = "openai/gpt-5.4-mini"
+    model: str = DEFAULT_TEST_AGENT_LLM_MODEL
 
 
 async def run_bot(

--- a/calibrate/agent/run_simulation.py
+++ b/calibrate/agent/run_simulation.py
@@ -1492,7 +1492,7 @@ async def _run_simulation_inner(
 
     llm = OpenAILLMService(
         api_key=os.getenv("OPENAI_API_KEY"),
-        settings=OpenAILLMService.Settings(model="gpt-5.2"),
+        settings=OpenAILLMService.Settings(model="gpt-5.4-mini"),
     )
 
     simulation_system_prompt = system_prompt
@@ -2019,7 +2019,7 @@ async def _run_single_simulation_inner(
     llm_config_data = config.get("llm", {})
     llm_config = LLMConfig(
         provider=llm_config_data.get("provider", "openrouter"),
-        model=llm_config_data.get("model", "openai/gpt-4.1"),
+        model=llm_config_data.get("model", "openai/gpt-5.4-mini"),
     )
     agent_speaks_first = config.get("settings", {}).get(
         "agent_speaks_first", DEFAULT_AGENT_SPEAKS_FIRST

--- a/calibrate/agent/run_simulation.py
+++ b/calibrate/agent/run_simulation.py
@@ -177,7 +177,14 @@ from pipecat.transports.websocket.client import (
 
 from pipecat.serializers.base_serializer import FrameSerializer
 from pipecat.serializers.protobuf import ProtobufFrameSerializer
-from calibrate.agent.bot import run_bot, STTConfig, TTSConfig, LLMConfig
+from calibrate.agent.bot import (
+    run_bot,
+    STTConfig,
+    TTSConfig,
+    LLMConfig,
+    DEFAULT_TEST_AGENT_LLM_MODEL,
+    DEFAULT_SIMULATED_USER_LLM_MODEL,
+)
 from pipecat.utils.time import time_now_iso8601
 
 PIPELINE_IDLE_TIMEOUT_SECS = 120  # 2 minutes
@@ -1492,7 +1499,7 @@ async def _run_simulation_inner(
 
     llm = OpenAILLMService(
         api_key=os.getenv("OPENAI_API_KEY"),
-        settings=OpenAILLMService.Settings(model="gpt-5.4-mini"),
+        settings=OpenAILLMService.Settings(model=DEFAULT_SIMULATED_USER_LLM_MODEL),
     )
 
     simulation_system_prompt = system_prompt
@@ -2019,7 +2026,7 @@ async def _run_single_simulation_inner(
     llm_config_data = config.get("llm", {})
     llm_config = LLMConfig(
         provider=llm_config_data.get("provider", "openrouter"),
-        model=llm_config_data.get("model", "openai/gpt-5.4-mini"),
+        model=llm_config_data.get("model", DEFAULT_TEST_AGENT_LLM_MODEL),
     )
     agent_speaks_first = config.get("settings", {}).get(
         "agent_speaks_first", DEFAULT_AGENT_SPEAKS_FIRST

--- a/tests/agent/test_bot.py
+++ b/tests/agent/test_bot.py
@@ -39,7 +39,7 @@ class TestLLMConfig(unittest.TestCase):
 
         cfg = LLMConfig()
         self.assertEqual(cfg.provider, "openrouter")
-        self.assertEqual(cfg.model, "openai/gpt-4.1")
+        self.assertEqual(cfg.model, "openai/gpt-5.4-mini")
 
     def test_custom(self):
         from calibrate.agent.bot import LLMConfig

--- a/tests/agent/test_bot.py
+++ b/tests/agent/test_bot.py
@@ -35,11 +35,11 @@ class TestTTSConfig(unittest.TestCase):
 
 class TestLLMConfig(unittest.TestCase):
     def test_default(self):
-        from calibrate.agent.bot import LLMConfig
+        from calibrate.agent.bot import DEFAULT_TEST_AGENT_LLM_MODEL, LLMConfig
 
         cfg = LLMConfig()
         self.assertEqual(cfg.provider, "openrouter")
-        self.assertEqual(cfg.model, "openai/gpt-5.4-mini")
+        self.assertEqual(cfg.model, DEFAULT_TEST_AGENT_LLM_MODEL)
 
     def test_custom(self):
         from calibrate.agent.bot import LLMConfig


### PR DESCRIPTION
## Summary
- Bump the internal voice-agent bot default from `openai/gpt-4.1` to `openai/gpt-5.4-mini` (OpenRouter).
- Bump the simulated user default from `gpt-5.2` to `gpt-5.4-mini` (OpenAI).
- Align the SDK `LLMConfig` default and the simulation config parser fallback with the new bot default.

## Test plan
- [x] `uv run pytest tests/agent/test_bot.py`