### PR TITLE
Add skills and onboarding pages to Agents tab

### DIFF
--- a/docs/agents/onboarding.mdx
+++ b/docs/agents/onboarding.mdx
@@ -1,0 +1,107 @@
+---
+title: "Guided onboarding"
+description: "Run /onboard and your agent takes you from nothing to a trustworthy first evaluation on Calibrate"
+---
+
+The `/onboard` skill guides you through setting up your first Calibrate
+evaluation step by step. It's an **orchestrator** — each phase delegates to a
+feature skill and produces a real Calibrate object, so you finish with a working
+evaluation, not a tutorial.
+
+## Quick start
+
+<Steps>
+  <Step title="Install the skills">
+    ```bash
+    npx skills add dalmia/calibrate-skills
+    ```
+    See [Agent skills](/agents/skills) for the full pack.
+  </Step>
+  <Step title="Open your AI coding agent">
+    Claude Code, Cursor, Codex, Windsurf, or any Agent Skills–compatible agent.
+  </Step>
+  <Step title="Run the onboarding skill">
+    ```
+    /onboard
+    ```
+    The skill handles everything from there — including installing the CLI and
+    authenticating if you haven't already.
+  </Step>
+</Steps>
+
+The onboarding is **resumable and adaptive**: progress is saved to
+`.calibrate/onboard.md`, so a later session picks up at the first incomplete
+phase, and the skill compresses or skips phases you've already answered.
+
+## What it creates
+
+By the end you have a real, inspectable evaluation on Calibrate:
+
+| Resource | What it is |
+| --- | --- |
+| Agent | Your system under test, connected and verified against its endpoint |
+| Tests | Test cases turning your goal into falsifiable `tool_call` / `response` checks |
+| Evaluator | An LLM or audio judge, if any case scores response quality |
+| Run | The first evaluation run, with pass/fail and judge reasoning |
+| Calibrated judge | The judge tuned against human labels, so you can trust the scores |
+| Benchmark | Optional model comparison across the linked tests |
+
+## The workflow
+
+`/onboard` walks these phases in order for a first-time user, and lets an expert
+compress or skip any they've already answered.
+
+<Steps>
+  <Step title="Setup">
+    Confirms the CLI is installed and authenticated (`calibrate whoami`, else
+    `calibrate login`) and scaffolds the resumable state file.
+  </Step>
+  <Step title="Connect the agent">
+    Asks what the agent does, who uses it, and where it fails today, then
+    delegates to `/connect-agent` to register and verify the connection.
+  </Step>
+  <Step title="Build the tests">
+    Turns your goal into a falsifiable hypothesis, then delegates to
+    `/build-test-suite` (or `/import-dataset` if you already have a dataset) to
+    author and upload test cases.
+  </Step>
+  <Step title="Design the evaluators">
+    Only if a case judges response quality — delegates to `/design-evaluator` to
+    create a judge. Skipped entirely when every case is a deterministic
+    `tool_call`.
+  </Step>
+  <Step title="Run">
+    Delegates to `/run-tests` to link the tests, run them, poll for results, and
+    present **failures first**.
+  </Step>
+  <Step title="Calibrate the judge">
+    Offered, not forced — when you care whether the scores are trustworthy,
+    `/calibrate-evaluator` measures human ↔ judge agreement and tunes the judge
+    until it matches humans. This is the step that makes it *Calibrate*, not just
+    a test runner.
+  </Step>
+  <Step title="Scale and wire into CI">
+    Delegates to `/benchmark-models` to compare models, and — when you mention
+    PRs, releases, or shipping — proposes wiring
+    `calibrate agent-tests run` into CI in agent mode.
+  </Step>
+</Steps>
+
+## Evaluation is a loop
+
+After the first run, `/onboard` expects one of: expand the test set when a defect
+surfaces, tune the hypothesis when the bar is too loose or strict, add a model,
+or tune the judge when agreement is too low. Each pass appends to the state file
+so prior baselines stay inspectable — stop when you've shipped or wired it into
+CI.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Browse the skills" icon="graduation-cap" href="/agents/skills">
+    See every skill `/onboard` orchestrates, and invoke them on their own.
+  </Card>
+  <Card title="Connect the MCP server" icon="plug" href="/mcp/overview">
+    Give your agent native Calibrate tools alongside the skills.
+  </Card>
+</CardGroup>

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -55,8 +55,8 @@ and match against the same workspace.
 | Claude Code | ✓ | ✓ | ✓ | ✓ |
 | Cursor | ✓ | ✓ | ✓ | ✓ |
 | Codex | ✓ | ✓ | ✓ | ✓ |
