### PR TITLE
Use your_api_key placeholder in docs instead of sk_your_api_key

### DIFF
--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -39,7 +39,7 @@ evaluation looks like, and the CLI (which the skills drive) *runs* it.
 | Layer | Purpose | Installation |
 | --- | --- | --- |
 | Skills | Teach agents how to design and run evaluations on Calibrate | `npx skills add dalmia/calibrate-skills` |
-| MCP server | Gives agents native tools to manage agents, tests, and runs | `claude mcp add --transport http calibrate https://mcp.calibrate.artpark.ai/mcp --header "X-API-Key: sk_your_api_key"` |
+| MCP server | Gives agents native tools to manage agents, tests, and runs | `claude mcp add --transport http calibrate https://mcp.calibrate.artpark.ai/mcp --header "X-API-Key: your_api_key"` |
 | CLI | Runs evaluations from any terminal with JSON output | `brew install dalmia/tap/calibrate` |
 | API | Direct HTTPS access for any language or runtime | REST over HTTPS — see the [API reference](/api-reference/introduction) |
 

--- a/docs/mcp/beginners-guide.mdx
+++ b/docs/mcp/beginners-guide.mdx
@@ -86,7 +86,7 @@ Edit the config file directly:
            "X-API-Key: ${CALIBRATE_API_KEY}"
          ],
          "env": {
-           "CALIBRATE_API_KEY": "sk_your_api_key"
+           "CALIBRATE_API_KEY": "your_api_key"
          }
        }
      }

--- a/docs/mcp/installation.mdx
+++ b/docs/mcp/installation.mdx
@@ -56,7 +56,7 @@ the `X-API-Key` header. Nothing to install or keep updated.
             "X-API-Key: ${CALIBRATE_API_KEY}"
           ],
           "env": {
-            "CALIBRATE_API_KEY": "sk_your_api_key"
+            "CALIBRATE_API_KEY": "your_api_key"
           }
         }
       }
@@ -79,7 +79,7 @@ the `X-API-Key` header. Nothing to install or keep updated.
             "X-API-Key: ${CALIBRATE_API_KEY}"
           ],
           "env": {
-            "CALIBRATE_API_KEY": "sk_your_api_key"
+            "CALIBRATE_API_KEY": "your_api_key"
           }
         }
       }
@@ -90,7 +90,7 @@ the `X-API-Key` header. Nothing to install or keep updated.
     ```bash
     claude mcp add --transport http calibrate \
       https://mcp.calibrate.artpark.ai/mcp \
-      --header "X-API-Key: sk_your_api_key"
+      --header "X-API-Key: your_api_key"
     ```
   </Tab>
 </Tabs>
@@ -117,7 +117,7 @@ package. It talks directly to the Calibrate API — no `mcp-remote` in between.
           "command": "npx",
           "args": ["-y", "@dalmia/calibrate-mcp", "start"],
           "env": {
-            "CALIBRATE_API_KEY_AUTH": "sk_your_api_key"
+            "CALIBRATE_API_KEY_AUTH": "your_api_key"
           }
         }
       }
@@ -132,7 +132,7 @@ package. It talks directly to the Calibrate API — no `mcp-remote` in between.
           "command": "npx",
           "args": ["-y", "@dalmia/calibrate-mcp", "start"],
           "env": {
-            "CALIBRATE_API_KEY_AUTH": "sk_your_api_key"
+            "CALIBRATE_API_KEY_AUTH": "your_api_key"
           }
         }
       }
@@ -141,7 +141,7 @@ package. It talks directly to the Calibrate API — no `mcp-remote` in between.
   </Tab>
   <Tab title="Claude Code">
     ```bash
-    claude mcp add calibrate -- npx -y @dalmia/calibrate-mcp start --api-key-auth sk_your_api_key
+    claude mcp add calibrate -- npx -y @dalmia/calibrate-mcp start --api-key-auth your_api_key
     ```
   </Tab>
 </Tabs>
@@ -172,7 +172,7 @@ git clone https://github.com/dalmia/calibrate-mcp
 cd calibrate-mcp
 npm install
 npm run build
-node bin/mcp-server.js start --api-key-auth sk_your_api_key
+node bin/mcp-server.js start --api-key-auth your_api_key
 ```
 
 ### MCP Inspector

--- a/docs/mcp/overview.mdx
+++ b/docs/mcp/overview.mdx
@@ -38,14 +38,14 @@ Ask your coding agent to:
         ```bash
         claude mcp add --transport http calibrate \
           https://mcp.calibrate.artpark.ai/mcp \
