### PR TITLE
Add background-noise injection for voice simulations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ site/
 .claude/*
 !.claude/skills
 !.claude/skills/**
+
+# Generated noise assets (built locally via scripts/fetch_noise_assets.py; not committed)
+calibrate_agent/agent/assets/noise/

--- a/NOISE_EXPERIMENTS.md
+++ b/NOISE_EXPERIMENTS.md
@@ -28,8 +28,7 @@ cp env.example .env          # then fill in the agent's provider keys (STT/TTS/L
 uv run uvicorn main:app --host 0.0.0.0 --port 7860 --reload
 ```
 The env file **must** live at `form-bharo/server/src/.env`. Fill in the agent's
-own provider keys (STT/TTS/LLM). **If you don't know what to put in it, ask Aman
-(aman.dalmia@artpark.in).**
+own provider keys (STT/TTS/LLM). **If you don't know what to put in it, ask Aman.**
 
 The agent is now running on **http://localhost:7860**.
 
@@ -106,7 +105,7 @@ Create a `.env` file at the **root of the calibrate repo** (`calibrate/.env`). T
 | `GOOGLE_APPLICATION_CREDENTIALS` | simulated-caller voice (Kannada, Google Chirp3-HD) |
 | `HF_TOKEN` (or `huggingface-cli login`) | pulling Vaani speaker clips (Part B.3) |
 
-**If you don't know what to put in this file, ask Aman (aman.dalmia@artpark.in).**
+**If you don't know what to put in this file, ask Aman.**
 
 ### 3. Build the noise assets  ⚠️ required, not in git
 The audio assets are **gitignored** (licensing), so you must build them once. They

--- a/NOISE_EXPERIMENTS.md
+++ b/NOISE_EXPERIMENTS.md
@@ -33,19 +33,12 @@ own provider keys (STT/TTS/LLM). **If you don't know what to put in it, ask Aman
 The agent is now running on **http://localhost:7860**.
 
 ### 2. Create the `swasth-kadam-v5` agent
-The experiments talk to a specific agent — a 12-question Hindi child-enrollment
-survey (name, district, anganwadi, pregnancy status, child name + DOB,
-phone/WhatsApp linkage, last-4-Aadhaar). A fresh clone won't have it, so create
-its folder and save the config below as `config.json`:
+Create the agent folder and save the config below as its `config.json`:
 
 ```bash
 mkdir -p server/db/agents/swasth-kadam-v5
 # then create server/db/agents/swasth-kadam-v5/config.json with the JSON below
 ```
-
-The agent is loaded purely from `server/db/agents/<agent-id>/config.json`
-(`ROOT_DB_DIR`, see `server/src/agent_store.py`), so this single file is all the
-server needs to serve `ws://localhost:7860/ws-client/swasth-kadam-v5`.
 
 <details>
 <summary><code>server/db/agents/swasth-kadam-v5/config.json</code></summary>
@@ -360,9 +353,6 @@ server needs to serve `ws://localhost:7860/ws-client/swasth-kadam-v5`.
 ```
 
 </details>
-
-<sub>An `access.json` (owner/workspace metadata) sits beside `config.json` for
-the hosted dashboard, but the local WebSocket run does **not** require it.</sub>
 
 ### 3. The agent URL Calibrate connects to
 Calibrate uses the pipecat non-telephony WebSocket endpoint:

--- a/NOISE_EXPERIMENTS.md
+++ b/NOISE_EXPERIMENTS.md
@@ -34,23 +34,332 @@ The agent is now running on **http://localhost:7860**.
 
 ### 2. Create the `swasth-kadam-v5` agent
 The experiments talk to a specific agent — a 12-question Hindi child-enrollment
-survey. A fresh clone won't have it, so create it by dropping in its config:
+survey (name, district, anganwadi, pregnancy status, child name + DOB,
+phone/WhatsApp linkage, last-4-Aadhaar). A fresh clone won't have it, so create
+its folder and save the config below as `config.json`:
 
 ```bash
 mkdir -p server/db/agents/swasth-kadam-v5
-# copy the config shipped in the calibrate branch for exact reproduction:
-cp <calibrate>/examples/agent/simulation/swasth-kadam-v5.config.json \
-   server/db/agents/swasth-kadam-v5/config.json
+# then create server/db/agents/swasth-kadam-v5/config.json with the JSON below
 ```
 
 The agent is loaded purely from `server/db/agents/<agent-id>/config.json`
 (`ROOT_DB_DIR`, see `server/src/agent_store.py`), so this single file is all the
-server needs to serve `ws://localhost:7860/ws-client/swasth-kadam-v5`. The exact
-config is committed in the calibrate branch at
-[`examples/agent/simulation/swasth-kadam-v5.config.json`](examples/agent/simulation/swasth-kadam-v5.config.json)
-— it defines the Hindi survey (name, district, anganwadi, pregnancy status,
-child name + DOB, phone/WhatsApp linkage, last-4-Aadhaar) with `language: hindi`,
-`agent_speaks_first: true`, and one-question-at-a-time asking.
+server needs to serve `ws://localhost:7860/ws-client/swasth-kadam-v5`.
+
+<details>
+<summary><code>server/db/agents/swasth-kadam-v5/config.json</code></summary>
+
+```json
+{
+    "title": "Swasth kadam Health Survey V5",
+    "questions": [
+        {
+            "name": "name",
+            "label": "name",
+            "type": "string",
+            "required": false,
+            "script": "\u0905\u092a\u0928\u093e \u092a\u0942\u0930\u093e \u0928\u093e\u092e \u092c\u0924\u093e\u0907\u090f",
+            "validation": {
+                "type": "min_length",
+                "rules": {
+                    "min_length": 2
+                }
+            },
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 1,
+                "retry_messages": [
+                    "\u0915\u0943\u092a\u092f\u093e \u0905\u092a\u0928\u093e \u092a\u0942\u0930\u093e \u0928\u093e\u092e \u092c\u0924\u093e\u0907\u090f\u0964"
+                ],
+                "exhausted_action": "skip"
+            }
+        },
+        {
+            "name": "district",
+            "label": "district",
+            "type": "single-select",
+            "options": [
+                "Mumbai",
+                "Aurangabad",
+                "Nashik",
+                "Nagpur",
+                "Pune"
+            ],
+            "required": true,
+            "advanced_instructions": "IMPORTANT: On the initial ask for this question, say ONLY the question Script exactly. Do NOT add the district options on the initial ask, even though this is a single-select question.",
+            "script": "\u0905\u092a\u0928\u0947 \u091c\u093f\u0932\u0947 \u0915\u093e \u0928\u093e\u092e \u092c\u0924\u093e\u090f\u0902",
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0906\u092a\u0915\u093e \u0906\u0902\u0917\u0928\u0935\u093e\u0921\u093c\u0940 \u0915\u093f\u0938 \u091c\u093f\u0932\u0947 \u092e\u0947\u0902 \u0906\u0924\u093e \u0939\u0948? \u0915\u0943\u092a\u092f\u093e \u0907\u0928\u092e\u0947\u0902 \u0938\u0947 \u090f\u0915 \u091a\u0941\u0928\u0947\u0902: Mumbai, Aurangabad, Nashik, Nagpur ya Pune\u0964",
+                    "\u0906\u092a\u0915\u093e \u0906\u0902\u0917\u0928\u0935\u093e\u0921\u093c\u0940 \u0915\u093f\u0938 \u091c\u093f\u0932\u0947 \u092e\u0947\u0902 \u0906\u0924\u093e \u0939\u0948? \u0915\u0943\u092a\u092f\u093e \u0907\u0928\u092e\u0947\u0902 \u0938\u0947 \u090f\u0915 \u091a\u0941\u0928\u0947\u0902: Mumbai, Aurangabad, Nashik, Nagpur ya Pune\u0964"
+                ],
+                "exhausted_action": "end_call"
+            }
+        },
+        {
+            "name": "anganwadi_name",
+            "label": "anganwadi_name",
+            "type": "string",
+            "required": false,
+            "skip_message": "\u0939\u092e \u0906\u0917\u0947 \u092c\u0922\u093c\u0924\u0947 \u0939\u0948\u0902\u0964",
+            "script": "\u0905\u092a\u0928\u0947 \u0906\u0902\u0917\u0928\u0935\u093e\u0921\u093c\u0940 \u0915\u093e \u0928\u093e\u092e \u092c\u0924\u093e\u090f\u0902",
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 1,
+                "retry_messages": [
+                    "\u0905\u0917\u0930 \u0906\u092a\u0915\u094b \u0905\u092a\u0928\u0947 \u0906\u0902\u0917\u0928\u0935\u093e\u0921\u093c\u0940 \u0915\u093e \u0928\u093e\u092e \u0928\u0939\u0940\u0902 \u092a\u0924\u093e \u0939\u0948, \u0924\u094b \u0915\u0943\u092a\u092f\u093e \\\"\u0928\u0939\u0940\u0902 \u092a\u0924\u093e\\\" \u092c\u094b\u0932\u093f\u090f\u0964"
+                ],
+                "exhausted_action": "skip"
+            }
+        },
+        {
+            "name": "pregnant_or_not",
+            "label": "pregnant_or_not",
+            "type": "boolean",
+            "required": true,
+            "script": "\u0915\u094d\u092f\u093e \u0906\u092a \u0905\u092d\u0940 \u0917\u0930\u094d\u092d\u0935\u0924\u0940 \u0939\u0948\u0902?",
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0915\u094d\u092f\u093e \u0906\u092a \u0905\u092d\u0940 \u0917\u0930\u094d\u092d\u0935\u0924\u0940 \u0939\u0948\u0902? \u0915\u0943\u092a\u092f\u093e \u0939\u093e\u0901 \u092f\u093e \u0928\u093e \u092e\u0947\u0902 \u091c\u0935\u093e\u092c \u0926\u0947\u0902\u0964",
+                    "\u0915\u094d\u092f\u093e \u0906\u092a \u0905\u092d\u0940 \u0917\u0930\u094d\u092d\u0935\u0924\u0940 \u0939\u0948\u0902? \u0915\u0943\u092a\u092f\u093e \u0939\u093e\u0901 \u092f\u093e \u0928\u093e \u092e\u0947\u0902 \u091c\u0935\u093e\u092c \u0926\u0947\u0902\u0964"
+                ],
+                "exhausted_action": "end_call"
+            }
+        },
+        {
+            "name": "gestational_age_months",
+            "label": "gestational_age_months",
+            "type": "number",
+            "number_format": "integer",
+            "required": false,
+            "advanced_instructions": "The answer is in number of months.",
+            "script": "\u0906\u092a\u0915\u094b \u0917\u0930\u094d\u092d\u0935\u0924\u0940 \u0939\u0941\u090f \u0915\u093f\u0924\u0928\u0947 \u092e\u0939\u0940\u0928\u0947 \u0939\u0941\u090f \u0939\u0948\u0902?",
+            "branch_id": "branch_pregnant",
+            "validation": {
+                "type": "number_range",
+                "rules": {
+                    "min": 1,
+                    "max": 9
+                }
+            },
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0906\u092a\u0915\u094b \u0917\u0930\u094d\u092d\u0935\u0924\u0940 \u0939\u0941\u090f \u0915\u093f\u0924\u0928\u0947 \u092e\u0939\u0940\u0928\u0947 \u0939\u0941\u090f \u0939\u0948\u0902? \u0915\u0943\u092a\u092f\u093e 1 \u0938\u0947 9 \u092e\u0939\u0940\u0928\u0947 \u0915\u0947 \u092c\u0940\u091a \u092e\u0947\u0902 \u092c\u0924\u093e\u0907\u090f\u0964",
+                    "\u0906\u092a\u0915\u094b \u0917\u0930\u094d\u092d\u0935\u0924\u0940 \u0939\u0941\u090f \u0915\u093f\u0924\u0928\u0947 \u092e\u0939\u0940\u0928\u0947 \u0939\u0941\u090f \u0939\u0948\u0902? \u0915\u0943\u092a\u092f\u093e 1 \u0938\u0947 9 \u092e\u0939\u0940\u0928\u0947 \u0915\u0947 \u092c\u0940\u091a \u092e\u0947\u0902 \u092c\u0924\u093e\u0907\u090f\u0964"
+                ],
+                "exhausted_action": "end_call"
+            }
+        },
+        {
+            "name": "child_name",
+            "label": "child_name",
+            "type": "string",
+            "required": false,
+            "script": "\u0906\u092a\u0915\u0947 \u092c\u091a\u094d\u091a\u0947 \u0915\u093e \u0928\u093e\u092e \u0915\u094d\u092f\u093e \u0939\u0948?",
+            "branch_id": "branch_not_pregnant",
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 1,
+                "retry_messages": [
+                    "\u0915\u0943\u092a\u092f\u093e \u0905\u092a\u0928\u0947 \u092c\u091a\u094d\u091a\u0947 \u0915\u093e \u092a\u0942\u0930\u093e \u0928\u093e\u092e \u092c\u0924\u093e\u0907\u090f\u0964"
+                ],
+                "exhausted_action": "end_call"
+            }
+        },
+        {
+            "name": "child_dob",
+            "label": "child_dob",
+            "type": "date",
+            "required": false,
+            "script": "\u0906\u092a\u0915\u0947 \u092c\u091a\u094d\u091a\u0947 \u0915\u0940 \u091c\u0928\u094d\u092e \u0924\u093e\u0930\u0940\u0916 \u092c\u0924\u093e\u090f\u0902",
+            "branch_id": "branch_not_pregnant",
+            "validation": {
+                "type": "date_today_or_past",
+                "rules": {}
+            },
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0915\u0943\u092a\u092f\u093e \u0905\u092a\u0928\u0947 \u092c\u091a\u094d\u091a\u0947 \u0915\u0940 \u091c\u0928\u094d\u092e \u0924\u093e\u0930\u0940\u0916 \u0926\u093f\u0928, \u092e\u0939\u0940\u0928\u093e \u0914\u0930 \u0935\u0930\u094d\u0937 \u0915\u0947 \u0915\u094d\u0930\u092e \u092e\u0947\u0902 \u092c\u0924\u093e\u090f\u0902 \u091c\u0948\u0938\u0947 \u0915\u093f 15 \u0905\u092a\u094d\u0930\u0948\u0932 2025\u0964",
+                    "\u0915\u0943\u092a\u092f\u093e \u0905\u092a\u0928\u0947 \u092c\u091a\u094d\u091a\u0947 \u0915\u0940 \u091c\u0928\u094d\u092e \u0924\u093e\u0930\u0940\u0916 \u0926\u093f\u0928, \u092e\u0939\u0940\u0928\u093e \u0914\u0930 \u0935\u0930\u094d\u0937 \u0915\u0947 \u0915\u094d\u0930\u092e \u092e\u0947\u0902 \u092c\u0924\u093e\u090f\u0902 \u091c\u0948\u0938\u0947 \u0915\u093f 15 \u0905\u092a\u094d\u0930\u0948\u0932 2025\u0964"
+                ],
+                "exhausted_action": "end_call"
+            }
+        },
+        {
+            "name": "is_phone_linked_to_anganwadi",
+            "label": "is_phone_linked_to_anganwadi",
+            "type": "boolean",
+            "required": false,
+            "advanced_instructions": "Before asking this question, say the following informational script EXACTLY and then ask the question: \"\u0905\u092c \u0915\u0947\u0935\u0932 4 \u0938\u0935\u093e\u0932 \u092c\u093e\u0915\u0940 \u0939\u0948\u0902\u0964\"",
+            "script": "\u0915\u094d\u092f\u093e \u092f\u0939 \u0928\u0902\u092c\u0930 \u0906\u0902\u0917\u0928\u0935\u093e\u0921\u093c\u0940 \u0938\u0947 \u091c\u0941\u0921\u093c\u093e \u0939\u0941\u0906 \u0939\u0948?",
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0915\u0943\u092a\u092f\u093e \u0906\u092a\u0915\u0947 \u092b\u094b\u0928 \u092a\u0930 \u0906\u090f \u0939\u0941\u090f SMS \u092e\u0947\u0902 6 \u0905\u0902\u0915\u094b\u0902 \u0915\u093e \u0915\u094b\u0921 \u092c\u0924\u093e\u0907\u090f\u0964",
+                    "\u0915\u0943\u092a\u092f\u093e \u0906\u092a\u0915\u0947 \u092b\u094b\u0928 \u092a\u0930 \u0906\u090f \u0939\u0941\u090f SMS \u092e\u0947\u0902 6 \u0905\u0902\u0915\u094b\u0902 \u0915\u093e \u0915\u094b\u0921 \u092c\u0924\u093e\u0907\u090f\u0964 \u0905\u0917\u0930 \u0906\u092a\u0915\u094b \u0928\u0939\u0940\u0902 \u092a\u0924\u093e \u0939\u0948, \u0924\u094b \\\"\u0928\u0939\u0940\u0902 \u092a\u0924\u093e\\\" \u092c\u094b\u0932\u093f\u090f\u0964"
+                ],
+                "exhausted_action": "skip"
+            }
+        },
+        {
+            "name": "anganwadi_linked_phone_number",
+            "label": "anganwadi_linked_phone_number",
+            "type": "number",
+            "number_format": "integer",
+            "required": false,
+            "script": "\u0915\u0943\u092a\u092f\u093e \u0906\u0902\u0917\u0928\u0935\u093e\u0921\u093c\u0940 \u0938\u0947 \u091c\u0941\u0921\u093c\u093e \u0939\u0941\u0906 \u0905\u092a\u0928\u093e \u092b\u094b\u0928 \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u090f\u0902\u0964",
+            "branch_id": "branch_phone_not_linked",
+            "validation": {
+                "type": "phone_number",
+                "rules": {
+                    "digits": 10
+                }
+            },
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0906\u0902\u0917\u0928\u0935\u093e\u0921\u093c\u0940 \u092e\u0947\u0902 \u091c\u0941\u0921\u093c\u093e \u0939\u0941\u0906 \u0906\u092a\u0915\u093e 10 \u0905\u0902\u0915\u094b\u0902 \u0915\u093e \u092b\u094b\u0928 \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u0907\u090f\u0964",
+                    "\u0906\u0902\u0917\u0928\u0935\u093e\u0921\u093c\u0940 \u092e\u0947\u0902 \u091c\u0941\u0921\u093c\u093e \u0939\u0941\u0906 \u0906\u092a\u0915\u093e 10 \u0905\u0902\u0915\u094b\u0902 \u0915\u093e \u092b\u094b\u0928 \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u0907\u090f\u0964 \u0905\u0917\u0930 \u0928\u0939\u0940\u0902 \u092a\u0924\u093e \u0939\u0948, \u0924\u094b \\\"\u0928\u0939\u0940\u0902 \u092a\u0924\u093e\\\" \u0910\u0938\u093e \u092c\u094b\u0932\u093f\u090f\u0964"
+                ],
+                "exhausted_action": "skip"
+            }
+        },
+        {
+            "name": "whatsapp_linked_to_calling_number",
+            "label": "whatsapp_linked_to_calling_number",
+            "type": "boolean",
+            "required": false,
+            "script": "\u0906\u092a\u0928\u0947 \u091c\u093f\u0938 \u0928\u0902\u092c\u0930 \u0938\u0947 \u0915\u0949\u0932 \u0915\u093f\u092f\u093e \u0939\u0948, \u0915\u094d\u092f\u093e \u0935\u0939\u0940 \u0928\u0902\u092c\u0930 \u0906\u092a\u0915\u0947 \u0935\u094d\u0939\u093e\u091f\u094d\u0938\u0910\u092a \u0938\u0947 \u092d\u0940 \u091c\u0941\u0921\u093c\u093e \u0939\u0941\u0906 \u0939\u0948?",
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0906\u092a\u0928\u0947 \u091c\u093f\u0938 \u0928\u0902\u092c\u0930 \u0938\u0947 \u0915\u0949\u0932 \u0915\u093f\u092f\u093e \u0939\u0948, \u0915\u094d\u092f\u093e \u0935\u0939 \u0935\u094d\u0939\u093e\u091f\u094d\u0938\u090f\u092a \u092e\u0947\u0902 \u092d\u0940 \u0926\u0930\u094d\u091c \u0939\u0948? \u0915\u0943\u092a\u092f\u093e \u0939\u093e\u0901 \u092f\u093e \u0928\u093e \u092e\u0947\u0902 \u091c\u0935\u093e\u092c \u0926\u0947\u0902\u0964",
+                    "\u0906\u092a\u0928\u0947 \u091c\u093f\u0938 \u0928\u0902\u092c\u0930 \u0938\u0947 \u0915\u0949\u0932 \u0915\u093f\u092f\u093e \u0939\u0948, \u0915\u094d\u092f\u093e \u0935\u0939 \u0935\u094d\u0939\u093e\u091f\u094d\u0938\u090f\u092a \u092e\u0947\u0902 \u092d\u0940 \u0926\u0930\u094d\u091c \u0939\u0948? \u0905\u0917\u0930 \u0928\u0939\u0940\u0902 \u092a\u0924\u093e \u0939\u0948, \u0924\u094b \\\"\u0928\u0939\u0940\u0902 \u092a\u0924\u093e\\\" \u092c\u094b\u0932\u093f\u090f\u0964"
+                ],
+                "exhausted_action": "skip"
+            }
+        },
+        {
+            "name": "whatsapp_number",
+            "label": "whatsapp_number",
+            "type": "number",
+            "number_format": "integer",
+            "required": false,
+            "script": "\u0915\u0943\u092a\u092f\u093e \u0905\u092a\u0928\u093e \u0935\u094d\u0939\u093e\u091f\u094d\u0938\u0910\u092a \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u0907\u090f\u0964",
+            "branch_id": "branch_whatsapp_not_linked",
+            "validation": {
+                "type": "phone_number",
+                "rules": {
+                    "digits": 10
+                }
+            },
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0935\u094d\u0939\u093e\u091f\u094d\u0938\u090f\u092a \u092e\u0947\u0902 \u091c\u0941\u0921\u093c\u093e \u0939\u0941\u0906 \u0906\u092a\u0915\u093e 10 \u0905\u0902\u0915\u094b\u0902 \u0915\u093e \u092b\u094b\u0928 \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u0907\u090f\u0964",
+                    "\u0935\u094d\u0939\u093e\u091f\u094d\u0938\u090f\u092a \u092e\u0947\u0902 \u091c\u0941\u0921\u093c\u093e \u0939\u0941\u0906 \u0906\u092a\u0915\u093e 10 \u0905\u0902\u0915\u094b\u0902 \u0915\u093e \u092b\u094b\u0928 \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u0907\u090f \u0905\u0917\u0930 \u0928\u0939\u0940\u0902 \u092a\u0924\u093e \u0939\u0948, \u0924\u094b \\\"\u0928\u0939\u0940\u0902 \u092a\u0924\u093e\\\" \u0910\u0938\u093e \u092c\u094b\u0932\u093f\u090f\u0964"
+                ],
+                "exhausted_action": "skip"
+            }
+        },
+        {
+            "name": "last_4_digits_of_aadhar",
+            "label": "last_4_digits_of_aadhar",
+            "type": "number",
+            "number_format": "integer",
+            "required": false,
+            "advanced_instructions": "Before asking this question, say the following informational script EXACTLY: \"\u0905\u092c \u091c\u094b \u0938\u0935\u093e\u0932 \u0906\u090f\u0917\u093e, \u0935\u0939 \u0906\u0916\u093c\u093f\u0930\u0940 \u0938\u0935\u093e\u0932 \u0939\u094b\u0917\u093e\u0964\"",
+            "script": "\u0905\u092a\u0928\u0947 \u0906\u0927\u093e\u0930 \u0915\u0947 \u0906\u0916\u093f\u0930\u0940 4 \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u0907\u090f\u0964",
+            "validation": {
+                "type": "exact_num_digits",
+                "rules": {
+                    "digits": 4
+                }
+            },
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0915\u0943\u092a\u092f\u093e \u0905\u092a\u0928\u0947 \u0906\u0927\u093e\u0930 \u0915\u093e\u0930\u094d\u0921 \u0915\u0947 \u0906\u0916\u093f\u0930\u0940 4 \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u0907\u090f\u0964",
+                    "\u0915\u0943\u092a\u092f\u093e \u0905\u092a\u0928\u0947 \u0906\u0927\u093e\u0930 \u0915\u093e\u0930\u094d\u0921 \u0915\u0947 \u0906\u0916\u093f\u0930\u0940 4 \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u0907\u090f\u0964 \u0905\u0917\u0930 \u0928\u0939\u0940\u0902 \u092a\u0924\u093e \u0939\u0948, \u0924\u094b \\\"\u0928\u0939\u0940\u0902 \u092a\u0924\u093e\\\" \u092c\u094b\u0932\u093f\u090f\u0964"
+                ],
+                "exhausted_action": "skip"
+            }
+        }
+    ],
+    "branches": [
+        {
+            "id": "branch_pregnant",
+            "condition": {
+                "field": "pregnant_or_not",
+                "equals": true
+            }
+        },
+        {
+            "id": "branch_not_pregnant",
+            "condition": {
+                "field": "pregnant_or_not",
+                "equals": false
+            }
+        },
+        {
+            "id": "branch_phone_not_linked",
+            "condition": {
+                "field": "is_phone_linked_to_anganwadi",
+                "equals": false
+            }
+        },
+        {
+            "id": "branch_whatsapp_not_linked",
+            "condition": {
+                "field": "whatsapp_linked_to_calling_number",
+                "equals": false
+            }
+        }
+    ],
+    "context": "This is a health survey call from Swasth Kadam to collect basic information from beneficiaries registered at Anganwadi centres. The agent is a health worker and the user is a pregnant mother or a mother with a young child. The agent is a health worker and the user is a pregnant mother. The agent is a health worker and the user is a pregnant mother. The agent is a health worker and the user is a pregnant mother. The agent is a health worker and the user is a pregnant mother.",
+    "validation_rules": "- 'name': Must be at least 2 characters long.\n- 'gestational_age_months': Must be between 1 and 9.\n- 'child_dob': Must be a valid DD-MM-YYYY date that is today or earlier.\n- 'anganwadi_linked_phone_number': Must be a valid phone number with exactly 10 digits.\n- 'whatsapp_number': Must be a valid phone number with exactly 10 digits.\n- 'last_4_digits_of_aadhar': Must be exactly 4 digits.",
+    "instructions": "IMPORTANT RETRY AND CALL-END RULES:\n\n- When retrying, use the EXACT retry script text specified for that retry attempt. Do NOT paraphrase.\n- Some questions have an informational script that must be spoken BEFORE asking that question. Follow those instructions exactly.\n- A brief hearing-only acknowledgement is already spoken before your reply \u2014 do NOT start with any acknowledgement or phrase implying you recorded, noted, or registered their answer (e.g. avoid '\u0926\u0930\u094d\u091c \u0915\u0930 \u0932\u093f\u092f\u093e', '\u091c\u093e\u0928\u0915\u093e\u0930\u0940 \u092e\u093f\u0932 \u0917\u0908', '\u0938\u092e\u091d \u0917\u0908'). Go straight to the next question Script, retry, or correction.\n- If the user explicitly asks you to repeat the question (e.g., 'Phir se bolo', 'Repeat karo', 'Dobara bolo'), repeat the current question exactly and do NOT count it as a retry attempt. If the user says they did not understand (e.g., 'Samajh nahi aaya', 'Kya bola', 'Sunai nahi diya'), treat it as a failed attempt and proceed according to the retry rules.",
+    "agent_speaks_first": true,
+    "ask_questions_one_by_one": true,
+    "status": "published",
+    "agent_persona": "health worker",
+    "user_persona": "pregnant mother",
+    "language": "hindi",
+    "scripts": {
+        "intro": "\u0928\u092e\u0938\u094d\u0924\u0947!",
+        "outro": "\u091c\u093e\u0928\u0915\u093e\u0930\u0940 \u0926\u0947\u0928\u0947 \u0915\u0947 \u0932\u093f\u090f \u0927\u0928\u094d\u092f\u0935\u093e\u0926\u0964 \u0939\u092e \u0906\u092a\u0915\u094b \u091c\u0932\u094d\u0926 \u0939\u0940 \u0939\u092e\u093e\u0930\u0940 \u0938\u0947\u0935\u093e \u0938\u0947 \u091c\u094b\u0921\u093c\u0947\u0902\u0917\u0947\u0964",
+        "outro_incomplete": "\u0915\u094d\u0937\u092e\u093e \u0915\u0940\u091c\u093f\u090f, \u0939\u092e \u0907\u0938 \u0938\u092e\u092f \u0906\u092a\u0915\u0940 \u091c\u093e\u0928\u0915\u093e\u0930\u0940 \u0926\u0930\u094d\u091c \u0928\u0939\u0940\u0902 \u0915\u0930 \u092a\u093e\u090f, \u0907\u0938\u0932\u093f\u090f \u0905\u092d\u0940 \u0915\u0949\u0932 \u0938\u092e\u093e\u092a\u094d\u0924 \u0915\u0940 \u091c\u093e \u0930\u0939\u0940 \u0939\u0948\u0964 \u0927\u0928\u094d\u092f\u0935\u093e\u0926\u0964"
+    }
+}
+```
+
+</details>
 
 <sub>An `access.json` (owner/workspace metadata) sits beside `config.json` for
 the hosted dashboard, but the local WebSocket run does **not** require it.</sub>

--- a/NOISE_EXPERIMENTS.md
+++ b/NOISE_EXPERIMENTS.md
@@ -1,0 +1,287 @@
+# Running background-noise voice-agent experiments
+
+End-to-end guide to reproduce the noise-injection experiments: stand up the agent
+under test, set up Calibrate on this branch, run the easy/hard noise batches, and
+read the results.
+
+**Two repos are involved:**
+| Repo | Role |
+|---|---|
+| **form-bharo** (`git@github.com:ARTPARK-SAHAI-ORG/form-bharo.git`) | the **agent under test** — the form-filling voice bot the simulated caller talks to |
+| **calibrate** (this repo, branch `claude/festive-rosalind-92d0d6`) | the **evaluator** — drives a simulated noisy caller and scores the agent |
+
+The flow: Calibrate spins up a simulated caller (with background noise mixed in),
+connects to the form-bharo agent over a WebSocket, they hold a Hindi enrollment
+conversation, and Calibrate saves audio + transcripts + scores. The agent, in
+parallel, writes the **filled form** it captured to disk (`data.json`) — the real
+ground truth.
+
+---
+
+## Part A — Set up the agent backend (form-bharo)
+
+### 1. Clone and run the server
+```bash
+git clone git@github.com:ARTPARK-SAHAI-ORG/form-bharo.git
+cd form-bharo/server/src
+cp env.example .env          # then fill in the agent's provider keys (STT/TTS/LLM, e.g. SARVAM/GOOGLE/OPENAI)
+uv run uvicorn main:app --host 0.0.0.0 --port 7860 --reload
+```
+The env file **must** live at `form-bharo/server/src/.env`. Fill in the agent's
+own provider keys (STT/TTS/LLM). **If you don't know what to put in it, ask Aman
+(aman.dalmia@artpark.in).**
+
+The agent is now running on **http://localhost:7860**.
+
+### 2. Create the `swasth-kadam-v5` agent
+The experiments talk to a specific agent — a 12-question Hindi child-enrollment
+survey. A fresh clone won't have it, so create it by dropping in its config:
+
+```bash
+mkdir -p server/db/agents/swasth-kadam-v5
+# copy the config shipped in the calibrate branch for exact reproduction:
+cp <calibrate>/examples/agent/simulation/swasth-kadam-v5.config.json \
+   server/db/agents/swasth-kadam-v5/config.json
+```
+
+The agent is loaded purely from `server/db/agents/<agent-id>/config.json`
+(`ROOT_DB_DIR`, see `server/src/agent_store.py`), so this single file is all the
+server needs to serve `ws://localhost:7860/ws-client/swasth-kadam-v5`. The exact
+config is committed in the calibrate branch at
+[`examples/agent/simulation/swasth-kadam-v5.config.json`](examples/agent/simulation/swasth-kadam-v5.config.json)
+— it defines the Hindi survey (name, district, anganwadi, pregnancy status,
+child name + DOB, phone/WhatsApp linkage, last-4-Aadhaar) with `language: hindi`,
+`agent_speaks_first: true`, and one-question-at-a-time asking.
+
+<sub>An `access.json` (owner/workspace metadata) sits beside `config.json` for
+the hosted dashboard, but the local WebSocket run does **not** require it.</sub>
+
+### 3. The agent URL Calibrate connects to
+Calibrate uses the pipecat non-telephony WebSocket endpoint:
+```
+ws://localhost:7860/ws-client/<agent-id>
+```
+`<agent-id>` is a folder name under `server/db/agents/`. The experiments use the
+**`swasth-kadam-v5`** agent (a Hindi child-enrollment form), so the URL is:
+```
+ws://localhost:7860/ws-client/swasth-kadam-v5
+```
+This exact URL is already set as `agent_url` in the example configs. To use a
+different agent, drop its `config.json` under `server/db/agents/<its-id>/` and
+point `agent_url` at `ws://localhost:7860/ws-client/<its-id>`.
+
+### 4. Where the agent stores what it captured (ground truth)
+Every call creates a conversation folder on the agent side:
+```
+server/db/agents/swasth-kadam-v5/conversations/<conversation-id>/
+├── data.json        # the FINAL filled form (form_data + form_status)  ← ground truth
+├── transcript.json  # the agent's view of the conversation
+├── recording.wav
+├── metrics.json
+└── events.json / conversation.log / turns/
+```
+`data.json → form_data` is the authoritative "what actually landed in the form",
+used later to judge accuracy (see Part E).
+
+---
+
+## Part B — Set up Calibrate (this branch)
+
+### 1. Clone, check out the branch, install
+```bash
+git clone git@github.com:ARTPARK-SAHAI-ORG/calibrate.git
+cd calibrate
+git checkout claude/festive-rosalind-92d0d6
+uv sync --extra dev
+```
+
+### 2. Provider keys — `.env` in the calibrate repo root
+Create a `.env` file at the **root of the calibrate repo** (`calibrate/.env`). The
+**simulated caller** side needs these (the agent uses its own keys, Part A):
+| Key | Used for |
+|---|---|
+| `OPENAI_API_KEY` | simulated-caller LLM + the evaluator judges |
+| `OPENROUTER_API_KEY` | evaluator judge models routed via OpenRouter |
+| `ELEVENLABS_API_KEY` | simulated-caller voice (English/Hindi) |
+| `GOOGLE_APPLICATION_CREDENTIALS` | simulated-caller voice (Kannada, Google Chirp3-HD) |
+| `HF_TOKEN` (or `huggingface-cli login`) | pulling Vaani speaker clips (Part B.3) |
+
+**If you don't know what to put in this file, ask Aman (aman.dalmia@artpark.in).**
+
+### 3. Build the noise assets  ⚠️ required, not in git
+The audio assets are **gitignored** (licensing), so you must build them once. They
+live under `calibrate_agent/agent/assets/noise/` and are generated from raw clips in
+`data/`:
+
+```
+data/env_raw/                      # environmental sounds (ESC-50, 16-bit)
+├── rain.wav wind.wav engine.wav vacuum_cleaner.wav train.wav siren.wav
+├── crying_baby.wav footsteps.wav keyboard_typing.wav laughing.wav
+├── dog/00.wav … 07.wav           # multiple samples (scattered, not looped)
+└── car_horn/00.wav … 07.wav
+data/vaani_raw/{english,hindi,kannada}/*.wav   # Vaani speaker clips, 16 kHz mono
+```
+- **Environmental clips**: the 13 ESC-50 classes above (ESC-50 is public; note it is
+  CC BY-NC, so treat as local-only until CC0-re-sourced before shipping).
+- **Speaker clips**: from the gated **ARTPARK-IISc/Vaani** HF dataset (CC BY 4.0) —
+  accept its terms + `huggingface-cli login`, then pull ~25–40 clips per language
+  (english/hindi/kannada), filtering rows by the `language` field.
+
+Then bundle them (resamples to 16 kHz mono):
+```bash
+uv run python -c "from calibrate_agent.agent.noise.assets import prepare_assets; prepare_assets()"
+```
+
+**Sanity check (no keys/assets needed):**
+```bash
+uv run pytest tests/agent/test_noise_*.py -q      # 57 tests, synthetic fixtures
+```
+
+---
+
+## Part C — The config
+
+A voice-sim config is one JSON with `personas`, `scenarios`, `evaluators`, `settings`,
+and `agent_url`. **Noise is a per-persona setting** — add a `noise` block inside each
+persona:
+
+```jsonc
+"noise": {
+  "mode": "fixed",              // off | fixed | random | mixture
+  "environment": "busy_street", // single sound, a scene, ["list"], or null
+  "people": "light",            // none | single | light | medium | heavy  (chatter, language-matched)
+  "loudness": "moderate"        // faint | moderate | loud | harsh   (louder = harder)
+}
+```
+Omit `noise` on a persona for a clean control. Difficulty rises with **loudness**
+(faint→harsh) and **people density** (crowds mask speech more than steady sounds).
+
+The two experiment configs live at
+`examples/agent/simulation/sample_voice_noise_{easy,hard}.json` and are reproduced
+below. **Easy** = env/people/mixed at faint→moderate; **Hard** = the same at
+loud→harsh; each ends with a clean baseline.
+
+### `sample_voice_noise_easy.json`
+```json
+{
+  "agent_url": "ws://localhost:7860/ws-client/swasth-kadam-v5",
+  "personas": [
+    { "label": "easy L1 · env · rain · faint", "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. a little soft rain outside.", "gender": "female", "language": "hindi", "interruption_sensitivity": "none", "noise": { "mode": "fixed", "environment": "rain", "people": "none", "loudness": "faint" } },
+    { "label": "easy L2 · env · wind · faint", "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. a soft breeze outside.", "gender": "female", "language": "hindi", "interruption_sensitivity": "none", "noise": { "mode": "fixed", "environment": "wind", "people": "none", "loudness": "faint" } },
+    { "label": "easy L3 · people · single · faint", "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. one person talking quietly nearby.", "gender": "female", "language": "hindi", "interruption_sensitivity": "none", "noise": { "mode": "fixed", "environment": null, "people": "single", "loudness": "faint" } },
+    { "label": "easy L4 · env · busy street · moderate", "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. standing near a moderately busy street.", "gender": "female", "language": "hindi", "interruption_sensitivity": "none", "noise": { "mode": "fixed", "environment": "busy_street", "people": "none", "loudness": "moderate" } },
+    { "label": "easy L5 · people · light · moderate", "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. a couple of people chatting nearby.", "gender": "female", "language": "hindi", "interruption_sensitivity": "none", "noise": { "mode": "fixed", "environment": null, "people": "light", "loudness": "moderate" } },
+    { "label": "easy L6 · mixed · street+light · moderate", "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. a busy street with a few people around.", "gender": "female", "language": "hindi", "interruption_sensitivity": "none", "noise": { "mode": "fixed", "environment": "busy_street", "people": "light", "loudness": "moderate" } },
+    { "label": "easy · baseline · clean", "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. you are at home in a quiet room.", "gender": "female", "language": "hindi", "interruption_sensitivity": "none" }
+  ],
+  "scenarios": [
+    { "name": "straightforward enrollment", "description": "Complete the Swasth Kadham signup for your child. Answer clearly right away. Facts: full name Priya Mehta; district Pune; Anganwadi Lakshmi Nagar Kendra; not pregnant; child Aarav Mehta, born 22 July 2023; this number is linked to your Anganwadi; WhatsApp on this number; last 4 Aadhaar digits 4827." }
+  ],
+  "evaluators": [
+    { "id": "form-complete-id", "name": "form_completed", "system_prompt": "Mark True if the agent collected the key enrollment fields (name, district, pregnancy status, child name+DOB, phone/WhatsApp linkage, last 4 Aadhaar digits) and gave a closing acknowledgment.", "judge_model": "openai/gpt-4.1" },
+    { "id": "patient-guidance-id", "name": "patient_guidance", "system_prompt": "Mark True if the agent was polite, asked questions one at a time, and patiently drew out information under noise.", "judge_model": "openai/gpt-4.1" }
+  ],
+  "settings": { "agent_speaks_first": true, "max_turns": 50 }
+}
+```
+
+### `sample_voice_noise_hard.json`
+```json
+{
+  "agent_url": "ws://localhost:7860/ws-client/swasth-kadam-v5",
+  "personas": [
+    { "label": "hard L1 · env · vehicle · loud", "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. on a moving bus, engine loud.", "gender": "female", "language": "hindi", "interruption_sensitivity": "none", "noise": { "mode": "fixed", "environment": "vehicle", "people": "none", "loudness": "loud" } },
+    { "label": "hard L2 · people · medium · loud", "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. in a cafe with several people talking.", "gender": "female", "language": "hindi", "interruption_sensitivity": "none", "noise": { "mode": "fixed", "environment": null, "people": "medium", "loudness": "loud" } },
+    { "label": "hard L3 · mixed · station+medium · loud", "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. at a crowded, loud railway station.", "gender": "female", "language": "hindi", "interruption_sensitivity": "none", "noise": { "mode": "fixed", "environment": "railway_station", "people": "medium", "loudness": "loud" } },
+    { "label": "hard L4 · env · vacuum · harsh", "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. at home with a vacuum running right nearby.", "gender": "female", "language": "hindi", "interruption_sensitivity": "none", "noise": { "mode": "fixed", "environment": "vacuum", "people": "none", "loudness": "harsh" } },
+    { "label": "hard L5 · people · heavy · harsh", "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. in a packed, very noisy crowd.", "gender": "female", "language": "hindi", "interruption_sensitivity": "none", "noise": { "mode": "fixed", "environment": null, "people": "heavy", "loudness": "harsh" } },
+    { "label": "hard L6 · mixed · rainy+heavy · harsh", "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. on a rainy street in a heavy crowd.", "gender": "female", "language": "hindi", "interruption_sensitivity": "none", "noise": { "mode": "fixed", "environment": "rainy_street", "people": "heavy", "loudness": "harsh" } },
+    { "label": "hard · baseline · clean", "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. you are at home in a quiet room.", "gender": "female", "language": "hindi", "interruption_sensitivity": "none" }
+  ],
+  "scenarios": [
+    { "name": "straightforward enrollment", "description": "Complete the Swasth Kadham signup for your child. Answer clearly right away. Facts: full name Priya Mehta; district Pune; Anganwadi Lakshmi Nagar Kendra; not pregnant; child Aarav Mehta, born 22 July 2023; this number is linked to your Anganwadi; WhatsApp on this number; last 4 Aadhaar digits 4827." }
+  ],
+  "evaluators": [
+    { "id": "form-complete-id", "name": "form_completed", "system_prompt": "Mark True if the agent collected the key enrollment fields (name, district, pregnancy status, child name+DOB, phone/WhatsApp linkage, last 4 Aadhaar digits) and gave a closing acknowledgment.", "judge_model": "openai/gpt-4.1" },
+    { "id": "patient-guidance-id", "name": "patient_guidance", "system_prompt": "Mark True if the agent was polite, asked questions one at a time, and patiently drew out information under noise.", "judge_model": "openai/gpt-4.1" }
+  ],
+  "settings": { "agent_speaks_first": true, "max_turns": 50 }
+}
+```
+
+---
+
+## Part D — Run the experiments
+
+With the **agent running** (Part A) and **assets built** (Part B):
+
+```bash
+# from the calibrate repo root, on branch claude/festive-rosalind-92d0d6
+uv run calibrate-agent simulations --type voice \
+  -c examples/agent/simulation/sample_voice_noise_easy.json -o ./out/easy --parallel 4
+
+uv run calibrate-agent simulations --type voice \
+  -c examples/agent/simulation/sample_voice_noise_hard.json -o ./out/hard --parallel 4
+```
+- `-o <dir>` — a **different output folder per run**.
+- `--parallel N` — run N calls at once (each is a real voice conversation; 4 is a good default). Each persona × scenario is one call.
+- Each call is a full Hindi conversation, so a 7-persona batch takes a few minutes.
+
+**If you want to match each call to its agent-side `data.json` (Part E), run
+`--parallel 1`** — sequential calls create agent conversations in persona order, which
+is the only reliable way to line them up (parallel + identical scenarios can't be
+matched).
+
+Other ready-made configs in the same folder: `sample_voice_noise_matrix.json`
+(type × difficulty grid), `_progressive.json` (one smooth ramp), `_showcase.json`
+(demonstrates random/mixture modes).
+
+---
+
+## Part E — Reading the output
+
+### Run-level (in `-o` dir)
+```
+out/easy/
+├── results.csv     # one row per sim: form_completed, patient_guidance, stt_llm_judge_score, e2e_latency
+├── metrics.json    # aggregated latency/STT metrics
+└── simulation_persona_<i>_scenario_<j>/   # one folder per call
+```
+
+### Per-simulation folder
+```
+simulation_persona_1_scenario_1/
+├── conversation.wav        # what the agent HEARD — caller speech + background noise
+├── clean_conversation.wav  # the caller's speech WITHOUT noise (reference)
+├── clean_*.wav             # per-turn clean copies
+├── noise_track.wav         # the exact looping background that was mixed in (afplay to hear it)
+├── transcript.json         # the conversation (agent messages + caller turns)
+├── stt_results.csv         # per-utterance: reference (what caller said) vs prediction (what agent heard) + score
+├── stt_outputs.json        # raw agent transcriptions
+├── evaluation_results.csv  # the judge scores (form_completed, patient_guidance)
+├── metrics.json            # per-call latency/STT
+├── audios/                 # per-turn wavs
+└── tool_calls.json, config.json, logs, results.log
+```
+Quick listen — noisy vs clean:
+```bash
+afplay out/easy/simulation_persona_5_scenario_1/conversation.wav        # agent-heard (noisy)
+afplay out/easy/simulation_persona_5_scenario_1/clean_conversation.wav  # clean
+afplay out/easy/simulation_persona_5_scenario_1/noise_track.wav         # the noise loop alone
+```
+
+### The real ground truth — the agent's filled form
+The judge scores (`form_completed`) are LLM-based and can misfire; the STT score can
+be deflated by turn-alignment under noise. The **authoritative** check is the agent's
+`data.json` (Part A.3): compare its `form_data` against the scenario facts
+(Priya Mehta / Pune / Lakshmi Nagar Kendra / not pregnant / Aarav Mehta / 22-07-2023 /
+phone✓ / WhatsApp✓ / 4827). Match a call to its conversation by running
+`--parallel 1` and taking the Nth conversation (by creation time) for persona N, or by
+fingerprinting the sim's `stt_results.csv` predictions against each conversation's
+`transcript.json`.
+
+### Interpreting across a run
+- **`conversation.wav` louder (higher RMS) than `clean_conversation.wav`** confirms noise was mixed in; harsher loudness = bigger gap.
+- **`form_completed` / `patient_guidance`** = task success / politeness (binary 1.0/0.0), but treat single results with caution — one call + one judge is noisy; run each condition several times.
+- **`data.json` diffs** show the real damage: dropped name parts, a wrong digit in a date, a bystander word pulled into a field, or (worst case) a collapsed call.
+- Expect a gradient: light/moderate noise → occasional single-field slips; loud → mostly fine; harsh crowds → corrupted fields and, at the extreme, a call that falls apart.

--- a/NOISE_EXPERIMENTS.md
+++ b/NOISE_EXPERIMENTS.md
@@ -404,28 +404,19 @@ Create a `.env` file at the **root of the calibrate repo** (`calibrate/.env`). T
 **If you don't know what to put in this file, ask Aman.**
 
 ### 3. Build the noise assets  ⚠️ required, not in git
-The audio assets are **gitignored** (licensing), so you must build them once. They
-live under `calibrate_agent/agent/assets/noise/` and are generated from raw clips in
-`data/`:
+The audio assets aren't in git — build them once with a single script. It downloads
+the raw clips (ESC-50 environmental sounds + Vaani speaker clips), places them under
+`data/`, and bundles them into `calibrate_agent/agent/assets/noise/` (resampled to
+16 kHz mono):
 
-```
-data/env_raw/                      # environmental sounds (ESC-50, 16-bit)
-├── rain.wav wind.wav engine.wav vacuum_cleaner.wav train.wav siren.wav
-├── crying_baby.wav footsteps.wav keyboard_typing.wav laughing.wav
-├── dog/00.wav … 07.wav           # multiple samples (scattered, not looped)
-└── car_horn/00.wav … 07.wav
-data/vaani_raw/{english,hindi,kannada}/*.wav   # Vaani speaker clips, 16 kHz mono
-```
-- **Environmental clips**: the 13 ESC-50 classes above (ESC-50 is public; note it is
-  CC BY-NC, so treat as local-only until CC0-re-sourced before shipping).
-- **Speaker clips**: from the gated **ARTPARK-IISc/Vaani** HF dataset (CC BY 4.0) —
-  accept its terms + `huggingface-cli login`, then pull ~25–40 clips per language
-  (english/hindi/kannada), filtering rows by the `language` field.
-
-Then bundle them (resamples to 16 kHz mono):
 ```bash
-uv run python -c "from calibrate_agent.agent.noise.assets import prepare_assets; prepare_assets()"
+uv run python scripts/fetch_noise_assets.py
 ```
+
+The speaker clips come from the **gated ARTPARK-IISc/Vaani** HF dataset, so accept
+its terms and log in first (`huggingface-cli login`, or set `HF_TOKEN`). The ESC-50
+half needs no login. To build only the environmental half (no HF login), run
+`--skip-speakers`.
 
 **Sanity check (no keys/assets needed):**
 ```bash

--- a/NOISE_EXPERIMENTS.md
+++ b/NOISE_EXPERIMENTS.md
@@ -40,8 +40,7 @@ mkdir -p server/db/agents/swasth-kadam-v5
 # then create server/db/agents/swasth-kadam-v5/config.json with the JSON below
 ```
 
-<details>
-<summary><code>server/db/agents/swasth-kadam-v5/config.json</code></summary>
+`server/db/agents/swasth-kadam-v5/config.json`:
 
 ```json
 {
@@ -351,8 +350,6 @@ mkdir -p server/db/agents/swasth-kadam-v5
     }
 }
 ```
-
-</details>
 
 ### 3. The agent URL Calibrate connects to
 Calibrate uses the pipecat non-telephony WebSocket endpoint:

--- a/NOISE_EXPERIMENTS.md
+++ b/NOISE_EXPERIMENTS.md
@@ -564,19 +564,3 @@ afplay out/easy/simulation_persona_5_scenario_1/conversation.wav        # agent-
 afplay out/easy/simulation_persona_5_scenario_1/clean_conversation.wav  # clean
 afplay out/easy/simulation_persona_5_scenario_1/noise_track.wav         # the noise loop alone
 ```
-
-### The real ground truth — the agent's filled form
-The judge scores (`form_completed`) are LLM-based and can misfire; the STT score can
-be deflated by turn-alignment under noise. The **authoritative** check is the agent's
-`data.json` (Part A.3): compare its `form_data` against the scenario facts
-(Priya Mehta / Pune / Lakshmi Nagar Kendra / not pregnant / Aarav Mehta / 22-07-2023 /
-phone✓ / WhatsApp✓ / 4827). Match a call to its conversation by running
-`--parallel 1` and taking the Nth conversation (by creation time) for persona N, or by
-fingerprinting the sim's `stt_results.csv` predictions against each conversation's
-`transcript.json`.
-
-### Interpreting across a run
-- **`conversation.wav` louder (higher RMS) than `clean_conversation.wav`** confirms noise was mixed in; harsher loudness = bigger gap.
-- **`form_completed` / `patient_guidance`** = task success / politeness (binary 1.0/0.0), but treat single results with caution — one call + one judge is noisy; run each condition several times.
-- **`data.json` diffs** show the real damage: dropped name parts, a wrong digit in a date, a bystander word pulled into a field, or (worst case) a collapsed call.
-- Expect a gradient: light/moderate noise → occasional single-field slips; loud → mostly fine; harsh crowds → corrupted fields and, at the extreme, a call that falls apart.

--- a/calibrate_agent/agent/noise/__init__.py
+++ b/calibrate_agent/agent/noise/__init__.py
@@ -1,0 +1,8 @@
+"""Background-noise injection for voice simulations.
+
+Generates a per-simulation background noise track (environmental sounds +
+distant "backgroundified" speaker chatter) that is mixed under the simulated
+caller's audio, so the tested agent's STT hears a realistic noisy caller.
+
+See design/noise_injection_spec.md for the full design.
+"""

--- a/calibrate_agent/agent/noise/assets.py
+++ b/calibrate_agent/agent/noise/assets.py
@@ -1,0 +1,191 @@
+"""Asset management for voice-sim background-noise injection.
+
+Populates and locates the bundled noise asset directory
+(``calibrate_agent/agent/assets/noise``) that the noise mixer draws from:
+
+- ``env/<name>.wav`` — steady environmental loops (16 kHz mono 16-bit).
+- ``env/dog/NN.wav`` and ``env/car_horn/NN.wav`` — single-event sample banks.
+- ``speakers/{english,hindi,kannada}/*.wav`` — distant chatter speaker pool.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+import soxr
+
+try:
+    from calibrate_agent.agent.noise.schema import (  # type: ignore
+        EVENT_SOUNDS,
+        SCENES,
+        SINGLE_SOUNDS,
+    )
+except Exception:  # pragma: no cover - schema.py may not exist yet
+    # TODO: remove this fallback once calibrate_agent/agent/noise/schema.py lands.
+    EVENT_SOUNDS = ["dog", "car_horn"]
+    SINGLE_SOUNDS = [
+        "rain",
+        "wind",
+        "engine",
+        "vacuum",
+        "train",
+        "siren",
+        "crying_baby",
+        "footsteps",
+        "keyboard_typing",
+        "laughing",
+        "dog",
+        "car_horn",
+    ]
+    SCENES = {
+        "busy_street": ["car_horn", "engine", "siren"],
+        "vehicle": ["engine", "wind", "car_horn"],
+        "railway_station": ["train", "footsteps"],
+        "office": ["keyboard_typing"],
+        "home_with_baby": ["crying_baby"],
+        "housework": ["vacuum"],
+        "rainy_street": ["rain", "wind", "car_horn"],
+        "quiet_home": ["dog"],
+    }
+
+TARGET_SR = 16000
+
+_ENV_ASSET_NAMES = {"vacuum_cleaner": "vacuum"}
+_SPEAKER_LANGUAGES = ("english", "hindi", "kannada")
+_ENV_DEST_ENV_ROOT = "env"
+_SPEAKERS_DEST_ROOT = "speakers"
+
+_ASSETS_ENV = "CALIBRATE_NOISE_ASSETS"
+
+
+def _default_assets_root() -> Path:
+    """Locate the bundled ``assets/noise`` dir, tolerating unpacked layouts."""
+    try:
+        from importlib.resources import files
+
+        base = files("calibrate_agent.agent")
+        candidate = Path(str(base)) / "assets" / "noise"
+        return candidate
+    except Exception:  # pragma: no cover - fallback for odd install layouts
+        return Path(__file__).resolve().parent.parent / "assets" / "noise"
+
+
+def _load_mono(path: Path) -> tuple[np.ndarray, int]:
+    data, sr = sf.read(str(path), dtype="float32", always_2d=False)
+    if data.ndim > 1:
+        data = data.mean(axis=1)
+    return np.asarray(data, dtype=np.float32), sr
+
+
+def _write_16k_mono(dest: Path, data: np.ndarray, sr: int) -> None:
+    if sr != TARGET_SR:
+        data = soxr.resample(data, sr, TARGET_SR)
+    data = np.asarray(data, dtype=np.float32)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(str(dest), data, TARGET_SR, subtype="PCM_16")
+
+
+def _is_16k_mono_pcm16(path: Path) -> bool:
+    try:
+        info = sf.info(str(path))
+    except Exception:
+        return False
+    return (
+        info.samplerate == TARGET_SR
+        and info.channels == 1
+        and info.subtype == "PCM_16"
+    )
+
+
+def prepare_assets(
+    src_env: str = "data/env_raw",
+    src_speakers: str = "data/vaani_raw",
+    dest: str | None = None,
+) -> None:
+    """Populate the bundled noise asset directory from raw clips.
+
+    Idempotent: re-running overwrites existing outputs with fresh conversions.
+    """
+    src_env_path = Path(src_env)
+    src_speakers_path = Path(src_speakers)
+    dest_root = Path(dest) if dest is not None else _default_assets_root()
+
+    env_dest = dest_root / _ENV_DEST_ENV_ROOT
+    env_dest.mkdir(parents=True, exist_ok=True)
+
+    # Steady single-clip environmental sounds.
+    for wav in sorted(src_env_path.glob("*.wav")):
+        stem = wav.stem
+        name = _ENV_ASSET_NAMES.get(stem, stem)
+        data, sr = _load_mono(wav)
+        _write_16k_mono(env_dest / f"{name}.wav", data, sr)
+
+    # Multi-sample event banks (dog, car_horn).
+    for event in EVENT_SOUNDS:
+        src_dir = src_env_path / event
+        if not src_dir.is_dir():
+            continue
+        for wav in sorted(src_dir.glob("*.wav")):
+            data, sr = _load_mono(wav)
+            _write_16k_mono(env_dest / event / wav.name, data, sr)
+
+    # Speaker pools (already 16k mono; verify and re-write if not).
+    for language in _SPEAKER_LANGUAGES:
+        src_dir = src_speakers_path / language
+        if not src_dir.is_dir():
+            continue
+        lang_dest = dest_root / _SPEAKERS_DEST_ROOT / language
+        lang_dest.mkdir(parents=True, exist_ok=True)
+        for wav in sorted(src_dir.glob("*.wav")):
+            out = lang_dest / wav.name
+            if _is_16k_mono_pcm16(wav):
+                shutil.copyfile(wav, out)
+            else:
+                data, sr = _load_mono(wav)
+                _write_16k_mono(out, data, sr)
+
+
+class NoiseAssets:
+    """Locates bundled noise assets and resolves scene/sound names to paths."""
+
+    def __init__(self, root: str | None = None):
+        if root is not None:
+            self.root = Path(root)
+        elif os.environ.get(_ASSETS_ENV):
+            self.root = Path(os.environ[_ASSETS_ENV])
+        else:
+            self.root = _default_assets_root()
+
+    def resolve_environment(self, environment) -> list[str]:
+        """Normalise an environment spec to a list of ingredient sound names."""
+        if environment is None:
+            return []
+        if isinstance(environment, (list, tuple)):
+            return list(environment)
+        if environment == "none":
+            return []
+        if environment in SCENES:
+            return list(SCENES[environment])
+        return [environment]
+
+    def env_ingredient_paths(self, name: str) -> list[str]:
+        """Return the wav path(s) backing an environmental sound name."""
+        env_root = self.root / _ENV_DEST_ENV_ROOT
+        event_dir = env_root / name
+        if event_dir.is_dir():
+            return [str(p) for p in sorted(event_dir.glob("*.wav"))]
+        steady = env_root / f"{name}.wav"
+        if steady.is_file():
+            return [str(steady)]
+        return []
+
+    def speaker_pool(self, language: str) -> list[str]:
+        """Return all speaker wav paths for a language."""
+        lang_dir = self.root / _SPEAKERS_DEST_ROOT / language
+        if not lang_dir.is_dir():
+            return []
+        return [str(p) for p in sorted(lang_dir.glob("*.wav"))]

--- a/calibrate_agent/agent/noise/resolver.py
+++ b/calibrate_agent/agent/noise/resolver.py
@@ -1,0 +1,103 @@
+"""Per-run resolution of a normalized noise config into a concrete draw."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from calibrate_agent.agent.noise.schema import (
+    DENSITIES,
+    LOUDNESS_LEVELS,
+    LOUDNESS_VOLUME,
+    SCENES,
+    SINGLE_SOUNDS,
+    NoiseAtom,
+    normalize_noise_config,
+)
+
+
+@dataclass(frozen=True)
+class ResolvedNoise:
+    atom: NoiseAtom
+    volume: float
+    seed: int
+
+
+def _resolve_loudness(loudness, rng) -> str:
+    """Collapse a loudness spec (level / list / 'any') to a single level."""
+    if loudness == "any":
+        return str(rng.choice(LOUDNESS_LEVELS))
+    if isinstance(loudness, list):
+        if not loudness:
+            raise ValueError("Loudness pool is empty.")
+        return str(rng.choice(loudness))
+    return loudness
+
+
+def resolve_for_run(
+    noise_cfg,
+    *,
+    language: str,
+    run_index: int,
+    base_seed: int | None,
+) -> ResolvedNoise | None:
+    """Deterministically resolve the noise config for a single run.
+
+    ``noise_cfg`` is the raw ``config["noise"]``. Returns None when this run
+    should be clean. Deterministic: the same (run_index, base_seed) always
+    yields the same result.
+    """
+    normalized = normalize_noise_config(noise_cfg)
+    if normalized is None:
+        return None
+
+    seed = (base_seed or 0) * 1_000_003 + run_index
+    rng = np.random.default_rng(seed)
+
+    mode = normalized["mode"]
+
+    if mode == "fixed":
+        loudness = _resolve_loudness(normalized.get("loudness", "moderate"), rng)
+        atom = NoiseAtom(
+            environment=normalized.get("environment"),
+            people=normalized.get("people", "none"),
+            loudness=loudness,
+        )
+        return ResolvedNoise(atom=atom, volume=LOUDNESS_VOLUME[loudness], seed=seed)
+
+    if mode == "random":
+        clean_fraction = normalized.get("clean_fraction", 0.0)
+        if clean_fraction > 0.0 and float(rng.random()) < clean_fraction:
+            return None
+        env_pool = normalized.get(
+            "environments", SINGLE_SOUNDS + list(SCENES) + ["none"]
+        )
+        people_pool = normalized.get("people", DENSITIES)
+        loud_pool = normalized.get("loudness", LOUDNESS_LEVELS)
+
+        environment = str(rng.choice(env_pool))
+        if environment == "none":
+            environment = None  # type: ignore[assignment]
+        people = str(rng.choice(people_pool))
+        loudness = _resolve_loudness(loud_pool, rng)
+        atom = NoiseAtom(environment=environment, people=people, loudness=loudness)
+        return ResolvedNoise(atom=atom, volume=LOUDNESS_VOLUME[loudness], seed=seed)
+
+    if mode == "mixture":
+        conditions = normalized["conditions"]
+        weights = np.array([c["weight"] for c in conditions], dtype=float)
+        weights = weights / weights.sum()
+        idx = int(rng.choice(len(conditions), p=weights))
+        spec = conditions[idx]["spec"]
+        if spec == "off":
+            return None
+        loudness = _resolve_loudness(spec.get("loudness", "moderate"), rng)
+        atom = NoiseAtom(
+            environment=spec.get("environment"),
+            people=spec.get("people", "none"),
+            loudness=loudness,
+        )
+        return ResolvedNoise(atom=atom, volume=LOUDNESS_VOLUME[loudness], seed=seed)
+
+    raise ValueError(f"Unhandled noise mode {mode!r}.")

--- a/calibrate_agent/agent/noise/save.py
+++ b/calibrate_agent/agent/noise/save.py
@@ -1,0 +1,120 @@
+"""Save clean and noisy conversation audio for noisy voice simulations.
+
+When background noise is enabled, the tested agent hears a continuous noise
+track under the caller. To reflect that faithfully, the unprefixed
+``conversation.wav`` is reconstructed as the NOISY (agent-heard) audio by
+mixing a looping noise track over the full clean timeline, while clean
+``clean_``-prefixed copies are kept as the reference.
+"""
+
+import glob
+import os
+import shutil
+import tempfile
+
+import numpy as np
+import soundfile as sf
+
+
+def mix_noise_over_wav(
+    clean_wav: str,
+    noise_track: str,
+    out_wav: str,
+    volume: float,
+    sample_rate: int = 16000,
+) -> str:
+    """Mix a looping noise track over a clean WAV.
+
+    Reads ``clean_wav`` and ``noise_track`` (both 16k mono 16-bit), tiles/loops
+    the noise to the clean length, computes ``clip(clean_int16 + noise_int16 *
+    volume)`` as int16, and writes ``out_wav`` (16k mono 16-bit). Matches
+    pipecat SoundfileMixer's ``clip(audio + sound * volume)``.
+    """
+    clean, _ = sf.read(clean_wav, dtype="int16")
+    noise, _ = sf.read(noise_track, dtype="int16")
+
+    clean = np.asarray(clean, dtype=np.int16).reshape(-1)
+    noise = np.asarray(noise, dtype=np.int16).reshape(-1)
+
+    n = clean.shape[0]
+
+    if noise.shape[0] == 0:
+        tiled = np.zeros(n, dtype=np.int16)
+    else:
+        reps = int(np.ceil(n / noise.shape[0]))
+        tiled = np.tile(noise, reps)[:n]
+
+    mixed = clean.astype(np.float64) + tiled.astype(np.float64) * float(volume)
+    mixed = np.clip(np.round(mixed), -32768, 32767).astype(np.int16)
+
+    sf.write(out_wav, mixed, sample_rate, subtype="PCM_16")
+    return out_wav
+
+
+def write_clean_and_noisy(
+    *,
+    audio_dir: str,
+    transcript_path: str,
+    conversation_path: str,
+    noise_track_path: str,
+    volume: float,
+    sample_rate: int = 16000,
+) -> None:
+    """Write clean per-turn copies and reconstruct the noisy conversation.
+
+    1. Copy every per-turn ``{N}_user.wav`` / ``{N}_bot.wav`` in ``audio_dir``
+       to ``clean_{N}_user.wav`` / ``clean_{N}_bot.wav``.
+    2. Build ``clean_conversation.wav`` next to ``conversation_path`` from the
+       clean-prefixed per-turn files.
+    3. Build the clean full timeline, then mix the looping noise over it so the
+       unprefixed ``conversation.wav`` is the noisy one.
+    """
+    from calibrate_agent.utils import combine_audio_files
+
+    turn_files = [
+        p
+        for p in glob.glob(os.path.join(audio_dir, "*.wav"))
+        if _is_turn_file(os.path.basename(p))
+    ]
+
+    if not turn_files:
+        return
+
+    for src in turn_files:
+        name = os.path.basename(src)
+        dst = os.path.join(audio_dir, f"clean_{name}")
+        shutil.copyfile(src, dst)
+
+    out_dir = os.path.dirname(conversation_path)
+    clean_conv_path = os.path.join(out_dir, "clean_conversation.wav")
+    combine_audio_files(
+        audio_dir, clean_conv_path, transcript_path, prefix="clean_"
+    )
+
+    tmp_fd, tmp_clean = tempfile.mkstemp(suffix=".wav", dir=out_dir or None)
+    os.close(tmp_fd)
+    try:
+        combine_audio_files(audio_dir, tmp_clean, transcript_path, prefix="")
+        mix_noise_over_wav(
+            tmp_clean,
+            noise_track_path,
+            conversation_path,
+            volume,
+            sample_rate=sample_rate,
+        )
+    finally:
+        if os.path.exists(tmp_clean):
+            os.remove(tmp_clean)
+
+
+def _is_turn_file(name: str) -> bool:
+    if name.startswith("clean_"):
+        return False
+    stem, ext = os.path.splitext(name)
+    if ext.lower() != ".wav":
+        return False
+    parts = stem.split("_")
+    if len(parts) != 2:
+        return False
+    idx, role = parts
+    return idx.isdigit() and role in ("user", "bot")

--- a/calibrate_agent/agent/noise/schema.py
+++ b/calibrate_agent/agent/noise/schema.py
@@ -1,0 +1,233 @@
+"""Config schema, constants, and normalization for voice-sim background noise."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+SAMPLE_RATE = 16000
+LANGUAGES = ["english", "hindi", "kannada"]
+SINGLE_SOUNDS = [
+    "rain",
+    "wind",
+    "engine",
+    "vacuum",
+    "train",
+    "siren",
+    "crying_baby",
+    "footsteps",
+    "keyboard_typing",
+    "laughing",
+    "dog",
+    "car_horn",
+]
+EVENT_SOUNDS = {"dog", "car_horn"}
+SCENES = {
+    "busy_street": ["car_horn", "engine", "siren"],
+    "vehicle": ["engine", "wind", "car_horn"],
+    "railway_station": ["train", "footsteps"],
+    "office": ["keyboard_typing"],
+    "home_with_baby": ["crying_baby"],
+    "housework": ["vacuum"],
+    "rainy_street": ["rain", "wind", "car_horn"],
+    "quiet_home": ["dog"],
+}
+DENSITY_VOICES = {"none": 0, "single": 1, "light": 3, "medium": 5, "heavy": 10}
+LOUDNESS_VOLUME = {"faint": 0.15, "moderate": 0.30, "loud": 0.55, "harsh": 0.85}
+DENSITIES = ["none", "single", "light", "medium", "heavy"]
+LOUDNESS_LEVELS = ["faint", "moderate", "loud", "harsh"]
+
+
+@dataclass(frozen=True)
+class NoiseAtom:
+    environment: str | list[str] | None
+    people: str = "none"
+    loudness: str = "moderate"
+
+
+def _validate_environment(env):
+    """Validate an environment value; return it unchanged if valid."""
+    if env is None or env == "none":
+        return env
+    if isinstance(env, str):
+        if env in SINGLE_SOUNDS or env in SCENES:
+            return env
+        raise ValueError(
+            f"Unknown environment {env!r}. Must be a single sound "
+            f"({', '.join(SINGLE_SOUNDS)}), a scene ({', '.join(SCENES)}), "
+            f"'none', or a list of single sounds."
+        )
+    if isinstance(env, list):
+        for item in env:
+            if item not in SINGLE_SOUNDS:
+                raise ValueError(
+                    f"Environment list entry {item!r} is not a known single "
+                    f"sound ({', '.join(SINGLE_SOUNDS)})."
+                )
+        return list(env)
+    raise ValueError(
+        f"Environment must be a string, list of sound names, or None; got "
+        f"{type(env).__name__}."
+    )
+
+
+def _validate_people(people):
+    if people not in DENSITIES:
+        raise ValueError(
+            f"Unknown people density {people!r}. Must be one of "
+            f"{', '.join(DENSITIES)}."
+        )
+    return people
+
+
+def _validate_loudness(loudness):
+    """Validate loudness: a single level, a list of levels, or 'any'."""
+    if loudness == "any":
+        return loudness
+    if isinstance(loudness, str):
+        if loudness in LOUDNESS_LEVELS:
+            return loudness
+        raise ValueError(
+            f"Unknown loudness {loudness!r}. Must be one of "
+            f"{', '.join(LOUDNESS_LEVELS)}, a list of them, or 'any'."
+        )
+    if isinstance(loudness, list):
+        for item in loudness:
+            if item not in LOUDNESS_LEVELS:
+                raise ValueError(
+                    f"Loudness list entry {item!r} is not a known level "
+                    f"({', '.join(LOUDNESS_LEVELS)})."
+                )
+        return list(loudness)
+    raise ValueError(
+        f"Loudness must be a string, list of levels, or 'any'; got "
+        f"{type(loudness).__name__}."
+    )
+
+
+def _normalize_atom(raw):
+    """Normalize a plain atom dict (environment/people/loudness)."""
+    if not isinstance(raw, dict):
+        raise ValueError(f"Expected an atom dict, got {type(raw).__name__}.")
+    environment = _validate_environment(raw.get("environment"))
+    people = _validate_people(raw.get("people", "none"))
+    loudness = _validate_loudness(raw.get("loudness", "moderate"))
+    return {
+        "environment": environment,
+        "people": people,
+        "loudness": loudness,
+    }
+
+
+def normalize_noise_config(raw) -> dict | None:
+    """Normalize ``config.get("noise")`` into a canonical dict, or None.
+
+    Returns None for a disabled config (None / "off" / {"mode": "off"}).
+    Otherwise returns a dict with a ``"mode"`` key in
+    {"fixed", "random", "mixture"}.
+    """
+    if raw is None:
+        return None
+    if raw == "off":
+        return None
+    if raw == "random":
+        return {"mode": "random", "clean_fraction": 0.0}
+
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"noise config must be None, 'off', 'random', or a dict; got "
+            f"{type(raw).__name__}."
+        )
+
+    mode = raw.get("mode")
+    if mode == "off":
+        return None
+
+    if mode is None:
+        atom = _normalize_atom(raw)
+        return {"mode": "fixed", **atom}
+
+    if mode == "sweep":
+        raise ValueError(
+            "noise mode 'sweep' is not supported. Use 'fixed', 'random', or "
+            "'mixture'."
+        )
+
+    if mode == "fixed":
+        atom = _normalize_atom(raw)
+        return {"mode": "fixed", **atom}
+
+    if mode == "random":
+        clean_fraction = raw.get("clean_fraction", 0.0)
+        if not isinstance(clean_fraction, (int, float)) or isinstance(
+            clean_fraction, bool
+        ):
+            raise ValueError("random clean_fraction must be a number in [0, 1].")
+        if not 0.0 <= clean_fraction <= 1.0:
+            raise ValueError(
+                f"random clean_fraction must be in [0, 1]; got {clean_fraction}."
+            )
+        out: dict = {"mode": "random", "clean_fraction": float(clean_fraction)}
+        if "environments" in raw:
+            envs = raw["environments"]
+            if not isinstance(envs, list):
+                raise ValueError("random 'environments' pool must be a list.")
+            out["environments"] = [_validate_environment(e) for e in envs]
+        if "people" in raw:
+            people = raw["people"]
+            if not isinstance(people, list):
+                raise ValueError("random 'people' pool must be a list.")
+            out["people"] = [_validate_people(p) for p in people]
+        if "loudness" in raw:
+            loud = raw["loudness"]
+            if loud == "any":
+                out["loudness"] = "any"
+            elif isinstance(loud, list):
+                for item in loud:
+                    if item not in LOUDNESS_LEVELS:
+                        raise ValueError(
+                            f"random loudness entry {item!r} is not a known "
+                            f"level ({', '.join(LOUDNESS_LEVELS)})."
+                        )
+                out["loudness"] = list(loud)
+            else:
+                raise ValueError(
+                    "random 'loudness' pool must be a list of levels or 'any'."
+                )
+        if "seed" in raw:
+            seed = raw["seed"]
+            if not isinstance(seed, int) or isinstance(seed, bool):
+                raise ValueError("random 'seed' must be an int.")
+            out["seed"] = seed
+        return out
+
+    if mode == "mixture":
+        conditions = raw.get("conditions")
+        if not isinstance(conditions, list) or not conditions:
+            raise ValueError(
+                "mixture 'conditions' must be a non-empty list of "
+                "{weight, spec} entries."
+            )
+        norm_conditions = []
+        for cond in conditions:
+            if not isinstance(cond, dict):
+                raise ValueError("Each mixture condition must be a dict.")
+            weight = cond.get("weight")
+            if not isinstance(weight, (int, float)) or isinstance(weight, bool):
+                raise ValueError("Each mixture condition needs a numeric 'weight'.")
+            if weight < 0:
+                raise ValueError("mixture condition 'weight' must be >= 0.")
+            spec = cond.get("spec")
+            if spec == "off" or spec is None:
+                norm_spec: str | dict = "off"
+            else:
+                norm_spec = _normalize_atom(spec)
+            norm_conditions.append({"weight": float(weight), "spec": norm_spec})
+        total = sum(c["weight"] for c in norm_conditions)
+        if total <= 0:
+            raise ValueError("mixture condition weights must sum to > 0.")
+        return {"mode": "mixture", "conditions": norm_conditions}
+
+    raise ValueError(
+        f"Unknown noise mode {mode!r}. Must be 'fixed', 'random', 'mixture', "
+        f"or 'off'."
+    )

--- a/calibrate_agent/agent/noise/simulation_noise_generator.py
+++ b/calibrate_agent/agent/noise/simulation_noise_generator.py
@@ -1,0 +1,267 @@
+"""Core DSP for the voice-sim background-noise feature.
+
+Builds one continuous, seamless-looping, RMS-normalized 16 kHz mono background
+track from a :class:`NoiseAtom` (environment ingredients + optional distant
+crowd chatter) and writes it as a 16-bit PCM WAV.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import soundfile as sf
+import soxr
+from scipy.signal import butter, fftconvolve, sosfilt
+
+# These mirror calibrate_agent/agent/noise/schema.py. They are re-declared here
+# (rather than imported at module top-level) so this module works even if
+# schema.py is absent, and so the DSP never depends on schema import order.
+SAMPLE_RATE = 16000
+DENSITY_VOICES = {"none": 0, "single": 1, "light": 3, "medium": 5, "heavy": 10}
+EVENT_SOUNDS = {"dog", "car_horn"}
+
+_TARGET_RMS_DBFS = -20.0
+_CROSSFADE_S = 0.05
+_LOOP_WRAP_S = 0.25
+_RIR_S = 0.4
+_REVERB_WET = 0.30
+_CROWD_UNDER_GAIN = 0.5  # people mixed ~-6 dB under env
+_SILENT_FLOOR = 1e-4  # near-silent output level for empty atoms
+
+
+def _load_wav_mono(path: str, sample_rate: int) -> np.ndarray | None:
+    """Load a wav as float32 mono at ``sample_rate``. Returns None on failure."""
+    try:
+        data, sr = sf.read(path, dtype="float32", always_2d=False)
+    except Exception:
+        return None
+    if data.ndim > 1:
+        data = data.mean(axis=1)
+    data = np.ascontiguousarray(data, dtype=np.float32)
+    if sr != sample_rate and data.size:
+        data = soxr.resample(data, sr, sample_rate).astype(np.float32)
+    return data
+
+
+def _tile_with_crossfades(
+    clip: np.ndarray, total: int, sample_rate: int
+) -> np.ndarray:
+    """Loop ``clip`` to ``total`` samples with short crossfades at each join."""
+    if clip.size == 0 or total <= 0:
+        return np.zeros(max(total, 0), dtype=np.float32)
+
+    fade = int(_CROSSFADE_S * sample_rate)
+    fade = min(fade, clip.size // 2)
+    out = np.zeros(total, dtype=np.float32)
+
+    if fade <= 0:
+        # Clip too short to crossfade; plain tile.
+        reps = int(np.ceil(total / clip.size))
+        tiled = np.tile(clip, reps)[:total]
+        return tiled.astype(np.float32)
+
+    fade_in = np.linspace(0.0, 1.0, fade, dtype=np.float32)
+    fade_out = fade_in[::-1]
+    step = clip.size - fade  # advance per placement (overlap = fade)
+
+    pos = 0
+    first = True
+    while pos < total:
+        seg = clip.copy()
+        if not first:
+            seg[:fade] *= fade_in
+        # Fade the tail so the next overlapping copy blends in cleanly.
+        seg[-fade:] *= fade_out
+        end = min(pos + seg.size, total)
+        out[pos:end] += seg[: end - pos]
+        pos += step
+        first = False
+    return out
+
+
+def _scatter_events(
+    clips: list[np.ndarray],
+    total: int,
+    sample_rate: int,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Scatter event clips over a silent buffer at random times/gaps/gains."""
+    out = np.zeros(total, dtype=np.float32)
+    clips = [c for c in clips if c.size]
+    if not clips or total <= 0:
+        return out
+
+    pos = int(rng.uniform(0.0, 2.0) * sample_rate)
+    while pos < total:
+        clip = clips[rng.integers(0, len(clips))]
+        gain = float(rng.uniform(0.7, 1.0))
+        end = min(pos + clip.size, total)
+        out[pos:end] += clip[: end - pos] * gain
+        gap = rng.uniform(1.0, 5.0)
+        pos = end + int(gap * sample_rate)
+    return out
+
+
+def _synthetic_rir(sample_rate: int, rng: np.random.Generator) -> np.ndarray:
+    """Exponentially-decaying white-noise room impulse response."""
+    n = max(1, int(_RIR_S * sample_rate))
+    decay = np.exp(-np.linspace(0.0, 6.0, n)).astype(np.float32)
+    rir = rng.standard_normal(n).astype(np.float32) * decay
+    peak = np.max(np.abs(rir))
+    if peak > 0:
+        rir = rir / peak
+    return rir
+
+
+def _backgroundify(
+    crowd: np.ndarray, sample_rate: int, rng: np.random.Generator
+) -> np.ndarray:
+    """Make a crowd sum sound like distant background chatter."""
+    if crowd.size == 0:
+        return crowd
+    nyq = sample_rate / 2.0
+    hp = butter(2, 150.0 / nyq, btype="highpass", output="sos")
+    lp = butter(4, min(3500.0, nyq - 1.0) / nyq, btype="lowpass", output="sos")
+    dry = sosfilt(lp, sosfilt(hp, crowd)).astype(np.float32)
+
+    rir = _synthetic_rir(sample_rate, rng)
+    wet = fftconvolve(dry, rir)[: dry.size].astype(np.float32)
+    return ((1.0 - _REVERB_WET) * dry + _REVERB_WET * wet).astype(np.float32)
+
+
+def _build_crowd(
+    speaker_paths: list[str],
+    count: int,
+    total: int,
+    sample_rate: int,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Sum ``count`` random speaker clips, each looped at a random offset."""
+    out = np.zeros(total, dtype=np.float32)
+    if count <= 0 or not speaker_paths or total <= 0:
+        return out
+    nyq = sample_rate / 2.0
+    for _ in range(count):
+        path = speaker_paths[rng.integers(0, len(speaker_paths))]
+        clip = _load_wav_mono(path, sample_rate)
+        if clip is None or clip.size == 0:
+            continue
+        voice = _tile_with_crossfades(clip, total, sample_rate)
+        offset = int(rng.uniform(0.0, min(2.0, total / sample_rate)) * sample_rate)
+        if offset:
+            voice = np.roll(voice, offset)
+        # Slight per-voice low-pass variation for depth.
+        cutoff = float(rng.uniform(2500.0, 3800.0))
+        lp = butter(2, min(cutoff, nyq - 1.0) / nyq, btype="lowpass", output="sos")
+        voice = sosfilt(lp, voice).astype(np.float32)
+        voice *= float(rng.uniform(0.7, 1.0))
+        out += voice
+    return _backgroundify(out, sample_rate, rng)
+
+
+def _rms_normalize(track: np.ndarray) -> np.ndarray:
+    rms = float(np.sqrt(np.mean(np.square(track)))) if track.size else 0.0
+    if rms > 0:
+        target = 10.0 ** (_TARGET_RMS_DBFS / 20.0)
+        track = track * (target / rms)
+    return np.clip(track, -1.0, 1.0).astype(np.float32)
+
+
+def _loop_wrap(track: np.ndarray, sample_rate: int) -> np.ndarray:
+    """Crossfade the tail into the head so the track loops without a click."""
+    fade = int(_LOOP_WRAP_S * sample_rate)
+    fade = min(fade, track.size // 2)
+    if fade <= 0:
+        return track
+    ramp = np.linspace(0.0, 1.0, fade, dtype=np.float32)
+    head = track[:fade].copy()
+    tail = track[-fade:].copy()
+    track = track[:-fade].copy()
+    track[:fade] = head * ramp + tail * (1.0 - ramp)
+    return track
+
+
+class SimulationNoiseGenerator:
+    """Builds one background-noise track per simulation from a NoiseAtom."""
+
+    def __init__(self, assets, sample_rate: int = SAMPLE_RATE):
+        self.assets = assets
+        self.sample_rate = sample_rate
+
+    def _build_env(
+        self, atom, total: int, rng: np.random.Generator
+    ) -> np.ndarray | None:
+        names = self.assets.resolve_environment(getattr(atom, "environment", None))
+        if not names:
+            return None
+        out = np.zeros(total, dtype=np.float32)
+        any_sound = False
+        for name in names:
+            paths = self.assets.env_ingredient_paths(name)
+            if not paths:
+                continue
+            if name in EVENT_SOUNDS:
+                clips = [_load_wav_mono(p, self.sample_rate) for p in paths]
+                clips = [c for c in clips if c is not None and c.size]
+                if clips:
+                    out += _scatter_events(
+                        clips, total, self.sample_rate, rng
+                    )
+                    any_sound = True
+            else:
+                clip = _load_wav_mono(paths[0], self.sample_rate)
+                if clip is not None and clip.size:
+                    out += _tile_with_crossfades(clip, total, self.sample_rate)
+                    any_sound = True
+        return out if any_sound else None
+
+    def build(
+        self,
+        atom,
+        *,
+        language: str,
+        out_path: str,
+        seed: int,
+        duration_s: float = 45.0,
+    ) -> str:
+        rng = np.random.default_rng(seed)
+        target_len = int(round(duration_s * self.sample_rate))
+        # Build extra tail so the loop-wrap crossfade leaves exactly target_len.
+        wrap = min(int(_LOOP_WRAP_S * self.sample_rate), target_len // 2)
+        total = target_len + wrap
+
+        env = self._build_env(atom, total, rng)
+
+        people = getattr(atom, "people", "none")
+        count = DENSITY_VOICES.get(people, 0)
+        crowd = None
+        if count > 0:
+            speakers = self.assets.speaker_pool(language)
+            crowd = _build_crowd(
+                speakers, count, total, self.sample_rate, rng
+            )
+            if not np.any(crowd):
+                crowd = None
+
+        if env is not None and crowd is not None:
+            track = _rms_normalize(env + _CROWD_UNDER_GAIN * crowd)
+        elif env is not None:
+            track = _rms_normalize(env)
+        elif crowd is not None:
+            track = _rms_normalize(crowd)
+        else:
+            # Empty atom: near-silent noise, no RMS normalize-up.
+            track = (
+                rng.standard_normal(total).astype(np.float32) * _SILENT_FLOOR
+            )
+            track = np.clip(track, -1.0, 1.0).astype(np.float32)
+
+        track = _loop_wrap(track, self.sample_rate)
+
+        sf.write(
+            out_path,
+            track,
+            self.sample_rate,
+            subtype="PCM_16",
+            format="WAV",
+        )
+        return out_path

--- a/calibrate_agent/agent/run_simulation.py
+++ b/calibrate_agent/agent/run_simulation.py
@@ -36,6 +36,13 @@ from calibrate_agent.utils import (
     save_transcript,
     TRANSCRIPT_FILE_NAME,
 )
+from calibrate_agent.agent.noise.resolver import resolve_for_run
+from calibrate_agent.agent.noise.assets import NoiseAssets
+from calibrate_agent.agent.noise.simulation_noise_generator import (
+    SimulationNoiseGenerator,
+)
+from calibrate_agent.agent.noise.save import write_clean_and_noisy
+from pipecat.audio.mixers.soundfile_mixer import SoundfileMixer
 from calibrate_agent.llm.metrics import evaluate_simuation, DEFAULT_SIMULATION_JUDGE_MODEL
 from calibrate_agent.stt.metrics import (
     get_llm_judge_score as stt_llm_judge_score,
@@ -1405,6 +1412,7 @@ async def run_simulation(
     fallback_stt_judge_model: str = DEFAULT_STT_JUDGE_MODEL,
     agent_uri: Optional[str] = None,
     serializer_name: str = DEFAULT_SERIALIZER_NAME,
+    noise=None,
 ) -> dict:
     require_simulation_evaluators(evaluators)
 
@@ -1459,6 +1467,7 @@ async def run_simulation(
             fallback_stt_judge_model=fallback_stt_judge_model,
             agent_uri=agent_uri,
             serializer_name=serializer_name,
+            noise=noise,
         )
     finally:
         logger.remove(error_sink_id)
@@ -1481,6 +1490,7 @@ async def _run_simulation_inner(
     fallback_stt_judge_model: str = DEFAULT_STT_JUDGE_MODEL,
     agent_uri: Optional[str] = None,
     serializer_name: str = DEFAULT_SERIALIZER_NAME,
+    noise=None,
 ) -> dict:
     if agent_uri:
         log_and_print(
@@ -1511,16 +1521,34 @@ async def _run_simulation_inner(
     latency_tracker = EndToEndLatencyTracker()
 
     uri = select_transport_uri(agent_uri, port)
+    noise_track_path = None
+    client_params_kwargs = dict(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+        add_wav_header=False,
+        serializer=resolve_serializer(serializer_name),
+        # vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
+        # turn_analyzer=LocalSmartTurnAnalyzerV3(),
+    )
+    if noise is not None:
+        assets = NoiseAssets()
+        noise_track_path = os.path.join(output_dir, "noise_track.wav")
+        SimulationNoiseGenerator(assets).build(
+            noise.atom,
+            language=language,
+            out_path=noise_track_path,
+            seed=noise.seed,
+        )
+        client_params_kwargs["audio_out_mixer"] = SoundfileMixer(
+            sound_files={"bg": noise_track_path},
+            default_sound="bg",
+            volume=noise.volume,
+            loop=True,
+            mixing=True,
+        )
     transport = WebsocketClientTransport(
         uri=uri,
-        params=WebsocketClientParams(
-            audio_in_enabled=True,
-            audio_out_enabled=True,
-            add_wav_header=False,
-            serializer=resolve_serializer(serializer_name),
-            # vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
-            # turn_analyzer=LocalSmartTurnAnalyzerV3(),
-        ),
+        params=WebsocketClientParams(**client_params_kwargs),
     )
     session = transport._session
     connect_lock = asyncio.Lock()
@@ -2086,6 +2114,21 @@ async def _run_single_simulation_inner(
     language = user_persona.get("language", "english")
     interruption_sensitivity = user_persona.get("interruption_sensitivity", "none")
 
+    # Resolve background noise for this run (default-off: no work when unset).
+    # Noise is a PER-PERSONA setting (a caller's environment); fall back to a
+    # top-level "noise" as a default that applies to all personas.
+    resolved_noise = None
+    noise_cfg = user_persona.get("noise", config.get("noise"))
+    if noise_cfg is not None:
+        run_index = persona_index * len(config.get("scenarios", [1])) + scenario_index
+        base_seed = noise_cfg.get("seed") if isinstance(noise_cfg, dict) else None
+        resolved_noise = resolve_for_run(
+            noise_cfg,
+            language=language,
+            run_index=run_index,
+            base_seed=base_seed,
+        )
+
     # Get interrupt probability from mapping
     interrupt_probability = interrupt_sensitivity_map.get(interruption_sensitivity)
     if interrupt_probability is None:
@@ -2239,6 +2282,7 @@ async def _run_single_simulation_inner(
                     max_turns=max_turns,
                     tools=config.get("tools", []),
                     agent_uri=agent_uri,
+                    noise=resolved_noise,
                 )
             )
             # In external mode there is no bot task to wait on — the external
@@ -2302,7 +2346,17 @@ async def _run_single_simulation_inner(
         log_and_print(f"Combined turn audio chunks in {audio_dir}")
         # Then combine all turn files into conversation.wav, using transcript for correct ordering
         transcript_path = os.path.join(simulation_output_dir, TRANSCRIPT_FILE_NAME)
-        combine_audio_files(audio_dir, conversation_audio_path, transcript_path)
+        if resolved_noise is not None:
+            noise_track_path = os.path.join(simulation_output_dir, "noise_track.wav")
+            write_clean_and_noisy(
+                audio_dir=audio_dir,
+                transcript_path=transcript_path,
+                conversation_path=conversation_audio_path,
+                noise_track_path=noise_track_path,
+                volume=resolved_noise.volume,
+            )
+        else:
+            combine_audio_files(audio_dir, conversation_audio_path, transcript_path)
         log_and_print(f"Combined audio saved to {conversation_audio_path}")
 
     # Return metrics for aggregation

--- a/calibrate_agent/utils.py
+++ b/calibrate_agent/utils.py
@@ -562,7 +562,7 @@ def save_transcript(output_dir: str | Path | None, transcript: list[dict]) -> No
 
 
 def combine_audio_files(
-    audio_dir: str, output_path: str, transcript_path: str = None
+    audio_dir: str, output_path: str, transcript_path: str = None, prefix: str = ""
 ) -> bool:
     """Combine all WAV files in a directory into a single conversation WAV file.
 
@@ -608,14 +608,14 @@ def combine_audio_files(
 
         role = msg.get("role")
         if role == "assistant":
-            file_path = os.path.join(audio_dir, f"{msg_index}_bot.wav")
+            file_path = os.path.join(audio_dir, f"{prefix}{msg_index}_bot.wav")
             if os.path.exists(file_path):
                 sorted_files.append(file_path)
             else:
                 logger.warning(f"Expected audio file not found: {file_path}")
             msg_index += 1
         elif role == "user":
-            file_path = os.path.join(audio_dir, f"{msg_index}_user.wav")
+            file_path = os.path.join(audio_dir, f"{prefix}{msg_index}_user.wav")
             if os.path.exists(file_path):
                 sorted_files.append(file_path)
             else:

--- a/design/noise_injection_spec.md
+++ b/design/noise_injection_spec.md
@@ -1,0 +1,732 @@
+# Background Noise Injection for Voice Simulations — Design Spec
+
+**Status:** Design complete; implementation not started.
+**Scope:** Voice-agent simulations only (not STT eval).
+**Branch:** `claude/festive-rosalind-92d0d6` (rebased onto `main`, pipecat **1.0.0**).
+**Package:** `calibrate_agent/` (post-#109 rename; was `calibrate/`). Code map re-anchored in §16.0.
+
+---
+
+## 1. Goal
+
+Make the **simulated caller** in a voice simulation sound like a real person calling
+from a real, noisy place — so we can measure how well a voice agent's STT / turn-taking
+holds up under realistic background conditions. Noise is mixed into the simulated
+user's outgoing audio, continuously, for the whole call; the agent's STT then hears
+`caller speech + background`.
+
+This is an **evaluation-realism / robustness** feature, not a production feature.
+
+---
+
+## 2. Motivation & references
+
+Two external inputs shaped the design:
+
+- **Coval** ([docs](https://docs.coval.ai/concepts/personas/overview#available-background-sounds)) —
+  attaches a **looping background track** to a persona (21 built-in sounds: Office, Cafe,
+  Crowd Talking, Street with Sirens, Heavy Rain, Newborn Baby Crying, …) plus custom
+  upload, with a volume slider. Takeaway we adopted: **named, realistic ambience**
+  beats abstract noise (white/pink), and it belongs to the *caller persona*.
+
+- **Vistaar / "Kathbath-Hard"** (arXiv [2305.15386](https://arxiv.org/abs/2305.15386)) —
+  builds a "hard" ASR benchmark by adding **ESC-50** background clips at a **random SNR
+  in [3, 30] dB**. Takeaway we adopted: **SNR-based additive mixing over a bounded
+  random range** is the principled difficulty knob.
+
+**Synthesis:** Coval gives the *what* (named, realistic ambience, persona-attached);
+Vistaar gives the *how* (SNR-bounded mixing). We combine them, and localize to India
+(the whole framework targets Indian voice agents — Kathbath/Svarah/Sarvam/Vaani).
+
+---
+
+## 3. Terminology (plain names we settled on)
+
+Jargon was actively removed during design. Canonical terms:
+
+- **Environmental sounds** — non-speech background: rain, wind, engine, siren, dog,
+  train, etc. (Language-neutral.)
+- **Speaker sounds** — background *people talking*.
+  Language-specific (english / hindi / kannada).
+- **Density** — how many background speakers overlap: **single / light / medium / heavy**.
+- **Loudness** — how loud the background is vs the caller (user-facing name for SNR;
+  see §12): **faint / moderate / loud / harsh**.
+- **Situation / scene** — a realistic named combination (e.g. `busy_street`), defined
+  as a *recipe* of ingredients, generated live.
+- **Background noise loop** — the single looping background track mixed under one call.
+- **Atom** — one fully-specified condition (environment + people + loudness).
+- **Distribution** — how atoms are assigned across a batch of simulations.
+
+### 3.1 Plain-English glossary
+
+One-sentence, no-jargon definitions for the technical terms used throughout this doc:
+
+- **SNR** — how loud the caller's voice is compared to the background; higher SNR means a
+  quieter background and an easier call.
+- **loudness** — this doc's user-facing knob for the same idea as SNR, but flipped so that
+  turning it up makes the call harder (louder background).
+- **dBFS** — a way of measuring audio loudness on a scale where 0 is the loudest a digital
+  file can go and everything else is a negative number (quieter).
+- **RMS / RMS-normalize** — RMS is a track's average loudness; to RMS-normalize is to set
+  every track to that same average loudness so none is accidentally louder than another.
+- **crossfade** — smoothly fading one clip out while fading the next one in, so the join
+  between them has no audible click or jump.
+- **seamless loop** — a clip whose end blends into its beginning so it can repeat forever
+  without a noticeable "restart" click.
+- **low-pass filter** — removes the high frequencies, leaving a muffled sound (like hearing
+  a party through a wall).
+- **high-pass filter** — removes the low frequencies, cutting the boomy, close-up "rumble"
+  of a voice recorded right on the microphone.
+- **reverb / impulse response (RIR)** — reverb is the echoey "in a room" quality of sound;
+  an impulse response (RIR) is a recorded (or synthetic) fingerprint of a room's echo that
+  can be stamped onto a dry recording to make it sound like it was in that room.
+- **VAD (voice activity detection)** — the agent's "is someone talking right now?" detector,
+  which decides when the caller has started and stopped speaking.
+- **mixer (SoundfileMixer)** — pipecat's component that plays a background sound file on
+  loop and blends it into the outgoing audio; here it's what actually adds the noise during
+  the live call.
+- **continuous loop** — a background sound that plays non-stop for the whole call, under
+  both speakers and during every pause (in this doc, the "background noise loop").
+- **background noise loop** — the single looping background track mixed under one call;
+  this is the canonical term this doc uses for that looping track.
+- **atom** — one complete recipe for a single call's background: which environment, how many
+  people, and how loud.
+- **distribution** — the strategy for handing out those recipes across a whole batch of
+  calls (e.g. all the same, or randomly varied).
+- **scatter (event sounds)** — placing one-off sounds like a dog bark or car horn at random
+  times and volumes, so a repeated clip doesn't sound like a robotic metronome.
+- **"mud" / muddy** — what you get when too many equally-loud sounds pile up and smear
+  together into a formless wash, like mixing all the paint colors into brown.
+- **resampling** — converting audio from one sample rate to another (e.g. 44.1 kHz down to
+  16 kHz) so it matches what the rest of the pipeline expects.
+- **mono** — single-channel audio (one speaker's worth), as opposed to stereo (left/right).
+- **seed / deterministic** — a starting number that anchors all the "random" choices;
+  deterministic means the same seed always reproduces the exact same result.
+- **backgroundify** — the processing chain that takes crisp close-up speech and makes it
+  sound like distant, muffled background chatter.
+
+---
+
+## 4. Scope & non-goals
+
+**In scope**
+- Voice-agent simulation path only (`calibrate_agent/agent/run_simulation.py`, the simulated
+  user's pipecat client transport).
+- Languages: **english, hindi, kannada** (the three the sim supports — see §14).
+- Environmental sounds + speaker sounds + their combination.
+- Save clean + noisy audio; vary noise across a batch; reproducible via seed.
+
+**Out of scope (deferred / separate)**
+- STT-eval noise injection (offline dataset). Explicitly dropped early — this is agent-sim only.
+- **Backchanneling** (caller says "mm-hmm"/"yeah") — that's a *user-simulator behavior*,
+  not a background track. Separate feature.
+- **Coval sounds not in ESC-50**: airport/ferry PA announcements, kids playing,
+  construction, doorbell, skatepark. Would need CC0 sourcing (announcements are
+  speech-like → could be Vaani-derived). Not in v1.
+- Composite/pre-mixed "scenes as files" — scenes are generated live instead (§8).
+
+---
+
+## 5. Data assets
+
+### 5.1 Environmental sounds (ESC-50)
+Pulled one representative clip per chosen class from ESC-50 (44.1 kHz mono 16-bit, 5 s),
+into `data/env_raw/`. **12 classes** (started 13, dropped `clock_alarm` — see §6.3):
+
+`rain · wind · engine · vacuum_cleaner · train · siren · crying_baby · footsteps ·
+keyboard_typing · laughing · dog · car_horn`
+
+- `dog` and `car_horn` are **single-event** clips (~95% silence + one bark/honk), so we
+  pulled **8 varied samples each** into `data/env_raw/dog/00..07.wav` and
+  `data/env_raw/car_horn/00..07.wav` — needed for natural scattering (§6.2).
+
+### 5.2 Speaker sounds (Vaani)
+Pulled from **ARTPARK-IISc/Vaani** (HF, **CC BY 4.0**, gated — token required), into
+`data/vaani_raw/{english,hindi,kannada}/`. Vaani is organized by `{State}_{District}`;
+each row carries a `language` and `gender` field; audio is **mono 16 kHz 16-bit** (no
+resampling needed). Spontaneous (image-prompted) speech → sounds like real chatter, not
+read speech.
+
+| Language | Clips | Female | Male | Source |
+|---|---|---|---|---|
+| english | 25 | 14 | 11 | Karnataka_Bangalore |
+| hindi   | 40 | 25 | 15 | Bangalore (F) + Delhi_NewDelhi (M) |
+| kannada | 25 | 20 | 5  | Karnataka_Bangalore |
+
+- **Hindi was initially all-female** (Bangalore's first ~414 rows had no male Hindi);
+  fixed by pulling 15 male Hindi from Delhi (`Delhi_NewDelhi_M_*.wav`).
+- **Kannada is light on male voices (5)** — fine for single/light/medium; a "heavy"
+  Kannada crowd would lean female. Deferred top-up (Mysore/Dharwad) if needed.
+- `data/vaani_raw/manifest.json` records per-clip source district, gender, duration.
+
+### 5.3 Licensing (critical)
+- **ESC-50 = CC BY-NC** (non-commercial). Calibrate is OSS on PyPI → **cannot bundle
+  ESC-50 clips as-is.** The pulled clips are **auditioning intermediates only.** For
+  shipping, the environmental loops must be re-sourced from **CC0** equivalents (ESC-50's
+  individually-CC0 Freesound origins, or CC0 Freesound loops matching the same classes).
+- **Vaani = CC BY 4.0** — bundleable with attribution (NOTICE + docs).
+- Raw pulls (`data/`) are **not committed** (intermediate, large, licensing).
+
+---
+
+## 6. Sound behavior (verified by waveform analysis, not filenames)
+
+We measured each env clip (silence %, number of bursts, envelope modulation, spectral
+flatness) rather than assuming from the name. Findings drove three handling classes:
+
+### 6.1 Steady loopers (loop as-is)
+`rain, wind, engine, vacuum_cleaner, train` — ~0% silence, low envelope modulation →
+continuous. A short crossfaded loop already sounds continuous.
+
+### 6.2 Intermittent / event sounds
+- **Naturally spaced events**: `dog` (96% silence, 1 bark), `car_horn` (94% silence,
+  1 honk), `footsteps` (97% silence, few steps). Looping one raw clip = a robotic
+  metronome (exact same bark every 5 s). Handling: **scatter multiple different samples
+  at random spacing + volume** over a quiet background noise loop → sounds like a real dog / real traffic.
+  (This is why we pulled 8 dog + 8 car_horn samples.)
+- **Multi-burst but frequent**: `crying_baby` (40% silence, cries in waves),
+  `keyboard_typing` (77% silence, 28 taps), `laughing` (85% silence, bursts),
+  `siren` (40% silence, oscillating wail). Fine with light spacing.
+
+### 6.3 Dropped: `clock_alarm`
+Measured 0% silence, dead steady → it **rings continuously** the whole clip. There's no
+natural gap to make it "occasional"; looping it = a constant alarm through the entire
+call (unrealistic + grating). **Dropped.** (User confirmed.)
+
+### 6.4 How looping works (Stage-1 mechanics)
+- **Seamless seam**: crossfade the clip's tail onto its head (fade tail 1→0, head 0→1,
+  add) so the wrap-around has no click.
+- **Length**: stitch several same-class clips with crossfades to ~30–60 s so it's not
+  audibly repetitive; then crossfade the whole thing's end into its start.
+- **Event scatter**: place different event samples at random offsets/gaps/volumes over a
+  quiet background noise loop (not a fixed loop).
+- pipecat's mixer does the actual endless repeating during the call; Stage 1 just makes
+  the track loop-friendly.
+
+*In plain terms: we build one ~30–60 second background clip. There are two kinds of joins
+to hide. First, the internal joins — where we glue several short clips end-to-end to reach
+that length — are smoothed with crossfades (one clip fading out as the next fades in) so
+you never hear a hard cut. Second, the loop seam — where the end of the whole clip wraps
+back to its beginning — is also crossfaded so it can repeat forever without an audible
+click. Stage 1 only makes that one seamless clip; the mixer is what actually plays it on
+repeat for the entire call.*
+
+---
+
+## 7. Speaker sounds (crowds)
+
+### 7.1 Why background speakers are the hardest noise
+Rain/engine sit in different frequency bands than speech, so STT can still "see" the
+words underneath. **Background speakers are speech masking speech** — same frequency band, same
+syllable-rate modulation — so the recognizer mistakes background words for foreground and
+inserts/swaps them. **Indian-language** background speakers matter specifically: an Indian-tuned STT
+exposed to background Hindi will hallucinate Hindi words — the exact production failure we
+want to test; Western background speakers under-test it. (This is why Vaani, not MUSAN/Common Voice
+English, is the source.)
+
+*In plain terms: a rumbling engine and a human voice live in different "pitch lanes," so
+the transcriber can still pick out the words over the engine. But other people talking sit
+in the exact same lane as the caller — same pitches, same rhythm of syllables — so the
+transcriber can't tell foreground from background and starts typing the wrong words. And
+if that background chatter is in the same Indian language, an India-tuned transcriber is
+especially likely to "hear" real words in it.*
+
+### 7.2 Density levels
+| Level | Voices | Feels like |
+|---|---|---|
+| single | 1 | one person nearby on another call / a family member |
+| light | 2–3 | a couple people, quiet office |
+| medium | 4–6 | a normal cafe |
+| heavy | 8–12 | packed cafe / market / crowded station |
+
+`single` is a distinct **hard** case (one intelligible voice → STT grabs its real words),
+not just "less crowd."
+
+### 7.3 Generation model — **B: generate live per simulation** (LOCKED)
+For each call we **assemble a fresh crowd**: randomly pick N distinct speakers
+(N = density) from that language's pool (25–40 clips), overlay at random offsets +
+volume jitter, mixing genders where available. Not a pick-one-of-a-few-prebuilt-files;
+each simulation's crowd is unique. Seeded → reproducible (run *i* → same crowd).
+Consequence: we **bundle the raw ingredient clips**, and **generate the background noise loop on the fly**
+at each sim start — we do NOT ship pre-rendered crowd tracks.
+
+### 7.4 "Backgroundify" the speaker sounds (REQUIRED — not just volume)
+The Vaani clips are **close-mic foreground speech** — a person talking *into* a microphone,
+crisp and intelligible. Lowering the volume alone leaves it sounding like quiet
+foreground speech, not background chatter. So every speaker background noise loop must pass a
+**backgroundify chain** to make it read as *distant room chatter*:
+
+- **Low-pass** (~3–4 kHz cutoff) — distance/air/obstacles kill the highs → muffled.
+- **High-pass** (~150–200 Hz) — remove close-mic proximity boom/rumble.
+- **Reverb / room simulation** — dry close-mic → wet distant; puts the voices *in a room*,
+  not on the mic. Done with **scipy**: a synthetic impulse response is convolved onto the
+  voices via `scipy.signal.fftconvolve` (a lightweight, dependency-free reverb). We do
+  **not** use `audiomentations` (its `RoomSimulator`/`ApplyImpulseResponse` conflict with
+  pipecat's `soxr` pin), so no `pyroomacoustics` dependency is pulled in.
+- **Per-voice variation** — slightly different cutoff / level / (optional) pan per speaker
+  so the crowd has depth instead of all voices at one "distance."
+- **Level** — plus the `loudness`→volume placement (§12).
+
+Effect: an **unintelligible distant murmur**, which is (a) what real background chatter
+sounds like, and (b) far less likely to false-trigger the agent's speech-onset VAD than
+clear foreground words (§18 VAD note). This chain lives in the Stage-1 background noise loop builder
+(`simulation_noise_generator.py`) and applies to the **speaker** ingredients; environmental sounds are
+already ambient and don't need it (a light shared room reverb to bind everything into one
+space is optional).
+
+*In plain terms: the crowd voices were recorded right up against a microphone, so they
+sound like someone standing next to you — too clear to pass as background. Each filter
+fakes the effect of distance: cutting the high frequencies makes them sound muffled (like
+hearing a party through a wall), cutting the very low frequencies removes the boomy
+close-up "chest" tone, and the reverb makes them sound like they're across a room instead
+of on the phone. The result is an unintelligible murmur — which is both more realistic and
+less likely to fool the agent into thinking the caller has started talking.*
+
+---
+
+## 8. Situations / scenes
+
+Three buckets, all generated live:
+
+1. **Environment-only** (no people): rain, vehicle, busy_street, housework, quiet_home…
+2. **People-only** (density): single / light / medium / heavy.
+3. **Mixed** (environment + people).
+
+**Environment options (menu):**
+- **Single sounds (12):** rain, wind, engine, vacuum, train, siren, crying_baby,
+  footsteps, keyboard_typing, laughing, dog, car_horn.
+- **Scenes (8)** — named *recipes* of ingredients (+ a default density):
+  `busy_street`=car_horn+engine+siren · `vehicle`=engine+wind+horn ·
+  `railway_station`=train+footsteps · `office`=keyboard_typing ·
+  `home_with_baby`=crying_baby · `housework`=vacuum · `rainy_street`=rain+wind+horn ·
+  `quiet_home`=dog.
+
+**Scenes are live-generated from a fixed recipe**, not pre-made files. Every `busy_street`
+call is a different busy street (different horns scattered, different crowd).
+
+---
+
+## 9. Combining environment + people
+
+Selected **independently** and merged for the call:
+- both set → mixed into **one** background noise loop, people kept **quieter under** the environment (so it
+  doesn't turn to mud);
+- only environment → environment-only; only people → people-only.
+- One background noise loop per call — a caller is in one place; the background noise loop is **constant for the whole call**;
+  variety happens *across* the batch (§11).
+- pipecat's mixer plays one file, so "combine" = mix the chosen tracks into one background noise loop at
+  sim start.
+- Because we combine on the fly, we do **not** pre-bake mixed situations — env pool +
+  people pool covers every combination.
+
+*In plain terms: when a scene has both weather/traffic and people, we tuck the people
+underneath the environmental sound rather than making them equally loud. If everything is
+blaring at the same volume, the layers stop being distinct and smear into a single formless
+wash ("mud") that would also drown out the actual caller. Keeping the chatter quieter under
+the environment keeps the caller's voice on top and the scene sounding real.*
+
+---
+
+## 10. Injection architecture (4 stages)
+
+```
+BUNDLED INGREDIENTS            PER-SIMULATION (live)
+env clips (CC0, compressed)    ┌─ resolve condition (env + people + loudness), seeded by run index
+vaani speaker pool (3 langs) ──┤─ STAGE 1: build ONE background noise loop (loop steady / scatter events / overlay crowd, crossfade)
+                               ├─ STAGE 2: attach mixer to sim-user transport → agent STT hears speech+background noise loop
+                               └─ STAGE 3: save clean (clean_*) + noisy (unprefixed) + both conversation.wav
+```
+
+- **Stage 1 — build background noise loop (live):** from bundled ingredients per the condition; seamless
+  loop; ~30–60 s.
+- **Stage 2 — inject (the actual mixing):** attach a continuous `SoundfileMixer` to the
+  simulated user's client transport output. Add `audio_out_mixer=SoundfileMixer(
+  sound_files={"bg": path}, default_sound="bg", volume=<from loudness>, loop=True,
+  mixing=True)` to the `WebsocketClientParams(...)` block at
+  [`run_simulation.py:1481`](calibrate_agent/agent/run_simulation.py:1481). Import
+  `from pipecat.audio.mixers.soundfile_mixer import SoundfileMixer`. The mixer loops the
+  background noise loop and mixes it into every outgoing audio frame for the whole call. Runtime control
+  (if we ever need to change volume/sound mid-call) via `MixerUpdateSettingsFrame({...})`
+  / `MixerEnableFrame(enable)`.
+  **HARD CONSTRAINT (verified in pipecat 1.0 source):** the mixer does **not** auto-resample
+  and does **not** auto-convert to mono. The background noise loop file must be **mono, 16-bit PCM, 16000 Hz**
+  (matching `audio_out_sample_rate=16000` at
+  [`run_simulation.py:1644`](calibrate_agent/agent/run_simulation.py:1644)) — a sample-rate
+  mismatch is **silently dropped** (no noise at all), and a stereo file **corrupts** the
+  mix. So Stage 1 must emit exactly 16 kHz / mono / 16-bit. (Vaani clips are already
+  16 kHz mono; ESC-50 env clips are 44.1 kHz → **must be resampled to 16 kHz** (converted
+  to the lower sample rate) during background noise loop
+  build.)
+- **Stage 3 — save clean + noisy (CORRECTED — see §18 defect #1):** per-turn chunks are
+  captured **upstream** of the mixer → they're clean. Copy them to `clean_`-prefixed
+  names + build `clean_conversation.wav` from the clean turns. Because the live mixer is
+  **continuous** (§18 #1: it self-generates background noise loop frames during silence and bot turns, not
+  just user turns), the noisy reconstruction must mix the background noise loop **continuously
+  across the whole call timeline** — NOT per-user-turn. Concretely: take the stitched
+  clean conversation timeline and mix the background noise loop over its **entire** length (from t=0,
+  same volume the live mixer used) → `conversation.wav`. So the *default* filenames hold
+  the realistic/agent-heard audio; `clean_` files are the clean reference, present **only
+  when noise is on**. (The earlier "mix into user turns only" plan was wrong — it would
+  have left bot turns and inter-turn gaps silent, which the agent did NOT experience.)
+
+*In plain terms: during the live call the background noise never stops — it plays under the
+caller, under the agent, and during every pause, for the whole call. But the caller-voice
+snippets we save to disk are captured before the noise is added, so they're clean. To
+recreate what the agent actually heard, we take the full clean conversation (including the
+agent's turns and the silent gaps) and lay the background noise over the entire timeline
+from start to finish — not just over the moments the caller was speaking. That's why the
+noisy file is a faithful re-creation rather than a copy.*
+- **Stage 4 — config/CLI:** default off → existing runs unchanged.
+
+**Honesty caveat:** the saved noisy audio is a faithful *reconstruction* — same background noise loop, same
+level, mixed continuously over the same timeline — not a byte-identical tap of the
+transmitted stream (the background noise loop's loop *phase* relative to the live call, and int16
+re-quantization, differ microscopically). Byte-identical would require tapping the
+transport internals.
+
+---
+
+## 11. Config schema
+
+Lives **inside each persona** in the simulation config JSON (`-c`), under a
+`noise` key on the persona object (a caller's environment belongs to the caller).
+A top-level `noise` is also accepted as a default for all personas. Read at
+`_run_single_simulation_inner` via `user_persona.get("noise", config.get("noise"))`.
+Omit → clean.
+CLI can override per-run.
+
+### 11.1 Atom (one condition)
+```jsonc
+{
+  "environment": <single | scene | [ingredients] | "none">,
+  "people":      "none" | "single" | "light" | "medium" | "heavy",
+  "loudness":    "faint" | "moderate" | "loud" | "harsh" | [list] | "any",
+  "seed":        <int>
+}
+```
+- `environment` three forms: a single sound, a named scene, or an explicit **merge list**
+  `["rain","car_horn","engine"]`.
+- `people` auto-matched to the **sim's language** (never set language here).
+- `loudness` = user-facing SNR (§12). **A list is a menu sampled from** (`["faint","loud"]`
+  → faint OR loud, no moderate). `"any"` = all four. Default: `moderate` in `fixed`;
+  `any` in variety modes.
+
+### 11.2 Distribution (assignment across the batch)
+`noise.mode` ∈ `off | fixed | random | mixture`:
+- **off** — clean everywhere.
+- **fixed** — one atom for every run (controlled A/B).
+- **random** — each simulation independently samples environment + people + loudness;
+  `clean_fraction` reserves some clean controls; seeded by run index.
+- **mixture** — weighted proportions of atoms (`{weight, spec}` list).
+
+*In plain terms: an "atom" is one complete recipe for a single call's background — which
+environment, how many people, how loud. A "distribution" is how you hand those recipes out
+across a whole batch of calls. The modes are the strategies: `off` = no noise anywhere;
+`fixed` = give every call the exact same recipe (good for a clean A/B comparison);
+`random` = let each call roll its own recipe for variety; `mixture` = specify proportions,
+e.g. "20% quiet, 30% busy street, …".*
+
+**`sweep` was dropped for v1** (§18 #8): the batch size is fixed at `|personas| ×
+|scenarios|`, so a `repeat: K` run-count knob doesn't fit. `random` gives variety within
+the fixed run count; revisit `sweep` later if guaranteed even coverage is needed.
+
+```jsonc
+{ "noise": { "mode": "random", "clean_fraction": 0.15, "seed": 123 } }
+{ "noise": { "mode": "mixture", "conditions": [
+    { "weight": 0.2, "spec": "off" },
+    { "weight": 0.3, "spec": { "environment": "busy_street", "people": "light" } },
+    { "weight": 0.3, "spec": { "people": "medium" } },
+    { "weight": 0.2, "spec": { "environment": "rain" } } ] } }
+```
+
+### 11.3 Resolution rules
+- Per simulation: draw one atom → build one background noise loop → inject → **constant for that call**.
+- Scene density precedence: **recipe default → explicit `people` override → sampled** (in
+  variety modes). Finalized per-simulation.
+- Seed: run *i* always gets the same draw *and* the same live-assembled crowd.
+
+### 11.4 Built-in variations (condition catalog)
+Additive flat menu (scenes already include people; do **not** multiply):
+**12 environment-only + 4 people densities + 8 scenes + 1 off = ~25 named condition
+types.** (Multiplicatively, environment 21 × people 5 ≈ 105, ×4 loudness ≈ 420 if each
+loudness counts — but the built-in *menu* is the ~25 flat list.) The actual audio inside
+any people-condition is unbounded (live crowd generation).
+
+---
+
+## 12. Loudness vs SNR
+
+- **SNR** (signal-to-noise ratio, dB) = caller-voice loudness vs background. **Higher SNR
+  = quieter background = easier** — inverted and jargony, so not exposed.
+- User-facing name: **`loudness`**, direction-intuitive (louder = harder), named levels
+  mapping to SNR internally: `faint ≈ 22 dB · moderate ≈ 16 · loud ≈ 11 · harsh ≈ 6`.
+- `random` mode samples a loudness per run (Vistaar-style bounded randomness).
+- Power-user escape hatch: `"loudness_db": [min, max]` (exact dB) — optional, not the
+  default surface.
+- Intensity default deferred by user ("configurable later"); mechanism must expose it.
+- Mechanically, `loudness` → a mixer volume calibrated from the (normalized) TTS level.
+
+*In plain terms: engineers measure difficulty as SNR — how much louder the voice is than
+the background. The catch is that SNR runs backwards for a normal reader: a bigger SNR
+number means an easier, quieter-background call. So we expose a plain "loudness" knob
+instead, where turning it up makes the background louder and the call harder — the
+intuitive direction. Under the hood we still convert those loudness levels back to SNR
+numbers; we just flipped the label so "more" means "harder."*
+
+---
+
+## 13. Reproducibility
+A single `seed` makes the whole batch deterministic: per-run condition draw + live crowd
+assembly are seeded by (base seed + run index). Re-running reproduces identical audio for
+debugging.
+
+*In plain terms: even though the noise and crowds are generated randomly, the randomness is
+anchored to a single starting number (the "seed"). Give it the same seed and every call
+comes out byte-for-byte identical to last time — the same environment, the same crowd, the
+same volumes. That means a bug you saw in run #3 will reappear exactly when you re-run it,
+instead of vanishing into fresh random noise.*
+
+---
+
+## 14. Prerequisite done — Kannada language support
+
+Before noise could language-match all three languages, the sim was clamped to
+english/hindi (kannada half-wired, and a latent bug: kannada fell back to an English
+ElevenLabs voice). Fixed (now in `main`, adapted to pipecat 1.0):
+- Widened `Literal["english","hindi"]` → `+ "kannada"` in `start_bot`,
+  `run_simulation`, `_run_simulation_inner`, and `_Simulation.run_single`.
+- Kannada simulated user → **Google Chirp3-HD** (ElevenLabs has no real Kannada voice),
+  gender-aware: **`kn-IN-Chirp3-HD-Achernar` (female) / `kn-IN-Chirp3-HD-Achird` (male)**.
+- Note: Google TTS isn't word-level, so Kannada mid-utterance interrupts commit slightly
+  coarser than the ElevenLabs english/hindi path.
+
+---
+
+## 15. Key decisions & tradeoffs (log)
+
+| # | Decision | Why / tradeoff |
+|---|---|---|
+| 1 | Agent-sim only (not STT eval) | Where realism matters for turn-taking; STT-eval deferred |
+| 2 | Continuous background noise loop (Coval-style), not per-utterance exact-SNR (Vistaar) | Realistic + robust + cheap; SNR is approximate/average not exact-per-turn |
+| 3 | Save both: unprefixed=noisy, `clean_`=clean; both conversation files | Nothing downstream breaks; debuggable; `clean_` only when noise on |
+| 4 | Vaani for speaker sounds (not MUSAN/Common Voice) | Indian, spontaneous, dialect-rich, CC BY, dogfoods ARTPARK's own data; triggers the Hindi-hallucination failure mode |
+| 5 | **B: generate crowds/background noise loops live per sim** | Infinite variety across a batch; bundle ingredients not tracks; seeded = still reproducible |
+| 6 | Drop `clock_alarm` | Waveform shows continuous ring → can't be "occasional" |
+| 7 | Pull 8 samples each for dog/car_horn | Single-event clips; scattering needs variety or it's a metronome |
+| 8 | `loudness` name, not `snr` | SNR is jargon and inverted |
+| 9 | Ship compressed (OGG) | ~12 MB vs ~115 MB WAV — bundleable |
+| 10 | Re-source env background noise loops CC0 for shipping | ESC-50 is CC BY-NC; can't ship |
+| 11 | Combine env+people on the fly, one background noise loop/call | Any combo without pre-baking; realistic single-environment call |
+| 12 | Scenes = live recipes, not files | Consistency with B; every instance differs |
+
+---
+
+## 16. Implementation plan
+
+*(Grounded against the current pipecat-1.0 codebase.)*
+
+### 16.0 Grounded code map (exact edit points)
+
+> **Post-#109 rename:** the package moved `calibrate/` → **`calibrate_agent/`** (imports
+> are now `from calibrate_agent.…`). Line numbers below are **re-anchored to the current
+> tree** (they shifted ~150–200 lines vs the first grounding pass, from the rename + the
+> intervening voice-sim commits). The old `calibrate/` dir is now just stale `__pycache__`.
+
+**Injection (Stage 2)** — `calibrate_agent/agent/run_simulation.py`
+- Sim-user transport at `1479-1489`: `WebsocketClientTransport` at `1479`,
+  `WebsocketClientParams(` at `1481`; add `audio_out_mixer=` **inside** that block
+  (~`1482-1488`, *not* on the opening line). Commented-out sim-user VAD at `1486`.
+- `WebsocketClientParams` inherits `audio_out_mixer: Optional[BaseAudioMixer | Mapping]`
+  from `TransportParams` — accepts the mixer directly. The base output transport runs it
+  via the continuous `with_mixer` loop
+  (`.venv/.../pipecat/transports/base_output.py:757-784` — see §18 #1).
+- `SoundfileMixer` = `pipecat.audio.mixers.soundfile_mixer`; ctor keyword-only:
+  `SoundfileMixer(*, sound_files, default_sound, volume=0.4, mixing=True, loop=True)`.
+- **Requires `soundfile` — NOT installed today.**
+
+**Config threading (Stage 4)** — `calibrate_agent/agent/run_simulation.py`
+- Config `json.load` in `main()` at `2298`; persona/scenario enumerated at `2322-2323`;
+  whole `config` passed to `run_single_simulation_task(...)` at `2324` (Semaphore at `2318`).
+- **Read `noise` + resolve/build the background noise loop** in `_run_single_simulation_inner` (def `1999`)
+  at ~`2087` (beside the `config.get("stt"/"tts"/"llm"/"settings")` reads). This site has
+  `config`, `persona_index`, `scenario_index` in scope — the seed source (§18 #3).
+- **Thread the temp background noise loop path + volume down** (not raw config): `run_simulation`
+  (def `1354`; delegation to inner at `1410`) → `_run_simulation_inner` (def `1432`;
+  consume at transport `1481`).
+- CLI: `simulations` subparser at `cli.py:373`; `main()` at `cli.py:152`.
+
+**Audio save (Stage 3)** — `calibrate_agent/agent/run_simulation.py` + `calibrate_agent/utils.py`
+- Chunks via `save_audio_chunk` (`utils.py:283`) → `<out>/audios`, named
+  `{turn}_{role}_{chunk}.wav`. Sim-user `_user` chunks written in `SilencePadder`
+  (class `1142`) at `run_simulation.py:1201`, tapped **before** `transport.output()` →
+  **saved audio is clean**; no live noisy capture → reconstruct offline.
+- Stitch helpers: `combine_turn_audio_chunks` (`utils.py:447`), `combine_audio_files`
+  (`utils.py:564`, transcript-ordered, hardcodes `{N}_bot.wav`/`{N}_user.wav` at `611`/`618`).
+- End-of-run stitch at `run_simulation.py:2229-2233`. **Hook here (continuous model)**:
+  after `combine_turn_audio_chunks` (`2229`) → (a) copy per-turn files to
+  `clean_{N}_{role}.wav`; (b) stitch clean set → `clean_conversation.wav` (needs a
+  **`prefix` kwarg on `combine_audio_files`**, default `""` so the existing `2233` call is
+  unchanged); (c) noisy `conversation.wav` = background noise loop mixed **continuously over the whole clean
+  timeline** at the live volume (§18 #1).
+- All injected audio must be 16 kHz / mono / 16-bit (matches `save_audio_chunk` width=2;
+  `combine_audio_files` same-format requirement).
+
+**Deps / packaging** — `pyproject.toml`
+- `numpy>=1.26.0` already present. **Add** `soundfile` and `audiomentations`
+  (audiomentations transitively pulls numpy+soundfile).
+- Bundle assets via `[tool.setuptools.package-data]."calibrate_agent"` at `71` (same
+  mechanism as `ui/cli.bundle.mjs`): add `"agent/assets/**/*.ogg"`. Load at runtime via
+  `importlib.resources.files("calibrate_agent.agent")/"assets"/...`.
+- Package name `calibrate-agent` (`2`), entry `calibrate_agent.cli:main` (`64`).
+- `.gitignore` bare `data` → `data/vaani_raw`, `data/env_raw` already ignored.
+
+**Tests** — `tests/agent/` (unittest + `AsyncMock`/`MagicMock`).
+
+### 16.1 Components
+- **`calibrate_agent/agent/noise/`** (new package)
+  - `assets.py` — resolve ingredient paths; the CC0-sourced env background noise loops + Vaani speaker pool.
+  - `background noise loops.py` — Stage-1 background noise loop builder: steady loop (crossfade), event scatter, crowd
+    overlay, **backgroundify the speaker crowd (low-pass + high-pass + reverb + per-voice
+    variation — §7.4)**, env+people merge, seamless-loop wrap; RMS-normalize (set every
+    background noise loop to the same average loudness) to a
+    fixed reference (§18 #6); emits a **16 kHz/mono/16-bit temp WAV**. numpy + soundfile
+    (+ audiomentations for the filters/reverb).
+  - `schema.py` — parse/validate the `noise` config; the atom + distribution model.
+  - `resolver.py` — per-run condition draw (fixed/random/mixture), seeded by
+    `persona_index`/`scenario_index`; scene recipe expansion; density precedence;
+    `loudness → volume` calibration (needs a per-voice TTS reference RMS — §18 #6).
+  - `background noise loops.py`/wiring — **temp-background noise loop lifecycle**: write the background noise loop under the per-sim
+    `simulation_output_dir` (unique — §18 #2/#4), delete in a `finally` that runs on the
+    cancel path (`run_simulation.py:1403-1404`).
+  - `save.py` — clean/noisy reconstruction: **continuous** offline mix over the full
+    timeline (§18 #1), plus the `combine_audio_files(prefix=...)` helper change.
+- **`calibrate_agent/agent/run_simulation.py`** — resolve/build background noise loop at ~`2087`; thread the
+  temp path + volume → `_run_simulation_inner`; attach mixer to the sim-user transport
+  (Stage 2); dual clean/noisy save (Stage 3).
+- **`calibrate_agent/cli.py`** — read `noise` from the sim config; optional `--noise`/`--loudness` overrides.
+- **`calibrate_agent/utils.py`** — add `prefix` kwarg (default `""`) to `combine_audio_files`.
+- **`pyproject.toml`** — add `soundfile` + `audiomentations`; register
+  `agent/assets/**/*.ogg` under the `"calibrate_agent"` package-data.
+- **`docs/` + example config**; **`tests/agent/`**.
+- **Dev-only** asset-prep scripts (Vaani/CC0 pull + OGG encode; not shipped).
+
+### 16.2 Parallelizable workstreams
+1. `noise/` package + unit tests (independent of the sim wiring).
+2. `run_simulation.py` wiring (mixer attach + dual save) — depends on `noise/` API shape.
+3. `cli.py` + config parsing.
+4. deps/packaging + docs + example + CC0 asset re-sourcing.
+(1) and (4) fully independent; (2)/(3) touch existing files, region/file split.
+
+### 16.3 Testing
+Pure unit tests (mirroring repo convention): background noise loop builder (seamless-loop RMS continuity,
+event scatter count, crowd overlay N-speakers, env+people merge levels), schema parse/
+validate, resolver (seeded draw determinism, scene-density precedence, loudness→volume),
+clean/noisy save layout, off=unchanged. pipecat mocked (AsyncMock/MagicMock).
+
+### 16.4 Open items before/at build
+- **CC0 re-sourcing** of env background noise loops (blocking for shipping, not for a local prototype).
+- **Add `soundfile`** — the mixer's `soundfile` backend is not installed today; decide
+  `soundfile` standalone dep vs `pipecat-ai[soundfile]` extra (audiomentations pulls it
+  transitively regardless).
+- **Background noise loops must be exactly 16 kHz / mono / 16-bit** or the mixer silently drops/corrupts
+  them — resample ESC-50 (44.1 kHz) during background noise loop build; Vaani is already 16 kHz mono.
+- **`combine_audio_files` needs a `prefix` kwarg** (`utils.py:564`, names at `611`/`618`) for the clean stitch.
+- Intensity/loudness default value (deferred by user).
+- Kannada male-voice top-up (optional; heavy Kannada crowd leans female).
+- Branch is on pipecat 1.0.0 — target that API.
+
+---
+
+## 17. Assets & paths summary
+
+| Path | Contents | Committed? |
+|---|---|---|
+| `data/env_raw/*.wav`, `dog/`, `car_horn/` | ESC-50 auditioning clips (CC BY-NC) | No |
+| `data/vaani_raw/{lang}/*.wav` + `manifest.json` | Vaani speaker pool (CC BY 4.0) | No |
+| `calibrate_agent/agent/assets/env/*.ogg` | CC0-sourced env background noise loops (shipped, 16 kHz mono) | Yes (future) |
+| `calibrate_agent/agent/assets/speakers/{lang}/*.ogg` | Vaani speaker pool, compressed (shipped, 16 kHz mono) | Yes (future) |
+| `design/noise_injection_spec.md` | this doc | Yes |
+
+---
+
+## 18. Verification pass — defects found & corrections
+
+Two adversarial agents verified this plan against the **installed pipecat 1.0.0 source**
+and the current code. **All §16.0 line-refs held up** (only nit: the mixer kwarg goes
+*inside* the `WebsocketClientParams(...)` block, not on its opening line). *(Line numbers
+here re-anchored post-#109 rename — see §16.0.)* The defects below were in the plan's
+*logic/completeness*, now corrected here.
+
+**#1 — Fidelity contradiction (was the biggest bug).** Verified in pipecat source
+(`base_output.py:757-784`, the `with_mixer` generator): once a mixer is attached, the
+output transport runs a **self-clocked continuous loop** — on `QueueEmpty` it manufactures
+`OutputAudioRawFrame(audio=mixer.mix(silence))`. So injected noise is **continuous for the
+whole call** (bot turns + silence included), added on top of speech
+(`clip(audio + sound*volume)`, `soundfile_mixer.py:193`). The plan's "reconstruct noisy
+audio on user turns only" would have omitted bot-turn/inter-turn ambience.
+**Fix:** Stage 3 now mixes the background noise loop **continuously over the full timeline** (§10, §16.0).
+
+**#2 — Temp-background noise loop file lifecycle.** `SoundfileMixer` reads a **file path**
+(`sound_files={name: path}`) at `mixer.start(sr)`, but background noise loops are generated *live in memory*.
+**Fix:** the resolver must **write the generated background noise loop to a temp 16 kHz/mono/16-bit WAV**,
+pass its path to the mixer, and delete it in a `finally` that runs on the **cancel path**
+too (the error sink cancels the pipeline at `run_simulation.py:1403-1404`). Owner:
+`noise/save.py` (or the wiring in `_run_simulation_inner`).
+
+**#3 — Seed / run-index threading.** A stable per-run id exists — `persona_index` +
+`scenario_index`, enumerated in `main()` at `2322-2323` and in scope at the
+`_run_single_simulation_inner` noise-read (~`2087`). **Fix:** resolve the condition + build
+the background noise loop **at that ~`2087` site** (which has config + both indices), seeding by
+`persona_index * len(scenarios) + scenario_index`; thread the **temp background noise loop path + volume**
+(not raw `noise` config) down `run_simulation → _run_simulation_inner → mixer`. This keeps
+the seed source in scope and avoids building the background noise loop deep where indices aren't available.
+
+**#4 — Concurrency collision.** Sims run in parallel under
+`asyncio.Semaphore(args.parallel)` (`2318`) into a shared `output_dir`. **Fix:** temp background noise loop
+path must be **unique per sim** — put it under the per-sim `simulation_output_dir`
+(`2030`) or key it by `simulation_run_id` (uuid, `2054`).
+
+**#5 — Bundled OGG sample rate.** The mixer needs exactly 16 kHz; the *shipped* assets are
+OGG. **Fix:** guarantee **all bundled OGGs (env + speaker) are encoded 16 kHz mono**, and
+the live overlay/merge re-quantizes to 16 kHz/mono/16-bit before writing the temp background noise loop.
+(Vaani raw is 16 kHz; CC0-re-sourced env clips must be resampled at asset-prep time.)
+
+**#6 — Loudness→volume needs a per-voice reference.** `volume` is a fixed scalar on the
+background noise loop; hitting a target `loudness`(SNR) needs the **caller speech RMS**, which differs by
+provider/voice (ElevenLabs en/hi vs Google Chirp3 kn). **Fix:** measure a per-voice
+reference RMS (or RMS-normalize the TTS reference) and map `loudness → volume` against it;
+document that absolute dB is approximate across providers. (Consistent with decision #2:
+SNR is average/approximate, not exact-per-utterance — and the same volume is used for the
+live mix and the offline reconstruction.)
+
+**#7 — `combine_audio_files` prefix kwarg default.** Must default to `""` so the existing
+`run_simulation.py:2233` call and the format-match check in `combine_audio_files`
+(`utils.py:564`) are unchanged.
+
+**#8 — `sweep` vs fixed batch size — RESOLVED: dropped for v1.** The batch size is fixed at
+`|personas| × |scenarios|` (`2115-2116`), so `sweep`'s `repeat: K` run-count knob doesn't
+fit. **Decision: drop `sweep`**; `random`/`mixture`/`fixed` all work within the fixed run
+count. Revisit later if guaranteed even per-condition coverage is wanted.
+
+**VAD under continuous noise — INTENDED, mitigated, test at build.** Continuous noise on
+the *sim-user* transport reaches the **agent's input VAD/endpointing** during the agent's
+own turns and gaps. **This is desired** — the goal is to stress the agent under realistic
+always-on background (decision #2), so we keep it continuous. Two things reduce the risk
+that it *mechanically* breaks turn-taking rather than fairly testing it: (1) the
+**backgroundify chain (§7.4)** makes speaker noise muffled/distant/reverberant, so the
+agent's SileroVAD is far less likely to latch onto it than onto clear foreground speech;
+(2) the sim-user's own VAD is commented out (`run_simulation.py:1486`), so the sim side
+won't self-trigger. The agent's VAD is external — **validate empirically** the first time
+we run with noise on. **Fallback if turn-taking still collapses:** gate the background noise loop to the
+caller's speech turns via `MixerEnableFrame(enable)` on turn boundaries — a config toggle,
+less realistic but stable, not a redesign.
+
+*(Sanity checks that passed during verification: `audio_out_mixer` IS a field on
+`WebsocketClientParams`; `SoundfileMixer` silently drops rate-mismatched files and mixes
+mono via a flat `np.frombuffer` add; the renamed `calibrate_agent.agent.run_simulation`
+imports cleanly on pipecat 1.0.)*
+
+> *Note:* an earlier draft had a second "Verification findings" section here; it's been
+> merged into the #1–#8 list above. Two details it added are folded in: **RMS-normalize each
+> background noise loop to a fixed reference** (so "medium rain" and "medium cafe" land at the same real SNR —
+> part of #6), and the **`MixerEnableFrame` VAD mitigation** (above).

--- a/design/noise_injection_spec.md
+++ b/design/noise_injection_spec.md
@@ -30,80 +30,72 @@ Two external inputs shaped the design:
   beats abstract noise (white/pink), and it belongs to the *caller persona*.
 
 - **Vistaar / "Kathbath-Hard"** (arXiv [2305.15386](https://arxiv.org/abs/2305.15386)) —
-  builds a "hard" ASR benchmark by adding **ESC-50** background clips at a **random SNR
-  in [3, 30] dB**. Takeaway we adopted: **SNR-based additive mixing over a bounded
-  random range** is the principled difficulty knob.
+  builds a "hard" ASR benchmark by mixing **ESC-50** background clips in at a **randomly
+  chosen loudness within a set range** (the paper uses a voice-to-background ratio of
+  3–30 dB). Takeaway we adopted: **add the background at a controlled loudness relative to
+  the speech, varied within a bounded range** — a simple, principled difficulty knob.
 
-**Synthesis:** Coval gives the *what* (named, realistic ambience, persona-attached);
-Vistaar gives the *how* (SNR-bounded mixing). We combine them, and localize to India
+**Synthesis:** Coval gives the *what* (named, realistic ambience, attached to the caller);
+Vistaar gives the *how* (mixing the background in at a controlled, varied loudness). We combine them, and localize to India
 (the whole framework targets Indian voice agents — Kathbath/Svarah/Sarvam/Vaani).
 
 ---
 
-## 3. Terminology (plain names we settled on)
+## 3. Terminology
 
-Jargon was actively removed during design. Canonical terms:
+Terms used throughout this doc.
+
+**The feature's own terms**
 
 - **Environmental sounds** — non-speech background: rain, wind, engine, siren, dog,
-  train, etc. (Language-neutral.)
-- **Speaker sounds** — background *people talking*.
-  Language-specific (english / hindi / kannada).
+  train, etc. (language-neutral).
+- **Speaker sounds** — background *people talking*, in the caller's language
+  (english / hindi / kannada), processed to sound distant (see *backgroundify*).
 - **Density** — how many background speakers overlap: **single / light / medium / heavy**.
-- **Loudness** — how loud the background is vs the caller (user-facing name for SNR;
-  see §12): **faint / moderate / loud / harsh**.
-- **Situation / scene** — a realistic named combination (e.g. `busy_street`), defined
-  as a *recipe* of ingredients, generated live.
-- **Background noise loop** — the single looping background track mixed under one call.
-- **Atom** — one fully-specified condition (environment + people + loudness).
-- **Distribution** — how atoms are assigned across a batch of simulations.
+- **Loudness** — how loud the background is relative to the caller: **faint / moderate /
+  loud / harsh** (louder = harder). Under the hood this is a voice-to-background ratio; see §12.
+- **Situation / scene** — a realistic named place (e.g. `busy_street`), defined as a
+  *recipe* of ingredients and built fresh for each call.
+- **Background noise loop** — the single looping background track mixed under one call;
+  it plays continuously for the whole call, under both speakers and during every pause.
+- **Atom** — one complete condition for a single call: which environment, how many people,
+  how loud.
+- **Distribution** — how those conditions are handed out across a batch of calls (all the
+  same, weighted, or randomly varied).
 
-### 3.1 Plain-English glossary
+**Audio terms**
 
-One-sentence, no-jargon definitions for the technical terms used throughout this doc:
-
-- **SNR** — how loud the caller's voice is compared to the background; higher SNR means a
-  quieter background and an easier call.
-- **loudness** — this doc's user-facing knob for the same idea as SNR, but flipped so that
-  turning it up makes the call harder (louder background).
-- **dBFS** — a way of measuring audio loudness on a scale where 0 is the loudest a digital
-  file can go and everything else is a negative number (quieter).
-- **RMS / RMS-normalize** — RMS is a track's average loudness; to RMS-normalize is to set
-  every track to that same average loudness so none is accidentally louder than another.
-- **crossfade** — smoothly fading one clip out while fading the next one in, so the join
-  between them has no audible click or jump.
-- **seamless loop** — a clip whose end blends into its beginning so it can repeat forever
-  without a noticeable "restart" click.
-- **low-pass filter** — removes the high frequencies, leaving a muffled sound (like hearing
+- **Backgroundify** — the processing that takes crisp close-up speech and makes it sound
+  like distant, muffled room chatter.
+- **Low-pass filter** — removes the high frequencies, leaving a muffled sound (like hearing
   a party through a wall).
-- **high-pass filter** — removes the low frequencies, cutting the boomy, close-up "rumble"
-  of a voice recorded right on the microphone.
-- **reverb / impulse response (RIR)** — reverb is the echoey "in a room" quality of sound;
-  an impulse response (RIR) is a recorded (or synthetic) fingerprint of a room's echo that
-  can be stamped onto a dry recording to make it sound like it was in that room.
-- **VAD (voice activity detection)** — the agent's "is someone talking right now?" detector,
-  which decides when the caller has started and stopped speaking.
-- **mixer (SoundfileMixer)** — pipecat's component that plays a background sound file on
-  loop and blends it into the outgoing audio; here it's what actually adds the noise during
-  the live call.
-- **continuous loop** — a background sound that plays non-stop for the whole call, under
-  both speakers and during every pause (in this doc, the "background noise loop").
-- **background noise loop** — the single looping background track mixed under one call;
-  this is the canonical term this doc uses for that looping track.
-- **atom** — one complete recipe for a single call's background: which environment, how many
-  people, and how loud.
-- **distribution** — the strategy for handing out those recipes across a whole batch of
-  calls (e.g. all the same, or randomly varied).
-- **scatter (event sounds)** — placing one-off sounds like a dog bark or car horn at random
-  times and volumes, so a repeated clip doesn't sound like a robotic metronome.
-- **"mud" / muddy** — what you get when too many equally-loud sounds pile up and smear
-  together into a formless wash, like mixing all the paint colors into brown.
-- **resampling** — converting audio from one sample rate to another (e.g. 44.1 kHz down to
-  16 kHz) so it matches what the rest of the pipeline expects.
-- **mono** — single-channel audio (one speaker's worth), as opposed to stereo (left/right).
-- **seed / deterministic** — a starting number that anchors all the "random" choices;
-  deterministic means the same seed always reproduces the exact same result.
-- **backgroundify** — the processing chain that takes crisp close-up speech and makes it
-  sound like distant, muffled background chatter.
+- **High-pass filter** — removes the low frequencies, cutting the boomy close-up rumble of
+  a voice recorded right on the microphone.
+- **Reverb / impulse response (RIR)** — reverb is the echoey "in a room" quality of sound;
+  an RIR is a fingerprint of a room's echo stamped onto a dry recording to place it in that
+  room.
+- **Crossfade** — fading one clip out while fading the next in, so the join has no audible
+  click.
+- **Seamless loop** — a clip whose end blends into its start so it can repeat forever with
+  no restart click.
+- **Scatter (event sounds)** — placing one-off sounds like a dog bark or car horn at random
+  times and volumes, so a repeated clip doesn't sound like a metronome.
+- **Mud / muddy** — what you get when too many equally-loud sounds pile up and smear into a
+  formless wash (like mixing every paint colour into brown).
+- **RMS-normalize** — set every track to the same average loudness so none is accidentally
+  louder than another.
+- **Resampling** — converting audio from one sample rate to another (e.g. 44.1 kHz → 16 kHz)
+  to match the rest of the pipeline.
+- **Mono** — single-channel audio, as opposed to stereo.
+- **Mixer (`SoundfileMixer`)** — pipecat's component that plays a sound file on loop and
+  blends it into the outgoing audio; what actually adds the noise during the live call.
+- **VAD (voice activity detection)** — the agent's "is someone talking right now?" detector;
+  decides when the caller starts and stops speaking.
+- **Seed** — a starting number that anchors every "random" choice, so the same seed always
+  reproduces the exact same result.
+- **SNR / dBFS** — the underlying measures behind *loudness*: SNR is the voice-to-background
+  ratio (higher = quieter background); dBFS measures level on a scale where 0 is the digital
+  maximum and lower (more negative) is quieter.
 
 ---
 
@@ -411,20 +403,30 @@ CLI can override per-run.
   → faint OR loud, no moderate). `"any"` = all four. Default: `moderate` in `fixed`;
   `any` in variety modes.
 
-### 11.2 Distribution (assignment across the batch)
+### 11.2 Distribution (assignment across *that persona's* runs)
+Because `noise` lives on a **persona**, `mode` is resolved **per simulation** — once for
+each `(persona × scenario)` pair, using that persona's noise block. So a persona's
+distribution spans **that persona's own runs (one per scenario)**, not the whole config;
+each persona has its own independent distribution. The seed is
+`run_index = persona_index × (#scenarios) + scenario_index`.
+
 `noise.mode` ∈ `off | fixed | random | mixture`:
-- **off** — clean everywhere.
-- **fixed** — one atom for every run (controlled A/B).
-- **random** — each simulation independently samples environment + people + loudness;
-  `clean_fraction` reserves some clean controls; seeded by run index.
-- **mixture** — weighted proportions of atoms (`{weight, spec}` list).
+- **off** — clean for all of this persona's runs.
+- **fixed** — the same atom for every one of this persona's runs (controlled A/B).
+- **random** — each of this persona's runs independently samples environment + people +
+  loudness; `clean_fraction` makes some of them clean; seeded by `run_index`.
+- **mixture** — each run weighted-picks one condition from the `{weight, spec}` list.
 
 *In plain terms: an "atom" is one complete recipe for a single call's background — which
-environment, how many people, how loud. A "distribution" is how you hand those recipes out
-across a whole batch of calls. The modes are the strategies: `off` = no noise anywhere;
-`fixed` = give every call the exact same recipe (good for a clean A/B comparison);
-`random` = let each call roll its own recipe for variety; `mixture` = specify proportions,
-e.g. "20% quiet, 30% busy street, …".*
+environment, how many people, how loud. A "distribution" is how a **persona** hands those
+recipes out across its own runs (it gets one run per scenario). `off` = no noise on this
+caller; `fixed` = the exact same recipe on every one of this caller's runs (clean A/B);
+`random` = each of this caller's runs rolls its own recipe; `mixture` = proportions, e.g.
+"20% quiet, 30% busy street, …". Consequence: `random`/`mixture` only show variety when a
+persona runs across **several scenarios** — a persona with one scenario just gets one
+seeded draw. Want each condition as its own labelled case → many personas on `fixed` (see
+`examples/agent/simulation/sample_voice_noise_matrix.json`); want one caller hit with a
+spread → one persona on `random`/`mixture` with several scenarios.*
 
 **`sweep` was dropped for v1** (§18 #8): the batch size is fixed at `|personas| ×
 |scenarios|`, so a `repeat: K` run-count knob doesn't fit. `random` gives variety within

--- a/design/noise_injection_todo.md
+++ b/design/noise_injection_todo.md
@@ -1,0 +1,58 @@
+# Noise Injection — Implementation TODO (living doc)
+
+Tracks the full build of the voice-sim background-noise feature. Spec:
+[`noise_injection_spec.md`](noise_injection_spec.md). Kept updated as we go.
+Status keys: ⬜ not started · 🔵 in progress · ✅ done · ⏸️ deferred.
+
+## Phase 0 — Setup
+- ✅ Deps: added `soundfile` + `scipy` (numpy already present). **audiomentations DROPPED** —
+  it pins `soxr<1.0` which conflicts with pipecat 1.0's `soxr>=1.0`; backgroundify/filters/
+  reverb/resample done with **numpy + scipy + soundfile + soxr** instead.
+- ✅ Package skeleton `calibrate_agent/agent/noise/__init__.py`; package-data glob for
+  `agent/assets/noise/**` registered in pyproject.
+
+## Phase 1 — Simulation noise generator (`noise/simulation_noise_generator.py`)  ✅
+- ✅ Steady loop w/ crossfade; event scatter (dog×8, car_horn×8); crowd overlay by density.
+- ✅ **Backgroundify** (HP150 + LP3.5k + synthetic-RIR reverb + per-voice variation).
+- ✅ env+people merge (people ~−6 dB under env), RMS-normalize −20 dBFS, seamless wrap,
+     16 kHz/mono/16-bit. 8 unit tests pass.
+- 🔵 **Audition set** — generate + listen (Wave 3, after wiring).
+
+## Phase 2 — Schema + resolver  ✅ (32 tests)
+- ✅ Parse/validate `noise` (off/fixed/random/mixture; sweep rejected).
+- ✅ Per-run draw seeded by `run_index = persona_index*len(scenarios)+scenario_index`.
+- ✅ Scene recipes; clean_fraction; `loudness → volume` via LOUDNESS_VOLUME (simple map v1;
+     per-voice RMS calibration deferred — §18 #6).
+
+## Phase 3 — Assets  ✅ (8 tests)
+- ✅ `NoiseAssets` + `prepare_assets` populated `agent/assets/noise/` (16 kHz mono):
+     env 10 + dog×8 + car_horn×8, speakers 25/40/25. Package-data registered.
+- ⏸️ OGG compression deferred (WAV for now; shrink before shipping).
+
+## Phase 4 — Pipecat wiring (`agent/run_simulation.py`)  🔵 (Wave 2 running)
+- 🔵 Thread `noise` (ResolvedNoise) → `run_simulation` → `_run_simulation_inner`.
+- 🔵 Attach `SoundfileMixer` via `audio_out_mixer=`; build track to per-sim `noise_track.wav`.
+
+## Phase 5 — Clean/noisy save  ✅ module (`noise/save.py`, 5 tests) · 🔵 wiring in Wave 2
+- ✅ `mix_noise_over_wav` (continuous) + `write_clean_and_noisy` (clean_ copies + both convs).
+- ✅ `prefix` kwarg on `combine_audio_files` (4 tests).
+
+## Phase 6 — CLI + config  ⏸️ deferred
+- ⏸️ v1 is **config-JSON driven** (`noise` block). CLI `--noise`/`--loudness` overrides deferred.
+
+## Phase 7 — Tests (`tests/agent/`)  ✅ unit (57 pass) · 🔵 integration in Wave 3
+- ✅ generator / schema / resolver / assets / save / prefix unit tests.
+
+## Phase 8 — Docs + example  ✅
+- ✅ `docs/noise-injection.mdx` + `examples/noise_simulation_config.json`.
+- ⬜ Add `"noise-injection"` to `docs/docs.json` nav (one-line follow-up).
+
+## Phase 9 — Empirical validation
+- ⬜ Run a noisy sim; check agent turn-taking survives continuous noise (§18 VAD note).
+- ⬜ If it collapses: wire `MixerEnableFrame` turn-gating fallback.
+
+## Phase 10 — FINAL (deferred to the very end) ⏸️
+- ⏸️ **CC0 re-sourcing** of environmental clips (ESC-50 is CC BY-NC → cannot ship).
+      Swap for CC0/public-domain equivalents; keep Vaani (CC BY 4.0) with attribution.
+      **Do this last, after everything else works**, per user direction.
+- ⏸️ NOTICE/attribution (Vaani CC BY 4.0) + license audit before release.

--- a/docs/noise-injection.mdx
+++ b/docs/noise-injection.mdx
@@ -164,8 +164,18 @@ is `moderate`; in the variety modes (`random`, `mixture`) the default is `any`.
 
 ## Modes
 
-`noise.mode` controls how conditions are assigned across the batch of
-simulations. The batch size is fixed at `personas × scenarios`.
+Because `noise` lives on a **persona**, `noise.mode` is applied **per persona** —
+it decides how conditions are assigned across *that persona's own runs* (a persona
+gets one run per scenario). Each persona has its own independent distribution; the
+draw is seeded per `(persona, scenario)` so it's reproducible.
+
+<Note>
+  `random` and `mixture` only show variety when a persona runs across **several
+  scenarios** — a persona with a single scenario just gets one seeded draw. For one
+  labelled condition per caller, use many personas on `fixed` (see
+  `examples/agent/simulation/sample_voice_noise_matrix.json`); to spray one caller
+  with varied noise, use one persona on `random`/`mixture` with several scenarios.
+</Note>
 
 <Tabs>
   <Tab title="off">
@@ -181,8 +191,8 @@ simulations. The batch size is fixed at `personas × scenarios`.
     ```
   </Tab>
   <Tab title="fixed">
-    One condition applied to every run — a controlled A/B against a clean
-    baseline.
+    One condition applied to every one of this persona's runs — a controlled A/B
+    against a clean baseline.
 
     ```json
     {
@@ -197,8 +207,9 @@ simulations. The batch size is fixed at `personas × scenarios`.
     ```
   </Tab>
   <Tab title="random">
-    Each simulation independently samples an environment, people density, and
-    loudness. `clean_fraction` reserves a portion of runs as clean controls.
+    Each of this persona's runs independently samples an environment, people
+    density, and loudness. `clean_fraction` makes some of those runs clean
+    controls. (Varies across the persona's scenarios — one scenario yields one draw.)
 
     ```json
     {
@@ -211,8 +222,8 @@ simulations. The batch size is fixed at `personas × scenarios`.
     ```
   </Tab>
   <Tab title="mixture">
-    Weighted proportions of conditions. Each entry has a `weight` and a `spec`
-    (an atom, or `"off"` for a clean slice).
+    Each of this persona's runs weighted-picks one condition from the list. Each
+    entry has a `weight` and a `spec` (an atom, or `"off"` for a clean slice).
 
     ```json
     {

--- a/docs/noise-injection.mdx
+++ b/docs/noise-injection.mdx
@@ -1,0 +1,255 @@
+---
+title: "Background Noise"
+description: "Simulate a caller in a noisy place to stress-test your agent's speech recognition"
+---
+
+Background noise makes the **simulated caller** in a [voice
+simulation](/quickstart/simulations) sound like a real person calling from a
+real, noisy place — a busy street, a cafe, a home with a crying baby. Noise is
+mixed continuously into the simulated user's outgoing audio for the whole call,
+so your agent's speech-to-text hears `caller speech + background`, exactly as it
+would in production.
+
+This is an **evaluation-realism** feature: it measures how well your agent's STT
+and turn-taking hold up under realistic background conditions. It only affects
+the voice-agent simulation path — not standalone STT evaluation.
+
+<Note>
+  Noise is **off by default**. Existing simulation runs are unchanged unless you
+  add a `noise` block to your config.
+</Note>
+
+## How it works
+
+For each simulation, Calibrate assembles one looping background track (a "bed")
+and mixes it under the simulated caller's voice. The bed is **constant for the
+whole call** — a caller is in one place — while variety happens *across* the
+batch of simulations.
+
+When noise is on, each run saves **both** the noisy audio the agent actually
+heard (the default `conversation.wav`) and a clean reference (`clean_`-prefixed
+files), so you can compare the two.
+
+## Why noisy speech is a good stress test
+
+Steady sounds like rain or an engine sit in a different frequency band than
+speech, so recognizers can often still "hear" the words underneath. Background
+**people talking** is the hard case — it is speech masking speech, in the same
+frequency band, so the recognizer can mistake background words for the caller's
+words. For Indian voice agents this matters specifically: an STT tuned for Indian
+languages exposed to background Hindi can hallucinate Hindi words — the exact
+production failure this feature helps you catch. Background speaker voices are
+therefore drawn from Indian-language speech and **matched to the simulation's
+language** automatically.
+
+## The `noise` block
+
+Noise is a **per-persona** setting — a caller's environment belongs to that
+caller. Add a `noise` block **inside a persona** in the `personas` array (the
+same config JSON you pass with `-c`). Different personas can have different
+noise; omit the block for a clean caller.
+
+```json
+{
+  "personas": [
+    {
+      "label": "customer calling from a market",
+      "characteristics": "...",
+      "language": "hindi",
+      "noise": {
+        "mode": "random",
+        "clean_fraction": 0.15,
+        "seed": 123
+      }
+    }
+  ]
+}
+```
+
+<Note>
+  A top-level `noise` block is also accepted as a default applied to all
+  personas, but the recommended, per-caller place is inside each persona.
+</Note>
+
+A single condition (an "atom") is described by three knobs plus an optional
+seed (this is the shape of the `noise` block you place inside a persona):
+
+```json
+{
+  "environment": "busy_street",
+  "people": "light",
+  "loudness": "moderate",
+  "seed": 42
+}
+```
+
+| Field         | Meaning                                                                 |
+| ------------- | ----------------------------------------------------------------------- |
+| `environment` | The non-speech ambience: a single sound, a named scene, an explicit list of ingredients, or `"none"`. |
+| `people`      | How many background people are talking: `"none"`, `"single"`, `"light"`, `"medium"`, or `"heavy"`. |
+| `loudness`    | How loud the background is versus the caller: `"faint"`, `"moderate"`, `"loud"`, `"harsh"`, a list to sample from, or `"any"`. |
+| `seed`        | Optional integer for reproducibility (see [Reproducibility](#reproducibility)). |
+
+`environment` and `people` are selected **independently** and merged into one
+bed. Set both for a mixed scene, one for environment-only or people-only, or
+neither for a clean call. You never set a language here — background people are
+matched to the simulation's language automatically.
+
+## Environment options
+
+`environment` accepts a single sound, a named scene, an explicit list of
+ingredients to merge (e.g. `["rain", "car_horn", "engine"]`), or `"none"`.
+Scenes are generated live from a recipe — every `busy_street` call is a
+different busy street.
+
+### Single sounds (12)
+
+| | | | |
+| ---------------- | --------------- | ---------------- | ---------------- |
+| `rain`           | `wind`          | `engine`         | `vacuum`         |
+| `train`          | `siren`         | `crying_baby`    | `footsteps`      |
+| `keyboard_typing`| `laughing`      | `dog`            | `car_horn`       |
+
+### Scenes (8)
+
+Each scene is a recipe of ingredients (and carries a default people density
+where it makes sense):
+
+| Scene             | Ingredients                     |
+| ----------------- | ------------------------------- |
+| `busy_street`     | car horn + engine + siren       |
+| `vehicle`         | engine + wind + horn            |
+| `railway_station` | train + footsteps               |
+| `office`          | keyboard typing                 |
+| `home_with_baby`  | crying baby                     |
+| `housework`       | vacuum                          |
+| `rainy_street`    | rain + wind + horn              |
+| `quiet_home`      | dog                             |
+
+## People densities
+
+`people` controls how many background voices overlap. Each crowd is assembled
+fresh per simulation from the simulation-language speaker pool, then processed to
+sound like distant room chatter — muffled and reverberant, not crisp
+foreground speech — so it reads as real background speakers.
+
+| Level    | Voices | Feels like                                        |
+| -------- | ------ | ------------------------------------------------- |
+| `single` | 1      | one person nearby on another call / a family member |
+| `light`  | 2–3    | a couple of people, a quiet office                |
+| `medium` | 4–6    | a normal cafe                                     |
+| `heavy`  | 8–12   | a packed cafe, market, or crowded station         |
+
+<Note>
+  `single` is its own hard case, not just "less crowd" — one clearly audible
+  voice gives the recognizer real words to grab onto.
+</Note>
+
+## Loudness
+
+`loudness` sets how loud the background is relative to the caller. Louder is
+harder. Higher loudness levels leave less of the caller's voice standing clear of
+the noise.
+
+| Level      | Background                                    |
+| ---------- | --------------------------------------------- |
+| `faint`    | just noticeable, easiest for the agent        |
+| `moderate` | clearly present                               |
+| `loud`     | competing with the caller                     |
+| `harsh`    | dominating, hardest for the agent             |
+
+You can also pass a **list** to sample from (`["faint", "loud"]` picks faint or
+loud, never moderate) or `"any"` for all four levels. In `fixed` mode the default
+is `moderate`; in the variety modes (`random`, `mixture`) the default is `any`.
+
+## Modes
+
+`noise.mode` controls how conditions are assigned across the batch of
+simulations. The batch size is fixed at `personas × scenarios`.
+
+<Tabs>
+  <Tab title="off">
+    Clean everywhere. Equivalent to omitting the `noise` block. Existing runs
+    are unchanged.
+
+    ```json
+    {
+      "noise": {
+        "mode": "off"
+      }
+    }
+    ```
+  </Tab>
+  <Tab title="fixed">
+    One condition applied to every run — a controlled A/B against a clean
+    baseline.
+
+    ```json
+    {
+      "noise": {
+        "mode": "fixed",
+        "environment": "busy_street",
+        "people": "light",
+        "loudness": "moderate",
+        "seed": 42
+      }
+    }
+    ```
+  </Tab>
+  <Tab title="random">
+    Each simulation independently samples an environment, people density, and
+    loudness. `clean_fraction` reserves a portion of runs as clean controls.
+
+    ```json
+    {
+      "noise": {
+        "mode": "random",
+        "clean_fraction": 0.15,
+        "seed": 123
+      }
+    }
+    ```
+  </Tab>
+  <Tab title="mixture">
+    Weighted proportions of conditions. Each entry has a `weight` and a `spec`
+    (an atom, or `"off"` for a clean slice).
+
+    ```json
+    {
+      "noise": {
+        "mode": "mixture",
+        "conditions": [
+          { "weight": 0.2, "spec": "off" },
+          { "weight": 0.3, "spec": { "environment": "busy_street", "people": "light" } },
+          { "weight": 0.3, "spec": { "people": "medium" } },
+          { "weight": 0.2, "spec": { "environment": "rain" } }
+        ]
+      }
+    }
+    ```
+  </Tab>
+</Tabs>
+
+<Note>
+  A `sweep` mode is **not** supported. The batch size is fixed at `personas ×
+  scenarios`, so there is no run-count knob to sweep over — use `random` for
+  variety within the fixed run count.
+</Note>
+
+## Reproducibility
+
+A single `seed` makes the whole batch deterministic: both the per-run condition
+draw and the live crowd assembly are seeded from it, so run *i* always gets the
+same condition and the same background audio. Re-running with the same seed
+reproduces identical audio, which is useful for debugging a specific failure.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Run Simulations" icon="comments" href="/quickstart/simulations">
+    Test your agent with combinations of personas and scenarios
+  </Card>
+  <Card title="Personas" icon="user" href="/core-concepts/personas">
+    Define who the simulated caller is and how they behave
+  </Card>
+</CardGroup>

--- a/examples/agent/simulation/README.md
+++ b/examples/agent/simulation/README.md
@@ -1,0 +1,61 @@
+# Agent simulation examples
+
+Example configs for `calibrate-agent simulations` — a simulated user (persona)
+holds a conversation with your agent so you can score how the agent behaves.
+
+Run any of them with:
+
+```bash
+uv run calibrate-agent simulations --type voice -c <config>.json -o ./out/<run-name>
+# text simulations use --type text
+```
+
+Each run creates one conversation per **persona × scenario** and writes a
+per-simulation folder with `transcript.json`, `conversation.wav`, evaluator
+results, and metrics.
+
+## Voice simulations
+
+| File | What it demonstrates |
+| --- | --- |
+| `sample_voice.json` | Baseline voice sim — 2 personas × 2 scenarios, no noise. Sarvam STT / Cartesia TTS / Gemini LLM. |
+| `sample_voice_agent_connection.json` | Driving an **external** agent over a WebSocket connection instead of the built-in bot. |
+
+## Background-noise variants
+
+These add a **`noise` block inside a persona** to simulate a caller in a noisy
+place — the noise is mixed continuously under the caller's speech, so the
+agent's STT hears `caller + background`. Noise is **off by default** (omit the
+block). See `docs/noise-injection.mdx` for the full option reference.
+
+| File | `noise` (per persona) | Simulates |
+| --- | --- | --- |
+| `sample_voice_noise_env.json` | `fixed` · `busy_street` · no people | Caller on a busy street (horns + engine + siren), no chatter. |
+| `sample_voice_noise_crowd.json` | `fixed` · people `medium` | Caller in a cafe — background English chatter only. |
+| `sample_voice_noise_mixed.json` | `fixed` · `railway_station` + `light` · `loud` | Caller at a station — train + footsteps + a few voices, loud. |
+| `sample_voice_noise_hindi.json` | `fixed` · `busy_street` + `heavy` · `loud`, **Hindi** persona | Hindi caller from a crowded market — heavy **Hindi** crowd + street. Shows language-matched chatter. |
+| `sample_voice_noise_random.json` | `random` · `clean_fraction 0.15` | Each run draws a random condition; ~15% stay clean as a control. |
+| `sample_voice_noise_mixture.json` | `mixture` (weighted) | Runs split by weight across clean / street+light / heavy-crowd conditions. |
+
+**Key ideas**
+
+- **Per persona.** `noise` lives on the persona object (a caller's environment
+  belongs to the caller); different personas can have different noise. A
+  top-level `noise` is accepted as a default for all personas.
+- **environment** (12 single sounds or 8 scenes like `busy_street`) and
+  **people** (`none`/`single`/`light`/`medium`/`heavy`) are chosen
+  independently and merged; **loudness** = `faint`/`moderate`/`loud`/`harsh`.
+- **people** chatter is **language-matched** to the persona's `language`
+  (english/hindi/kannada) and muffled to sound like distant background.
+- **modes**: `off` / `fixed` (one condition) / `random` (varies per run) /
+  `mixture` (weighted mix). `sweep` is not supported.
+- Outputs when noise is on: `conversation.wav` is the **noisy** (agent-heard)
+  audio; `clean_conversation.wav` and `clean_*.wav` are the clean reference.
+
+## Text simulations
+
+| File | What it demonstrates |
+| --- | --- |
+| `sample_text_internal_agent.json` | Text sim against the built-in agent. |
+| `sample_text_agent_connection.json` | Text sim driving an external agent connection. |
+| `sample_text_dataset.json` | Eval-only over a dataset of pre-existing transcripts. |

--- a/examples/agent/simulation/sample_voice_noise_crowd.json
+++ b/examples/agent/simulation/sample_voice_noise_crowd.json
@@ -1,0 +1,78 @@
+{
+  "system_prompt": "You are a helpful customer support assistant for an online store.\n\nYou help customers with:\n1. Checking order status\n2. Processing returns\n3. Answering product questions\n\nAfter each customer message, call the `log_inquiry` tool to categorize the inquiry type and capture any order ID mentioned.\n\nBe friendly, helpful, and concise in your responses.",
+  "tools": [
+    {
+      "type": "structured_output",
+      "name": "log_inquiry",
+      "description": "Log and categorize the customer inquiry. Call this after each customer message to track the conversation.",
+      "parameters": [
+        {
+          "id": "inquiry_type",
+          "type": "string",
+          "description": "Type of inquiry: order_status, return_request, product_question, or general",
+          "required": true
+        },
+        {
+          "id": "order_id",
+          "type": "string",
+          "description": "The order ID if mentioned by the customer, otherwise null",
+          "required": false
+        },
+        {
+          "id": "sentiment",
+          "type": "string",
+          "description": "Customer sentiment: positive, neutral, or negative",
+          "required": true
+        }
+      ]
+    }
+  ],
+  "personas": [
+    {
+      "label": "patient customer",
+      "characteristics": "You are a polite customer checking your order status. Your order ID is ORD-12345. You wait for the agent to finish speaking before responding.",
+      "gender": "neutral",
+      "language": "english",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": null,
+        "people": "medium",
+        "loudness": "moderate"
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "name": "simple order inquiry",
+      "description": "Ask about your order status directly and provide your order ID right away."
+    }
+  ],
+  "evaluators": [
+    {
+      "id": "tool-usage-id",
+      "name": "tool_usage",
+      "system_prompt": "You are a highly accurate evaluator assessing a conversation between an agent (a helpful customer support assistant for an online store) and a simulated user.\n\nYou will be given the chat history of the conversation. Mark True if the agent called the `log_inquiry` tool with the correct `inquiry_type` and `order_id` whenever the customer provided one.",
+      "judge_model": "openai/gpt-5.2"
+    },
+    {
+      "id": "response-quality-id",
+      "name": "response_quality",
+      "system_prompt": "You are a highly accurate evaluator assessing a conversation between an agent (a helpful customer support assistant for an online store) and a simulated user.\n\nYou will be given the chat history of the conversation. Mark True if the agent was helpful, polite, and guided the customer through the process.",
+      "judge_model": "openai/gpt-5.2"
+    }
+  ],
+  "settings": {
+    "agent_speaks_first": true,
+    "max_turns": 2
+  },
+  "stt": {
+    "provider": "sarvam"
+  },
+  "tts": {
+    "provider": "cartesia"
+  },
+  "llm": {
+    "model": "google/gemini-3-flash-preview"
+  }
+}

--- a/examples/agent/simulation/sample_voice_noise_easy.json
+++ b/examples/agent/simulation/sample_voice_noise_easy.json
@@ -1,0 +1,114 @@
+{
+  "agent_url": "ws://localhost:7860/ws-client/swasth-kadam-v5",
+  "personas": [
+    {
+      "label": "easy L1 · env · rain · faint",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. a little soft rain outside.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "rain",
+        "people": "none",
+        "loudness": "faint"
+      }
+    },
+    {
+      "label": "easy L2 · env · wind · faint",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. a soft breeze outside.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "wind",
+        "people": "none",
+        "loudness": "faint"
+      }
+    },
+    {
+      "label": "easy L3 · people · single · faint",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. one person talking quietly nearby.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": null,
+        "people": "single",
+        "loudness": "faint"
+      }
+    },
+    {
+      "label": "easy L4 · env · busy street · moderate",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. standing near a moderately busy street.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "busy_street",
+        "people": "none",
+        "loudness": "moderate"
+      }
+    },
+    {
+      "label": "easy L5 · people · light · moderate",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. a couple of people chatting nearby.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": null,
+        "people": "light",
+        "loudness": "moderate"
+      }
+    },
+    {
+      "label": "easy L6 · mixed · street+light · moderate",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. a busy street with a few people around.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "busy_street",
+        "people": "light",
+        "loudness": "moderate"
+      }
+    },
+    {
+      "label": "easy · baseline · clean",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. you are at home in a quiet room.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none"
+    }
+  ],
+  "scenarios": [
+    {
+      "name": "straightforward enrollment",
+      "description": "Complete the Swasth Kadham signup for your child. Answer clearly right away. Facts: full name Priya Mehta; district Pune; Anganwadi Lakshmi Nagar Kendra; not pregnant; child Aarav Mehta, born 22 July 2023; this number is linked to your Anganwadi; WhatsApp on this number; last 4 Aadhaar digits 4827."
+    }
+  ],
+  "evaluators": [
+    {
+      "id": "form-complete-id",
+      "name": "form_completed",
+      "system_prompt": "Mark True if the agent collected the key enrollment fields (name, district, pregnancy status, child name+DOB, phone/WhatsApp linkage, last 4 Aadhaar digits) and gave a closing acknowledgment.",
+      "judge_model": "openai/gpt-4.1"
+    },
+    {
+      "id": "patient-guidance-id",
+      "name": "patient_guidance",
+      "system_prompt": "Mark True if the agent was polite, asked questions one at a time, and patiently drew out information under noise.",
+      "judge_model": "openai/gpt-4.1"
+    }
+  ],
+  "settings": {
+    "agent_speaks_first": true,
+    "max_turns": 50
+  }
+}

--- a/examples/agent/simulation/sample_voice_noise_env.json
+++ b/examples/agent/simulation/sample_voice_noise_env.json
@@ -1,0 +1,78 @@
+{
+  "system_prompt": "You are a helpful customer support assistant for an online store.\n\nYou help customers with:\n1. Checking order status\n2. Processing returns\n3. Answering product questions\n\nAfter each customer message, call the `log_inquiry` tool to categorize the inquiry type and capture any order ID mentioned.\n\nBe friendly, helpful, and concise in your responses.",
+  "tools": [
+    {
+      "type": "structured_output",
+      "name": "log_inquiry",
+      "description": "Log and categorize the customer inquiry. Call this after each customer message to track the conversation.",
+      "parameters": [
+        {
+          "id": "inquiry_type",
+          "type": "string",
+          "description": "Type of inquiry: order_status, return_request, product_question, or general",
+          "required": true
+        },
+        {
+          "id": "order_id",
+          "type": "string",
+          "description": "The order ID if mentioned by the customer, otherwise null",
+          "required": false
+        },
+        {
+          "id": "sentiment",
+          "type": "string",
+          "description": "Customer sentiment: positive, neutral, or negative",
+          "required": true
+        }
+      ]
+    }
+  ],
+  "personas": [
+    {
+      "label": "patient customer",
+      "characteristics": "You are a polite customer checking your order status. Your order ID is ORD-12345. You wait for the agent to finish speaking before responding.",
+      "gender": "neutral",
+      "language": "english",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "busy_street",
+        "people": "none",
+        "loudness": "moderate"
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "name": "simple order inquiry",
+      "description": "Ask about your order status directly and provide your order ID right away."
+    }
+  ],
+  "evaluators": [
+    {
+      "id": "tool-usage-id",
+      "name": "tool_usage",
+      "system_prompt": "You are a highly accurate evaluator assessing a conversation between an agent (a helpful customer support assistant for an online store) and a simulated user.\n\nYou will be given the chat history of the conversation. Mark True if the agent called the `log_inquiry` tool with the correct `inquiry_type` and `order_id` whenever the customer provided one.",
+      "judge_model": "openai/gpt-5.2"
+    },
+    {
+      "id": "response-quality-id",
+      "name": "response_quality",
+      "system_prompt": "You are a highly accurate evaluator assessing a conversation between an agent (a helpful customer support assistant for an online store) and a simulated user.\n\nYou will be given the chat history of the conversation. Mark True if the agent was helpful, polite, and guided the customer through the process.",
+      "judge_model": "openai/gpt-5.2"
+    }
+  ],
+  "settings": {
+    "agent_speaks_first": true,
+    "max_turns": 2
+  },
+  "stt": {
+    "provider": "sarvam"
+  },
+  "tts": {
+    "provider": "cartesia"
+  },
+  "llm": {
+    "model": "google/gemini-3-flash-preview"
+  }
+}

--- a/examples/agent/simulation/sample_voice_noise_hard.json
+++ b/examples/agent/simulation/sample_voice_noise_hard.json
@@ -1,0 +1,114 @@
+{
+  "agent_url": "ws://localhost:7860/ws-client/swasth-kadam-v5",
+  "personas": [
+    {
+      "label": "hard L1 · env · vehicle · loud",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. on a moving bus, engine loud.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "vehicle",
+        "people": "none",
+        "loudness": "loud"
+      }
+    },
+    {
+      "label": "hard L2 · people · medium · loud",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. in a cafe with several people talking.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": null,
+        "people": "medium",
+        "loudness": "loud"
+      }
+    },
+    {
+      "label": "hard L3 · mixed · station+medium · loud",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. at a crowded, loud railway station.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "railway_station",
+        "people": "medium",
+        "loudness": "loud"
+      }
+    },
+    {
+      "label": "hard L4 · env · vacuum · harsh",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. at home with a vacuum running right nearby.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "vacuum",
+        "people": "none",
+        "loudness": "harsh"
+      }
+    },
+    {
+      "label": "hard L5 · people · heavy · harsh",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. in a packed, very noisy crowd.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": null,
+        "people": "heavy",
+        "loudness": "harsh"
+      }
+    },
+    {
+      "label": "hard L6 · mixed · rainy+heavy · harsh",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. on a rainy street in a heavy crowd.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "rainy_street",
+        "people": "heavy",
+        "loudness": "harsh"
+      }
+    },
+    {
+      "label": "hard · baseline · clean",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. you are at home in a quiet room.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none"
+    }
+  ],
+  "scenarios": [
+    {
+      "name": "straightforward enrollment",
+      "description": "Complete the Swasth Kadham signup for your child. Answer clearly right away. Facts: full name Priya Mehta; district Pune; Anganwadi Lakshmi Nagar Kendra; not pregnant; child Aarav Mehta, born 22 July 2023; this number is linked to your Anganwadi; WhatsApp on this number; last 4 Aadhaar digits 4827."
+    }
+  ],
+  "evaluators": [
+    {
+      "id": "form-complete-id",
+      "name": "form_completed",
+      "system_prompt": "Mark True if the agent collected the key enrollment fields (name, district, pregnancy status, child name+DOB, phone/WhatsApp linkage, last 4 Aadhaar digits) and gave a closing acknowledgment.",
+      "judge_model": "openai/gpt-4.1"
+    },
+    {
+      "id": "patient-guidance-id",
+      "name": "patient_guidance",
+      "system_prompt": "Mark True if the agent was polite, asked questions one at a time, and patiently drew out information under noise.",
+      "judge_model": "openai/gpt-4.1"
+    }
+  ],
+  "settings": {
+    "agent_speaks_first": true,
+    "max_turns": 50
+  }
+}

--- a/examples/agent/simulation/sample_voice_noise_hindi.json
+++ b/examples/agent/simulation/sample_voice_noise_hindi.json
@@ -1,0 +1,78 @@
+{
+  "system_prompt": "You are a helpful customer support assistant for an online store.\n\nYou help customers with:\n1. Checking order status\n2. Processing returns\n3. Answering product questions\n\nAfter each customer message, call the `log_inquiry` tool to categorize the inquiry type and capture any order ID mentioned.\n\nBe friendly, helpful, and concise in your responses.",
+  "tools": [
+    {
+      "type": "structured_output",
+      "name": "log_inquiry",
+      "description": "Log and categorize the customer inquiry. Call this after each customer message to track the conversation.",
+      "parameters": [
+        {
+          "id": "inquiry_type",
+          "type": "string",
+          "description": "Type of inquiry: order_status, return_request, product_question, or general",
+          "required": true
+        },
+        {
+          "id": "order_id",
+          "type": "string",
+          "description": "The order ID if mentioned by the customer, otherwise null",
+          "required": false
+        },
+        {
+          "id": "sentiment",
+          "type": "string",
+          "description": "Customer sentiment: positive, neutral, or negative",
+          "required": true
+        }
+      ]
+    }
+  ],
+  "personas": [
+    {
+      "label": "customer calling from a crowded market",
+      "characteristics": "You are a customer who speaks Hindi, calling from a busy, noisy market. You want to check your order status; your order ID is ORD-98765. Because it is loud around you, you speak clearly and occasionally repeat yourself. You are polite and patient.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "busy_street",
+        "people": "heavy",
+        "loudness": "loud"
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "name": "order inquiry from a noisy market",
+      "description": "Greet the agent in Hindi and ask about your order status, giving your order ID."
+    }
+  ],
+  "evaluators": [
+    {
+      "id": "tool-usage-id",
+      "name": "tool_usage",
+      "system_prompt": "You are a highly accurate evaluator assessing a conversation between an agent (a helpful customer support assistant for an online store) and a simulated user.\n\nYou will be given the chat history of the conversation. Mark True if the agent called the `log_inquiry` tool with the correct `inquiry_type` and `order_id` whenever the customer provided one.",
+      "judge_model": "openai/gpt-5.2"
+    },
+    {
+      "id": "response-quality-id",
+      "name": "response_quality",
+      "system_prompt": "You are a highly accurate evaluator assessing a conversation between an agent (a helpful customer support assistant for an online store) and a simulated user.\n\nYou will be given the chat history of the conversation. Mark True if the agent was helpful, polite, and guided the customer through the process.",
+      "judge_model": "openai/gpt-5.2"
+    }
+  ],
+  "settings": {
+    "agent_speaks_first": true,
+    "max_turns": 2
+  },
+  "stt": {
+    "provider": "sarvam"
+  },
+  "tts": {
+    "provider": "cartesia"
+  },
+  "llm": {
+    "model": "google/gemini-3-flash-preview"
+  }
+}

--- a/examples/agent/simulation/sample_voice_noise_matrix.json
+++ b/examples/agent/simulation/sample_voice_noise_matrix.json
@@ -1,0 +1,192 @@
+{
+  "agent_url": "ws://localhost:7860/ws-client/swasth-kadam-v5",
+  "personas": [
+    {
+      "label": "clean control (no noise)",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. You are at home in a quiet room.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none"
+    },
+    {
+      "label": "env-only · rain · faint",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. Light rain outside your home.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "rain",
+        "people": "none",
+        "loudness": "faint"
+      }
+    },
+    {
+      "label": "env-only · busy street · moderate",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. Standing on a busy street.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "busy_street",
+        "people": "none",
+        "loudness": "moderate"
+      }
+    },
+    {
+      "label": "env-only · moving bus · loud",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. On a moving bus, engine humming.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "vehicle",
+        "people": "none",
+        "loudness": "loud"
+      }
+    },
+    {
+      "label": "env-only · appliance · harsh",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. At home while a vacuum runs nearby.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "vacuum",
+        "people": "none",
+        "loudness": "harsh"
+      }
+    },
+    {
+      "label": "people-only · single · faint",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. One family member talking nearby.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": null,
+        "people": "single",
+        "loudness": "faint"
+      }
+    },
+    {
+      "label": "people-only · light · moderate",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. A couple of people chatting nearby.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": null,
+        "people": "light",
+        "loudness": "moderate"
+      }
+    },
+    {
+      "label": "people-only · medium · loud",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. In a cafe with people talking.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": null,
+        "people": "medium",
+        "loudness": "loud"
+      }
+    },
+    {
+      "label": "people-only · heavy · harsh",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. In a packed, noisy crowd.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": null,
+        "people": "heavy",
+        "loudness": "harsh"
+      }
+    },
+    {
+      "label": "mixed · quiet home + single · faint",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. At home with a dog and one person nearby.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "quiet_home",
+        "people": "single",
+        "loudness": "faint"
+      }
+    },
+    {
+      "label": "mixed · busy street + light · moderate",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. On a busy street with a few people around.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "busy_street",
+        "people": "light",
+        "loudness": "moderate"
+      }
+    },
+    {
+      "label": "mixed · railway station + medium · loud",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. At a crowded railway station.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "railway_station",
+        "people": "medium",
+        "loudness": "loud"
+      }
+    },
+    {
+      "label": "mixed · rainy street + heavy · harsh",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. On a rainy street in a heavy crowd.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "rainy_street",
+        "people": "heavy",
+        "loudness": "harsh"
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "name": "straightforward enrollment",
+      "description": "Complete the Swasth Kadham signup for your child. Answer clearly right away. Facts: full name Priya Mehta; district Pune; Anganwadi Lakshmi Nagar Kendra; not pregnant; child Aarav Mehta, born 22 July 2023; this number is linked to your Anganwadi; WhatsApp on this number; last 4 Aadhaar digits 4827."
+    }
+  ],
+  "evaluators": [
+    {
+      "id": "form-complete-id",
+      "name": "form_completed",
+      "system_prompt": "Mark True if the agent collected the key enrollment fields (name, district, pregnancy status, child name+DOB, phone/WhatsApp linkage, last 4 Aadhaar digits) and gave a closing acknowledgment.",
+      "judge_model": "openai/gpt-4.1"
+    },
+    {
+      "id": "patient-guidance-id",
+      "name": "patient_guidance",
+      "system_prompt": "Mark True if the agent was polite, asked questions one at a time, and patiently drew out information under noise.",
+      "judge_model": "openai/gpt-4.1"
+    }
+  ],
+  "settings": {
+    "agent_speaks_first": true,
+    "max_turns": 3
+  }
+}

--- a/examples/agent/simulation/sample_voice_noise_mixed.json
+++ b/examples/agent/simulation/sample_voice_noise_mixed.json
@@ -1,0 +1,78 @@
+{
+  "system_prompt": "You are a helpful customer support assistant for an online store.\n\nYou help customers with:\n1. Checking order status\n2. Processing returns\n3. Answering product questions\n\nAfter each customer message, call the `log_inquiry` tool to categorize the inquiry type and capture any order ID mentioned.\n\nBe friendly, helpful, and concise in your responses.",
+  "tools": [
+    {
+      "type": "structured_output",
+      "name": "log_inquiry",
+      "description": "Log and categorize the customer inquiry. Call this after each customer message to track the conversation.",
+      "parameters": [
+        {
+          "id": "inquiry_type",
+          "type": "string",
+          "description": "Type of inquiry: order_status, return_request, product_question, or general",
+          "required": true
+        },
+        {
+          "id": "order_id",
+          "type": "string",
+          "description": "The order ID if mentioned by the customer, otherwise null",
+          "required": false
+        },
+        {
+          "id": "sentiment",
+          "type": "string",
+          "description": "Customer sentiment: positive, neutral, or negative",
+          "required": true
+        }
+      ]
+    }
+  ],
+  "personas": [
+    {
+      "label": "patient customer",
+      "characteristics": "You are a polite customer checking your order status. Your order ID is ORD-12345. You wait for the agent to finish speaking before responding.",
+      "gender": "neutral",
+      "language": "english",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "railway_station",
+        "people": "light",
+        "loudness": "loud"
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "name": "simple order inquiry",
+      "description": "Ask about your order status directly and provide your order ID right away."
+    }
+  ],
+  "evaluators": [
+    {
+      "id": "tool-usage-id",
+      "name": "tool_usage",
+      "system_prompt": "You are a highly accurate evaluator assessing a conversation between an agent (a helpful customer support assistant for an online store) and a simulated user.\n\nYou will be given the chat history of the conversation. Mark True if the agent called the `log_inquiry` tool with the correct `inquiry_type` and `order_id` whenever the customer provided one.",
+      "judge_model": "openai/gpt-5.2"
+    },
+    {
+      "id": "response-quality-id",
+      "name": "response_quality",
+      "system_prompt": "You are a highly accurate evaluator assessing a conversation between an agent (a helpful customer support assistant for an online store) and a simulated user.\n\nYou will be given the chat history of the conversation. Mark True if the agent was helpful, polite, and guided the customer through the process.",
+      "judge_model": "openai/gpt-5.2"
+    }
+  ],
+  "settings": {
+    "agent_speaks_first": true,
+    "max_turns": 2
+  },
+  "stt": {
+    "provider": "sarvam"
+  },
+  "tts": {
+    "provider": "cartesia"
+  },
+  "llm": {
+    "model": "google/gemini-3-flash-preview"
+  }
+}

--- a/examples/agent/simulation/sample_voice_noise_mixture.json
+++ b/examples/agent/simulation/sample_voice_noise_mixture.json
@@ -1,0 +1,101 @@
+{
+  "system_prompt": "You are a helpful customer support assistant for an online store.\n\nYou help customers with:\n1. Checking order status\n2. Processing returns\n3. Answering product questions\n\nAfter each customer message, call the `log_inquiry` tool to categorize the inquiry type and capture any order ID mentioned.\n\nBe friendly, helpful, and concise in your responses.",
+  "tools": [
+    {
+      "type": "structured_output",
+      "name": "log_inquiry",
+      "description": "Log and categorize the customer inquiry. Call this after each customer message to track the conversation.",
+      "parameters": [
+        {
+          "id": "inquiry_type",
+          "type": "string",
+          "description": "Type of inquiry: order_status, return_request, product_question, or general",
+          "required": true
+        },
+        {
+          "id": "order_id",
+          "type": "string",
+          "description": "The order ID if mentioned by the customer, otherwise null",
+          "required": false
+        },
+        {
+          "id": "sentiment",
+          "type": "string",
+          "description": "Customer sentiment: positive, neutral, or negative",
+          "required": true
+        }
+      ]
+    }
+  ],
+  "personas": [
+    {
+      "label": "patient customer",
+      "characteristics": "You are a polite customer checking your order status. Your order ID is ORD-12345. You wait for the agent to finish speaking before responding.",
+      "gender": "neutral",
+      "language": "english",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "mixture",
+        "conditions": [
+          {
+            "weight": 0.34,
+            "spec": "off"
+          },
+          {
+            "weight": 0.33,
+            "spec": {
+              "environment": "busy_street",
+              "people": "light",
+              "loudness": "moderate"
+            }
+          },
+          {
+            "weight": 0.33,
+            "spec": {
+              "environment": null,
+              "people": "heavy",
+              "loudness": "loud"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "name": "simple order inquiry",
+      "description": "Ask about your order status directly and provide your order ID right away."
+    },
+    {
+      "name": "vague inquiry",
+      "description": "Start by asking about your order without providing the order ID. Only provide it after being asked."
+    }
+  ],
+  "evaluators": [
+    {
+      "id": "tool-usage-id",
+      "name": "tool_usage",
+      "system_prompt": "You are a highly accurate evaluator assessing a conversation between an agent (a helpful customer support assistant for an online store) and a simulated user.\n\nYou will be given the chat history of the conversation. Mark True if the agent called the `log_inquiry` tool with the correct `inquiry_type` and `order_id` whenever the customer provided one.",
+      "judge_model": "openai/gpt-5.2"
+    },
+    {
+      "id": "response-quality-id",
+      "name": "response_quality",
+      "system_prompt": "You are a highly accurate evaluator assessing a conversation between an agent (a helpful customer support assistant for an online store) and a simulated user.\n\nYou will be given the chat history of the conversation. Mark True if the agent was helpful, polite, and guided the customer through the process.",
+      "judge_model": "openai/gpt-5.2"
+    }
+  ],
+  "settings": {
+    "agent_speaks_first": true,
+    "max_turns": 2
+  },
+  "stt": {
+    "provider": "sarvam"
+  },
+  "tts": {
+    "provider": "cartesia"
+  },
+  "llm": {
+    "model": "google/gemini-3-flash-preview"
+  }
+}

--- a/examples/agent/simulation/sample_voice_noise_progressive.json
+++ b/examples/agent/simulation/sample_voice_noise_progressive.json
@@ -1,0 +1,179 @@
+{
+  "agent_url": "ws://localhost:7860/ws-client/swasth-kadam-v5",
+  "personas": [
+    {
+      "label": "L1 · env-only · faint",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. A little soft rain outside.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "rain",
+        "people": "none",
+        "loudness": "faint"
+      }
+    },
+    {
+      "label": "L2 · env-only · faint",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. A soft breeze/wind outside.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "wind",
+        "people": "none",
+        "loudness": "faint"
+      }
+    },
+    {
+      "label": "L3 · people-only · faint · single",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. One person talking quietly nearby.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": null,
+        "people": "single",
+        "loudness": "faint"
+      }
+    },
+    {
+      "label": "L4 · env-only · moderate",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. Standing near a moderately busy street.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "busy_street",
+        "people": "none",
+        "loudness": "moderate"
+      }
+    },
+    {
+      "label": "L5 · people-only · moderate · light",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. A couple of people chatting nearby.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": null,
+        "people": "light",
+        "loudness": "moderate"
+      }
+    },
+    {
+      "label": "L6 · mixed · moderate · light",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. A busy street with a few people around.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "busy_street",
+        "people": "light",
+        "loudness": "moderate"
+      }
+    },
+    {
+      "label": "L7 · env-only · loud",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. On a moving bus, engine loud.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "vehicle",
+        "people": "none",
+        "loudness": "loud"
+      }
+    },
+    {
+      "label": "L8 · people-only · loud · medium",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. In a cafe with several people talking.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": null,
+        "people": "medium",
+        "loudness": "loud"
+      }
+    },
+    {
+      "label": "L9 · mixed · loud · medium",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. At a crowded, loud railway station.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "railway_station",
+        "people": "medium",
+        "loudness": "loud"
+      }
+    },
+    {
+      "label": "L10 · people-only · harsh · heavy",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. In a packed, very noisy crowd.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": null,
+        "people": "heavy",
+        "loudness": "harsh"
+      }
+    },
+    {
+      "label": "L11 · mixed · harsh · heavy",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. On a rainy street in a heavy crowd.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "rainy_street",
+        "people": "heavy",
+        "loudness": "harsh"
+      }
+    },
+    {
+      "label": "baseline · clean (no noise)",
+      "characteristics": "You are a Hindi-speaking mother enrolling your child in Swasth Kadham. You answer politely, one question at a time. You are at home in a quiet room.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none"
+    }
+  ],
+  "scenarios": [
+    {
+      "name": "straightforward enrollment",
+      "description": "Complete the Swasth Kadham signup for your child. Answer clearly right away. Facts: full name Priya Mehta; district Pune; Anganwadi Lakshmi Nagar Kendra; not pregnant; child Aarav Mehta, born 22 July 2023; this number is linked to your Anganwadi; WhatsApp on this number; last 4 Aadhaar digits 4827."
+    }
+  ],
+  "evaluators": [
+    {
+      "id": "form-complete-id",
+      "name": "form_completed",
+      "system_prompt": "Mark True if the agent collected the key enrollment fields (name, district, pregnancy status, child name+DOB, phone/WhatsApp linkage, last 4 Aadhaar digits) and gave a closing acknowledgment.",
+      "judge_model": "openai/gpt-4.1"
+    },
+    {
+      "id": "patient-guidance-id",
+      "name": "patient_guidance",
+      "system_prompt": "Mark True if the agent was polite, asked questions one at a time, and patiently drew out information under noise.",
+      "judge_model": "openai/gpt-4.1"
+    }
+  ],
+  "settings": {
+    "agent_speaks_first": true,
+    "max_turns": 3
+  }
+}

--- a/examples/agent/simulation/sample_voice_noise_random.json
+++ b/examples/agent/simulation/sample_voice_noise_random.json
@@ -1,0 +1,81 @@
+{
+  "system_prompt": "You are a helpful customer support assistant for an online store.\n\nYou help customers with:\n1. Checking order status\n2. Processing returns\n3. Answering product questions\n\nAfter each customer message, call the `log_inquiry` tool to categorize the inquiry type and capture any order ID mentioned.\n\nBe friendly, helpful, and concise in your responses.",
+  "tools": [
+    {
+      "type": "structured_output",
+      "name": "log_inquiry",
+      "description": "Log and categorize the customer inquiry. Call this after each customer message to track the conversation.",
+      "parameters": [
+        {
+          "id": "inquiry_type",
+          "type": "string",
+          "description": "Type of inquiry: order_status, return_request, product_question, or general",
+          "required": true
+        },
+        {
+          "id": "order_id",
+          "type": "string",
+          "description": "The order ID if mentioned by the customer, otherwise null",
+          "required": false
+        },
+        {
+          "id": "sentiment",
+          "type": "string",
+          "description": "Customer sentiment: positive, neutral, or negative",
+          "required": true
+        }
+      ]
+    }
+  ],
+  "personas": [
+    {
+      "label": "patient customer",
+      "characteristics": "You are a polite customer checking your order status. Your order ID is ORD-12345. You wait for the agent to finish speaking before responding.",
+      "gender": "neutral",
+      "language": "english",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "random",
+        "clean_fraction": 0.15,
+        "seed": 42
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "name": "simple order inquiry",
+      "description": "Ask about your order status directly and provide your order ID right away."
+    },
+    {
+      "name": "vague inquiry",
+      "description": "Start by asking about your order without providing the order ID. Only provide it after being asked."
+    }
+  ],
+  "evaluators": [
+    {
+      "id": "tool-usage-id",
+      "name": "tool_usage",
+      "system_prompt": "You are a highly accurate evaluator assessing a conversation between an agent (a helpful customer support assistant for an online store) and a simulated user.\n\nYou will be given the chat history of the conversation. Mark True if the agent called the `log_inquiry` tool with the correct `inquiry_type` and `order_id` whenever the customer provided one.",
+      "judge_model": "openai/gpt-5.2"
+    },
+    {
+      "id": "response-quality-id",
+      "name": "response_quality",
+      "system_prompt": "You are a highly accurate evaluator assessing a conversation between an agent (a helpful customer support assistant for an online store) and a simulated user.\n\nYou will be given the chat history of the conversation. Mark True if the agent was helpful, polite, and guided the customer through the process.",
+      "judge_model": "openai/gpt-5.2"
+    }
+  ],
+  "settings": {
+    "agent_speaks_first": true,
+    "max_turns": 2
+  },
+  "stt": {
+    "provider": "sarvam"
+  },
+  "tts": {
+    "provider": "cartesia"
+  },
+  "llm": {
+    "model": "google/gemini-3-flash-preview"
+  }
+}

--- a/examples/agent/simulation/sample_voice_noise_showcase.json
+++ b/examples/agent/simulation/sample_voice_noise_showcase.json
@@ -1,0 +1,120 @@
+{
+  "agent_url": "ws://localhost:7860/ws-client/swasth-kadam-v5",
+  "personas": [
+    {
+      "label": "patient rural mother (home)",
+      "characteristics": "You are Sunita, a 32-year-old homemaker from rural Maharashtra. You speak Hindi with a soft, polite tone. You answer one question at a time and use natural pauses like \"haan\" and \"theek hai\". You are calm and trusting of the health worker.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": [
+          "dog",
+          "crying_baby"
+        ],
+        "people": "single",
+        "loudness": "faint"
+      }
+    },
+    {
+      "label": "busy working mother (shop/street)",
+      "characteristics": "You are Kavita, a 29-year-old shopkeeper in Nashik. You speak Hindi quickly and get impatient when the call drags, but stay polite. You sometimes answer before the agent finishes and may need one repeat for long number questions.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "random",
+        "clean_fraction": 0.1,
+        "environments": [
+          "busy_street",
+          "vehicle",
+          "none"
+        ],
+        "people": [
+          "medium",
+          "heavy"
+        ],
+        "loudness": [
+          "moderate",
+          "loud",
+          "harsh"
+        ],
+        "seed": 7
+      }
+    },
+    {
+      "label": "mother travelling on a bus",
+      "characteristics": "You are Meena, a 27-year-old mother on a crowded bus in Maharashtra. You speak Hindi and raise your voice a little over the engine noise. You answer questions but sometimes ask the agent to repeat because it is noisy. You want to finish before your stop.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "fixed",
+        "environment": "vehicle",
+        "people": "none",
+        "loudness": "loud"
+      }
+    },
+    {
+      "label": "mother at a crowded Anganwadi centre",
+      "characteristics": "You are Rekha, a 34-year-old mother waiting at a busy Anganwadi centre with many parents around. You speak Hindi, are patient, and answer clearly, occasionally pausing when it gets loud around you.",
+      "gender": "female",
+      "language": "hindi",
+      "interruption_sensitivity": "none",
+      "noise": {
+        "mode": "mixture",
+        "conditions": [
+          {
+            "weight": 0.3,
+            "spec": "off"
+          },
+          {
+            "weight": 0.4,
+            "spec": {
+              "environment": null,
+              "people": "heavy",
+              "loudness": "moderate"
+            }
+          },
+          {
+            "weight": 0.3,
+            "spec": {
+              "environment": "crying_baby",
+              "people": "light",
+              "loudness": "loud"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "name": "straightforward enrollment",
+      "description": "Complete the Swasth Kadham signup for your child. When the agent asks a question, answer clearly right away. Your facts: full name Priya Mehta; district Pune; Anganwadi Lakshmi Nagar Kendra; you are not pregnant; child name Aarav Mehta, born 22 July 2023; this calling number is linked to your Anganwadi; WhatsApp is on this same number; last 4 digits of Aadhaar are 4827."
+    },
+    {
+      "name": "vague then complete",
+      "description": "You want to sign up for Swasth Kadham but start vague — say only that you contacted the Anganwadi and want health messages. Do not volunteer your district, Anganwadi name, child details, or phone/WhatsApp facts until the agent asks each one specifically. Once asked, give the correct answer. Your facts: full name Fatima Khan; district Aurangabad; Anganwadi Station Road centre; not pregnant; child name Zara Khan, born 8 March 2024; calling number is not the Anganwadi-linked number — Anganwadi phone is 9876543210; WhatsApp is on the number you are calling from; last 4 Aadhaar digits 6391."
+    }
+  ],
+  "evaluators": [
+    {
+      "id": "form-complete-id",
+      "name": "form_completed",
+      "system_prompt": "You are evaluating a voice call where a health worker agent collects enrollment form fields. Mark True if the agent collected the key fields (name, district, pregnancy status, and either gestational age OR child name+DOB, plus phone/WhatsApp linkage and last 4 Aadhaar digits) and gave a closing acknowledgment.",
+      "judge_model": "openai/gpt-4.1"
+    },
+    {
+      "id": "patient-guidance-id",
+      "name": "patient_guidance",
+      "system_prompt": "You are evaluating a voice enrollment call. Mark True if the agent was polite, asked questions clearly one at a time, and patiently drew out information when the caller was vague or rushed.",
+      "judge_model": "openai/gpt-4.1"
+    }
+  ],
+  "settings": {
+    "agent_speaks_first": true,
+    "max_turns": 3
+  }
+}

--- a/examples/agent/simulation/swasth-kadam-v5.config.json
+++ b/examples/agent/simulation/swasth-kadam-v5.config.json
@@ -1,0 +1,306 @@
+{
+    "title": "Swasth kadam Health Survey V5",
+    "questions": [
+        {
+            "name": "name",
+            "label": "name",
+            "type": "string",
+            "required": false,
+            "script": "\u0905\u092a\u0928\u093e \u092a\u0942\u0930\u093e \u0928\u093e\u092e \u092c\u0924\u093e\u0907\u090f",
+            "validation": {
+                "type": "min_length",
+                "rules": {
+                    "min_length": 2
+                }
+            },
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 1,
+                "retry_messages": [
+                    "\u0915\u0943\u092a\u092f\u093e \u0905\u092a\u0928\u093e \u092a\u0942\u0930\u093e \u0928\u093e\u092e \u092c\u0924\u093e\u0907\u090f\u0964"
+                ],
+                "exhausted_action": "skip"
+            }
+        },
+        {
+            "name": "district",
+            "label": "district",
+            "type": "single-select",
+            "options": [
+                "Mumbai",
+                "Aurangabad",
+                "Nashik",
+                "Nagpur",
+                "Pune"
+            ],
+            "required": true,
+            "advanced_instructions": "IMPORTANT: On the initial ask for this question, say ONLY the question Script exactly. Do NOT add the district options on the initial ask, even though this is a single-select question.",
+            "script": "\u0905\u092a\u0928\u0947 \u091c\u093f\u0932\u0947 \u0915\u093e \u0928\u093e\u092e \u092c\u0924\u093e\u090f\u0902",
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0906\u092a\u0915\u093e \u0906\u0902\u0917\u0928\u0935\u093e\u0921\u093c\u0940 \u0915\u093f\u0938 \u091c\u093f\u0932\u0947 \u092e\u0947\u0902 \u0906\u0924\u093e \u0939\u0948? \u0915\u0943\u092a\u092f\u093e \u0907\u0928\u092e\u0947\u0902 \u0938\u0947 \u090f\u0915 \u091a\u0941\u0928\u0947\u0902: Mumbai, Aurangabad, Nashik, Nagpur ya Pune\u0964",
+                    "\u0906\u092a\u0915\u093e \u0906\u0902\u0917\u0928\u0935\u093e\u0921\u093c\u0940 \u0915\u093f\u0938 \u091c\u093f\u0932\u0947 \u092e\u0947\u0902 \u0906\u0924\u093e \u0939\u0948? \u0915\u0943\u092a\u092f\u093e \u0907\u0928\u092e\u0947\u0902 \u0938\u0947 \u090f\u0915 \u091a\u0941\u0928\u0947\u0902: Mumbai, Aurangabad, Nashik, Nagpur ya Pune\u0964"
+                ],
+                "exhausted_action": "end_call"
+            }
+        },
+        {
+            "name": "anganwadi_name",
+            "label": "anganwadi_name",
+            "type": "string",
+            "required": false,
+            "skip_message": "\u0939\u092e \u0906\u0917\u0947 \u092c\u0922\u093c\u0924\u0947 \u0939\u0948\u0902\u0964",
+            "script": "\u0905\u092a\u0928\u0947 \u0906\u0902\u0917\u0928\u0935\u093e\u0921\u093c\u0940 \u0915\u093e \u0928\u093e\u092e \u092c\u0924\u093e\u090f\u0902",
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 1,
+                "retry_messages": [
+                    "\u0905\u0917\u0930 \u0906\u092a\u0915\u094b \u0905\u092a\u0928\u0947 \u0906\u0902\u0917\u0928\u0935\u093e\u0921\u093c\u0940 \u0915\u093e \u0928\u093e\u092e \u0928\u0939\u0940\u0902 \u092a\u0924\u093e \u0939\u0948, \u0924\u094b \u0915\u0943\u092a\u092f\u093e \\\"\u0928\u0939\u0940\u0902 \u092a\u0924\u093e\\\" \u092c\u094b\u0932\u093f\u090f\u0964"
+                ],
+                "exhausted_action": "skip"
+            }
+        },
+        {
+            "name": "pregnant_or_not",
+            "label": "pregnant_or_not",
+            "type": "boolean",
+            "required": true,
+            "script": "\u0915\u094d\u092f\u093e \u0906\u092a \u0905\u092d\u0940 \u0917\u0930\u094d\u092d\u0935\u0924\u0940 \u0939\u0948\u0902?",
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0915\u094d\u092f\u093e \u0906\u092a \u0905\u092d\u0940 \u0917\u0930\u094d\u092d\u0935\u0924\u0940 \u0939\u0948\u0902? \u0915\u0943\u092a\u092f\u093e \u0939\u093e\u0901 \u092f\u093e \u0928\u093e \u092e\u0947\u0902 \u091c\u0935\u093e\u092c \u0926\u0947\u0902\u0964",
+                    "\u0915\u094d\u092f\u093e \u0906\u092a \u0905\u092d\u0940 \u0917\u0930\u094d\u092d\u0935\u0924\u0940 \u0939\u0948\u0902? \u0915\u0943\u092a\u092f\u093e \u0939\u093e\u0901 \u092f\u093e \u0928\u093e \u092e\u0947\u0902 \u091c\u0935\u093e\u092c \u0926\u0947\u0902\u0964"
+                ],
+                "exhausted_action": "end_call"
+            }
+        },
+        {
+            "name": "gestational_age_months",
+            "label": "gestational_age_months",
+            "type": "number",
+            "number_format": "integer",
+            "required": false,
+            "advanced_instructions": "The answer is in number of months.",
+            "script": "\u0906\u092a\u0915\u094b \u0917\u0930\u094d\u092d\u0935\u0924\u0940 \u0939\u0941\u090f \u0915\u093f\u0924\u0928\u0947 \u092e\u0939\u0940\u0928\u0947 \u0939\u0941\u090f \u0939\u0948\u0902?",
+            "branch_id": "branch_pregnant",
+            "validation": {
+                "type": "number_range",
+                "rules": {
+                    "min": 1,
+                    "max": 9
+                }
+            },
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0906\u092a\u0915\u094b \u0917\u0930\u094d\u092d\u0935\u0924\u0940 \u0939\u0941\u090f \u0915\u093f\u0924\u0928\u0947 \u092e\u0939\u0940\u0928\u0947 \u0939\u0941\u090f \u0939\u0948\u0902? \u0915\u0943\u092a\u092f\u093e 1 \u0938\u0947 9 \u092e\u0939\u0940\u0928\u0947 \u0915\u0947 \u092c\u0940\u091a \u092e\u0947\u0902 \u092c\u0924\u093e\u0907\u090f\u0964",
+                    "\u0906\u092a\u0915\u094b \u0917\u0930\u094d\u092d\u0935\u0924\u0940 \u0939\u0941\u090f \u0915\u093f\u0924\u0928\u0947 \u092e\u0939\u0940\u0928\u0947 \u0939\u0941\u090f \u0939\u0948\u0902? \u0915\u0943\u092a\u092f\u093e 1 \u0938\u0947 9 \u092e\u0939\u0940\u0928\u0947 \u0915\u0947 \u092c\u0940\u091a \u092e\u0947\u0902 \u092c\u0924\u093e\u0907\u090f\u0964"
+                ],
+                "exhausted_action": "end_call"
+            }
+        },
+        {
+            "name": "child_name",
+            "label": "child_name",
+            "type": "string",
+            "required": false,
+            "script": "\u0906\u092a\u0915\u0947 \u092c\u091a\u094d\u091a\u0947 \u0915\u093e \u0928\u093e\u092e \u0915\u094d\u092f\u093e \u0939\u0948?",
+            "branch_id": "branch_not_pregnant",
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 1,
+                "retry_messages": [
+                    "\u0915\u0943\u092a\u092f\u093e \u0905\u092a\u0928\u0947 \u092c\u091a\u094d\u091a\u0947 \u0915\u093e \u092a\u0942\u0930\u093e \u0928\u093e\u092e \u092c\u0924\u093e\u0907\u090f\u0964"
+                ],
+                "exhausted_action": "end_call"
+            }
+        },
+        {
+            "name": "child_dob",
+            "label": "child_dob",
+            "type": "date",
+            "required": false,
+            "script": "\u0906\u092a\u0915\u0947 \u092c\u091a\u094d\u091a\u0947 \u0915\u0940 \u091c\u0928\u094d\u092e \u0924\u093e\u0930\u0940\u0916 \u092c\u0924\u093e\u090f\u0902",
+            "branch_id": "branch_not_pregnant",
+            "validation": {
+                "type": "date_today_or_past",
+                "rules": {}
+            },
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0915\u0943\u092a\u092f\u093e \u0905\u092a\u0928\u0947 \u092c\u091a\u094d\u091a\u0947 \u0915\u0940 \u091c\u0928\u094d\u092e \u0924\u093e\u0930\u0940\u0916 \u0926\u093f\u0928, \u092e\u0939\u0940\u0928\u093e \u0914\u0930 \u0935\u0930\u094d\u0937 \u0915\u0947 \u0915\u094d\u0930\u092e \u092e\u0947\u0902 \u092c\u0924\u093e\u090f\u0902 \u091c\u0948\u0938\u0947 \u0915\u093f 15 \u0905\u092a\u094d\u0930\u0948\u0932 2025\u0964",
+                    "\u0915\u0943\u092a\u092f\u093e \u0905\u092a\u0928\u0947 \u092c\u091a\u094d\u091a\u0947 \u0915\u0940 \u091c\u0928\u094d\u092e \u0924\u093e\u0930\u0940\u0916 \u0926\u093f\u0928, \u092e\u0939\u0940\u0928\u093e \u0914\u0930 \u0935\u0930\u094d\u0937 \u0915\u0947 \u0915\u094d\u0930\u092e \u092e\u0947\u0902 \u092c\u0924\u093e\u090f\u0902 \u091c\u0948\u0938\u0947 \u0915\u093f 15 \u0905\u092a\u094d\u0930\u0948\u0932 2025\u0964"
+                ],
+                "exhausted_action": "end_call"
+            }
+        },
+        {
+            "name": "is_phone_linked_to_anganwadi",
+            "label": "is_phone_linked_to_anganwadi",
+            "type": "boolean",
+            "required": false,
+            "advanced_instructions": "Before asking this question, say the following informational script EXACTLY and then ask the question: \"\u0905\u092c \u0915\u0947\u0935\u0932 4 \u0938\u0935\u093e\u0932 \u092c\u093e\u0915\u0940 \u0939\u0948\u0902\u0964\"",
+            "script": "\u0915\u094d\u092f\u093e \u092f\u0939 \u0928\u0902\u092c\u0930 \u0906\u0902\u0917\u0928\u0935\u093e\u0921\u093c\u0940 \u0938\u0947 \u091c\u0941\u0921\u093c\u093e \u0939\u0941\u0906 \u0939\u0948?",
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0915\u0943\u092a\u092f\u093e \u0906\u092a\u0915\u0947 \u092b\u094b\u0928 \u092a\u0930 \u0906\u090f \u0939\u0941\u090f SMS \u092e\u0947\u0902 6 \u0905\u0902\u0915\u094b\u0902 \u0915\u093e \u0915\u094b\u0921 \u092c\u0924\u093e\u0907\u090f\u0964",
+                    "\u0915\u0943\u092a\u092f\u093e \u0906\u092a\u0915\u0947 \u092b\u094b\u0928 \u092a\u0930 \u0906\u090f \u0939\u0941\u090f SMS \u092e\u0947\u0902 6 \u0905\u0902\u0915\u094b\u0902 \u0915\u093e \u0915\u094b\u0921 \u092c\u0924\u093e\u0907\u090f\u0964 \u0905\u0917\u0930 \u0906\u092a\u0915\u094b \u0928\u0939\u0940\u0902 \u092a\u0924\u093e \u0939\u0948, \u0924\u094b \\\"\u0928\u0939\u0940\u0902 \u092a\u0924\u093e\\\" \u092c\u094b\u0932\u093f\u090f\u0964"
+                ],
+                "exhausted_action": "skip"
+            }
+        },
+        {
+            "name": "anganwadi_linked_phone_number",
+            "label": "anganwadi_linked_phone_number",
+            "type": "number",
+            "number_format": "integer",
+            "required": false,
+            "script": "\u0915\u0943\u092a\u092f\u093e \u0906\u0902\u0917\u0928\u0935\u093e\u0921\u093c\u0940 \u0938\u0947 \u091c\u0941\u0921\u093c\u093e \u0939\u0941\u0906 \u0905\u092a\u0928\u093e \u092b\u094b\u0928 \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u090f\u0902\u0964",
+            "branch_id": "branch_phone_not_linked",
+            "validation": {
+                "type": "phone_number",
+                "rules": {
+                    "digits": 10
+                }
+            },
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0906\u0902\u0917\u0928\u0935\u093e\u0921\u093c\u0940 \u092e\u0947\u0902 \u091c\u0941\u0921\u093c\u093e \u0939\u0941\u0906 \u0906\u092a\u0915\u093e 10 \u0905\u0902\u0915\u094b\u0902 \u0915\u093e \u092b\u094b\u0928 \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u0907\u090f\u0964",
+                    "\u0906\u0902\u0917\u0928\u0935\u093e\u0921\u093c\u0940 \u092e\u0947\u0902 \u091c\u0941\u0921\u093c\u093e \u0939\u0941\u0906 \u0906\u092a\u0915\u093e 10 \u0905\u0902\u0915\u094b\u0902 \u0915\u093e \u092b\u094b\u0928 \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u0907\u090f\u0964 \u0905\u0917\u0930 \u0928\u0939\u0940\u0902 \u092a\u0924\u093e \u0939\u0948, \u0924\u094b \\\"\u0928\u0939\u0940\u0902 \u092a\u0924\u093e\\\" \u0910\u0938\u093e \u092c\u094b\u0932\u093f\u090f\u0964"
+                ],
+                "exhausted_action": "skip"
+            }
+        },
+        {
+            "name": "whatsapp_linked_to_calling_number",
+            "label": "whatsapp_linked_to_calling_number",
+            "type": "boolean",
+            "required": false,
+            "script": "\u0906\u092a\u0928\u0947 \u091c\u093f\u0938 \u0928\u0902\u092c\u0930 \u0938\u0947 \u0915\u0949\u0932 \u0915\u093f\u092f\u093e \u0939\u0948, \u0915\u094d\u092f\u093e \u0935\u0939\u0940 \u0928\u0902\u092c\u0930 \u0906\u092a\u0915\u0947 \u0935\u094d\u0939\u093e\u091f\u094d\u0938\u0910\u092a \u0938\u0947 \u092d\u0940 \u091c\u0941\u0921\u093c\u093e \u0939\u0941\u0906 \u0939\u0948?",
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0906\u092a\u0928\u0947 \u091c\u093f\u0938 \u0928\u0902\u092c\u0930 \u0938\u0947 \u0915\u0949\u0932 \u0915\u093f\u092f\u093e \u0939\u0948, \u0915\u094d\u092f\u093e \u0935\u0939 \u0935\u094d\u0939\u093e\u091f\u094d\u0938\u090f\u092a \u092e\u0947\u0902 \u092d\u0940 \u0926\u0930\u094d\u091c \u0939\u0948? \u0915\u0943\u092a\u092f\u093e \u0939\u093e\u0901 \u092f\u093e \u0928\u093e \u092e\u0947\u0902 \u091c\u0935\u093e\u092c \u0926\u0947\u0902\u0964",
+                    "\u0906\u092a\u0928\u0947 \u091c\u093f\u0938 \u0928\u0902\u092c\u0930 \u0938\u0947 \u0915\u0949\u0932 \u0915\u093f\u092f\u093e \u0939\u0948, \u0915\u094d\u092f\u093e \u0935\u0939 \u0935\u094d\u0939\u093e\u091f\u094d\u0938\u090f\u092a \u092e\u0947\u0902 \u092d\u0940 \u0926\u0930\u094d\u091c \u0939\u0948? \u0905\u0917\u0930 \u0928\u0939\u0940\u0902 \u092a\u0924\u093e \u0939\u0948, \u0924\u094b \\\"\u0928\u0939\u0940\u0902 \u092a\u0924\u093e\\\" \u092c\u094b\u0932\u093f\u090f\u0964"
+                ],
+                "exhausted_action": "skip"
+            }
+        },
+        {
+            "name": "whatsapp_number",
+            "label": "whatsapp_number",
+            "type": "number",
+            "number_format": "integer",
+            "required": false,
+            "script": "\u0915\u0943\u092a\u092f\u093e \u0905\u092a\u0928\u093e \u0935\u094d\u0939\u093e\u091f\u094d\u0938\u0910\u092a \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u0907\u090f\u0964",
+            "branch_id": "branch_whatsapp_not_linked",
+            "validation": {
+                "type": "phone_number",
+                "rules": {
+                    "digits": 10
+                }
+            },
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0935\u094d\u0939\u093e\u091f\u094d\u0938\u090f\u092a \u092e\u0947\u0902 \u091c\u0941\u0921\u093c\u093e \u0939\u0941\u0906 \u0906\u092a\u0915\u093e 10 \u0905\u0902\u0915\u094b\u0902 \u0915\u093e \u092b\u094b\u0928 \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u0907\u090f\u0964",
+                    "\u0935\u094d\u0939\u093e\u091f\u094d\u0938\u090f\u092a \u092e\u0947\u0902 \u091c\u0941\u0921\u093c\u093e \u0939\u0941\u0906 \u0906\u092a\u0915\u093e 10 \u0905\u0902\u0915\u094b\u0902 \u0915\u093e \u092b\u094b\u0928 \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u0907\u090f \u0905\u0917\u0930 \u0928\u0939\u0940\u0902 \u092a\u0924\u093e \u0939\u0948, \u0924\u094b \\\"\u0928\u0939\u0940\u0902 \u092a\u0924\u093e\\\" \u0910\u0938\u093e \u092c\u094b\u0932\u093f\u090f\u0964"
+                ],
+                "exhausted_action": "skip"
+            }
+        },
+        {
+            "name": "last_4_digits_of_aadhar",
+            "label": "last_4_digits_of_aadhar",
+            "type": "number",
+            "number_format": "integer",
+            "required": false,
+            "advanced_instructions": "Before asking this question, say the following informational script EXACTLY: \"\u0905\u092c \u091c\u094b \u0938\u0935\u093e\u0932 \u0906\u090f\u0917\u093e, \u0935\u0939 \u0906\u0916\u093c\u093f\u0930\u0940 \u0938\u0935\u093e\u0932 \u0939\u094b\u0917\u093e\u0964\"",
+            "script": "\u0905\u092a\u0928\u0947 \u0906\u0927\u093e\u0930 \u0915\u0947 \u0906\u0916\u093f\u0930\u0940 4 \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u0907\u090f\u0964",
+            "validation": {
+                "type": "exact_num_digits",
+                "rules": {
+                    "digits": 4
+                }
+            },
+            "retry_config": {
+                "allow_retries": true,
+                "until_answered": false,
+                "max_retries": 2,
+                "retry_messages": [
+                    "\u0915\u0943\u092a\u092f\u093e \u0905\u092a\u0928\u0947 \u0906\u0927\u093e\u0930 \u0915\u093e\u0930\u094d\u0921 \u0915\u0947 \u0906\u0916\u093f\u0930\u0940 4 \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u0907\u090f\u0964",
+                    "\u0915\u0943\u092a\u092f\u093e \u0905\u092a\u0928\u0947 \u0906\u0927\u093e\u0930 \u0915\u093e\u0930\u094d\u0921 \u0915\u0947 \u0906\u0916\u093f\u0930\u0940 4 \u0928\u0902\u092c\u0930 \u092c\u0924\u093e\u0907\u090f\u0964 \u0905\u0917\u0930 \u0928\u0939\u0940\u0902 \u092a\u0924\u093e \u0939\u0948, \u0924\u094b \\\"\u0928\u0939\u0940\u0902 \u092a\u0924\u093e\\\" \u092c\u094b\u0932\u093f\u090f\u0964"
+                ],
+                "exhausted_action": "skip"
+            }
+        }
+    ],
+    "branches": [
+        {
+            "id": "branch_pregnant",
+            "condition": {
+                "field": "pregnant_or_not",
+                "equals": true
+            }
+        },
+        {
+            "id": "branch_not_pregnant",
+            "condition": {
+                "field": "pregnant_or_not",
+                "equals": false
+            }
+        },
+        {
+            "id": "branch_phone_not_linked",
+            "condition": {
+                "field": "is_phone_linked_to_anganwadi",
+                "equals": false
+            }
+        },
+        {
+            "id": "branch_whatsapp_not_linked",
+            "condition": {
+                "field": "whatsapp_linked_to_calling_number",
+                "equals": false
+            }
+        }
+    ],
+    "context": "This is a health survey call from Swasth Kadam to collect basic information from beneficiaries registered at Anganwadi centres. The agent is a health worker and the user is a pregnant mother or a mother with a young child. The agent is a health worker and the user is a pregnant mother. The agent is a health worker and the user is a pregnant mother. The agent is a health worker and the user is a pregnant mother. The agent is a health worker and the user is a pregnant mother.",
+    "validation_rules": "- 'name': Must be at least 2 characters long.\n- 'gestational_age_months': Must be between 1 and 9.\n- 'child_dob': Must be a valid DD-MM-YYYY date that is today or earlier.\n- 'anganwadi_linked_phone_number': Must be a valid phone number with exactly 10 digits.\n- 'whatsapp_number': Must be a valid phone number with exactly 10 digits.\n- 'last_4_digits_of_aadhar': Must be exactly 4 digits.",
+    "instructions": "IMPORTANT RETRY AND CALL-END RULES:\n\n- When retrying, use the EXACT retry script text specified for that retry attempt. Do NOT paraphrase.\n- Some questions have an informational script that must be spoken BEFORE asking that question. Follow those instructions exactly.\n- A brief hearing-only acknowledgement is already spoken before your reply \u2014 do NOT start with any acknowledgement or phrase implying you recorded, noted, or registered their answer (e.g. avoid '\u0926\u0930\u094d\u091c \u0915\u0930 \u0932\u093f\u092f\u093e', '\u091c\u093e\u0928\u0915\u093e\u0930\u0940 \u092e\u093f\u0932 \u0917\u0908', '\u0938\u092e\u091d \u0917\u0908'). Go straight to the next question Script, retry, or correction.\n- If the user explicitly asks you to repeat the question (e.g., 'Phir se bolo', 'Repeat karo', 'Dobara bolo'), repeat the current question exactly and do NOT count it as a retry attempt. If the user says they did not understand (e.g., 'Samajh nahi aaya', 'Kya bola', 'Sunai nahi diya'), treat it as a failed attempt and proceed according to the retry rules.",
+    "agent_speaks_first": true,
+    "ask_questions_one_by_one": true,
+    "status": "published",
+    "agent_persona": "health worker",
+    "user_persona": "pregnant mother",
+    "language": "hindi",
+    "scripts": {
+        "intro": "\u0928\u092e\u0938\u094d\u0924\u0947!",
+        "outro": "\u091c\u093e\u0928\u0915\u093e\u0930\u0940 \u0926\u0947\u0928\u0947 \u0915\u0947 \u0932\u093f\u090f \u0927\u0928\u094d\u092f\u0935\u093e\u0926\u0964 \u0939\u092e \u0906\u092a\u0915\u094b \u091c\u0932\u094d\u0926 \u0939\u0940 \u0939\u092e\u093e\u0930\u0940 \u0938\u0947\u0935\u093e \u0938\u0947 \u091c\u094b\u0921\u093c\u0947\u0902\u0917\u0947\u0964",
+        "outro_incomplete": "\u0915\u094d\u0937\u092e\u093e \u0915\u0940\u091c\u093f\u090f, \u0939\u092e \u0907\u0938 \u0938\u092e\u092f \u0906\u092a\u0915\u0940 \u091c\u093e\u0928\u0915\u093e\u0930\u0940 \u0926\u0930\u094d\u091c \u0928\u0939\u0940\u0902 \u0915\u0930 \u092a\u093e\u090f, \u0907\u0938\u0932\u093f\u090f \u0905\u092d\u0940 \u0915\u0949\u0932 \u0938\u092e\u093e\u092a\u094d\u0924 \u0915\u0940 \u091c\u093e \u0930\u0939\u0940 \u0939\u0948\u0964 \u0927\u0928\u094d\u092f\u0935\u093e\u0926\u0964"
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,10 @@ dependencies = [
     "pipecat-ai[cartesia,deepgram,google,groq,local-smart-turn-v3,openrouter,smallest,tracing,webrtc,websocket]==1.0.0",
     "python-dotenv>=1.2.1",
     "sarvamai>=0.1.21",
+    "scipy>=1.11",
     "simpleaudio>=1.0.4",
     "sounddevice>=0.5.3",
+    "soundfile>=0.12.1",
     "uvicorn>=0.38.0",
     "whisper-normalizer>=0.1.12",
 ]
@@ -72,6 +74,8 @@ exclude = ["ui*", "examples*", "docs*", "images*"]
 "calibrate_agent" = [
     "ui/cli.bundle.mjs",
     "stt/sarvam_intent_entity/prompt_template.txt",
+    "agent/assets/noise/**/*.wav",
+    "agent/assets/noise/**/*.ogg",
 ]
 
 [tool.setuptools_scm]

--- a/scripts/fetch_noise_assets.py
+++ b/scripts/fetch_noise_assets.py
@@ -1,0 +1,172 @@
+"""Fetch and build the voice-sim background-noise assets in one shot.
+
+Downloads the raw clips from their public sources, places them under ``data/``,
+then runs ``prepare_assets()`` to populate the bundled asset directory the noise
+mixer reads from (``calibrate_agent/agent/assets/noise/``).
+
+Two sources:
+- **Environmental sounds** — ESC-50 (`ashraq/esc50` on the Hugging Face Hub, no
+  auth). One clip per steady sound; a small bank for the scattered events
+  (`dog`, `car_horn`).
+- **Speaker chatter** — the ARTPARK-IISc/Vaani dataset (gated: set ``HF_TOKEN``
+  or run ``huggingface-cli login`` first). Indian-language clips per simulation
+  language, used as distant background voices.
+
+Usage:
+    uv run python scripts/fetch_noise_assets.py                 # everything
+    uv run python scripts/fetch_noise_assets.py --skip-speakers # env only (no HF login)
+    uv run python scripts/fetch_noise_assets.py --languages hindi,english
+
+Idempotent: existing files are left in place unless ``--overwrite`` is passed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+from calibrate_agent.agent.noise.assets import prepare_assets
+
+# --- Environmental sounds (ESC-50 category -> how many clips to pull) ---------
+# 1 clip for steady loops; a bank of 8 for the scattered single-shot events.
+ENV_SINGLE = [
+    "rain",
+    "wind",
+    "engine",
+    "vacuum_cleaner",
+    "train",
+    "siren",
+    "crying_baby",
+    "footsteps",
+    "keyboard_typing",
+    "laughing",
+]
+ENV_EVENTS = {"dog": 8, "car_horn": 8}
+
+# --- Vaani speaker clips (dataset language -> [(hf config, count), ...]) -------
+VAANI_LANGUAGES = {
+    "english": ("English", [("Karnataka_Bangalore", 25)]),
+    "hindi": ("Hindi", [("Karnataka_Bangalore", 25), ("Delhi_NewDelhi", 15)]),
+    "kannada": ("Kannada", [("Karnataka_Bangalore", 25)]),
+}
+
+ESC50_DATASET = "ashraq/esc50"
+VAANI_DATASET = "ARTPARK-IISc/Vaani"
+
+ENV_RAW = Path("data/env_raw")
+VAANI_RAW = Path("data/vaani_raw")
+
+
+def _decode_audio(audio: dict) -> tuple[np.ndarray, int]:
+    """Decode an undecoded HF audio cell (``{'bytes':..., 'path':...}``)."""
+    if audio.get("bytes"):
+        arr, sr = sf.read(io.BytesIO(audio["bytes"]), dtype="float32", always_2d=False)
+    else:
+        arr, sr = sf.read(audio["path"], dtype="float32", always_2d=False)
+    if arr.ndim > 1:
+        arr = arr.mean(axis=1)
+    return np.asarray(arr, dtype=np.float32), sr
+
+
+def _write_wav(dest: Path, audio: np.ndarray, sr: int, overwrite: bool) -> bool:
+    if dest.exists() and not overwrite:
+        return False
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(str(dest), np.asarray(audio, dtype=np.float32), sr, subtype="PCM_16")
+    return True
+
+
+def _stream_undecoded(dataset: str, config: str | None):
+    """Stream a dataset with the audio column left as raw bytes (no torchcodec)."""
+    from datasets import Audio, load_dataset
+
+    ds = load_dataset(dataset, config, split="train", streaming=True)
+    return ds.cast_column("audio", Audio(decode=False))
+
+
+def fetch_env(overwrite: bool) -> None:
+    """Pull the ESC-50 environmental clips into ``data/env_raw``."""
+    wanted = {c: 1 for c in ENV_SINGLE}
+    wanted.update(ENV_EVENTS)
+    remaining = dict(wanted)
+
+    print(f"[env] streaming {ESC50_DATASET} …")
+    for row in _stream_undecoded(ESC50_DATASET, None):
+        if not any(remaining.values()):
+            break
+        cat = row["category"]
+        if remaining.get(cat, 0) <= 0:
+            continue
+        arr, sr = _decode_audio(row["audio"])
+        idx = wanted[cat] - remaining[cat]
+        if cat in ENV_EVENTS:
+            dest = ENV_RAW / cat / f"{idx:02d}.wav"
+        else:
+            dest = ENV_RAW / f"{cat}.wav"
+        if _write_wav(dest, arr, sr, overwrite):
+            print(f"[env]   {dest}")
+        remaining[cat] -= 1
+
+    missing = [c for c, n in remaining.items() if n > 0]
+    if missing:
+        print(f"[env] WARNING: could not fill {missing} from {ESC50_DATASET}")
+
+
+def fetch_speakers(languages: list[str], overwrite: bool) -> None:
+    """Pull Vaani speaker clips per language into ``data/vaani_raw/<lang>``."""
+    for lang in languages:
+        target_lang, configs = VAANI_LANGUAGES[lang]
+        out_dir = VAANI_RAW / lang
+        written = 0
+        for config, count in configs:
+            print(f"[spk] streaming {VAANI_DATASET}:{config} for {target_lang} …")
+            got = 0
+            for row in _stream_undecoded(VAANI_DATASET, config):
+                if got >= count:
+                    break
+                if str(row.get("language", "")).strip().lower() != target_lang.lower():
+                    continue
+                arr, sr = _decode_audio(row["audio"])
+                dest = out_dir / f"{config}_{written:03d}.wav"
+                if _write_wav(dest, arr, sr, overwrite):
+                    print(f"[spk]   {dest}")
+                written += 1
+                got += 1
+            if got < count:
+                print(f"[spk] WARNING: {config} yielded {got}/{count} {target_lang} clips")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--languages",
+        default="english,hindi,kannada",
+        help="comma-separated speaker languages to pull (default: all three)",
+    )
+    ap.add_argument("--skip-env", action="store_true", help="skip ESC-50 environmental clips")
+    ap.add_argument("--skip-speakers", action="store_true", help="skip Vaani speaker clips (no HF login needed)")
+    ap.add_argument("--no-prepare", action="store_true", help="don't run prepare_assets() at the end")
+    ap.add_argument("--overwrite", action="store_true", help="re-download clips that already exist")
+    args = ap.parse_args()
+
+    if not args.skip_env:
+        fetch_env(args.overwrite)
+    if not args.skip_speakers:
+        languages = [l.strip() for l in args.languages.split(",") if l.strip()]
+        unknown = [l for l in languages if l not in VAANI_LANGUAGES]
+        if unknown:
+            ap.error(f"unknown languages: {unknown} (choose from {list(VAANI_LANGUAGES)})")
+        fetch_speakers(languages, args.overwrite)
+
+    if not args.no_prepare:
+        print("[build] prepare_assets() → calibrate_agent/agent/assets/noise/")
+        prepare_assets()
+    print("[done] noise assets ready.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agent/test_noise_assets.py
+++ b/tests/agent/test_noise_assets.py
@@ -1,0 +1,80 @@
+"""Tests for calibrate_agent.agent.noise.assets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import soundfile as sf
+
+from calibrate_agent.agent.noise.assets import NoiseAssets
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RAW_ENV = REPO_ROOT / "data" / "env_raw"
+
+
+def _bundle_root() -> Path:
+    return REPO_ROOT / "calibrate_agent" / "agent" / "assets" / "noise"
+
+
+def _bundle_ready() -> bool:
+    return _bundle_root().is_dir() and RAW_ENV.is_dir()
+
+
+pytestmark = pytest.mark.skipif(
+    not _bundle_ready(),
+    reason="raw data/ clips or populated bundle absent",
+)
+
+
+def test_bundle_files_are_16k_mono_pcm16():
+    root = _bundle_root()
+    wavs = list(root.rglob("*.wav"))
+    assert wavs, "no wav assets found in bundle"
+    for wav in wavs:
+        info = sf.info(str(wav))
+        assert info.samplerate == 16000, f"{wav} sr={info.samplerate}"
+        assert info.channels == 1, f"{wav} channels={info.channels}"
+        assert info.subtype == "PCM_16", f"{wav} subtype={info.subtype}"
+
+
+def test_resolve_environment_scene():
+    assets = NoiseAssets(root=str(_bundle_root()))
+    assert assets.resolve_environment("busy_street") == ["car_horn", "engine", "siren"]
+
+
+def test_resolve_environment_single_sound():
+    assets = NoiseAssets(root=str(_bundle_root()))
+    assert assets.resolve_environment("rain") == ["rain"]
+
+
+def test_resolve_environment_list_passthrough():
+    assets = NoiseAssets(root=str(_bundle_root()))
+    assert assets.resolve_environment(["rain", "siren"]) == ["rain", "siren"]
+
+
+def test_resolve_environment_none_and_off():
+    assets = NoiseAssets(root=str(_bundle_root()))
+    assert assets.resolve_environment(None) == []
+    assert assets.resolve_environment("none") == []
+
+
+def test_env_ingredient_paths_event_bank():
+    assets = NoiseAssets(root=str(_bundle_root()))
+    paths = assets.env_ingredient_paths("dog")
+    assert len(paths) > 1
+    assert all(Path(p).is_file() for p in paths)
+
+
+def test_env_ingredient_paths_steady():
+    assets = NoiseAssets(root=str(_bundle_root()))
+    paths = assets.env_ingredient_paths("rain")
+    assert len(paths) == 1
+    assert Path(paths[0]).is_file()
+
+
+def test_speaker_pool_hindi():
+    assets = NoiseAssets(root=str(_bundle_root()))
+    pool = assets.speaker_pool("hindi")
+    assert pool, "hindi speaker pool empty"
+    assert all(Path(p).is_file() for p in pool)

--- a/tests/agent/test_noise_generator.py
+++ b/tests/agent/test_noise_generator.py
@@ -1,0 +1,201 @@
+"""Unit tests for the simulation noise DSP generator."""
+
+from __future__ import annotations
+
+import filecmp
+from dataclasses import dataclass, field
+
+import numpy as np
+import soundfile as sf
+
+from calibrate_agent.agent.noise.simulation_noise_generator import (
+    SimulationNoiseGenerator,
+)
+
+
+@dataclass(frozen=True)
+class _Atom:
+    environment: object = None
+    people: str = "none"
+    loudness: str = "medium"
+
+
+def _write_wav(path, sample_rate, seconds=1.0, seed=0):
+    rng = np.random.default_rng(seed)
+    n = int(seconds * sample_rate)
+    data = (rng.standard_normal(n) * 0.2).astype(np.float32)
+    sf.write(str(path), data, sample_rate, subtype="PCM_16", format="WAV")
+    return str(path)
+
+
+class _StubAssets:
+    """Minimal assets stub producing small synthetic wavs."""
+
+    def __init__(self, tmp_path):
+        self.tmp = tmp_path
+        # A 16k steady sound, an event sound with several 44.1k clips,
+        # and a pool of 16k speaker clips.
+        self.steady = _write_wav(tmp_path / "traffic.wav", 16000, seed=1)
+        self.dog = [
+            _write_wav(tmp_path / f"dog_{i}.wav", 44100, seconds=0.5, seed=10 + i)
+            for i in range(3)
+        ]
+        self.speakers = [
+            _write_wav(tmp_path / f"spk_{i}.wav", 16000, seed=100 + i)
+            for i in range(6)
+        ]
+
+    def resolve_environment(self, environment):
+        if environment is None:
+            return []
+        if isinstance(environment, str):
+            return [environment]
+        return list(environment)
+
+    def env_ingredient_paths(self, name):
+        if name == "traffic":
+            return [self.steady]
+        if name == "dog":
+            return list(self.dog)
+        if name == "missing":
+            return ["/nonexistent/file.wav"]
+        return []
+
+    def speaker_pool(self, language):
+        return list(self.speakers)
+
+
+def _info(path):
+    info = sf.info(path)
+    return info
+
+
+def test_env_only_output_format(tmp_path):
+    assets = _StubAssets(tmp_path)
+    gen = SimulationNoiseGenerator(assets)
+    out = tmp_path / "env.wav"
+    gen.build(
+        _Atom(environment="traffic"),
+        language="hi",
+        out_path=str(out),
+        seed=7,
+        duration_s=3.0,
+    )
+    info = _info(out)
+    assert info.samplerate == 16000
+    assert info.channels == 1
+    assert "PCM_16" in info.subtype
+    assert abs(info.duration - 3.0) < 0.1
+
+
+def test_people_only_medium(tmp_path):
+    assets = _StubAssets(tmp_path)
+    gen = SimulationNoiseGenerator(assets)
+    out = tmp_path / "people.wav"
+    gen.build(
+        _Atom(people="medium"),
+        language="hi",
+        out_path=str(out),
+        seed=3,
+        duration_s=3.0,
+    )
+    info = _info(out)
+    assert info.samplerate == 16000
+    assert info.channels == 1
+    data, _ = sf.read(str(out))
+    assert np.any(data != 0)
+
+
+def test_env_plus_people(tmp_path):
+    assets = _StubAssets(tmp_path)
+    gen = SimulationNoiseGenerator(assets)
+    out = tmp_path / "both.wav"
+    gen.build(
+        _Atom(environment=["traffic", "dog"], people="light"),
+        language="hi",
+        out_path=str(out),
+        seed=11,
+        duration_s=3.0,
+    )
+    info = _info(out)
+    assert info.samplerate == 16000
+    assert info.channels == 1
+    data, _ = sf.read(str(out))
+    assert np.max(np.abs(data)) <= 1.0
+    assert np.any(data != 0)
+
+
+def test_deterministic_same_seed(tmp_path):
+    assets = _StubAssets(tmp_path)
+    gen = SimulationNoiseGenerator(assets)
+    a = tmp_path / "a.wav"
+    b = tmp_path / "b.wav"
+    atom = _Atom(environment=["traffic", "dog"], people="medium")
+    gen.build(atom, language="hi", out_path=str(a), seed=42, duration_s=3.0)
+    gen.build(atom, language="hi", out_path=str(b), seed=42, duration_s=3.0)
+    assert filecmp.cmp(str(a), str(b), shallow=False)
+
+
+def test_different_seed_differs(tmp_path):
+    assets = _StubAssets(tmp_path)
+    gen = SimulationNoiseGenerator(assets)
+    a = tmp_path / "a.wav"
+    b = tmp_path / "b.wav"
+    atom = _Atom(environment=["traffic", "dog"], people="medium")
+    gen.build(atom, language="hi", out_path=str(a), seed=1, duration_s=3.0)
+    gen.build(atom, language="hi", out_path=str(b), seed=2, duration_s=3.0)
+    assert not filecmp.cmp(str(a), str(b), shallow=False)
+
+
+def test_resamples_44k_event_clip(tmp_path):
+    # dog clips are 44.1k; using them must not crash and output stays 16k.
+    assets = _StubAssets(tmp_path)
+    gen = SimulationNoiseGenerator(assets)
+    out = tmp_path / "dog.wav"
+    gen.build(
+        _Atom(environment="dog"),
+        language="hi",
+        out_path=str(out),
+        seed=5,
+        duration_s=3.0,
+    )
+    info = _info(out)
+    assert info.samplerate == 16000
+    data, _ = sf.read(str(out))
+    assert np.any(data != 0)
+
+
+def test_empty_atom_near_silent(tmp_path):
+    assets = _StubAssets(tmp_path)
+    gen = SimulationNoiseGenerator(assets)
+    out = tmp_path / "silent.wav"
+    gen.build(
+        _Atom(environment=None, people="none"),
+        language="hi",
+        out_path=str(out),
+        seed=0,
+        duration_s=2.0,
+    )
+    info = _info(out)
+    assert info.samplerate == 16000
+    assert info.channels == 1
+    data, _ = sf.read(str(out))
+    rms = float(np.sqrt(np.mean(data**2)))
+    assert rms < 0.01
+
+
+def test_missing_files_skipped(tmp_path):
+    assets = _StubAssets(tmp_path)
+    gen = SimulationNoiseGenerator(assets)
+    out = tmp_path / "missing.wav"
+    # "missing" resolves to a nonexistent path -> treated as empty env.
+    gen.build(
+        _Atom(environment="missing"),
+        language="hi",
+        out_path=str(out),
+        seed=0,
+        duration_s=2.0,
+    )
+    info = _info(out)
+    assert info.samplerate == 16000
+    assert info.channels == 1

--- a/tests/agent/test_noise_resolver.py
+++ b/tests/agent/test_noise_resolver.py
@@ -1,0 +1,122 @@
+from calibrate_agent.agent.noise.schema import LOUDNESS_VOLUME, NoiseAtom
+from calibrate_agent.agent.noise.resolver import ResolvedNoise, resolve_for_run
+
+
+def _resolve(cfg, run_index=0, base_seed=42, language="english"):
+    return resolve_for_run(
+        cfg, language=language, run_index=run_index, base_seed=base_seed
+    )
+
+
+def test_off_and_none_return_none():
+    assert _resolve(None) is None
+    assert _resolve("off") is None
+    assert _resolve({"mode": "off"}) is None
+
+
+def test_determinism_same_inputs():
+    cfg = {"mode": "random", "seed": 1}
+    a = _resolve(cfg, run_index=3, base_seed=99)
+    b = _resolve(cfg, run_index=3, base_seed=99)
+    assert a == b
+    assert isinstance(a, ResolvedNoise)
+
+
+def test_varies_across_run_index():
+    cfg = {"mode": "random"}
+    results = {
+        (
+            _resolve(cfg, run_index=i, base_seed=5).atom.environment,
+            _resolve(cfg, run_index=i, base_seed=5).atom.people,
+            _resolve(cfg, run_index=i, base_seed=5).atom.loudness,
+        )
+        for i in range(20)
+    }
+    assert len(results) > 1
+
+
+def test_fixed_returns_exact_atom():
+    cfg = {
+        "mode": "fixed",
+        "environment": "office",
+        "people": "light",
+        "loudness": "loud",
+    }
+    res = _resolve(cfg)
+    assert res.atom == NoiseAtom(
+        environment="office", people="light", loudness="loud"
+    )
+    assert res.volume == LOUDNESS_VOLUME["loud"]
+
+
+def test_fixed_loudness_list_sampled():
+    cfg = {"mode": "fixed", "environment": "office", "loudness": ["faint", "harsh"]}
+    res = _resolve(cfg)
+    assert res.atom.loudness in {"faint", "harsh"}
+    assert res.volume == LOUDNESS_VOLUME[res.atom.loudness]
+
+
+def test_clean_fraction_half_seeded_count():
+    cfg = {"mode": "random", "clean_fraction": 0.5}
+    n = 200
+    clean = sum(
+        1
+        for i in range(n)
+        if _resolve(cfg, run_index=i, base_seed=123) is None
+    )
+    # Seeded -> deterministic; assert the exact count and that it's roughly half.
+    assert 80 < clean < 120
+    clean2 = sum(
+        1
+        for i in range(n)
+        if _resolve(cfg, run_index=i, base_seed=123) is None
+    )
+    assert clean == clean2
+
+
+def test_mixture_weight_one_always_chosen():
+    cfg = {
+        "mode": "mixture",
+        "conditions": [
+            {"weight": 1, "spec": {"environment": "rain", "loudness": "faint"}},
+        ],
+    }
+    for i in range(30):
+        res = _resolve(cfg, run_index=i)
+        assert res is not None
+        assert res.atom.environment == "rain"
+        assert res.atom.loudness == "faint"
+
+
+def test_mixture_off_condition_returns_none():
+    cfg = {
+        "mode": "mixture",
+        "conditions": [{"weight": 1, "spec": "off"}],
+    }
+    for i in range(10):
+        assert _resolve(cfg, run_index=i) is None
+
+
+def test_random_env_none_maps_to_none():
+    cfg = {"mode": "random", "environments": ["none"], "people": ["none"]}
+    res = _resolve(cfg)
+    assert res is not None
+    assert res.atom.environment is None
+
+
+def test_volume_matches_table():
+    for level in ("faint", "moderate", "loud", "harsh"):
+        cfg = {"mode": "fixed", "environment": "rain", "loudness": level}
+        res = _resolve(cfg)
+        assert res.volume == LOUDNESS_VOLUME[level]
+
+
+def test_base_seed_none_ok():
+    res = resolve_for_run(
+        {"mode": "fixed", "environment": "rain"},
+        language="hindi",
+        run_index=0,
+        base_seed=None,
+    )
+    assert res is not None
+    assert res.seed == 0

--- a/tests/agent/test_noise_save.py
+++ b/tests/agent/test_noise_save.py
@@ -1,0 +1,201 @@
+import json
+import os
+
+import numpy as np
+import soundfile as sf
+
+from calibrate_agent.agent.noise.save import mix_noise_over_wav, write_clean_and_noisy
+
+SR = 16000
+
+
+def _write_wav(path, samples):
+    sf.write(path, np.asarray(samples, dtype=np.int16), SR, subtype="PCM_16")
+
+
+def _rms(path):
+    data, _ = sf.read(path, dtype="int16")
+    return float(np.sqrt(np.mean(np.asarray(data, dtype=np.float64) ** 2)))
+
+
+def _make_sine(n, amp=8000, freq=220):
+    t = np.arange(n)
+    return (amp * np.sin(2 * np.pi * freq * t / SR)).astype(np.int16)
+
+
+def test_mix_noise_over_wav_basic(tmp_path):
+    n = SR  # 1 second
+    clean = _make_sine(n)
+    noise = (2000 * np.sin(2 * np.pi * 500 * np.arange(n // 3) / SR)).astype(np.int16)
+
+    clean_p = str(tmp_path / "clean.wav")
+    noise_p = str(tmp_path / "noise.wav")
+    out_p = str(tmp_path / "out.wav")
+    _write_wav(clean_p, clean)
+    _write_wav(noise_p, noise)
+
+    volume = 0.7
+    ret = mix_noise_over_wav(clean_p, noise_p, out_p, volume)
+    assert ret == out_p
+
+    data, sr = sf.read(out_p, dtype="int16")
+    assert sr == SR
+    assert data.ndim == 1  # mono
+    assert data.dtype == np.int16
+    assert data.shape[0] == n  # same length as clean
+
+    # Expected: clip(clean + tiled_noise * volume)
+    reps = int(np.ceil(n / noise.shape[0]))
+    tiled = np.tile(noise, reps)[:n]
+    expected = np.clip(
+        np.round(clean.astype(np.float64) + tiled.astype(np.float64) * volume),
+        -32768,
+        32767,
+    ).astype(np.int16)
+    assert np.max(np.abs(data.astype(np.int64) - expected.astype(np.int64))) <= 1
+
+
+def test_mix_noise_volume_zero_is_clean(tmp_path):
+    n = SR
+    clean = _make_sine(n)
+    noise = (3000 * np.sin(2 * np.pi * 400 * np.arange(n // 4) / SR)).astype(np.int16)
+
+    clean_p = str(tmp_path / "clean.wav")
+    noise_p = str(tmp_path / "noise.wav")
+    out_p = str(tmp_path / "out.wav")
+    _write_wav(clean_p, clean)
+    _write_wav(noise_p, noise)
+
+    mix_noise_over_wav(clean_p, noise_p, out_p, 0.0)
+    data, _ = sf.read(out_p, dtype="int16")
+    assert np.array_equal(np.asarray(data, dtype=np.int16), clean)
+
+
+def test_mix_noise_louder_is_higher_rms(tmp_path):
+    n = SR
+    # Low-amplitude clean so headroom keeps mixing from clipping to a wall.
+    clean = _make_sine(n, amp=1000)
+    noise = (4000 * np.sin(2 * np.pi * 350 * np.arange(n // 5) / SR)).astype(np.int16)
+
+    clean_p = str(tmp_path / "clean.wav")
+    noise_p = str(tmp_path / "noise.wav")
+    quiet_p = str(tmp_path / "quiet.wav")
+    loud_p = str(tmp_path / "loud.wav")
+    _write_wav(clean_p, clean)
+    _write_wav(noise_p, noise)
+
+    mix_noise_over_wav(clean_p, noise_p, quiet_p, 0.2)
+    mix_noise_over_wav(clean_p, noise_p, loud_p, 1.0)
+    assert _rms(loud_p) > _rms(quiet_p)
+
+
+def _stub_combine(monkeypatch, audio_dir):
+    """Stub combine_audio_files: concatenate {prefix}{N}_{role}.wav per transcript."""
+
+    def _combine(a_dir, output_path, transcript_path=None, prefix=""):
+        with open(transcript_path) as f:
+            transcript = json.load(f)
+        chunks = []
+        idx = 1
+        for msg in transcript:
+            if msg.get("content") is None:
+                continue
+            role = msg["role"]
+            fname = "bot" if role == "assistant" else "user"
+            p = os.path.join(a_dir, f"{prefix}{idx}_{fname}.wav")
+            if os.path.exists(p):
+                data, _ = sf.read(p, dtype="int16")
+                chunks.append(np.asarray(data, dtype=np.int16))
+            idx += 1
+        combined = (
+            np.concatenate(chunks) if chunks else np.zeros(0, dtype=np.int16)
+        )
+        _write_wav(output_path, combined)
+        return True
+
+    monkeypatch.setattr("calibrate_agent.utils.combine_audio_files", _combine)
+
+
+def test_write_clean_and_noisy(tmp_path, monkeypatch):
+    audio_dir = tmp_path / "audio"
+    audio_dir.mkdir()
+
+    _write_wav(str(audio_dir / "1_user.wav"), _make_sine(SR, amp=3000, freq=200))
+    _write_wav(str(audio_dir / "1_bot.wav"), _make_sine(SR, amp=3000, freq=300))
+    _write_wav(str(audio_dir / "2_user.wav"), _make_sine(SR, amp=3000, freq=250))
+
+    transcript = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": "bye"},
+    ]
+    transcript_path = str(tmp_path / "transcript.json")
+    with open(transcript_path, "w") as f:
+        json.dump(transcript, f)
+
+    noise_path = str(tmp_path / "noise.wav")
+    _write_wav(noise_path, (4000 * np.sin(2 * np.pi * 500 * np.arange(SR // 2) / SR)).astype(np.int16))
+
+    conversation_path = str(tmp_path / "conversation.wav")
+
+    _stub_combine(monkeypatch, str(audio_dir))
+
+    write_clean_and_noisy(
+        audio_dir=str(audio_dir),
+        transcript_path=transcript_path,
+        conversation_path=conversation_path,
+        noise_track_path=noise_path,
+        volume=0.8,
+    )
+
+    # Clean per-turn copies created.
+    assert os.path.exists(audio_dir / "clean_1_user.wav")
+    assert os.path.exists(audio_dir / "clean_1_bot.wav")
+    assert os.path.exists(audio_dir / "clean_2_user.wav")
+
+    clean_conv = tmp_path / "clean_conversation.wav"
+    assert clean_conv.exists()
+    assert os.path.exists(conversation_path)
+
+    # No leftover temp files.
+    leftover = [
+        p
+        for p in os.listdir(tmp_path)
+        if p.endswith(".wav")
+        and p not in ("conversation.wav", "clean_conversation.wav", "noise.wav")
+    ]
+    assert leftover == []
+
+    # Noisy conversation is noisier than the clean stitch.
+    assert _rms(conversation_path) > _rms(str(clean_conv))
+
+
+def test_write_clean_and_noisy_no_turns_noop(tmp_path, monkeypatch):
+    audio_dir = tmp_path / "audio"
+    audio_dir.mkdir()
+
+    transcript_path = str(tmp_path / "transcript.json")
+    with open(transcript_path, "w") as f:
+        json.dump([], f)
+    noise_path = str(tmp_path / "noise.wav")
+    _write_wav(noise_path, np.zeros(SR // 2, dtype=np.int16))
+    conversation_path = str(tmp_path / "conversation.wav")
+
+    called = {"v": False}
+
+    def _combine(*a, **k):
+        called["v"] = True
+        return True
+
+    monkeypatch.setattr("calibrate_agent.utils.combine_audio_files", _combine)
+
+    write_clean_and_noisy(
+        audio_dir=str(audio_dir),
+        transcript_path=transcript_path,
+        conversation_path=conversation_path,
+        noise_track_path=noise_path,
+        volume=0.8,
+    )
+
+    assert not os.path.exists(conversation_path)
+    assert not called["v"]

--- a/tests/agent/test_noise_schema.py
+++ b/tests/agent/test_noise_schema.py
@@ -1,0 +1,169 @@
+import pytest
+
+from calibrate_agent.agent.noise.schema import (
+    DENSITIES,
+    DENSITY_VOICES,
+    EVENT_SOUNDS,
+    LANGUAGES,
+    LOUDNESS_LEVELS,
+    LOUDNESS_VOLUME,
+    SAMPLE_RATE,
+    SCENES,
+    SINGLE_SOUNDS,
+    NoiseAtom,
+    normalize_noise_config,
+)
+
+
+def test_constants_sane():
+    assert SAMPLE_RATE == 16000
+    assert LANGUAGES == ["english", "hindi", "kannada"]
+    assert EVENT_SOUNDS <= set(SINGLE_SOUNDS)
+    assert set(DENSITY_VOICES) == set(DENSITIES)
+    assert set(LOUDNESS_VOLUME) == set(LOUDNESS_LEVELS)
+    for scene, sounds in SCENES.items():
+        for s in sounds:
+            assert s in SINGLE_SOUNDS, (scene, s)
+
+
+def test_none_off_return_none():
+    assert normalize_noise_config(None) is None
+    assert normalize_noise_config("off") is None
+    assert normalize_noise_config({"mode": "off"}) is None
+
+
+def test_random_string_shorthand():
+    out = normalize_noise_config("random")
+    assert out["mode"] == "random"
+
+
+def test_plain_atom_is_fixed():
+    out = normalize_noise_config(
+        {"environment": "rain", "people": "light", "loudness": "loud"}
+    )
+    assert out == {
+        "mode": "fixed",
+        "environment": "rain",
+        "people": "light",
+        "loudness": "loud",
+    }
+
+
+def test_fixed_defaults():
+    out = normalize_noise_config({"mode": "fixed", "environment": "office"})
+    assert out["mode"] == "fixed"
+    assert out["people"] == "none"
+    assert out["loudness"] == "moderate"
+
+
+def test_fixed_scene_and_list_env():
+    assert normalize_noise_config({"environment": "busy_street"})["environment"] == (
+        "busy_street"
+    )
+    out = normalize_noise_config({"environment": ["rain", "wind"]})
+    assert out["environment"] == ["rain", "wind"]
+
+
+def test_fixed_env_none():
+    out = normalize_noise_config({"environment": "none", "people": "heavy"})
+    assert out["environment"] == "none"
+
+
+def test_random_full():
+    out = normalize_noise_config(
+        {
+            "mode": "random",
+            "clean_fraction": 0.5,
+            "environments": ["rain", "office"],
+            "people": ["none", "heavy"],
+            "loudness": ["faint", "loud"],
+            "seed": 7,
+        }
+    )
+    assert out["mode"] == "random"
+    assert out["clean_fraction"] == 0.5
+    assert out["environments"] == ["rain", "office"]
+    assert out["people"] == ["none", "heavy"]
+    assert out["loudness"] == ["faint", "loud"]
+    assert out["seed"] == 7
+
+
+def test_random_defaults_clean_fraction():
+    out = normalize_noise_config({"mode": "random"})
+    assert out["clean_fraction"] == 0.0
+
+
+def test_random_loudness_any():
+    out = normalize_noise_config({"mode": "random", "loudness": "any"})
+    assert out["loudness"] == "any"
+
+
+def test_mixture():
+    out = normalize_noise_config(
+        {
+            "mode": "mixture",
+            "conditions": [
+                {"weight": 3, "spec": "off"},
+                {"weight": 1, "spec": {"environment": "rain", "loudness": "loud"}},
+            ],
+        }
+    )
+    assert out["mode"] == "mixture"
+    assert out["conditions"][0]["spec"] == "off"
+    assert out["conditions"][0]["weight"] == 3.0
+    assert out["conditions"][1]["spec"]["environment"] == "rain"
+
+
+def test_sweep_rejected():
+    with pytest.raises(ValueError, match="sweep"):
+        normalize_noise_config({"mode": "sweep"})
+
+
+def test_bad_env_name():
+    with pytest.raises(ValueError, match="environment"):
+        normalize_noise_config({"environment": "spaceship"})
+
+
+def test_bad_env_list_entry():
+    with pytest.raises(ValueError):
+        normalize_noise_config({"environment": ["rain", "busy_street"]})
+
+
+def test_bad_density():
+    with pytest.raises(ValueError, match="density"):
+        normalize_noise_config({"environment": "rain", "people": "tons"})
+
+
+def test_bad_loudness():
+    with pytest.raises(ValueError, match="loudness|Loudness"):
+        normalize_noise_config({"environment": "rain", "loudness": "deafening"})
+
+
+def test_bad_clean_fraction():
+    with pytest.raises(ValueError):
+        normalize_noise_config({"mode": "random", "clean_fraction": 1.5})
+
+
+def test_unknown_mode():
+    with pytest.raises(ValueError, match="mode"):
+        normalize_noise_config({"mode": "wat"})
+
+
+def test_mixture_needs_conditions():
+    with pytest.raises(ValueError):
+        normalize_noise_config({"mode": "mixture", "conditions": []})
+
+
+def test_mixture_zero_total_weight():
+    with pytest.raises(ValueError):
+        normalize_noise_config(
+            {"mode": "mixture", "conditions": [{"weight": 0, "spec": "off"}]}
+        )
+
+
+def test_atom_dataclass_frozen():
+    atom = NoiseAtom(environment="rain")
+    assert atom.people == "none"
+    assert atom.loudness == "moderate"
+    with pytest.raises(Exception):
+        atom.people = "heavy"  # type: ignore[misc]

--- a/tests/test_combine_audio_files_prefix.py
+++ b/tests/test_combine_audio_files_prefix.py
@@ -1,0 +1,91 @@
+import json
+import os
+import wave
+
+from calibrate_agent.utils import combine_audio_files
+
+SAMPLE_RATE = 16000
+
+
+def _write_wav(path, frames):
+    """Write a mono 16-bit 16k WAV with the given number of silent-ish frames."""
+    with wave.open(path, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(SAMPLE_RATE)
+        # Distinct byte content per file so combined outputs differ.
+        wf.writeframes(frames)
+
+
+def _read_wav_bytes(path):
+    with wave.open(path, "rb") as wf:
+        return wf.readframes(wf.getnframes())
+
+
+def _setup_dir(tmp_path):
+    audio_dir = tmp_path / "audio"
+    audio_dir.mkdir()
+
+    # Unprefixed files (default behavior). msg_index is a single running
+    # counter over transcript messages: user -> 1, assistant -> 2.
+    _write_wav(str(audio_dir / "1_user.wav"), b"\x01\x00" * 100)
+    _write_wav(str(audio_dir / "2_bot.wav"), b"\x02\x00" * 100)
+
+    # Prefixed "clean_" files with different content AND length.
+    _write_wav(str(audio_dir / "clean_1_user.wav"), b"\x0a\x00" * 250)
+    _write_wav(str(audio_dir / "clean_2_bot.wav"), b"\x0b\x00" * 250)
+
+    transcript = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    transcript_path = tmp_path / "transcript.json"
+    with open(transcript_path, "w") as f:
+        json.dump(transcript, f)
+
+    return str(audio_dir), str(transcript_path)
+
+
+def test_default_prefix_stitches_unprefixed(tmp_path):
+    audio_dir, transcript_path = _setup_dir(tmp_path)
+    out = str(tmp_path / "out_default.wav")
+
+    assert combine_audio_files(audio_dir, out, transcript_path, prefix="") is True
+    assert os.path.exists(out)
+
+    expected = b"\x01\x00" * 100 + b"\x02\x00" * 100
+    assert _read_wav_bytes(out) == expected
+
+
+def test_prefix_stitches_prefixed_files(tmp_path):
+    audio_dir, transcript_path = _setup_dir(tmp_path)
+    out = str(tmp_path / "out_clean.wav")
+
+    assert (
+        combine_audio_files(audio_dir, out, transcript_path, prefix="clean_") is True
+    )
+    assert os.path.exists(out)
+
+    expected = b"\x0a\x00" * 250 + b"\x0b\x00" * 250
+    assert _read_wav_bytes(out) == expected
+
+
+def test_prefixed_and_default_outputs_differ(tmp_path):
+    audio_dir, transcript_path = _setup_dir(tmp_path)
+    out1 = str(tmp_path / "out1.wav")
+    out2 = str(tmp_path / "out2.wav")
+
+    combine_audio_files(audio_dir, out1, transcript_path, prefix="")
+    combine_audio_files(audio_dir, out2, transcript_path, prefix="clean_")
+
+    assert _read_wav_bytes(out1) != _read_wav_bytes(out2)
+
+
+def test_backcompat_positional_args_only(tmp_path):
+    audio_dir, transcript_path = _setup_dir(tmp_path)
+    out = str(tmp_path / "out_positional.wav")
+
+    # No prefix passed at all -> default unchanged behavior.
+    assert combine_audio_files(audio_dir, out, transcript_path) is True
+    expected = b"\x01\x00" * 100 + b"\x02\x00" * 100
+    assert _read_wav_bytes(out) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -364,8 +364,10 @@ dependencies = [
     { name = "pipecat-ai-small-webrtc-prebuilt" },
     { name = "python-dotenv" },
     { name = "sarvamai" },
+    { name = "scipy" },
     { name = "simpleaudio" },
     { name = "sounddevice" },
+    { name = "soundfile" },
     { name = "uvicorn" },
     { name = "whisper-normalizer" },
 ]
@@ -409,8 +411,10 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "sarvamai", specifier = ">=0.1.21" },
+    { name = "scipy", specifier = ">=1.11" },
     { name = "simpleaudio", specifier = ">=1.0.4" },
     { name = "sounddevice", specifier = ">=0.5.3" },
+    { name = "soundfile", specifier = ">=0.12.1" },
     { name = "uvicorn", specifier = ">=0.38.0" },
     { name = "whisper-normalizer", specifier = ">=0.1.12" },
 ]
@@ -4318,6 +4322,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/39/714118f8413e0e353436914f2b976665161f1be2b6483ac15a8f61484c14/sounddevice-0.5.3-py3-none-macosx_10_6_x86_64.macosx_10_6_universal2.whl", hash = "sha256:278dc4451fff70934a176df048b77d80d7ce1623a6ec9db8b34b806f3112f9c2", size = 108306, upload-time = "2025-10-19T13:23:53.277Z" },
     { url = "https://files.pythonhosted.org/packages/f5/74/52186e3e5c833d00273f7949a9383adff93692c6e02406bf359cb4d3e921/sounddevice-0.5.3-py3-none-win32.whl", hash = "sha256:845d6927bcf14e84be5292a61ab3359cf8e6b9145819ec6f3ac2619ff089a69c", size = 312882, upload-time = "2025-10-19T13:23:54.829Z" },
     { url = "https://files.pythonhosted.org/packages/66/c7/16123d054aef6d445176c9122bfbe73c11087589b2413cab22aff5a7839a/sounddevice-0.5.3-py3-none-win_amd64.whl", hash = "sha256:f55ad20082efc2bdec06928e974fbcae07bc6c405409ae1334cefe7d377eb687", size = 364025, upload-time = "2025-10-19T13:23:56.362Z" },
+]
+
+[[package]]
+name = "soundfile"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/db/949331952a6fb1c5b12e9de80fd08747966c2039d1a61db4764fbd3981c2/soundfile-0.14.0.tar.gz", hash = "sha256:ba1c1a2d618bca5c406647c83b89f07cc8810fa506a50622a6993ba130c1de11", size = 47842, upload-time = "2026-06-06T08:58:47.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/d1/5e338af9ca6ed0786cd5bb03f6d60de1c325728c1189014f3b59aae7403c/soundfile-0.14.0-py2.py3-none-any.whl", hash = "sha256:8ba81ae3a89fd5ab3bef8a8eb481fbbe794e806309675a89b4df48b8d31908a8", size = 26799, upload-time = "2026-06-06T08:58:33.269Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/72/c6b21e58d3113596e7e8de0a08d6f1d95173492cfbca0a4db14148cbba2a/soundfile-0.14.0-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:19be05428da76ed61a4cad29b8e4bcf43a3e5c100089d2ec81dc961eed1b0dd4", size = 1144568, upload-time = "2026-06-06T08:58:35.231Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/dfdd6f8c748988427119f75eb860a3cedd858d1aea1fe28f39ad8559ef22/soundfile-0.14.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:d828d35a059626da52f1415b5faee610aeab393319cb3fc4a9aef47b619fc14c", size = 1103726, upload-time = "2026-06-06T08:58:37.948Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f8/fc39fad6f879633461d27394cd1ddaf1f769ffa0597dca35872f51b16461/soundfile-0.14.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:e85724a90bc99a6e8062c0b4ddf725f53b2a3b70afd4da875e9d2cfc4e92f377", size = 1238050, upload-time = "2026-06-06T08:58:39.932Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a2/70fd4432b924684c372df8b0a45708c36c057ef3596c9eb53e0a806b980b/soundfile-0.14.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:1e38bac1853412871318e82a1ba69a8be677619b56025bbfcccdb41b6cafe82d", size = 1315963, upload-time = "2026-06-06T08:58:41.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/34/c9e80783d83eab739a9531fdee03675d53e0bf1b2ccb4bb3af5844675046/soundfile-0.14.0-py2.py3-none-win32.whl", hash = "sha256:0a6ae43c50c71b4e020cc55382925cb89451c1ed1a0c3d0f5d802da269226849", size = 902199, upload-time = "2026-06-06T08:58:43.289Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/97/b39c18ac1df45e755ca22b8b00e872929da5d107998a207a5e4ac831bfda/soundfile-0.14.0-py2.py3-none-win_amd64.whl", hash = "sha256:299491d3499460fb1b74bb4bd78b57ffc2d243a5fafa7b6ec1b264875c78453e", size = 1021480, upload-time = "2026-06-06T08:58:45.016Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/83/55c65e61cf457805ce2ec157c1c6ae17715d0851aa2374422de0538838ca/soundfile-0.14.0-py2.py3-none-win_arm64.whl", hash = "sha256:e090704718e124e7c844695236f1fce8d18a5e761eaf7c82dfcd124620805f98", size = 888858, upload-time = "2026-06-06T08:58:46.593Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
- Simulate a caller in a noisy place (street / cafe / crowd / home) so the tested agent's STT is stressed under realistic background. Noise is a **per-persona** setting, mixed continuously under the simulated caller's audio; **off by default**.
- New `calibrate_agent/agent/noise/` package — config schema + per-run resolver (off/fixed/random/mixture, seeded), asset prep, the generator (steady loop / event scatter / crowd overlay + backgroundify filters + synthetic-IR reverb / merge / RMS-normalize / seamless loop), and clean+noisy save — wired into `run_simulation.py` via `SoundfileMixer`. Adds a `prefix` kwarg to `combine_audio_files`.
- Per-persona example configs + README, a user docs page, and the full design spec + TODO under `design/`.

## Notes
- Generated ESC-50-derived assets (CC BY-NC) are **gitignored** — CC0 re-source before shipping (Phase 10 in `design/noise_injection_todo.md`); regenerate locally via `prepare_assets`.
- `audiomentations` couldn't be used (its `soxr<1.0` pin conflicts with pipecat 1.0) → implemented with `scipy` + `soundfile` + `soxr`.
- 57 unit tests; verified end-to-end across all noise modes with real sims. A pre-existing Sarvam STT websocket-drop flakiness (unrelated) was spun off as a separate task.
- `docs/noise-injection.mdx` isn't in `docs/docs.json` nav yet.