### PR TITLE
Reorder docs tabs to put API reference after Home

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -51,6 +51,48 @@
         ]
       },
       {
+        "tab": "API reference",
+        "groups": [
+          {
+            "group": "Getting started",
+            "pages": [
+              "api-reference/introduction"
+            ]
+          },
+          {
+            "group": "Agent tests",
+            "openapi": "api-reference/openapi.json",
+            "pages": [
+              "POST /agent-tests/agent/{agent_uuid}/run",
+              "POST /agent-tests/run",
+              "GET /agent-tests/run/{task_id}"
+            ]
+          },
+          {
+            "group": "Agents",
+            "openapi": "api-reference/openapi.json",
+            "pages": [
+              "GET /agents",
+              "POST /agents",
+              "POST /agents/resolve",
+              "GET /agents/{agent_uuid}",
+              "PUT /agents/{agent_uuid}"
+            ]
+          },
+          {
+            "group": "Tests",
+            "openapi": "api-reference/openapi.json",
+            "pages": [
+              "GET /tests",
+              "POST /tests",
+              "POST /tests/bulk",
+              "GET /tests/{test_uuid}",
+              "PUT /tests/{test_uuid}"
+            ]
+          }
+        ]
+      },
+      {
         "tab": "CLI",
         "groups": [
           {
@@ -105,48 +147,6 @@
               "sdk/tests/bulk_create",
               "sdk/tests/get",
               "sdk/tests/update"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "API reference",
-        "groups": [
-          {
-            "group": "Getting started",
-            "pages": [
-              "api-reference/introduction"
-            ]
-          },
-          {
-            "group": "Agent tests",
-            "openapi": "api-reference/openapi.json",
-            "pages": [
-              "POST /agent-tests/agent/{agent_uuid}/run",
-              "POST /agent-tests/run",
-              "GET /agent-tests/run/{task_id}"
-            ]
-          },
-          {
-            "group": "Agents",
-            "openapi": "api-reference/openapi.json",
-            "pages": [
-              "GET /agents",
-              "POST /agents",
-              "POST /agents/resolve",
-              "GET /agents/{agent_uuid}",
-              "PUT /agents/{agent_uuid}"
-            ]
-          },
-          {
-            "group": "Tests",
-            "openapi": "api-reference/openapi.json",
-            "pages": [
-              "GET /tests",
-              "POST /tests",
-              "POST /tests/bulk",
-              "GET /tests/{test_uuid}",
-              "PUT /tests/{test_uuid}"
             ]
           }
         ]

--- a/scripts/generate_cli_docs.py
+++ b/scripts/generate_cli_docs.py
@@ -52,7 +52,7 @@ OUTPUT_ROOT = DOCS_ROOT / "cli" / "calibrate"
 TEMPLATE_DIR = REPO_ROOT / "docs" / "templates" / "cli" / "calibrate"
 
 TAB_NAME = "CLI"
-INSERT_AFTER_TAB = "Home"
+INSERT_AFTER_TAB = ("API reference", "Home")
 ROOT_FILE = "calibrate.md"
 
 # Hand-written conceptual pages copied verbatim into the Getting-started group,
@@ -340,7 +340,9 @@ def _prune_stale(output_root: Path, keep_page_ids: set[str]) -> list[Path]:
     return removed
 
 
-def patch_docs_json(docs_json: Path, tab: dict, insert_after_tab: str) -> None:
+def patch_docs_json(
+    docs_json: Path, tab: dict, insert_after_tab: str | tuple[str, ...]
+) -> None:
     data = json.loads(docs_json.read_text(encoding="utf-8"))
     data["navigation"]["tabs"] = insert_tab(
         data["navigation"]["tabs"], tab, after=insert_after_tab

--- a/tests/test_generate_cli_docs.py
+++ b/tests/test_generate_cli_docs.py
@@ -378,8 +378,8 @@ def test_generate_cli_docs_end_to_end(tmp_path: Path) -> None:
     assert not (output_root / "widgets" / "list.mdx").exists()
 
     tabs = json.loads(docs_json.read_text())["navigation"]["tabs"]
-    # the cloud CLI tab is named "CLI", inserted after "Home"
-    assert [t["tab"] for t in tabs] == ["Home", "CLI", "API reference"]
+    # the cloud CLI tab is named "CLI", inserted after "API reference"
+    assert [t["tab"] for t in tabs] == ["Home", "API reference", "CLI"]
     cli_tab = next(t for t in tabs if t["tab"] == "CLI")
     groups = {g["group"]: g["pages"] for g in cli_tab["groups"]}
     assert groups["Getting started"] == ["cli/calibrate/overview", "cli/calibrate/agent-mode"]


### PR DESCRIPTION
## What
- Reorder the Mintlify nav tabs to Home → API reference → CLI → Python SDK → Calibrate Local → Integrations → Use cases.
- Update the CLI docs generator anchor (`INSERT_AFTER_TAB`) to `("API reference", "Home")` so CLI stays after API reference on regeneration.

## Notes
- The Python SDK generator already anchors after CLI, so ordering is stable across `fetch_public_openapi.py` regeneration.