-          --header "X-API-Key: sk_your_api_key"
+          --header "X-API-Key: your_api_key"
         ```
       </Tab>
       <Tab title="Local (npx)">
         Runs the server on your own machine:
 
         ```bash
-        npx -y @dalmia/calibrate-mcp start --api-key-auth sk_your_api_key
+        npx -y @dalmia/calibrate-mcp start --api-key-auth your_api_key
         ```
       </Tab>
     </Tabs>

--- a/docs/mcp/troubleshooting.mdx
+++ b/docs/mcp/troubleshooting.mdx
@@ -54,7 +54,7 @@ full restart. Work through the section that matches your symptom.
     auth. Paste it as plain text with no surrounding characters.
   </Accordion>
   <Accordion title="Check the header format (hosted server)">
-    For the hosted server the header must be exactly `X-API-Key: sk_your_api_key`
+    For the hosted server the header must be exactly `X-API-Key: your_api_key`
     (or `X-API-Key: ${CALIBRATE_API_KEY}` with the env var set). For the local
     server the key goes in `CALIBRATE_API_KEY_AUTH` or the `--api-key-auth` flag.
   </Accordion>
@@ -71,7 +71,7 @@ full restart. Work through the section that matches your symptom.
     Test the local server directly and watch the output:
 
     ```bash
