### PR TITLE
Build sim transcript from an ordered event log, not the mutable context

### DIFF
--- a/calibrate/agent/run_simulation.py
+++ b/calibrate/agent/run_simulation.py
@@ -190,6 +190,9 @@ from pipecat.utils.time import time_now_iso8601
 PIPELINE_IDLE_TIMEOUT_SECS = 120  # 2 minutes
 EVAL_TIMEOUT_SECS = 3000
 TRANSCRIPT_FILE_NAME = "transcript.json"
+# Punctuation that should attach to the preceding word when joining TTS text
+# fragments into a persona turn (covers Latin plus the Devanagari danda).
+_PERSONA_TEXT_CLINGING_PUNCTUATION = frozenset(",.!?;:।॥")
 
 DEFAULT_SERIALIZER_NAME = "protobuf"
 SERIALIZER_REGISTRY = {"protobuf": ProtobufFrameSerializer}
@@ -471,9 +474,10 @@ class RTVIMessageFrameAdapter(FrameProcessor):
         #   {"role": "agent"|"persona", "content": str}
         #   {"role": "tool_calls", "tool_calls": [...]}
         self._transcript_events: list[dict] = []
-        # Text the sim user (persona) has spoken in the current, not-yet-committed
-        # turn, accumulated from ``TTSTextFrame``s. Flushed into an event when the
-        # turn commits, a tool call / agent turn follows it, or at teardown.
+        # Text the sim user (persona) has spoken in the current turn, accumulated
+        # from ``TTSTextFrame``s (what was actually said, so it survives a mid-turn
+        # teardown). Flushed into an event when a tool call / agent turn follows it,
+        # or included as the trailing turn at build time.
         self._pending_persona_text = ""
         self._ended_due_to_max_turns = False
         self._bot_audio_chunk_indices = {}  # Track chunk indices for bot audio per turn
@@ -626,28 +630,24 @@ class RTVIMessageFrameAdapter(FrameProcessor):
                 {"role": "agent", "content": content.strip()}
             )
 
-    def record_persona_committed(self, content: Optional[str]) -> None:
-        """Record the authoritative text of a committed persona turn.
-
-        Fired from ``on_assistant_turn_stopped``. When it carries content it
-        supersedes whatever ``TTSTextFrame`` fragments were buffered for the same
-        turn (cleaner text); an empty commit is ignored so the buffered spoken
-        text survives to be flushed later.
-        """
-        if content and content.strip():
-            self._pending_persona_text = ""
-            self._transcript_events.append(
-                {"role": "persona", "content": content.strip()}
-            )
-
     def record_persona_text(self, text: Optional[str]) -> None:
-        """Accumulate a ``TTSTextFrame`` fragment for the current persona turn."""
+        """Accumulate a ``TTSTextFrame`` fragment for the current persona turn.
+
+        Fragments arrive as whole words (sometimes bare punctuation). Join with a
+        single space, except a fragment that starts with closing punctuation
+        attaches to the previous word so we don't get ``foo ,``.
+        """
         if not text:
             return
-        if self._pending_persona_text:
-            self._pending_persona_text = f"{self._pending_persona_text} {text.strip()}"
+        fragment = text.strip()
+        if not fragment:
+            return
+        if not self._pending_persona_text:
+            self._pending_persona_text = fragment
+        elif fragment[0] in _PERSONA_TEXT_CLINGING_PUNCTUATION:
+            self._pending_persona_text += fragment
         else:
