### PR TITLE
Expand docs tab overviews to cover the full evaluation loop

### DIFF
--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -5,7 +5,17 @@ description: "Authenticate and call the Calibrate Public API programmatically"
 
 {/* Generated from docs/templates/api-reference/introduction.mdx — do not edit directly. */}
 
-The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launch LLM test runs, and poll results.
+The Calibrate REST API gives you programmatic access to the full evaluation loop — create and connect agents, author test cases and evaluators, link tests to agents, launch test runs and benchmarks, poll results, and route runs to human reviewers with annotation tasks.
+
+## What you can build
+
+| Resource | What it does |
+| --- | --- |
+| **Agents** | Create, update, list, and verify-connect the agents under evaluation |
+| **Tests** | Author test cases one at a time or in bulk, and link them to agents |
+| **Evaluators** | Define and version the LLM judges that score runs |
+| **Agent tests** | Launch runs and benchmarks, then poll status and per-test-case results |
+| **Annotation tasks** | Route run outputs to human reviewers and measure inter-rater agreement |
 
 ## Getting started
 

--- a/docs/cli/calibrate/overview.mdx
+++ b/docs/cli/calibrate/overview.mdx
@@ -3,12 +3,24 @@ title: "Overview"
 description: "Command-line interface for the Calibrate AI evaluation platform"
 ---
 
-The Calibrate CLI provides terminal access to Calibrate's evaluation APIs for
-scripting, automation, and CI/CD integration.
+The Calibrate CLI brings the full evaluation loop to your terminal — create and
+connect agents, author tests and evaluators, launch runs and benchmarks, poll
+results, and set up annotation tasks — for scripting, automation, and CI/CD
+integration. It's [agent-mode](/cli/calibrate/agent-mode) aware, emitting
+structured errors and compact TOON output when an AI coding agent drives it.
 
 <Card title="Calibrate CLI on GitHub" icon="github" href="https://github.com/dalmia/calibrate-cli">
   View source, releases, and contribute
 </Card>
+
+## What you can do
+
+- **Manage agents** — create, update, list, and verify-connect agents; resolve friendly names to UUIDs
+- **Build test suites** — author test cases individually or in bulk, update them, and link them to agents
+- **Configure evaluators** — create and version the judges that score runs
+- **Run evaluations** — launch test runs and benchmarks for one agent or many, then poll status and per-test-case results
+- **Review with humans** — create annotation tasks, run evaluators over them, and measure reviewer agreement
+- **Script anything** — JSON, YAML, table, or TOON output with `jq` filtering, plus a non-interactive mode built for CI/CD
 
 ## Quick start
 

--- a/docs/cli/calibrate/overview.mdx
+++ b/docs/cli/calibrate/overview.mdx
@@ -48,7 +48,16 @@ scripting, automation, and CI/CD integration.
     List agents and resolve names to UUIDs.
   </Card>
   <Card title="Agent tests" icon="flask" href="/cli/calibrate/agent-tests">
-    Launch test runs and poll their results.
+    Link tests, launch runs and benchmarks, and poll their results.
+  </Card>
+  <Card title="Tests" icon="list-check" href="/cli/calibrate/tests">
+    Create test cases individually or in bulk, and update them.
+  </Card>
+  <Card title="Evaluators" icon="scale-balanced" href="/cli/calibrate/evaluators">
+    Create and version the judges that score runs.
+  </Card>
+  <Card title="Annotation tasks" icon="user-check" href="/cli/calibrate/annotation-tasks">
+    Route runs to human reviewers and measure agreement.
   </Card>
 </CardGroup>
 