-    CALIBRATE_API_KEY_AUTH=sk_your_api_key npx -y @dalmia/calibrate-mcp start
+    CALIBRATE_API_KEY_AUTH=your_api_key npx -y @dalmia/calibrate-mcp start
     ```
 
     Or list the tools over the hosted endpoint:

--- a/docs/sdk/agent-tests/benchmark.mdx
+++ b/docs/sdk/agent-tests/benchmark.mdx
@@ -11,7 +11,7 @@ description: "Run a multi-model benchmark on an agent's linked tests as a backgr
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.agent_tests.benchmark(

--- a/docs/sdk/agent-tests/get_benchmark.mdx
+++ b/docs/sdk/agent-tests/get_benchmark.mdx
@@ -11,7 +11,7 @@ description: "Get the results of a benchmark run"
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.agent_tests.get_benchmark(

--- a/docs/sdk/agent-tests/get_run.mdx
+++ b/docs/sdk/agent-tests/get_run.mdx
@@ -11,7 +11,7 @@ description: "Poll a test run for its status and evaluation results."
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.agent_tests.get_run(

--- a/docs/sdk/agent-tests/link.mdx
+++ b/docs/sdk/agent-tests/link.mdx
@@ -11,7 +11,7 @@ description: "Link one or more tests to an agent. Tests that are already linked 
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.agent_tests.link(

--- a/docs/sdk/agent-tests/list_for_agent.mdx
+++ b/docs/sdk/agent-tests/list_for_agent.mdx
@@ -11,7 +11,7 @@ description: "List the tests linked to an agent."
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.agent_tests.list_for_agent(

--- a/docs/sdk/agent-tests/list_runs_for_agent.mdx
+++ b/docs/sdk/agent-tests/list_runs_for_agent.mdx
@@ -11,7 +11,7 @@ description: "List an agent's test runs with their results"
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.agent_tests.list_runs_for_agent(

--- a/docs/sdk/agent-tests/run.mdx
+++ b/docs/sdk/agent-tests/run.mdx
@@ -11,7 +11,7 @@ description: "Run an agent's linked tests as a background job, returning a task 
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.agent_tests.run(

--- a/docs/sdk/agent-tests/run_batch.mdx
+++ b/docs/sdk/agent-tests/run_batch.mdx
@@ -11,7 +11,7 @@ description: "Run agent tests for every agent, or for a selected set."
 from calibrate import Calibrate, BatchRunRequest
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.agent_tests.run_batch(

--- a/docs/sdk/agents/create.mdx
+++ b/docs/sdk/agents/create.mdx
@@ -11,7 +11,7 @@ description: "Create an agent to test inside Calibrate or connect your existing 
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.agents.create(

--- a/docs/sdk/agents/get.mdx
+++ b/docs/sdk/agents/get.mdx
@@ -11,7 +11,7 @@ description: "Get one agent by its ID"
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.agents.get(

--- a/docs/sdk/agents/list.mdx
+++ b/docs/sdk/agents/list.mdx
@@ -11,7 +11,7 @@ description: "Get the list of all your agents"
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.agents.list()

--- a/docs/sdk/agents/resolve.mdx
+++ b/docs/sdk/agents/resolve.mdx
@@ -11,7 +11,7 @@ description: "Get the IDs for your agents by their names"
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.agents.resolve(

--- a/docs/sdk/agents/update.mdx
+++ b/docs/sdk/agents/update.mdx
@@ -11,7 +11,7 @@ description: "Update an agent's configuration"
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.agents.update(

--- a/docs/sdk/agents/verify_connection.mdx
+++ b/docs/sdk/agents/verify_connection.mdx
@@ -11,7 +11,7 @@ description: "Verify an agent's connection and persist the result when successfu
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.agents.verify_connection(

--- a/docs/sdk/annotation-tasks/add_items.mdx
+++ b/docs/sdk/annotation-tasks/add_items.mdx
@@ -11,7 +11,7 @@ description: "Bulk-create annotation items in a task, optionally seeding human a
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.annotation_tasks.add_items(

--- a/docs/sdk/annotation-tasks/create.mdx
+++ b/docs/sdk/annotation-tasks/create.mdx
@@ -11,7 +11,7 @@ description: "Create an annotation task for annotators to label items against ev
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.annotation_tasks.create(

--- a/docs/sdk/annotation-tasks/create_evaluator_run.mdx
+++ b/docs/sdk/annotation-tasks/create_evaluator_run.mdx
@@ -11,7 +11,7 @@ description: "Run evaluators on task items as a background job"
 from calibrate import Calibrate, EvaluatorRunRequestEntry
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.annotation_tasks.create_evaluator_run(

--- a/docs/sdk/annotation-tasks/get.mdx
+++ b/docs/sdk/annotation-tasks/get.mdx
@@ -11,7 +11,7 @@ description: "Get one annotation task with linked evaluators, items, and labelli
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.annotation_tasks.get(

--- a/docs/sdk/annotation-tasks/get_agreement.mdx
+++ b/docs/sdk/annotation-tasks/get_agreement.mdx
@@ -11,7 +11,7 @@ description: "Get human-vs-human and human-vs-evaluator agreement metrics for a 
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.annotation_tasks.get_agreement(

--- a/docs/sdk/annotation-tasks/get_evaluator_run.mdx
+++ b/docs/sdk/annotation-tasks/get_evaluator_run.mdx
@@ -11,7 +11,7 @@ description: "Get one evaluator-run job with results and human-agreement summary
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.annotation_tasks.get_evaluator_run(

--- a/docs/sdk/annotation-tasks/get_summary.mdx
+++ b/docs/sdk/annotation-tasks/get_summary.mdx
@@ -11,7 +11,7 @@ description: "Get a paginated summary table of items, evaluator runs, and human 
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.annotation_tasks.get_summary(

--- a/docs/sdk/annotation-tasks/link_evaluator.mdx
+++ b/docs/sdk/annotation-tasks/link_evaluator.mdx
@@ -11,7 +11,7 @@ description: "Link an evaluator to a task, appending it to the display order"
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.annotation_tasks.link_evaluator(

--- a/docs/sdk/annotation-tasks/list.mdx
+++ b/docs/sdk/annotation-tasks/list.mdx
@@ -11,7 +11,7 @@ description: "List annotation tasks with linked evaluators"
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.annotation_tasks.list()

--- a/docs/sdk/annotation-tasks/update_items.mdx
+++ b/docs/sdk/annotation-tasks/update_items.mdx
@@ -11,7 +11,7 @@ description: "Bulk-update item payloads in a task"
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.annotation_tasks.update_items(

--- a/docs/sdk/evaluators/create.mdx
+++ b/docs/sdk/evaluators/create.mdx
@@ -11,7 +11,7 @@ description: "Create an evaluator along with its first version, which is set liv
 from calibrate import Calibrate, EvaluatorVersionCreate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.evaluators.create(

--- a/docs/sdk/evaluators/create_version.mdx
+++ b/docs/sdk/evaluators/create_version.mdx
@@ -11,7 +11,7 @@ description: "Add a new version to an evaluator you created"
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.evaluators.create_version(

--- a/docs/sdk/evaluators/get.mdx
+++ b/docs/sdk/evaluators/get.mdx
@@ -11,7 +11,7 @@ description: "Get one evaluator with its full version history"
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.evaluators.get(

--- a/docs/sdk/evaluators/list.mdx
+++ b/docs/sdk/evaluators/list.mdx
@@ -11,7 +11,7 @@ description: "List your evaluators"
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.evaluators.list()

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -20,7 +20,7 @@ Create an API key under [**Workspace settings → API keys**](https://calibrate.
 ```python
 from calibrate import Calibrate
 