-            self._pending_persona_text = text.strip()
+            self._pending_persona_text = f"{self._pending_persona_text} {fragment}"
 
     def record_tool_call(self, data: Optional[dict]) -> None:
         """Record an agent tool call at arrival time, ordered after the turn it followed.
@@ -1744,12 +1744,13 @@ async def _run_simulation_inner(
 
     @context_aggregator.assistant().event_handler("on_assistant_turn_stopped")
     async def on_assistant_turn_stopped(aggregator, message):
-        # The "assistant" for the simulation pipeline is the simulated user
+        # The "assistant" for the simulation pipeline is the simulated user. Its
+        # spoken text is captured from TTSTextFrames (IOLogger → record_persona_text)
+        # rather than here, since this commit fires empty when the agent ends the
+        # call the instant it hears the sim user.
         eval_logger.info(
             f"Eval transcript: [{message.timestamp}] assistant: {message.content}"
         )
-
-        rtvi_message_adapter.record_persona_committed(message.content)
 
     runner = PipelineRunner(handle_sigint=False)
 

--- a/calibrate/agent/run_simulation.py
+++ b/calibrate/agent/run_simulation.py
@@ -33,6 +33,8 @@ from calibrate.utils import (
     create_tts_service,
     provider_log_file,
     summarize_metric_distribution,
+    save_transcript,
+    TRANSCRIPT_FILE_NAME,
 )
 from calibrate.llm.metrics import evaluate_simuation, DEFAULT_SIMULATION_JUDGE_MODEL
 from calibrate.stt.metrics import (
@@ -189,7 +191,6 @@ from pipecat.utils.time import time_now_iso8601
 
 PIPELINE_IDLE_TIMEOUT_SECS = 120  # 2 minutes
 EVAL_TIMEOUT_SECS = 3000
-TRANSCRIPT_FILE_NAME = "transcript.json"
 # Punctuation that should attach to the preceding word when joining TTS text
 # fragments into a persona turn (covers Latin plus the Devanagari danda).
 _PERSONA_TEXT_CLINGING_PUNCTUATION = frozenset(",.!?;:।॥")
@@ -750,11 +751,7 @@ class RTVIMessageFrameAdapter(FrameProcessor):
         """
         self._output_dir.mkdir(parents=True, exist_ok=True)
         self._serialized_transcript = transcript