-| Windsurf | ✓ | — | ✓ | ✓ |
-| Claude Desktop | — | ✓ | — | ✓ |
+| Windsurf | ✓ | ✓ | ✓ | ✓ |
+| Claude Desktop | ✓ | ✓ | — | ✓ |
 | Any agent | — | — | ✓ | ✓ |
 
 All you need is a Calibrate API key — create one under

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -55,7 +55,7 @@ and match against the same workspace.
 | Claude Code | ✓ | ✓ | ✓ | ✓ |
 | Cursor | ✓ | ✓ | ✓ | ✓ |
 | Codex | ✓ | ✓ | ✓ | ✓ |
-| Windsurf | ✓ | ✓ | ✓ | ✓ |
+| Windsurf | ✓ | — | ✓ | ✓ |
 | Claude Desktop | — | ✓ | — | ✓ |
 | Any agent | — | — | ✓ | ✓ |
 

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -1,16 +1,25 @@
 ---
 title: "Overview"
-description: "Give your AI agents the tools to evaluate voice agents on Calibrate through MCP, CLI, or API"
+description: "Give your AI coding agents the tools and knowledge to evaluate voice agents on Calibrate through skills, MCP, CLI, or API"
 ---
 
-Calibrate meets your AI agent where it already works — Claude Code,
-Cursor, Codex, and others. Connect it once and your agent can manage agents,
-build test sets, launch runs, and score outputs from Calibrate through the
-interface that fits your workflow.
+Calibrate meets your AI coding agent where it already works — Claude Code,
+Cursor, Codex, Windsurf, and others. Install the skills once and your agent
+learns how to connect an agent, build test sets, run evaluations, and calibrate
+the LLM judges against human labels — driving Calibrate through the interface
+that fits your workflow.
 
 ## Get started
 
 <CardGroup cols={2}>
+  <Card title="Agent skills" icon="graduation-cap" href="/agents/skills">
+    Install evaluation expertise with one command. Your agent learns how to
+    build test suites, design judges, and run evals on Calibrate.
+  </Card>
+  <Card title="Guided onboarding" icon="wand-magic-sparkles" href="/agents/onboarding">
+    Run `/onboard` and your agent walks you through setting up a complete
+    evaluation from scratch — connect, test, run, calibrate.
+  </Card>
   <Card title="MCP server" icon="plug" href="/mcp/overview">
     Connect the Calibrate MCP server for native tool access in Claude Code,
     Cursor, Codex, and other MCP clients.
@@ -19,37 +28,36 @@ interface that fits your workflow.
     The Calibrate CLI gives agents structured JSON output for scripting
     evaluations in any terminal.
   </Card>
-  <Card title="API" icon="code" href="/api-reference/introduction">
-    Call the Calibrate REST API directly from any language for full control
-    over agents, tests, and runs.
-  </Card>
 </CardGroup>
 
-## Access methods
+## How agents use Calibrate
 
-Every method maps to the same Calibrate evaluation API — pick the one that fits
-how your agent works.
+Skills are the knowledge layer; the MCP server, CLI, and API are the execution
+layers underneath. Combine them — skills teach your agent *what* a good
+evaluation looks like, and the CLI (which the skills drive) *runs* it.
 
 | Layer | Purpose | Installation |
 | --- | --- | --- |