-client = Calibrate(api_key="sk_your_api_key")
+client = Calibrate(api_key="your_api_key")
 
 for agent in client.agents.list():
     print(agent.uuid, agent.name)

--- a/docs/sdk/tests/bulk_create.mdx
+++ b/docs/sdk/tests/bulk_create.mdx
@@ -11,7 +11,7 @@ description: "Create many test cases at once and link them to your agents"
 from calibrate import Calibrate, BulkTestItem, ChatMessage
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.tests.bulk_create(

--- a/docs/sdk/tests/create.mdx
+++ b/docs/sdk/tests/create.mdx
@@ -11,7 +11,7 @@ description: "Create a test that runs your agent against a conversation and eval
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.tests.create(

--- a/docs/sdk/tests/get.mdx
+++ b/docs/sdk/tests/get.mdx
@@ -11,7 +11,7 @@ description: "Get an agent test case by its ID"
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.tests.get(

--- a/docs/sdk/tests/list.mdx
+++ b/docs/sdk/tests/list.mdx
@@ -11,7 +11,7 @@ description: "List all the test cases for your agents"
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.tests.list()

--- a/docs/sdk/tests/update.mdx
+++ b/docs/sdk/tests/update.mdx
@@ -11,7 +11,7 @@ description: "Update an agent test case"
 from calibrate import Calibrate
 
 client = Calibrate(
-    api_key="sk_your_api_key",
+    api_key="your_api_key",
 )
 
 client.tests.update(

--- a/docs/templates/mcp/beginners-guide.mdx
+++ b/docs/templates/mcp/beginners-guide.mdx
@@ -86,7 +86,7 @@ Edit the config file directly:
            "X-API-Key: ${CALIBRATE_API_KEY}"
          ],
          "env": {
-           "CALIBRATE_API_KEY": "sk_your_api_key"
+           "CALIBRATE_API_KEY": "your_api_key"
          }
        }
      }

--- a/docs/templates/mcp/installation.mdx
+++ b/docs/templates/mcp/installation.mdx
@@ -56,7 +56,7 @@ the `X-API-Key` header. Nothing to install or keep updated.
             "X-API-Key: ${CALIBRATE_API_KEY}"
           ],
           "env": {
-            "CALIBRATE_API_KEY": "sk_your_api_key"
+            "CALIBRATE_API_KEY": "your_api_key"
           }
         }
       }
@@ -79,7 +79,7 @@ the `X-API-Key` header. Nothing to install or keep updated.
             "X-API-Key: ${CALIBRATE_API_KEY}"
           ],
           "env": {
-            "CALIBRATE_API_KEY": "sk_your_api_key"
+            "CALIBRATE_API_KEY": "your_api_key"
           }
         }
       }
@@ -90,7 +90,7 @@ the `X-API-Key` header. Nothing to install or keep updated.
     ```bash
     claude mcp add --transport http calibrate \
       https://mcp.calibrate.artpark.ai/mcp \
-      --header "X-API-Key: sk_your_api_key"
+      --header "X-API-Key: your_api_key"
     ```
   </Tab>
 </Tabs>
@@ -117,7 +117,7 @@ package. It talks directly to the Calibrate API — no `mcp-remote` in between.
           "command": "npx",
           "args": ["-y", "@dalmia/calibrate-mcp", "start"],
           "env": {
-            "CALIBRATE_API_KEY_AUTH": "sk_your_api_key"
+            "CALIBRATE_API_KEY_AUTH": "your_api_key"
           }
         }
       }
@@ -132,7 +132,7 @@ package. It talks directly to the Calibrate API — no `mcp-remote` in between.
           "command": "npx",
           "args": ["-y", "@dalmia/calibrate-mcp", "start"],
           "env": {
-            "CALIBRATE_API_KEY_AUTH": "sk_your_api_key"
+            "CALIBRATE_API_KEY_AUTH": "your_api_key"
           }
         }
       }
@@ -141,7 +141,7 @@ package. It talks directly to the Calibrate API — no `mcp-remote` in between.
   </Tab>
   <Tab title="Claude Code">
     ```bash
-    claude mcp add calibrate -- npx -y @dalmia/calibrate-mcp start --api-key-auth sk_your_api_key
+    claude mcp add calibrate -- npx -y @dalmia/calibrate-mcp start --api-key-auth your_api_key
     ```
   </Tab>
 </Tabs>
