### PR TITLE
Point public API base URL to api.calibrate.artpark.ai

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ ENVIRONMENT=development # langfuse tracing environment
 ENABLE_TRACING=true
 
 # Calibrate Public API (docs sync + generated API reference pages)
-PUBLIC_API_BASE_URL=https://pense-backend.artpark.ai
+PUBLIC_API_BASE_URL=https://api.calibrate.artpark.ai
 
 # OTLP endpoint (defaults to localhost:4317 if not set)
 # OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel" # 🇪🇺 EU data region

--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -32,7 +32,7 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
     Pass your key in the `X-API-Key` header on every request:
 
     ```bash
-    curl https://pense-backend.artpark.ai/agents \
+    curl https://api.calibrate.artpark.ai/agents \
       -H "X-API-Key: your_api_key"
     ```
 
@@ -41,7 +41,7 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
     Enumerate every agent in your org:
 
     ```bash
-    curl https://pense-backend.artpark.ai/agents \
+    curl https://api.calibrate.artpark.ai/agents \
       -H "X-API-Key: your_api_key"
     ```
 
@@ -50,7 +50,7 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
     Launch a test run for an agent:
 
     ```bash
-    curl -X POST "https://pense-backend.artpark.ai/agent-tests/agent/{agent_uuid}/run" \
+    curl -X POST "https://api.calibrate.artpark.ai/agent-tests/agent/{agent_uuid}/run" \
       -H "X-API-Key: your_api_key" \
       -H "Content-Type: application/json" \
       -d '{}'
@@ -72,7 +72,7 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
     Poll the returned `task_id` for status and results:
 
     ```bash
-    curl "https://pense-backend.artpark.ai/agent-tests/run/{task_id}" \
+    curl "https://api.calibrate.artpark.ai/agent-tests/run/{task_id}" \
       -H "X-API-Key: your_api_key"
     ```
 
@@ -82,7 +82,7 @@ The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launc
 ## Base URL
 
 ```bash
-https://pense-backend.artpark.ai
+https://api.calibrate.artpark.ai
 ```
 
 ## OpenAPI specification
@@ -91,7 +91,7 @@ The public API schema is published at an unauthenticated endpoint.
 
 ```bash
 # Fetch the live spec (JSON)
-curl -s https://pense-backend.artpark.ai/public-api/openapi.json
+curl -s https://api.calibrate.artpark.ai/public-api/openapi.json
 ```
 
 ## Authentication

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://pense-backend.artpark.ai",
+      "url": "https://api.calibrate.artpark.ai",
       "description": "Production"
     }
   ],

--- a/docs/reference/api-keys.mdx
+++ b/docs/reference/api-keys.mdx
@@ -37,7 +37,7 @@ API keys authenticate Calibrate in the [GitHub Action](/reference/github-actions
 Include the key in the `X-API-Key` header with every request:
 
 ```bash
-curl https://pense-backend.artpark.ai/agents \
+curl https://api.calibrate.artpark.ai/agents \
   -H "X-API-Key: your_api_key"
 ```
 

--- a/docs/reference/github-actions.mdx
+++ b/docs/reference/github-actions.mdx
@@ -139,7 +139,7 @@ To trigger:
 | --------------- | ------- | -------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `api-key`       | string  | Yes      | —                                  | Calibrate API key (`sk_…`). Store as a secret.                                                                                          |
 | `agents`        | string  | No       | All agents                         | Agent names, comma- or newline-separated. Runs all linked tests for each. Omit to run every agent in the account linked to the API key. |
-| `base-url`      | string  | No       | `https://pense-backend.artpark.ai` | Backend API URL. Override only for self-hosted.                                                                                         |
+| `base-url`      | string  | No       | `https://api.calibrate.artpark.ai` | Backend API URL. Override only for self-hosted.                                                                                         |
 | `app-url`       | string  | No       | `https://calibrate.artpark.ai`     | Web UI base URL for view links in the report.                                                                                           |
 | `mode`          | string  | No       | `gate`                             | `gate` fails the job on any failure; `report` always succeeds.                                                                          |
 | `poll-interval` | integer | No       | `5`                                | Seconds between status polls.                                                                                                           |
@@ -168,7 +168,7 @@ The action talks to the Calibrate Public API with your API key. For each invocat
 
 When `agents` is set, it resolves the names to UUIDs:
 
-**Endpoint:** `POST https://pense-backend.artpark.ai/agents/resolve`
+**Endpoint:** `POST https://api.calibrate.artpark.ai/agents/resolve`
 
 **Request:**
 
@@ -192,7 +192,7 @@ When `agents` is set, it resolves the names to UUIDs:
 
 When `agents` is omitted, it lists every agent in the account instead:
 
-**Endpoint:** `GET https://pense-backend.artpark.ai/agents`
+**Endpoint:** `GET https://api.calibrate.artpark.ai/agents`
 
 **Response:**
 
@@ -204,7 +204,7 @@ When `agents` is omitted, it lists every agent in the account instead:
 
 For each agent, it triggers all linked tests. The agent is selected by UUID in the URL path and the body is empty:
 
-**Endpoint:** `POST https://pense-backend.artpark.ai/agent-tests/agent/{agent_uuid}/run`
+**Endpoint:** `POST https://api.calibrate.artpark.ai/agent-tests/agent/{agent_uuid}/run`
 
 **Request:**
 
@@ -224,7 +224,7 @@ For each agent, it triggers all linked tests. The agent is selected by UUID in t
 
 It polls each task until it finishes:
 
-**Endpoint:** `GET https://pense-backend.artpark.ai/agent-tests/run/{task_id}`
+**Endpoint:** `GET https://api.calibrate.artpark.ai/agent-tests/run/{task_id}`
 
 **Response:**
 


### PR DESCRIPTION
## What
- Update `PUBLIC_API_BASE_URL` from `https://pense-backend.artpark.ai` to `https://api.calibrate.artpark.ai`.
- Regenerate the templated API-reference docs (`openapi.json`, `introduction.mdx`, `api-keys.mdx`, `github-actions.mdx`) off the new host.

## Notes
- New domain is live and served the OpenAPI spec during regeneration (5 paths).
- Docs are single-sourced from the env var via `scripts/fetch_public_openapi.py`; no hardcoded host remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)