+| Skills | Teach agents how to design and run evaluations on Calibrate | `npx skills add dalmia/calibrate-skills` |
 | MCP server | Gives agents native tools to manage agents, tests, and runs | `claude mcp add --transport http calibrate https://calibrate-mcp-106430091675.asia-south1.run.app/mcp --header "X-API-Key: sk_your_api_key"` |
 | CLI | Runs evaluations from any terminal with JSON output | `brew install dalmia/tap/calibrate` |
 | API | Direct HTTPS access for any language or runtime | REST over HTTPS — see the [API reference](/api-reference/introduction) |
 
-The [MCP server](/mcp/overview) and [CLI](/cli/calibrate/overview) both wrap the
-[public API](/api-reference/introduction), so you can mix and match — use the MCP
-server inside your editor and the CLI in CI, against the same workspace.
+The [skills](/agents/skills) drive the cloud [CLI](/cli/calibrate/overview),
+while the [MCP server](/mcp/overview) exposes the same operations as native
+tools — both wrap the [public API](/api-reference/introduction), so you can mix
+and match against the same workspace.
 
 ## Supported agents
 
-| Agent | MCP | CLI | API |
-| --- | --- | --- | --- |
-| Claude Code | ✓ | ✓ | ✓ |
-| Cursor | ✓ | ✓ | ✓ |
-| Codex | ✓ | ✓ | ✓ |
-| Claude Desktop | ✓ | — | ✓ |
-| Windsurf | ✓ | ✓ | ✓ |
-| Any agent | — | ✓ | ✓ |
+| Agent | Skills | MCP | CLI | API |
+| --- | --- | --- | --- | --- |
+| Claude Code | ✓ | ✓ | ✓ | ✓ |
+| Cursor | ✓ | ✓ | ✓ | ✓ |
+| Codex | ✓ | ✓ | ✓ | ✓ |
+| Windsurf | ✓ | ✓ | ✓ | ✓ |
+| Claude Desktop | — | ✓ | — | ✓ |
+| Any agent | — | — | ✓ | ✓ |
 
 All you need is a Calibrate API key — create one under
 [**Workspace settings → API keys**](https://calibrate.artpark.ai/workspace-settings?tab=api-keys)
@@ -58,6 +66,12 @@ All you need is a Calibrate API key — create one under
 ## Next steps
 
 <CardGroup cols={2}>
+  <Card title="Install the skills" icon="graduation-cap" href="/agents/skills">
+    One command to teach your agent the full Calibrate evaluation loop.
+  </Card>
+  <Card title="Run guided onboarding" icon="wand-magic-sparkles" href="/agents/onboarding">
+    Go from nothing to a trustworthy first evaluation with `/onboard`.
+  </Card>
   <Card title="Set up the MCP server" icon="plug" href="/mcp/installation">
     Config file locations for each client and platform.
   </Card>

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -39,7 +39,7 @@ evaluation looks like, and the CLI (which the skills drive) *runs* it.
 | Layer | Purpose | Installation |
 | --- | --- | --- |
 | Skills | Teach agents how to design and run evaluations on Calibrate | `npx skills add dalmia/calibrate-skills` |
-| MCP server | Gives agents native tools to manage agents, tests, and runs | `claude mcp add --transport http calibrate https://calibrate-mcp-106430091675.asia-south1.run.app/mcp --header "X-API-Key: sk_your_api_key"` |
+| MCP server | Gives agents native tools to manage agents, tests, and runs | `claude mcp add --transport http calibrate https://mcp.calibrate.artpark.ai/mcp --header "X-API-Key: sk_your_api_key"` |
 | CLI | Runs evaluations from any terminal with JSON output | `brew install dalmia/tap/calibrate` |
 | API | Direct HTTPS access for any language or runtime | REST over HTTPS — see the [API reference](/api-reference/introduction) |
 

--- a/docs/agents/skills.mdx
+++ b/docs/agents/skills.mdx
@@ -1,0 +1,108 @@
+---
+title: "Agent skills"
+description: "Install evaluation expertise into your AI coding agent — one command teaches it the full Calibrate loop"
+---
+
+Agent skills are modular knowledge packages that teach your AI coding agent how
+to evaluate voice agents on Calibrate. They follow the open
+[Agent Skills](https://agentskills.io) standard, so they work with Claude Code,
+Cursor, Codex, Windsurf, and other compatible agents.
+
+Each skill drives the cloud `calibrate` CLI against Calibrate's public API and
+covers the full loop: connect an agent, build tests, run them, and — Calibrate's
+signature move — **calibrate the LLM judges against human labels** so the
+automated scores are trustworthy.
+
+## Install
+
+Install every Calibrate skill with a single command:
+
+```bash
+npx skills add dalmia/calibrate-skills
+```
+
+You also need the Calibrate CLI (which the skills drive) and an API key:
+
+```bash
+# Install the Calibrate CLI
+brew install dalmia/tap/calibrate
+
+# Authenticate (API key from Workspace settings → API keys)
+calibrate login
+```
+
+<Note>
+  Skills are the knowledge layer — they teach your agent *how* to evaluate. The
+  CLI they drive is the execution layer. See the
+  [overview](/agents/overview#how-agents-use-calibrate) for how skills, MCP, and
+  the CLI fit together.
+</Note>
+
+## Skills versus MCP and CLI
+
+| Layer | What it is | Reach for it when |
+| --- | --- | --- |
+| Skills | Knowledge — how to design and run evaluations | Your agent should decide *what* to test and *how* to judge it |
+| MCP server | Native tools inside your editor | You want the agent to call Calibrate operations as tools |
+| CLI | Terminal execution with JSON output | You're scripting evals or wiring them into CI/CD |
+
+Skills and the CLI work best together: the skills carry the methodology, and the
+CLI runs the operations they describe.
+
+## Available skills
+
+Installing the pack adds the following skills. Invoke any of them by name (e.g.
+`/connect-agent`), or start with [`/onboard`](/agents/onboarding), which
+orchestrates the whole set.
+
+| Category | Skill | What it does |
+| --- | --- | --- |
+| Overview | `calibrate-resources` | Orientation: the primitives, the CLI, auth, and which skill to reach for |
+| Onboarding | [`onboard`](/agents/onboarding) | Guided end-to-end first evaluation (orchestrator) |
+| Agents | `connect-agent` | Connect or create an agent under test and verify its connection |
+| Tests | `build-test-suite` | Author test cases (`tool_call` / `response`) and bulk-upload them |
+| Tests | `import-dataset` | Turn a CSV / JSONL / HuggingFace dataset into test cases |
+| Agent tests | `run-tests` | Link tests to an agent, run them, and read pass/fail with judge reasoning |
+| Agent tests | `benchmark-models` | Compare models on the agent's tests on a leaderboard |
+| Evaluators | `design-evaluator` | Create a versioned LLM or audio judge (binary or rating) |
+| Evaluators | `iterate-evaluator` | Add and tune an evaluator version, then pin it live |
+| Annotation | `calibrate-evaluator` | Measure human ↔ judge agreement and tune the judge until it matches humans |
+
+## The primitives
+
+Every skill maps to one of Calibrate's five public API resources — deliberately,
+there is no persona, simulation, trace, dashboard, or report resource.
+
+| Primitive | CLI group | Skills |
+| --- | --- | --- |
+| Agent | `agents` | `connect-agent` |
+| Test | `tests` | `build-test-suite`, `import-dataset` |
+| Agent test | `agent-tests` | `run-tests`, `benchmark-models` |
+| Evaluator | `evaluators` | `design-evaluator`, `iterate-evaluator` |
+| Annotation task | `annotation-tasks` | `calibrate-evaluator` |
+
+## How skills load
+
+Skills load progressively, so they stay cheap in context:
+
+- **At startup** — only each skill's name and description load (~100 tokens
+  total), enough for your agent to know one exists.
+- **On activation** — the full `SKILL.md` instructions load when a skill is
+  triggered.
+- **On demand** — reference files, assets, and scripts load only when a skill
+  needs them.
+
+Each skill lives in `skills/<category>/<skill-name>/` with a `SKILL.md`
+entrypoint and optional `references/`, `assets/`, and `scripts/` folders. The
+full source is on [GitHub](https://github.com/dalmia/calibrate-skills).
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Run guided onboarding" icon="wand-magic-sparkles" href="/agents/onboarding">
+    Kick off `/onboard` to go from nothing to a trustworthy first evaluation.
+  </Card>
+  <Card title="Connect the MCP server" icon="plug" href="/mcp/overview">
+    Give your agent native Calibrate tools alongside the skills.
+  </Card>
+</CardGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -56,7 +56,9 @@
           {
             "group": "AI agents",
             "pages": [
-              "agents/overview"
+              "agents/overview",
+              "agents/skills",
+              "agents/onboarding"
             ]
           }
         ]

--- a/docs/mcp/beginners-guide.mdx
+++ b/docs/mcp/beginners-guide.mdx
@@ -81,7 +81,7 @@ Edit the config file directly:
          "args": [
            "-y",
            "mcp-remote",
-           "https://calibrate-mcp-106430091675.asia-south1.run.app/mcp",
+           "https://mcp.calibrate.artpark.ai/mcp",
            "--header",
            "X-API-Key: ${CALIBRATE_API_KEY}"
          ],

--- a/docs/mcp/installation.mdx
+++ b/docs/mcp/installation.mdx
@@ -35,7 +35,7 @@ Where each client stores its MCP config:
 ## Hosted server (recommended)
 
 Point your client at the managed endpoint
-`https://calibrate-mcp-106430091675.asia-south1.run.app/mcp` via
+`https://mcp.calibrate.artpark.ai/mcp` via
 [`mcp-remote`](https://www.npmjs.com/package/mcp-remote), passing your API key in
 the `X-API-Key` header. Nothing to install or keep updated.
 
@@ -51,7 +51,7 @@ the `X-API-Key` header. Nothing to install or keep updated.
           "args": [
             "-y",
             "mcp-remote",
-            "https://calibrate-mcp-106430091675.asia-south1.run.app/mcp",
+            "https://mcp.calibrate.artpark.ai/mcp",
             "--header",
             "X-API-Key: ${CALIBRATE_API_KEY}"
           ],
@@ -74,7 +74,7 @@ the `X-API-Key` header. Nothing to install or keep updated.
           "args": [
             "-y",
             "mcp-remote",
-            "https://calibrate-mcp-106430091675.asia-south1.run.app/mcp",
+            "https://mcp.calibrate.artpark.ai/mcp",
             "--header",
             "X-API-Key: ${CALIBRATE_API_KEY}"
           ],
@@ -89,7 +89,7 @@ the `X-API-Key` header. Nothing to install or keep updated.
   <Tab title="Claude Code">
     ```bash
     claude mcp add --transport http calibrate \
-      https://calibrate-mcp-106430091675.asia-south1.run.app/mcp \
+      https://mcp.calibrate.artpark.ai/mcp \
       --header "X-API-Key: sk_your_api_key"
     ```
   </Tab>

--- a/docs/mcp/overview.mdx
+++ b/docs/mcp/overview.mdx
@@ -37,7 +37,7 @@ Ask your coding agent to:
 
         ```bash
         claude mcp add --transport http calibrate \
-          https://calibrate-mcp-106430091675.asia-south1.run.app/mcp \
+          https://mcp.calibrate.artpark.ai/mcp \
           --header "X-API-Key: sk_your_api_key"
         ```
       </Tab>

--- a/docs/mcp/troubleshooting.mdx
+++ b/docs/mcp/troubleshooting.mdx
@@ -77,7 +77,7 @@ full restart. Work through the section that matches your symptom.
     Or list the tools over the hosted endpoint:
 
     ```bash
-    curl -s -X POST https://calibrate-mcp-106430091675.asia-south1.run.app/mcp \
+    curl -s -X POST https://mcp.calibrate.artpark.ai/mcp \
       -H "Content-Type: application/json" \
       -H "Accept: application/json, text/event-stream" \
       -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'

--- a/docs/templates/mcp/beginners-guide.mdx
+++ b/docs/templates/mcp/beginners-guide.mdx
@@ -81,7 +81,7 @@ Edit the config file directly:
          "args": [
            "-y",
            "mcp-remote",
-           "https://calibrate-mcp-106430091675.asia-south1.run.app/mcp",
+           "https://mcp.calibrate.artpark.ai/mcp",
            "--header",
            "X-API-Key: ${CALIBRATE_API_KEY}"
          ],

--- a/docs/templates/mcp/installation.mdx
+++ b/docs/templates/mcp/installation.mdx
@@ -35,7 +35,7 @@ Where each client stores its MCP config:
 ## Hosted server (recommended)
 
 Point your client at the managed endpoint
-`https://calibrate-mcp-106430091675.asia-south1.run.app/mcp` via
+`https://mcp.calibrate.artpark.ai/mcp` via
 [`mcp-remote`](https://www.npmjs.com/package/mcp-remote), passing your API key in
 the `X-API-Key` header. Nothing to install or keep updated.
 
@@ -51,7 +51,7 @@ the `X-API-Key` header. Nothing to install or keep updated.
           "args": [
             "-y",
             "mcp-remote",
-            "https://calibrate-mcp-106430091675.asia-south1.run.app/mcp",
+            "https://mcp.calibrate.artpark.ai/mcp",
             "--header",
             "X-API-Key: ${CALIBRATE_API_KEY}"
           ],
@@ -74,7 +74,7 @@ the `X-API-Key` header. Nothing to install or keep updated.
           "args": [
             "-y",
             "mcp-remote",
-            "https://calibrate-mcp-106430091675.asia-south1.run.app/mcp",
+            "https://mcp.calibrate.artpark.ai/mcp",
             "--header",
             "X-API-Key: ${CALIBRATE_API_KEY}"
           ],
@@ -89,7 +89,7 @@ the `X-API-Key` header. Nothing to install or keep updated.
   <Tab title="Claude Code">
     ```bash
     claude mcp add --transport http calibrate \
-      https://calibrate-mcp-106430091675.asia-south1.run.app/mcp \
+      https://mcp.calibrate.artpark.ai/mcp \
       --header "X-API-Key: sk_your_api_key"
     ```
   </Tab>

--- a/docs/templates/mcp/overview.mdx
+++ b/docs/templates/mcp/overview.mdx
@@ -37,7 +37,7 @@ Ask your coding agent to:
 
         ```bash
         claude mcp add --transport http calibrate \
-          https://calibrate-mcp-106430091675.asia-south1.run.app/mcp \
+          https://mcp.calibrate.artpark.ai/mcp \
           --header "X-API-Key: sk_your_api_key"
         ```
       </Tab>

--- a/docs/templates/mcp/troubleshooting.mdx
+++ b/docs/templates/mcp/troubleshooting.mdx
@@ -77,7 +77,7 @@ full restart. Work through the section that matches your symptom.
     Or list the tools over the hosted endpoint:
 
     ```bash
-    curl -s -X POST https://calibrate-mcp-106430091675.asia-south1.run.app/mcp \
+    curl -s -X POST https://mcp.calibrate.artpark.ai/mcp \
       -H "Content-Type: application/json" \
       -H "Accept: application/json, text/event-stream" \
       -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'


### PR DESCRIPTION
## What
- Add **Agent skills** and **Guided onboarding** pages under the Agents tab, sourced from `dalmia/calibrate-skills`, mirroring Coval's agents docs.
- Rework the Agents overview to lead with skills + onboarding alongside MCP/CLI/API (new Get started cards, a Skills knowledge layer in the usage table and supported-agents matrix, cross-linked Next steps).

## Notes
- Skills install is documented as `npx skills add dalmia/calibrate-skills` — the agentskills.io-standard installer Coval uses. The calibrate-skills README's quick-start only shows brew + `calibrate login` + `/onboard`, so confirm this is the intended install one-liner.
- Agents tab is hand-maintained in `docs.json` (no generator/test), so no generated docs or tests were touched.