--- a/docs/mcp/overview.mdx
+++ b/docs/mcp/overview.mdx
@@ -7,19 +7,20 @@ description: "Expose Calibrate to coding agents over the Model Context Protocol"
 
 The Calibrate [MCP server](https://modelcontextprotocol.io) lets AI assistants
 like Claude Code, Cursor, and Codex work with Calibrate's evaluation API through
-the Model Context Protocol — so they can manage agents and tests and launch runs
-without leaving your editor. Every tool maps 1-to-1 to a
+the Model Context Protocol — so they can manage agents, tests, and evaluators,
+launch runs and benchmarks, and set up annotation tasks without leaving your
+editor. Every tool maps 1-to-1 to a
 [public API](/api-reference/introduction) operation.
 
 ## What you can do
 
 Ask your coding agent to:
 
-- List agents and resolve friendly names to UUIDs
-- Create and update agents
-- Create, bulk-upload, and update tests
-- Launch agent test runs — for one agent or every agent in your workspace
-- Poll a run for status and per-test-case results
+- Create and connect agents, and resolve friendly names to UUIDs
+- Author, bulk-upload, and update test cases
+- Create and version evaluators
+- Link tests, launch runs and benchmarks — for one agent or every agent in your workspace — and poll per-test-case results
+- Create annotation tasks, run evaluators over them, and check reviewer agreement
 
 ## Quick start
 
@@ -80,9 +81,11 @@ Once connected, you can ask your coding agent things like:
 
 - "List all my agents"
 - "Resolve the names support-bot and billing-bot to UUIDs"
+- "Create a test case for support-bot and link it"
 - "Run the tests for support-bot and give me the task id"
 - "Run tests for every agent in my workspace"
 - "What's the status and results of run abc123?"
+- "Create an annotation task from that run and check reviewer agreement"
 
 ## Requirements
 

--- a/docs/mcp/overview.mdx
+++ b/docs/mcp/overview.mdx
@@ -19,7 +19,7 @@ Ask your coding agent to:
 - Create and connect agents, and resolve friendly names to UUIDs
 - Author, bulk-upload, and update test cases
 - Create and version evaluators
-- Link tests, launch runs and benchmarks — for one agent or every agent in your workspace — and poll per-test-case results
+- Link tests, launch runs and benchmarks, and poll per-test-case results
 - Create annotation tasks, run evaluators over them, and check reviewer agreement
 
 ## Quick start

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -5,6 +5,8 @@ description: "Get started with Calibrate's Python SDK"
 
 {/* Generated from docs/templates/sdk/overview.mdx — do not edit directly. */}
 
+The Calibrate Python SDK is a typed client for the full evaluation loop — manage agents, tests, and evaluators, launch runs and benchmarks, and set up human-in-the-loop annotation tasks, all from Python.
+
 ## Install
 
 ```bash
@@ -23,6 +25,18 @@ client = Calibrate(api_key="sk_your_api_key")
 for agent in client.agents.list():
     print(agent.uuid, agent.name)
 ```
+
+## What you can do
+
+Every REST resource maps to a namespace on the client:
+
+| Namespace | Methods |
+| --- | --- |
+| `client.agents` | `create`, `list`, `get`, `resolve`, `update`, `verify_connection` |
+| `client.tests` | `create`, `bulk_create`, `list`, `get`, `update` |
+| `client.evaluators` | `create`, `create_version`, `list`, `get` |
+| `client.agent_tests` | `link`, `run`, `run_batch`, `benchmark`, `list_for_agent`, `list_runs_for_agent`, `get_run`, `get_benchmark` |
+| `client.annotation_tasks` | `create`, `add_items`, `update_items`, `link_evaluator`, `create_evaluator_run`, `get_evaluator_run`, `get_agreement`, `get_summary`, `list`, `get` |
 
 ## Resources
 

--- a/docs/templates/api-reference/introduction.mdx
+++ b/docs/templates/api-reference/introduction.mdx
@@ -5,7 +5,17 @@ description: "Authenticate and call the Calibrate Public API programmatically"
 
 {/* Generated from docs/templates/api-reference/introduction.mdx — do not edit directly. */}
 
-The Calibrate REST API lets you list agents, resolve agent names to UUIDs, launch LLM test runs, and poll results.
+The Calibrate REST API gives you programmatic access to the full evaluation loop — create and connect agents, author test cases and evaluators, link tests to agents, launch test runs and benchmarks, poll results, and route runs to human reviewers with annotation tasks.
+
+## What you can build
+
+| Resource | What it does |
+| --- | --- |
+| **Agents** | Create, update, list, and verify-connect the agents under evaluation |
+| **Tests** | Author test cases one at a time or in bulk, and link them to agents |
+| **Evaluators** | Define and version the LLM judges that score runs |
+| **Agent tests** | Launch runs and benchmarks, then poll status and per-test-case results |
+| **Annotation tasks** | Route run outputs to human reviewers and measure inter-rater agreement |
 
 ## Getting started
 

--- a/docs/templates/cli/calibrate/overview.mdx
+++ b/docs/templates/cli/calibrate/overview.mdx
@@ -3,12 +3,24 @@ title: "Overview"
 description: "Command-line interface for the Calibrate AI evaluation platform"
 ---
 
-The Calibrate CLI provides terminal access to Calibrate's evaluation APIs for
-scripting, automation, and CI/CD integration.
+The Calibrate CLI brings the full evaluation loop to your terminal — create and
+connect agents, author tests and evaluators, launch runs and benchmarks, poll
+results, and set up annotation tasks — for scripting, automation, and CI/CD
+integration. It's [agent-mode](/cli/calibrate/agent-mode) aware, emitting
+structured errors and compact TOON output when an AI coding agent drives it.
 
 <Card title="Calibrate CLI on GitHub" icon="github" href="https://github.com/dalmia/calibrate-cli">
   View source, releases, and contribute
 </Card>
+
+## What you can do
+
+- **Manage agents** — create, update, list, and verify-connect agents; resolve friendly names to UUIDs
+- **Build test suites** — author test cases individually or in bulk, update them, and link them to agents
+- **Configure evaluators** — create and version the judges that score runs
+- **Run evaluations** — launch test runs and benchmarks for one agent or many, then poll status and per-test-case results
+- **Review with humans** — create annotation tasks, run evaluators over them, and measure reviewer agreement
+- **Script anything** — JSON, YAML, table, or TOON output with `jq` filtering, plus a non-interactive mode built for CI/CD
 
 ## Quick start
 

--- a/docs/templates/cli/calibrate/overview.mdx
+++ b/docs/templates/cli/calibrate/overview.mdx
@@ -48,7 +48,16 @@ scripting, automation, and CI/CD integration.
     List agents and resolve names to UUIDs.
   </Card>
   <Card title="Agent tests" icon="flask" href="/cli/calibrate/agent-tests">
-    Launch test runs and poll their results.
+    Link tests, launch runs and benchmarks, and poll their results.
+  </Card>
+  <Card title="Tests" icon="list-check" href="/cli/calibrate/tests">
+    Create test cases individually or in bulk, and update them.
+  </Card>
+  <Card title="Evaluators" icon="scale-balanced" href="/cli/calibrate/evaluators">
+    Create and version the judges that score runs.
+  </Card>
+  <Card title="Annotation tasks" icon="user-check" href="/cli/calibrate/annotation-tasks">
+    Route runs to human reviewers and measure agreement.
   </Card>
 </CardGroup>
 

--- a/docs/templates/mcp/overview.mdx
+++ b/docs/templates/mcp/overview.mdx
@@ -7,19 +7,20 @@ description: "Expose Calibrate to coding agents over the Model Context Protocol"
 
 The Calibrate [MCP server](https://modelcontextprotocol.io) lets AI assistants
 like Claude Code, Cursor, and Codex work with Calibrate's evaluation API through
-the Model Context Protocol — so they can manage agents and tests and launch runs
-without leaving your editor. Every tool maps 1-to-1 to a
+the Model Context Protocol — so they can manage agents, tests, and evaluators,
+launch runs and benchmarks, and set up annotation tasks without leaving your
+editor. Every tool maps 1-to-1 to a
 [public API](/api-reference/introduction) operation.
 
 ## What you can do
 
 Ask your coding agent to:
 
-- List agents and resolve friendly names to UUIDs
-- Create and update agents
-- Create, bulk-upload, and update tests
-- Launch agent test runs — for one agent or every agent in your workspace
-- Poll a run for status and per-test-case results
+- Create and connect agents, and resolve friendly names to UUIDs
+- Author, bulk-upload, and update test cases
+- Create and version evaluators
+- Link tests, launch runs and benchmarks — for one agent or every agent in your workspace — and poll per-test-case results
+- Create annotation tasks, run evaluators over them, and check reviewer agreement
 
 ## Quick start
 
@@ -72,9 +73,11 @@ Once connected, you can ask your coding agent things like:
 
 - "List all my agents"
 - "Resolve the names support-bot and billing-bot to UUIDs"
+- "Create a test case for support-bot and link it"
 - "Run the tests for support-bot and give me the task id"
 - "Run tests for every agent in my workspace"
 - "What's the status and results of run abc123?"
+- "Create an annotation task from that run and check reviewer agreement"
 
 ## Requirements
 

--- a/docs/templates/mcp/overview.mdx
+++ b/docs/templates/mcp/overview.mdx
@@ -19,7 +19,7 @@ Ask your coding agent to:
 - Create and connect agents, and resolve friendly names to UUIDs
 - Author, bulk-upload, and update test cases
 - Create and version evaluators
-- Link tests, launch runs and benchmarks — for one agent or every agent in your workspace — and poll per-test-case results
+- Link tests, launch runs and benchmarks, and poll per-test-case results
 - Create annotation tasks, run evaluators over them, and check reviewer agreement
 
 ## Quick start

--- a/docs/templates/sdk/overview.mdx
+++ b/docs/templates/sdk/overview.mdx
@@ -5,6 +5,8 @@ description: "Get started with Calibrate's Python SDK"
 
 {/* Generated from docs/templates/sdk/overview.mdx — do not edit directly. */}
 
+The Calibrate Python SDK is a typed client for the full evaluation loop — manage agents, tests, and evaluators, launch runs and benchmarks, and set up human-in-the-loop annotation tasks, all from Python.
+
 ## Install
 
 ```bash
@@ -23,6 +25,18 @@ client = Calibrate(api_key="sk_your_api_key")
 for agent in client.agents.list():
     print(agent.uuid, agent.name)
 ```
+
+## What you can do
+
+Every REST resource maps to a namespace on the client:
+
+| Namespace | Methods |
+| --- | --- |
+| `client.agents` | `create`, `list`, `get`, `resolve`, `update`, `verify_connection` |
+| `client.tests` | `create`, `bulk_create`, `list`, `get`, `update` |
+| `client.evaluators` | `create`, `create_version`, `list`, `get` |
+| `client.agent_tests` | `link`, `run`, `run_batch`, `benchmark`, `list_for_agent`, `list_runs_for_agent`, `get_run`, `get_benchmark` |
+| `client.annotation_tasks` | `create`, `add_items`, `update_items`, `link_evaluator`, `create_evaluator_run`, `get_evaluator_run`, `get_agreement`, `get_summary`, `list`, `get` |
 
 ## Resources
 


### PR DESCRIPTION
## What
- The API reference, Python SDK, MCP, and CLI overview pages were written when only "list agents + run tests" was public; they now describe the whole loop — creating agents, authoring tests and evaluators, linking, running tests and benchmarks, viewing results, and annotation tasks.
- Added a capability section per tab: API "What you can build" resource table, SDK client-namespace/methods table, expanded MCP "What you can do" bullets + example queries, and a CLI features list.

## Notes
- Every edit was made to both the `docs/templates/**` source and the generated page, so they stay consistent until the next docs sync.
- Verified all four pages render (HTTP 200) against a local `mint dev` server.