@@ -172,7 +172,7 @@ git clone https://github.com/dalmia/calibrate-mcp
 cd calibrate-mcp
 npm install
 npm run build
-node bin/mcp-server.js start --api-key-auth sk_your_api_key
+node bin/mcp-server.js start --api-key-auth your_api_key
 ```
 
 ### MCP Inspector

--- a/docs/templates/mcp/overview.mdx
+++ b/docs/templates/mcp/overview.mdx
@@ -38,14 +38,14 @@ Ask your coding agent to:
         ```bash
         claude mcp add --transport http calibrate \
           https://mcp.calibrate.artpark.ai/mcp \
-          --header "X-API-Key: sk_your_api_key"
+          --header "X-API-Key: your_api_key"
         ```
       </Tab>
       <Tab title="Local (npx)">
         Runs the server on your own machine:
 
         ```bash
-        npx -y @dalmia/calibrate-mcp start --api-key-auth sk_your_api_key
+        npx -y @dalmia/calibrate-mcp start --api-key-auth your_api_key
         ```
       </Tab>
     </Tabs>

--- a/docs/templates/mcp/troubleshooting.mdx
+++ b/docs/templates/mcp/troubleshooting.mdx
@@ -54,7 +54,7 @@ full restart. Work through the section that matches your symptom.
     auth. Paste it as plain text with no surrounding characters.
   </Accordion>
   <Accordion title="Check the header format (hosted server)">
-    For the hosted server the header must be exactly `X-API-Key: sk_your_api_key`
+    For the hosted server the header must be exactly `X-API-Key: your_api_key`
     (or `X-API-Key: ${CALIBRATE_API_KEY}` with the env var set). For the local
     server the key goes in `CALIBRATE_API_KEY_AUTH` or the `--api-key-auth` flag.
   </Accordion>
@@ -71,7 +71,7 @@ full restart. Work through the section that matches your symptom.
     Test the local server directly and watch the output:
 
     ```bash
-    CALIBRATE_API_KEY_AUTH=sk_your_api_key npx -y @dalmia/calibrate-mcp start
+    CALIBRATE_API_KEY_AUTH=your_api_key npx -y @dalmia/calibrate-mcp start
     ```
 
     Or list the tools over the hosted endpoint:

--- a/docs/templates/sdk/overview.mdx
+++ b/docs/templates/sdk/overview.mdx
@@ -20,7 +20,7 @@ Create an API key under [**Workspace settings → API keys**](https://calibrate.
 ```python
 from calibrate import Calibrate
 
-client = Calibrate(api_key="sk_your_api_key")
+client = Calibrate(api_key="your_api_key")
 
 for agent in client.agents.list():
     print(agent.uuid, agent.name)

--- a/scripts/sdk_reference.py
+++ b/scripts/sdk_reference.py
@@ -167,8 +167,8 @@ def _simplify_usage_code(code: str) -> str:
             continue
         if "environment=CalibrateEnvironment" in line:
             continue
-        line = line.replace('api_key="<value>"', 'api_key="sk_your_api_key"')
-        line = line.replace('api_key="YOUR_API_KEY"', 'api_key="sk_your_api_key"')
+        line = line.replace('api_key="<value>"', 'api_key="your_api_key"')
+        line = line.replace('api_key="YOUR_API_KEY"', 'api_key="your_api_key"')
         lines.append(line)
     cleaned = "\n".join(lines).strip()
     while "\n\n\n" in cleaned:

--- a/tests/test_sdk_reference.py
+++ b/tests/test_sdk_reference.py
@@ -171,7 +171,7 @@ def test_parse_reference_md_extracts_method() -> None:
     doc = methods[("agents", "list")]
     assert "List all agents" in doc.description
     assert "client.agents.list()" in doc.usage_code
-    assert 'api_key="sk_your_api_key"' in doc.usage_code
+    assert 'api_key="your_api_key"' in doc.usage_code
 
 
 def test_routes_with_sdk_docs_pairs_only_when_reference_exists() -> None:


### PR DESCRIPTION
## What
- Replace `sk_your_api_key` with `your_api_key` as the API-key placeholder across all docs (SDK, MCP, CLI, agents pages) and their `docs/templates/` sources.
- Update `scripts/sdk_reference.py` so generated SDK docs emit the new placeholder, and adjust its guarding test.

## Notes
- SDK/MCP pages under `docs/sdk/**` and `docs/mcp/**` are generated; both the output and the source (script + templates) were updated so a regen keeps the new value.