-
-        with open(
-            os.path.join(self._output_dir, TRANSCRIPT_FILE_NAME), "w"
-        ) as transcripts_file:
-            json.dump(transcript, transcripts_file, indent=4)
+        save_transcript(self._output_dir, transcript)
 
     async def _save_intermediate_state(
         self,

--- a/calibrate/agent/run_simulation.py
+++ b/calibrate/agent/run_simulation.py
@@ -461,6 +461,20 @@ class RTVIMessageFrameAdapter(FrameProcessor):
         self._pending_user_turn = False  # set True on bot-started-speaking; False on bot-stopped-speaking after frames are pushed
         self._turns_concluded = set()
         self._serialized_transcript = []  # Store transcripts for return
+        # Append-only, event-time record of the conversation — the source of truth
+        # for the serialized transcript. Entries are appended as turns commit and
+        # tool calls arrive, so order is preserved even when the pipeline is torn
+        # down mid-turn (e.g. the agent fires ``end_call`` the instant it hears the
+        # sim user, before the aggregator commits that turn to the LLM context).
+        # Reconstructing from the mutable context at teardown used to silently drop
+        # that final turn and misplace the tool calls; this list does not.
+        #   {"role": "agent"|"persona", "content": str}
+        #   {"role": "tool_calls", "tool_calls": [...]}
+        self._transcript_events: list[dict] = []
+        # Text the sim user (persona) has spoken in the current, not-yet-committed
+        # turn, accumulated from ``TTSTextFrame``s. Flushed into an event when the
+        # turn commits, a tool call / agent turn follows it, or at teardown.
+        self._pending_persona_text = ""
         self._ended_due_to_max_turns = False
         self._bot_audio_chunk_indices = {}  # Track chunk indices for bot audio per turn
         self._awaiting_first_bot_audio_chunk = (
@@ -591,78 +605,112 @@ class RTVIMessageFrameAdapter(FrameProcessor):
         # Save intermediate state after each turn
         await self._save_intermediate_state(concluded_turn)
 
+    def _flush_pending_persona_turn(self) -> None:
+        """Commit the buffered in-flight persona turn (if any) as an ordered event.
+
+        Called before recording an agent turn or a tool call — either of which
+        follows the sim user's turn in real time — so the persona's spoken text
+        keeps its position ahead of them even when its own turn never committed to
+        the LLM context.
+        """
+        text = self._pending_persona_text.strip()
+        self._pending_persona_text = ""
+        if text:
+            self._transcript_events.append({"role": "persona", "content": text})
+
+    def record_agent_turn(self, content: Optional[str]) -> None:
+        """Record a committed turn from the agent under test (``on_user_turn_stopped``)."""
+        self._flush_pending_persona_turn()
+        if content and content.strip():
+            self._transcript_events.append(
+                {"role": "agent", "content": content.strip()}
+            )
+
+    def record_persona_committed(self, content: Optional[str]) -> None:
+        """Record the authoritative text of a committed persona turn.
+
+        Fired from ``on_assistant_turn_stopped``. When it carries content it
+        supersedes whatever ``TTSTextFrame`` fragments were buffered for the same
+        turn (cleaner text); an empty commit is ignored so the buffered spoken
+        text survives to be flushed later.
+        """
+        if content and content.strip():
+            self._pending_persona_text = ""
+            self._transcript_events.append(
+                {"role": "persona", "content": content.strip()}
+            )
+
+    def record_persona_text(self, text: Optional[str]) -> None:
+        """Accumulate a ``TTSTextFrame`` fragment for the current persona turn."""
+        if not text:
+            return
+        if self._pending_persona_text:
+            self._pending_persona_text = f"{self._pending_persona_text} {text.strip()}"
+        else:
+            self._pending_persona_text = text.strip()
+
+    def record_tool_call(self, data: Optional[dict]) -> None:
+        """Record an agent tool call at arrival time, ordered after the turn it followed.
+
+        Consecutive tool calls (no persona turn between them) are grouped into a
+        single ``assistant`` entry, matching how a model emits parallel calls.
+        """
+        data = data or {}
+        self._flush_pending_persona_turn()
+        entry = {
+            "id": data.get("tool_call_id"),
+            "function": {
+                "name": data.get("function_name"),
+                "arguments": json.dumps(data.get("args", {})),
+            },
+            "type": "function",
+        }
+        if self._transcript_events and self._transcript_events[-1].get("role") == (
+            "tool_calls"
+        ):
+            self._transcript_events[-1]["tool_calls"].append(entry)
+        else:
+            self._transcript_events.append(
+                {"role": "tool_calls", "tool_calls": [entry]}
+            )
+
     def _build_serialized_transcript(
         self, end_reason: Optional[str] = None
     ) -> list[dict]:
-        """Build serialized transcript from context messages and tool calls.
+        """Build the serialized transcript from the ordered event log.
+
+        Roles are flipped so the file reads from the tested agent's perspective:
+        the agent's turns become ``assistant`` and the sim user's (persona) turns
+        become ``user``. Any in-flight persona text that hasn't been flushed yet is
+        appended so a conversation that ends on the sim user's turn still captures
+        it.
 
         Args:
             end_reason: Optional reason for ending the conversation (e.g., "max_turns")
 
         Returns:
-            List of transcript entries with roles flipped (user becomes assistant and vice versa)
+            List of transcript entries with roles flipped.
         """
+        events = list(self._transcript_events)
+        pending = self._pending_persona_text.strip()
+        if pending:
+            events.append({"role": "persona", "content": pending})
+
         serialized_transcript: list[dict] = []
-
-        # Group tool calls by position
-        tool_calls_by_position = defaultdict(list)
-        for tool_call in self._tool_calls:
-            position = tool_call.get("position")
-            data = tool_call.get("data", {})
-            tool_calls_by_position[position].append(
-                {
-                    "id": data.get("tool_call_id"),
-                    "function": {
-                        "name": data.get("function_name"),
-                        "arguments": json.dumps(data.get("args", {})),
-                    },
-                    "type": "function",
-                }
-            )
-
-        for index, message in enumerate(self._context.get_messages()):
-            if not isinstance(message, dict):
-                continue
-            role = message.get("role")
-
-            # Add tool calls that occurred at this position
-            if index in tool_calls_by_position:
+        for event in events:
+            role = event.get("role")
+            if role == "tool_calls":
                 serialized_transcript.append(
-                    {
-                        "role": "assistant",
-                        "tool_calls": tool_calls_by_position[index],
-                    }
+                    {"role": "assistant", "tool_calls": event["tool_calls"]}
                 )
-
-            # flip the role as the user for the transcript is the agent and vice versa
-            if role == "user":
-                role = "assistant"
-            elif role == "assistant":
-                role = "user"
-
-            serialized_transcript.append(
-                {
-                    "role": role,
-                    "content": message.get("content", ""),
-                }
-            )
-
-        # Add any remaining tool calls that occurred after all messages
-        max_message_index = len(self._context.get_messages())
-        for position in sorted(tool_calls_by_position.keys()):
-            if position >= max_message_index:
+            elif role == "agent":
                 serialized_transcript.append(
-                    {
-                        "role": "assistant",
-                        "tool_calls": tool_calls_by_position[position],
-                    }
+                    {"role": "assistant", "content": event.get("content", "")}
                 )
-
-        serialized_transcript = [
-            message
-            for message in serialized_transcript
-            if message.get("role") in {"user", "assistant"}
-        ]
+            elif role == "persona":
+                serialized_transcript.append(
+                    {"role": "user", "content": event.get("content", "")}
+                )
 
         # Merge consecutive content messages from the same role into one. Tool-call
         # entries (no ``content`` key) act as separators and are left untouched.
@@ -1047,8 +1095,10 @@ class STTLogger(FrameProcessor):
 class IOLogger(FrameProcessor):
     def __init__(
         self,
+        rtvi_adapter: Optional["RTVIMessageFrameAdapter"] = None,
     ):
         super().__init__()
+        self._rtvi_adapter = rtvi_adapter
 
     async def process_frame(self, frame, direction):
         await super().process_frame(frame, direction)
@@ -1057,6 +1107,11 @@ class IOLogger(FrameProcessor):
             log_and_print(
                 f"{USER_MESSAGE_COLOR}[User]\033[0m: {frame.text}{RESET_COLOR}"
             )
+            # ``TTSTextFrame`` is the sim user's spoken output. Capture it here (the
+            # only point downstream of TTS) so the persona's turn is recorded even
+            # if the agent ends the call before the assistant aggregator commits it.
+            if self._rtvi_adapter is not None:
+                self._rtvi_adapter.record_persona_text(frame.text)
 
         await self.push_frame(frame, direction)
 
@@ -1197,12 +1252,16 @@ class RTVIFunctionCallResponder(FrameProcessor):
         self._tool_calls = tool_calls
         self._context = context
         self._webhook_configs = webhook_configs or {}
+        self._transcript_recorder = None
 
     def set_frame_sender(self, sender):
         self._send_frame = sender
 
     def set_end_call_callback(self, callback):
         self._end_call_callback = callback
+
+    def set_transcript_recorder(self, recorder):
+        self._transcript_recorder = recorder
 
     async def process_frame(self, frame, direction):
         await super().process_frame(frame, direction)
@@ -1224,6 +1283,11 @@ class RTVIFunctionCallResponder(FrameProcessor):
                             "data": message.get("data"),
                         }
                     )
+
+                    if self._transcript_recorder is not None:
+                        self._transcript_recorder.record_tool_call(
+                            message.get("data")
+                        )
 
                     data = message.get("data") or {}
                     function_name = data.get("function_name")
@@ -1545,7 +1609,7 @@ async def _run_simulation_inner(
 
     stt_logger = STTLogger(stt_outputs, rtvi_message_adapter)
 
-    output_logger = IOLogger()
+    output_logger = IOLogger(rtvi_adapter=rtvi_message_adapter)
 
     # Add silence padding after TTS to help STT services (like Google, Sarvam) flush transcriptions
     silence_padder = SilencePadder(
@@ -1617,6 +1681,7 @@ async def _run_simulation_inner(
         await task.cancel()
 
     function_call_handler.set_end_call_callback(_handle_end_call_request)
+    function_call_handler.set_transcript_recorder(rtvi_message_adapter)
 
     # @audio_buffer.event_handler("on_user_turn_audio_data")
     # async def on_user_turn_audio_data(buffer, audio, sample_rate, num_channels):
@@ -1660,6 +1725,8 @@ async def _run_simulation_inner(
             f"{AGENT_MESSAGE_COLOR}[Agent]{RESET_COLOR}: {message.content}{RESET_COLOR}"
         )
 
+        rtvi_message_adapter.record_agent_turn(message.content)
+
         # Enforce max_turns here, when the agent's turn has committed, rather than
         # when its next turn starts. Ending on the next bot-started dropped that
         # message and left the transcript ending on a user turn or an assistant
@@ -1681,6 +1748,8 @@ async def _run_simulation_inner(
         eval_logger.info(
             f"Eval transcript: [{message.timestamp}] assistant: {message.content}"
         )
+
+        rtvi_message_adapter.record_persona_committed(message.content)
 
     runner = PipelineRunner(handle_sigint=False)
 

--- a/calibrate/agent/test.py
+++ b/calibrate/agent/test.py
@@ -13,6 +13,7 @@ from typing import Literal
 
 from calibrate.utils import (
     save_audio_chunk,
+    save_transcript,
     create_stt_service,
     create_tts_service,
     build_tools_schema,
@@ -384,8 +385,7 @@ async def run_bot(
         message for message in context.get_messages() if message.get("role") != "system"
     ]
 
-    with open(join(output_dir, "transcript.json"), "w") as transcript_file:
-        json.dump(transcript, transcript_file, indent=4)
+    save_transcript(output_dir, transcript)
 
     print(f"Conversation transcript saved to {join(output_dir, 'transcript.json')}")
 

--- a/calibrate/llm/run_simulation.py
+++ b/calibrate/llm/run_simulation.py
@@ -22,6 +22,7 @@ from calibrate.utils import (
     current_simulation_name,
     provider_log_file,
     summarize_metric_distribution,
+    save_transcript,
 )
 from pipecat.frames.frames import (
     TranscriptionFrame,
@@ -272,9 +273,7 @@ class Processor(FrameProcessor):
             if message["role"] not in ["system"]
         ]
 
-        transcript_path = join(self._output_dir, "transcript.json")
-        with open(transcript_path, "w") as f:
-            json.dump(transcript, f, indent=4)
+        save_transcript(self._output_dir, transcript)
 
     async def _handle_completed_response(self, response: str):
         should_continue = True
@@ -581,15 +580,6 @@ async def run_simulation(
     }
 
 
-def _save_transcript(output_dir: str | None, transcript: list[dict]) -> None:
-    if not output_dir:
-        return
-
-    transcript_path = join(output_dir, "transcript.json")
-    with open(transcript_path, "w") as f:
-        json.dump(transcript, f, indent=4)
-
-
 async def run_simulation_with_agent(
     agent: "TextAgentConnection",
     user_system_prompt: str,
@@ -686,7 +676,7 @@ async def run_simulation_with_agent(
         user_messages.append({"role": "assistant", "content": user_message})
         transcript.append({"role": "user", "content": user_message})
         log_and_print(f"\033[93m[User]: {user_message}\033[0m")
-        _save_transcript(output_dir, transcript)
+        save_transcript(output_dir, transcript)
 
         # --- External agent turn ---
         agent_messages.append({"role": "user", "content": user_message})
@@ -696,7 +686,7 @@ async def run_simulation_with_agent(
         agent_messages.append({"role": "assistant", "content": agent_text})
         transcript.append({"role": "assistant", "content": agent_text})
         log_and_print(f"\033[94m[Agent]: {agent_text}\033[0m")
-        _save_transcript(output_dir, transcript)
+        save_transcript(output_dir, transcript)
 
         # Prepare user simulator for next turn
         user_messages.append({"role": "user", "content": agent_text})
@@ -707,7 +697,7 @@ async def run_simulation_with_agent(
     if max_turns_reached:
         transcript.append({"role": "end_reason", "content": "max_turns"})
 
-    _save_transcript(output_dir, transcript)
+    save_transcript(output_dir, transcript)
 
     evaluation_results = await _judge_and_emit(
         transcript, evaluators, fallback_judge_model, emit=log_and_print
@@ -839,8 +829,7 @@ async def run_single_simulation_task(
                         metric_dict["value"]
                     )
 
-                with open(join(simulation_output_dir, "transcript.json"), "w") as f:
-                    json.dump(output["transcript"], f, indent=4)
+                save_transcript(simulation_output_dir, output["transcript"])
 
                 df = pd.DataFrame(output["evaluation_results"])
                 df.to_csv(
@@ -1135,8 +1124,7 @@ async def run_eval_only_simulation_task(
             emit=lambda line: print(f"[{display_name}] {line}"),
         )
 
-        with open(join(simulation_output_dir, "transcript.json"), "w") as f:
-            json.dump(transcript, f, indent=4)
+        save_transcript(simulation_output_dir, transcript)
 
         pd.DataFrame(evaluation_results).to_csv(
             join(simulation_output_dir, "evaluation_results.csv"), index=False

--- a/calibrate/utils.py
+++ b/calibrate/utils.py
@@ -549,6 +549,18 @@ def combine_turn_audio_chunks(audio_dir: str) -> bool:
     return True
 
 
+TRANSCRIPT_FILE_NAME = "transcript.json"
+
+
+def save_transcript(output_dir: str | Path | None, transcript: list[dict]) -> None:
+    """Write conversation messages to transcript.json under output_dir."""
+    if not output_dir:
+        return
+    os.makedirs(output_dir, exist_ok=True)
+    with open(os.path.join(output_dir, TRANSCRIPT_FILE_NAME), "w") as f:
+        json.dump(transcript, f, indent=4, ensure_ascii=False)
+
+
 def combine_audio_files(
     audio_dir: str, output_path: str, transcript_path: str = None
 ) -> bool:

--- a/tests/agent/test_rtvi_adapter.py
+++ b/tests/agent/test_rtvi_adapter.py
@@ -52,8 +52,8 @@ class TestBuildSerializedTranscript(unittest.TestCase):
 
     def test_role_flipping(self):
         adapter = _make_adapter()
-        adapter.record_agent_turn("hi")             # agent → assistant
-        adapter.record_persona_committed("hello")   # persona → user
+        adapter.record_agent_turn("hi")        # agent → assistant
+        adapter.record_persona_text("hello")   # persona → user (flushed at build)
         result = adapter._build_serialized_transcript()
         self.assertEqual(result[0]["role"], "assistant")
         self.assertEqual(result[0]["content"], "hi")
@@ -73,7 +73,8 @@ class TestBuildSerializedTranscript(unittest.TestCase):
         adapter = _make_adapter()
         adapter.record_agent_turn("")
         adapter.record_agent_turn(None)
-        adapter.record_persona_committed("   ")
+        adapter.record_persona_text("   ")
+        adapter.record_persona_text(None)
         self.assertEqual(adapter._build_serialized_transcript(), [])
 
     def test_with_end_reason(self):
@@ -85,7 +86,7 @@ class TestBuildSerializedTranscript(unittest.TestCase):
     def test_tool_call_recorded_after_the_turn_it_followed(self):
         adapter = _make_adapter()
         adapter.record_agent_turn("what is your name?")
-        adapter.record_persona_committed("my name is Geeta")
+        adapter.record_persona_text("my name is Geeta")
         adapter.record_tool_call(
             {
                 "tool_call_id": "c1",
@@ -123,18 +124,16 @@ class TestBuildSerializedTranscript(unittest.TestCase):
         names = [c["function"]["name"] for c in tool_entries[0]["tool_calls"]]
         self.assertEqual(names, ["plan_next_question", "end_call"])
 
-    def test_final_persona_turn_captured_when_never_committed(self):
+    def test_final_persona_turn_captured_when_call_ends_abruptly(self):
         """The regression: agent ends the call the instant it hears the persona.
 
-        The persona turn never commits via ``on_assistant_turn_stopped`` (fires
-        empty), but its spoken ``TTSTextFrame`` fragments must still land in the
+        The persona turn's spoken ``TTSTextFrame`` fragments must still land in the
         transcript, ahead of the tool calls that ended the call.
         """
         adapter = _make_adapter()
         adapter.record_agent_turn("what is your name?")
         for frag in ["my", "name", "is", "Geeta", "Prasad"]:
             adapter.record_persona_text(frag)
-        adapter.record_persona_committed("")  # empty commit must not wipe buffer
         adapter.record_tool_call(
             {"tool_call_id": "c1", "function_name": "plan_next_question", "args": {}}
         )
@@ -148,14 +147,25 @@ class TestBuildSerializedTranscript(unittest.TestCase):
         self.assertEqual(result[1]["content"], "my name is Geeta Prasad")
         self.assertEqual(len(result[2]["tool_calls"]), 2)
 
-    def test_committed_text_supersedes_fragments(self):
+    def test_persona_turn_recorded_once(self):
+        """A persona turn flushed by a tool call is not duplicated afterwards."""
         adapter = _make_adapter()
-        for frag in ["my", "name"]:
+        for frag in ["my", "name", "is", "Geeta"]:
             adapter.record_persona_text(frag)
-        adapter.record_persona_committed("my name is Geeta")
+        adapter.record_tool_call(
+            {"tool_call_id": "c1", "function_name": "plan_next_question", "args": {}}
+        )
         result = adapter._build_serialized_transcript()
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["content"], "my name is Geeta")
+        persona_lines = [m for m in result if m.get("role") == "user"]
+        self.assertEqual(len(persona_lines), 1)
+        self.assertEqual(persona_lines[0]["content"], "my name is Geeta")
+
+    def test_punctuation_fragment_attaches_to_previous_word(self):
+        adapter = _make_adapter()
+        for frag in ["Geeta", "Prasad", "."]:
+            adapter.record_persona_text(frag)
+        result = adapter._build_serialized_transcript()
+        self.assertEqual(result[-1]["content"], "Geeta Prasad.")
 
     def test_pending_persona_included_when_ending_on_persona(self):
         adapter = _make_adapter()

--- a/tests/agent/test_rtvi_adapter.py
+++ b/tests/agent/test_rtvi_adapter.py
@@ -51,28 +51,30 @@ class TestBuildSerializedTranscript(unittest.TestCase):
         self.assertEqual(result, [])
 
     def test_role_flipping(self):
-        ctx = MagicMock()
-        ctx.get_messages.return_value = [
-            {"role": "user", "content": "hi"},      # → assistant
-            {"role": "assistant", "content": "hello"},  # → user
-        ]
-        adapter = _make_adapter(context=ctx)
+        adapter = _make_adapter()
+        adapter.record_agent_turn("hi")             # agent → assistant
+        adapter.record_persona_committed("hello")   # persona → user
         result = adapter._build_serialized_transcript()
         self.assertEqual(result[0]["role"], "assistant")
         self.assertEqual(result[0]["content"], "hi")
         self.assertEqual(result[1]["role"], "user")
+        self.assertEqual(result[1]["content"], "hello")
 
     def test_merges_consecutive_same_role(self):
-        ctx = MagicMock()
-        ctx.get_messages.return_value = [
-            {"role": "user", "content": "a"},
-            {"role": "user", "content": "b"},
-        ]
-        adapter = _make_adapter(context=ctx)
+        adapter = _make_adapter()
+        adapter.record_agent_turn("a")
+        adapter.record_agent_turn("b")
         result = adapter._build_serialized_transcript()
-        # Both became assistant, merged
+        # Both agent turns became assistant and merged
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["content"], "a b")
+
+    def test_empty_turns_are_dropped(self):
+        adapter = _make_adapter()
+        adapter.record_agent_turn("")
+        adapter.record_agent_turn(None)
+        adapter.record_persona_committed("   ")
+        self.assertEqual(adapter._build_serialized_transcript(), [])
 
     def test_with_end_reason(self):
         adapter = _make_adapter()
@@ -80,53 +82,98 @@ class TestBuildSerializedTranscript(unittest.TestCase):
         self.assertEqual(result[-1]["role"], "end_reason")
         self.assertEqual(result[-1]["content"], "max_turns")
 
-    def test_tool_calls_inserted(self):
-        ctx = MagicMock()
-        ctx.get_messages.return_value = [
-            {"role": "user", "content": "hi"},
-        ]
-        tool_calls = [{
-            "position": 0,
-            "data": {
-                "tool_call_id": "call_1",
-                "function_name": "foo",
-                "args": {"x": 1},
-            },
-        }]
-        adapter = _make_adapter(context=ctx, tool_calls=tool_calls)
+    def test_tool_call_recorded_after_the_turn_it_followed(self):
+        adapter = _make_adapter()
+        adapter.record_agent_turn("what is your name?")
+        adapter.record_persona_committed("my name is Geeta")
+        adapter.record_tool_call(
+            {
+                "tool_call_id": "c1",
+                "function_name": "plan_next_question",
+                "args": {"i": 2},
+            }
+        )
         result = adapter._build_serialized_transcript()
-        # First entry is tool_calls, then the message
-        self.assertEqual(result[0]["role"], "assistant")
-        self.assertIn("tool_calls", result[0])
+        self.assertEqual(
+            [m["role"] for m in result], ["assistant", "user", "assistant"]
+        )
+        self.assertEqual(result[0]["content"], "what is your name?")
+        self.assertEqual(result[1]["content"], "my name is Geeta")
+        self.assertIn("tool_calls", result[2])
+        self.assertEqual(
+            result[2]["tool_calls"][0]["function"]["name"], "plan_next_question"
+        )
+        self.assertEqual(
+            result[2]["tool_calls"][0]["function"]["arguments"], '{"i": 2}'
+        )
 
-    def test_tool_calls_after_messages(self):
-        ctx = MagicMock()
-        ctx.get_messages.return_value = [
-            {"role": "user", "content": "hi"},
-        ]
-        tool_calls = [{
-            "position": 5,
-            "data": {
-                "tool_call_id": "call_x",
-                "function_name": "y",
-                "args": {},
-            },
-        }]
-        adapter = _make_adapter(context=ctx, tool_calls=tool_calls)
+    def test_consecutive_tool_calls_grouped(self):
+        adapter = _make_adapter()
+        adapter.record_agent_turn("hi")
+        adapter.record_tool_call(
+            {"tool_call_id": "c1", "function_name": "plan_next_question", "args": {}}
+        )
+        adapter.record_tool_call(
+            {"tool_call_id": "c2", "function_name": "end_call", "args": {}}
+        )
         result = adapter._build_serialized_transcript()
-        # Tool call at position 5 (after all messages) appended
-        self.assertEqual(result[-1]["role"], "assistant")
-        self.assertIn("tool_calls", result[-1])
+        # Both calls collapse into a single assistant tool_calls entry
+        tool_entries = [m for m in result if "tool_calls" in m]
+        self.assertEqual(len(tool_entries), 1)
+        names = [c["function"]["name"] for c in tool_entries[0]["tool_calls"]]
+        self.assertEqual(names, ["plan_next_question", "end_call"])
 
-    def test_skip_non_dict_messages(self):
-        ctx = MagicMock()
-        ctx.get_messages.return_value = [
-            "not a dict",
-            {"role": "user", "content": "hi"},
-        ]
-        adapter = _make_adapter(context=ctx)
+    def test_final_persona_turn_captured_when_never_committed(self):
+        """The regression: agent ends the call the instant it hears the persona.
+
+        The persona turn never commits via ``on_assistant_turn_stopped`` (fires
+        empty), but its spoken ``TTSTextFrame`` fragments must still land in the
+        transcript, ahead of the tool calls that ended the call.
+        """
+        adapter = _make_adapter()
+        adapter.record_agent_turn("what is your name?")
+        for frag in ["my", "name", "is", "Geeta", "Prasad"]:
+            adapter.record_persona_text(frag)
+        adapter.record_persona_committed("")  # empty commit must not wipe buffer
+        adapter.record_tool_call(
+            {"tool_call_id": "c1", "function_name": "plan_next_question", "args": {}}
+        )
+        adapter.record_tool_call(
+            {"tool_call_id": "c2", "function_name": "end_call", "args": {}}
+        )
+        result = adapter._build_serialized_transcript()
+        self.assertEqual(
+            [m["role"] for m in result], ["assistant", "user", "assistant"]
+        )
+        self.assertEqual(result[1]["content"], "my name is Geeta Prasad")
+        self.assertEqual(len(result[2]["tool_calls"]), 2)
+
+    def test_committed_text_supersedes_fragments(self):
+        adapter = _make_adapter()
+        for frag in ["my", "name"]:
+            adapter.record_persona_text(frag)
+        adapter.record_persona_committed("my name is Geeta")
         result = adapter._build_serialized_transcript()
         self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["content"], "my name is Geeta")
+
+    def test_pending_persona_included_when_ending_on_persona(self):
+        adapter = _make_adapter()
+        adapter.record_agent_turn("anything else?")
+        adapter.record_persona_text("no")
+        adapter.record_persona_text("thanks")
+        # No flush event follows; build must still surface the in-flight turn.
+        result = adapter._build_serialized_transcript()
+        self.assertEqual(result[-1]["role"], "user")
+        self.assertEqual(result[-1]["content"], "no thanks")
+
+    def test_build_does_not_mutate_pending(self):
+        adapter = _make_adapter()
+        adapter.record_persona_text("hello")
+        adapter._build_serialized_transcript()
+        # Building twice yields the same result (pending not consumed).
+        again = adapter._build_serialized_transcript()
+        self.assertEqual(again[-1]["content"], "hello")
 
 
 class TestSaveTranscript(unittest.TestCase):

--- a/tests/llm/test_run_simulation_extra.py
+++ b/tests/llm/test_run_simulation_extra.py
@@ -109,15 +109,15 @@ class TestValidateSimulationEvalOnlyDataset(unittest.TestCase):
 
 class TestSaveTranscript(unittest.TestCase):
     def test_no_output_dir_returns(self):
-        from calibrate.llm.run_simulation import _save_transcript
+        from calibrate.utils import save_transcript
 
-        _save_transcript(None, [{"role": "user", "content": "hi"}])
+        save_transcript(None, [{"role": "user", "content": "hi"}])
 
     def test_writes_file(self):
-        from calibrate.llm.run_simulation import _save_transcript
+        from calibrate.utils import save_transcript
 
         with tempfile.TemporaryDirectory() as tmp:
-            _save_transcript(tmp, [{"role": "user", "content": "hi"}])
+            save_transcript(tmp, [{"role": "user", "content": "hi"}])
             self.assertTrue((Path(tmp) / "transcript.json").exists())
 
 


### PR DESCRIPTION
## What
- Record each turn and tool call to an append-only event log as it happens, and build the serialized transcript from that instead of re-reading the sim user's mutable LLM context at teardown.
- Fixes the sim user's final turn being dropped when the agent ends the call in direct response to it (e.g. one-question form: agent hears the answer and fires `end_call` before that turn commits to the context).
- Fixes tool calls landing at the end instead of after the turn that triggered them (they were placed by a `position` index into the same context that had lost the turn).

## Notes
- Persona turns come from `on_assistant_turn_stopped` (clean text) with `TTSTextFrame` fragments as the pre-cancel fallback; consecutive tool calls group into one entry; `tool_calls.json` still carries `position` for backward compat.
- Verified against the real run's logged event sequence via unit tests, but not yet re-run against a live external sim — worth confirming TTS fragment spacing (e.g. trailing `।`) on a real run.