### PR TITLE
Add estimated STT cost metrics

### DIFF
--- a/calibrate_agent/pricing.py
+++ b/calibrate_agent/pricing.py
@@ -46,7 +46,6 @@ def resolve_pricing(
         "currency": "USD",
         "billing_unit": "minute",
         "price_per_minute_usd": float(price),
-        "pricing_source": "calibrate_default",
     }
 
 

--- a/calibrate_agent/pricing.py
+++ b/calibrate_agent/pricing.py
@@ -1,0 +1,59 @@
+"""Pricing lookup used by Calibrate metrics."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from importlib import resources
+
+from calibrate_agent.utils import STT_PROVIDER_MODELS
+
+
+def resolve_pricing(
+    component: str,
+    provider: str,
+    model: str | None = None,
+) -> dict | None:
+    """Return normalized STT pricing for a provider/model.
+
+    Only STT pricing is supported in this PR. Add a new component here when
+    the corresponding metric pipeline is implemented.
+    """
+    if component != "stt":
+        raise ValueError(f"Unsupported pricing component: {component}")
+
+    provider_key = provider.lower()
+    model_name = model or STT_PROVIDER_MODELS.get(provider_key)
+    if not model_name:
+        return None
+
+    component_pricing = _load_pricing_data().get("stt", {})
+    provider_pricing = component_pricing.get(provider_key)
+    if not isinstance(provider_pricing, dict):
+        return None
+
+    model_pricing = provider_pricing.get(model_name)
+    if not isinstance(model_pricing, dict):
+        return None
+
+    price = model_pricing.get("price_per_minute_usd")
+    if not isinstance(price, (int, float)) or price < 0:
+        return None
+
+    return {
+        "provider": provider,
+        "model": model_name,
+        "currency": "USD",
+        "billing_unit": "minute",
+        "price_per_minute_usd": float(price),
+        "pricing_source": "calibrate_default",
+    }
+
+
+@lru_cache(maxsize=1)
+def _load_pricing_data() -> dict:
+    try:
+        pricing_path = resources.files(__package__).joinpath("pricing_data.json")
+        return json.loads(pricing_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, ModuleNotFoundError):
+        return {}

--- a/calibrate_agent/pricing_data.json
+++ b/calibrate_agent/pricing_data.json
@@ -1,0 +1,47 @@
+{
+  "stt": {
+    "deepgram": {
+      "nova-3": {
+        "price_per_minute_usd": 0.0043
+      }
+    },
+    "openai": {
+      "gpt-4o-transcribe": {
+        "price_per_minute_usd": 0.006
+      }
+    },
+    "groq": {
+      "whisper-large-v3-turbo": {
+        "price_per_minute_usd": 0.0006666667
+      }
+    },
+    "google": {
+      "chirp_2": {
+        "price_per_minute_usd": 0.016
+      },
+      "chirp_3": {
+        "price_per_minute_usd": 0.016
+      }
+    },
+    "sarvam": {
+      "saaras:v3": {
+        "price_per_minute_usd": 0.006
+      }
+    },
+    "elevenlabs": {
+      "scribe_v2_realtime": {
+        "price_per_minute_usd": 0.0036666667
+      }
+    },
+    "cartesia": {
+      "ink-whisper": {
+        "price_per_minute_usd": 0.0021666667
+      }
+    },
+    "smallest": {
+      "pulse": {
+        "price_per_minute_usd": 0.008
+      }
+    }
+  }
+}

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -25,6 +25,7 @@ import pandas as pd
 
 from calibrate_agent.utils import (
     get_stt_language_code,
+    get_wav_duration_seconds,
     validate_stt_language,
     STT_PROVIDER_MODELS,
     get_gemini_api_key,
@@ -49,6 +50,7 @@ from calibrate_agent.langfuse import (
     langfuse,
     langfuse_enabled,
 )
+from calibrate_agent.pricing import resolve_pricing
 from calibrate_agent.rate_limit import (
     STT_PROVIDER_TIMEOUT_SECONDS,
     STT_STREAMING_IDLE_TIMEOUT_SECONDS,
@@ -59,6 +61,71 @@ from calibrate_agent.rate_limit import (
 # =============================================================================
 # STT Provider API Methods
 # =============================================================================
+
+
+def _default_stt_model(provider: str, language: str | None = None) -> str | None:
+    if provider == "google":
+        model, _region = _google_stt_model_and_region(language)
+        return model
+    return STT_PROVIDER_MODELS.get(provider)
+
+
+def _google_stt_model_and_region(language: str | None) -> tuple[str, str]:
+    if language and language.lower() == "sindhi":
+        return "chirp_2", "asia-southeast1"
+    return STT_PROVIDER_MODELS["google"], "us"
+
+
+def _stt_result_row(
+    row_id: object,
+    gt_text: object,
+    pred_text: str,
+    audio_dir: Path,
+) -> dict:
+    return {
+        "id": row_id,
+        "gt": gt_text,
+        "pred": pred_text,
+        "audio_duration_seconds": get_wav_duration_seconds(audio_dir / f"{row_id}.wav"),
+    }
+
+
+def _build_stt_cost_metrics(
+    provider: str,
+    audio_duration_seconds: list[float | None] | None,
+    model: str | None = None,
+) -> dict | None:
+    """Build STT cost metrics from audio duration and provider price config."""
+    durations = [
+        float(duration)
+        for duration in (audio_duration_seconds or [])
+        if duration is not None and not pd.isna(duration)
+    ]
+    if not durations:
+        return None
+
+    total_seconds = float(sum(durations))
+    audio_minutes = round(total_seconds / 60.0, 4)
+    metrics = {
+        "provider": provider,
+        "pricing_model": model,
+        "currency": "USD",
+        "billing_unit": "minute",
+        "total_seconds": total_seconds,
+        "audio_minutes": audio_minutes,
+        "pricing_source": "unavailable",
+    }
+
+    pricing = resolve_pricing("stt", provider, model=model)
+    if not pricing:
+        return metrics
+
+    price_per_minute = pricing["price_per_minute_usd"]
+    metrics["pricing_source"] = pricing["pricing_source"]
+    metrics["pricing_model"] = pricing["model"]
+    metrics["cost_per_minute_usd"] = price_per_minute
+    metrics["cost_usd"] = audio_minutes * price_per_minute
+    return metrics
 
 
 def load_audio(audio_path: Path, as_file: bool = False, raw_pcm: bool = False):
@@ -385,13 +452,7 @@ async def transcribe_google(audio_path: Path, language: str) -> str:
 
     lang_code = get_stt_language_code(language, "google")
 
-    # Use chirp_2 model and asia-southeast1 region for Sindhi
-    if language.lower() == "sindhi":
-        model = "chirp_2"
-        region = "asia-southeast1"
-    else:
-        model = STT_PROVIDER_MODELS["google"]
-        region = "us"
+    model, region = _google_stt_model_and_region(language)
 
     result = await asyncio.wait_for(
         asyncio.to_thread(
@@ -932,11 +993,13 @@ async def run_stt_eval(
             raise
 
         # Save immediately after each file
+        audio_duration_seconds = _get_wav_duration_seconds(audio_path)
         results.append(
             {
                 "id": gt_info["id"],
                 "gt": gt_info["gt"],
                 "pred": transcript,
+                "audio_duration_seconds": audio_duration_seconds,
             }
         )
         pd.DataFrame(results).to_csv(results_csv_path, index=False)
@@ -1190,11 +1253,12 @@ async def run_single_provider_eval(
                 for gt_info in gt_data:
                     if gt_info["id"] not in processed_ids:
                         results.append(
-                            {
-                                "id": gt_info["id"],
-                                "gt": gt_info["gt"],
-                                "pred": "",
-                            }
+                            _stt_result_row(
+                                gt_info["id"],
+                                gt_info["gt"],
+                                "",
+                                audio_dir,
+                            )
                         )
 
                 pd.DataFrame(results).to_csv(results_csv_path, index=False)
@@ -1219,6 +1283,19 @@ async def run_single_provider_eval(
         all_ids = results_df["id"].tolist()
         all_gt_transcripts = results_df["gt"].astype(str).tolist()
         all_pred_transcripts = results_df["pred"].fillna("").astype(str).tolist()
+        audio_durations = []
+        for row_index, row_id in enumerate(all_ids):
+            duration = None
+            if "audio_duration_seconds" in results_df.columns:
+                duration = results_df.iloc[row_index]["audio_duration_seconds"]
+            if duration is None or pd.isna(duration):
+                duration = get_wav_duration_seconds(audio_dir / f"{row_id}.wav")
+            audio_durations.append(duration)
+        cost_metrics = _build_stt_cost_metrics(
+            provider=provider,
+            audio_duration_seconds=audio_durations,
+            model=_default_stt_model(provider, language),
+        )
 
         _log(f"gt_transcripts: {all_gt_transcripts}", to_terminal=False)
         _log(f"pred_transcripts: {all_pred_transcripts}", to_terminal=False)
@@ -1235,6 +1312,8 @@ async def run_single_provider_eval(
             judge_evaluators=judge_evaluators,
             language=language,
             run_sarvam_judges=run_sarvam_judges,
+            audio_durations=audio_durations,
+            cost_metrics=cost_metrics,
         )
 
         return {
@@ -1291,6 +1370,8 @@ async def _score_and_write_results(
     judge_evaluators: list[dict] = None,
     language: str = "english",
     run_sarvam_judges: bool = True,
+    cost_metrics: dict | None = None,
+    audio_durations: list[float | None] | None = None,
 ) -> dict:
     """Run WER/CER (and optional LLM-judge evaluators) over (gt, pred) pairs.
 
@@ -1386,6 +1467,8 @@ async def _score_and_write_results(
     if llm_results is not None:
         for name, score_dict in llm_results["scores"].items():
             metrics_data[name] = score_dict
+    if cost_metrics:
+        metrics_data["cost"] = cost_metrics
 
     ie_per_row = (
         intent_entity_results["per_row"]
@@ -1401,8 +1484,14 @@ async def _score_and_write_results(
         llm_results["per_row"] if llm_results is not None else [None] * len(ids)
     )
 
+    audio_durations = list(audio_durations or [])
+    if len(audio_durations) < len(ids):
+        audio_durations.extend([None] * (len(ids) - len(audio_durations)))
+    elif len(audio_durations) > len(ids):
+        audio_durations = audio_durations[: len(ids)]
+
     data = []
-    for _id, gt_text, pred_text, wer, cer, ie_row, llm_wer_row, llm_row in zip(
+    for _id, gt_text, pred_text, wer, cer, ie_row, llm_wer_row, llm_row, duration in zip(
         ids,
         gt_transcripts,
         pred_transcripts,
@@ -1411,6 +1500,7 @@ async def _score_and_write_results(
         ie_per_row,
         llm_wer_per_row,
         llm_per_row,
+        audio_durations,
     ):
         row = {
             "id": _id,
@@ -1419,6 +1509,8 @@ async def _score_and_write_results(
             "wer": wer,
             "cer": cer,
         }
+        if duration is not None and not pd.isna(duration):
+            row["audio_duration_seconds"] = duration
         if ie_row is not None:
             row["sarvam_intent_score"] = int(ie_row["intent_score"])
             row["sarvam_intent_reasoning"] = ie_row["intent_explanation"]
@@ -1430,13 +1522,14 @@ async def _score_and_write_results(
             row["sarvam_llm_wer_reasoning"] = json.dumps(
                 llm_wer_row["segments"], ensure_ascii=False
             )
-        for name, ev in _evaluators_by_name.items():
-            ev_result = llm_row[name]
-            if is_rating(ev):
-                row[name] = ev_result["score"]
-            else:
-                row[name] = bool(ev_result["match"])
-            row[f"{name}_reasoning"] = ev_result["reasoning"]
+        if llm_row is not None:
+            for name, ev in _evaluators_by_name.items():
+                ev_result = llm_row[name]
+                if is_rating(ev):
+                    row[name] = ev_result["score"]
+                else:
+                    row[name] = bool(ev_result["match"])
+                row[f"{name}_reasoning"] = ev_result["reasoning"]
         data.append(row)
 
     with open(join(output_dir, "metrics.json"), "w") as f:
@@ -1540,6 +1633,9 @@ def format_metrics_summary(metrics: dict, prefix: str = "") -> str:
         for k, v in metrics.items()
         if isinstance(v, dict) and "type" in v
     )
+    cost = metrics.get("cost")
+    if isinstance(cost, dict) and cost.get("cost_usd") is not None:
+        parts.append(f"cost=${cost['cost_usd']:.6f}")
     return f"  {prefix}" + ", ".join(parts)
 
 

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -66,6 +66,9 @@ from calibrate_agent.rate_limit import (
 
 
 def _default_stt_model(provider: str, language: str | None = None) -> str | None:
+    # Mirrors the model each transcribe_* uses (table, or the Google helper for
+    # the Sindhi exception) so cost prices the model actually benchmarked. If a
+    # provider gains a language-specific model, update it here too.
     if provider == "google":
         model, _region = google_stt_model_and_location(language)
         return model
@@ -92,11 +95,13 @@ def _build_stt_cost_metrics(
     model: str | None = None,
 ) -> dict | None:
     """Build STT cost metrics from audio duration and provider price config."""
-    durations = [
-        float(duration)
-        for duration in (audio_duration_seconds or [])
-        if duration is not None and not pd.isna(duration)
-    ]
+    durations = []
+    excluded_row_indices = []
+    for index, duration in enumerate(audio_duration_seconds or []):
+        if duration is not None and not pd.isna(duration):
+            durations.append(float(duration))
+        else:
+            excluded_row_indices.append(index)
     if not durations:
         return None
 
@@ -105,19 +110,22 @@ def _build_stt_cost_metrics(
         return None
 
     total_seconds = float(sum(durations))
-    audio_minutes = round(total_seconds / 60.0, 4)
+    total_minutes = total_seconds / 60.0
     price_per_minute = pricing["price_per_minute_usd"]
-    return {
+    metrics = {
         "provider": provider,
         "pricing_model": pricing["model"],
         "currency": "USD",
         "billing_unit": "minute",
         "total_seconds": total_seconds,
-        "audio_minutes": audio_minutes,
+        "audio_minutes": round(total_minutes, 4),
         "pricing_source": pricing["pricing_source"],
         "cost_per_minute_usd": price_per_minute,
-        "cost_usd": audio_minutes * price_per_minute,
+        "cost_usd": total_minutes * price_per_minute,
     }
+    if excluded_row_indices:
+        metrics["excluded_row_indices"] = excluded_row_indices
+    return metrics
 
 
 def load_audio(audio_path: Path, as_file: bool = False, raw_pcm: bool = False):
@@ -985,14 +993,8 @@ async def run_stt_eval(
             raise
 
         # Save immediately after each file
-        audio_duration_seconds = get_audio_duration_seconds(audio_path)
         results.append(
-            {
-                "id": gt_info["id"],
-                "gt": gt_info["gt"],
-                "pred": transcript,
-                "audio_duration_seconds": audio_duration_seconds,
-            }
+            _stt_result_row(gt_info["id"], gt_info["gt"], transcript, audio_dir)
         )
         pd.DataFrame(results).to_csv(results_csv_path, index=False)
 

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -119,7 +119,6 @@ def _build_stt_cost_metrics(
         "billing_unit": "minute",
         "total_seconds": total_seconds,
         "audio_minutes": round(total_minutes, 4),
-        "pricing_source": pricing["pricing_source"],
         "cost_per_minute_usd": price_per_minute,
         "cost_usd": total_minutes * price_per_minute,
     }

--- a/calibrate_agent/utils.py
+++ b/calibrate_agent/utils.py
@@ -24,6 +24,18 @@ from pipecat.transcriptions.language import Language
 current_context: ContextVar[str] = ContextVar("current_context", default="UNKNOWN")
 
 
+def get_wav_duration_seconds(audio_path: str | Path) -> float | None:
+    """Return WAV duration in seconds, or None when it cannot be read."""
+    try:
+        with wave.open(str(audio_path), "rb") as wav_file:
+            frame_rate = wav_file.getframerate()
+            if frame_rate <= 0:
+                return None
+            return wav_file.getnframes() / float(frame_rate)
+    except Exception:
+        return None
+
+
 def patch_langfuse_trace(trace_name: str):
     from pipecat.utils.tracing import service_decorators
 
@@ -2277,7 +2289,12 @@ def read_leaderboard_metrics(metrics_path: Path) -> dict:
     metrics: dict = {}
     if isinstance(data, dict) and "metric_name" not in data:
         for key, value in data.items():
-            if isinstance(value, dict) and "mean" in value:
+            if key == "cost" and isinstance(value, dict):
+                for cost_key in ("audio_minutes", "cost_per_minute_usd", "cost_usd"):
+                    scalar = value.get(cost_key)
+                    if isinstance(scalar, (int, float)):
+                        metrics[cost_key] = float(scalar)
+            elif isinstance(value, dict) and "mean" in value:
                 metrics[key] = value["mean"]
             elif isinstance(value, dict) and "p50" in value:
                 for pct in ("p50", "p95", "p99"):

--- a/docs/cli/speech-to-text.mdx
+++ b/docs/cli/speech-to-text.mdx
@@ -136,6 +136,12 @@ Refer to the [sample config](https://github.com/ARTPARK-SAHAI-ORG/calibrate/blob
 
 Once all the providers have completed, it displays a leaderboard measuring key metrics along with bar charts for better visualization.
 
+Each provider output directory includes:
+
+- `results.csv` with one row per input audio. In addition to `id`, `gt`, `pred`, WER, evaluator scores, and evaluator reasoning, STT runs include `audio_duration_seconds`.
+- `metrics.json` with aggregate `wer`, evaluator summaries, and a `cost` object. The cost object includes `provider`, `pricing_model`, `currency`, `billing_unit`, `total_seconds`, `audio_minutes`, `cost_per_minute_usd`, and `cost_usd`. Cost is a proportional estimate from bundled rates; provider invoices may differ because of per-file rounding, minimums, tiers, or regional pricing.
+- `leaderboard/stt_leaderboard.xlsx` with scalar cost columns in the summary sheet: `audio_minutes`, `cost_per_minute_usd`, and `cost_usd`.
+
 <Frame>
   <img src="./images/stt_leaderboard.png" alt="STT leaderboard" />
 </Frame>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ exclude = ["ui*", "examples*", "docs*", "images*"]
     "ui/cli.bundle.mjs",
     "stt/sarvam_intent_entity/prompt_template.txt",
     "stt/sarvam_llm_wer/prompt_template.txt",
+    "pricing_data.json",
 ]
 
 [tool.setuptools_scm]

--- a/tests/stt/test_eval_extra.py
+++ b/tests/stt/test_eval_extra.py
@@ -821,6 +821,107 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
                 run_sarvam_judges=False,
             )
 
+    async def test_short_row_extras_do_not_truncate_results(self):
+        from calibrate_agent.stt import eval as E
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(E, "get_wer_score", return_value={"score": 0.1, "per_row": [0.1, 0.2]}), \
+                 patch.object(E, "get_llm_judge_score", AsyncMock(return_value={
+                     "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
+                     "per_row": [
+                         {"semantic_match": {"match": True, "reasoning": "ok"}},
+                         {"semantic_match": {"match": False, "reasoning": "no"}},
+                     ],
+                 })):
+                await E._score_and_write_results(
+                    ids=["a", "b"],
+                    gt_transcripts=["x", "y"],
+                    pred_transcripts=["x", "z"],
+                    output_dir=tmp,
+                    evaluator_config_dir=tmp,
+                    audio_durations=[1.0],
+                )
+
+            df = pd.read_csv(Path(tmp) / "results.csv")
+            self.assertEqual(len(df), 2)
+            self.assertEqual(df.iloc[0]["audio_duration_seconds"], 1.0)
+
+
+class TestSTTCostMetrics(unittest.TestCase):
+    def test_builds_cost_metrics_from_default_pricing(self):
+        from calibrate_agent.stt import eval as E
+
+        metrics = E._build_stt_cost_metrics(
+            provider="openai",
+            audio_duration_seconds=[60.0],
+            model="gpt-4o-transcribe",
+        )
+
+        self.assertEqual(metrics["billing_unit"], "minute")
+        self.assertEqual(metrics["pricing_source"], "calibrate_default")
+        self.assertEqual(metrics["pricing_model"], "gpt-4o-transcribe")
+        self.assertEqual(metrics["total_seconds"], 60.0)
+        self.assertEqual(metrics["audio_minutes"], 1.0)
+        self.assertEqual(metrics["cost_per_minute_usd"], 0.006)
+        self.assertEqual(metrics["cost_usd"], 0.006)
+
+    def test_builds_cost_metrics_from_multiple_durations(self):
+        from calibrate_agent.stt import eval as E
+
+        metrics = E._build_stt_cost_metrics(
+            provider="openai",
+            audio_duration_seconds=[30.0, 90.0, None],
+            model="gpt-4o-transcribe",
+        )
+
+        self.assertEqual(metrics["billing_unit"], "minute")
+        self.assertEqual(metrics["pricing_source"], "calibrate_default")
+        self.assertEqual(metrics["total_seconds"], 120.0)
+        self.assertEqual(metrics["audio_minutes"], 2.0)
+        self.assertEqual(metrics["cost_per_minute_usd"], 0.006)
+        self.assertEqual(metrics["cost_usd"], 0.012)
+
+    def test_rounds_audio_minutes_for_cost_metrics(self):
+        from calibrate_agent.stt import eval as E
+
+        metrics = E._build_stt_cost_metrics(
+            provider="openai",
+            audio_duration_seconds=[100.0],
+            model="gpt-4o-transcribe",
+        )
+
+        self.assertEqual(metrics["audio_minutes"], 1.6667)
+
+    def test_uses_google_sindhi_pricing_model(self):
+        from calibrate_agent.stt import eval as E
+
+        metrics = E._build_stt_cost_metrics(
+            provider="google",
+            audio_duration_seconds=[60.0],
+            model=E._default_stt_model("google", "sindhi"),
+        )
+
+        self.assertEqual(metrics["pricing_model"], "chirp_2")
+        self.assertEqual(metrics["pricing_source"], "calibrate_default")
+        self.assertEqual(metrics["cost_usd"], 0.016)
+
+    def test_all_supported_providers_with_default_pricing(self):
+        from calibrate_agent.stt import eval as E
+        from calibrate_agent.stt.eval import STT_PROVIDERS
+
+        providers_without_per_minute_pricing = {"gemini"}
+        for provider in STT_PROVIDERS:
+            if provider in providers_without_per_minute_pricing:
+                continue
+            with self.subTest(provider=provider):
+                metrics = E._build_stt_cost_metrics(
+                    provider=provider,
+                    audio_duration_seconds=[60.0],
+                    model=E._default_stt_model(provider, "english"),
+                )
+                self.assertEqual(metrics["pricing_source"], "calibrate_default")
+                self.assertIn("cost_usd", metrics)
+
 
 # --- run_eval_only --------------------------------------------------------
 

--- a/tests/stt/test_eval_extra.py
+++ b/tests/stt/test_eval_extra.py
@@ -879,7 +879,6 @@ class TestSTTCostMetrics(unittest.TestCase):
         )
 
         self.assertEqual(metrics["billing_unit"], "minute")
-        self.assertEqual(metrics["pricing_source"], "calibrate_default")
         self.assertEqual(metrics["pricing_model"], "gpt-4o-transcribe")
         self.assertEqual(metrics["total_seconds"], 60.0)
         self.assertEqual(metrics["audio_minutes"], 1.0)
@@ -897,7 +896,6 @@ class TestSTTCostMetrics(unittest.TestCase):
         )
 
         self.assertEqual(metrics["billing_unit"], "minute")
-        self.assertEqual(metrics["pricing_source"], "calibrate_default")
         self.assertEqual(metrics["total_seconds"], 120.0)
         self.assertEqual(metrics["audio_minutes"], 2.0)
         self.assertEqual(metrics["cost_per_minute_usd"], 0.006)
@@ -925,7 +923,6 @@ class TestSTTCostMetrics(unittest.TestCase):
         )
 
         self.assertEqual(metrics["pricing_model"], "chirp_2")
-        self.assertEqual(metrics["pricing_source"], "calibrate_default")
         self.assertEqual(metrics["cost_usd"], 0.016)
 
     def test_returns_none_when_no_pricing(self):
@@ -953,7 +950,6 @@ class TestSTTCostMetrics(unittest.TestCase):
                     audio_duration_seconds=[60.0],
                     model=E._default_stt_model(provider, "english"),
                 )
-                self.assertEqual(metrics["pricing_source"], "calibrate_default")
                 self.assertIn("cost_usd", metrics)
 
 

--- a/tests/stt/test_eval_extra.py
+++ b/tests/stt/test_eval_extra.py
@@ -885,6 +885,7 @@ class TestSTTCostMetrics(unittest.TestCase):
         self.assertEqual(metrics["audio_minutes"], 1.0)
         self.assertEqual(metrics["cost_per_minute_usd"], 0.006)
         self.assertEqual(metrics["cost_usd"], 0.006)
+        self.assertNotIn("excluded_row_indices", metrics)
 
     def test_builds_cost_metrics_from_multiple_durations(self):
         from calibrate_agent.stt import eval as E
@@ -901,6 +902,7 @@ class TestSTTCostMetrics(unittest.TestCase):
         self.assertEqual(metrics["audio_minutes"], 2.0)
         self.assertEqual(metrics["cost_per_minute_usd"], 0.006)
         self.assertEqual(metrics["cost_usd"], 0.012)
+        self.assertEqual(metrics["excluded_row_indices"], [2])
 
     def test_rounds_audio_minutes_for_cost_metrics(self):
         from calibrate_agent.stt import eval as E

--- a/tests/stt/test_leaderboard.py
+++ b/tests/stt/test_leaderboard.py
@@ -85,6 +85,28 @@ class TestSTTLeaderboard(unittest.TestCase):
             self.assertIn("semantic_match", summary.columns)
             self.assertIn("completeness", summary.columns)
 
+    def test_cost_metrics_surface_as_scalar_columns(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            _write_provider(base, "openai", {
+                "wer": 0.1,
+                "semantic_match": {"type": "binary", "mean": 0.9},
+                "cost": {
+                    "audio_minutes": 2.0,
+                    "cost_per_minute_usd": 0.006,
+                    "cost_usd": 0.012,
+                },
+            })
+
+            save_dir = base / "leaderboard"
+            generate_stt_leaderboard(str(base), str(save_dir))
+
+            summary = pd.read_excel(save_dir / "stt_leaderboard.xlsx", sheet_name="summary")
+            self.assertIn("audio_minutes", summary.columns)
+            self.assertIn("cost_per_minute_usd", summary.columns)
+            self.assertIn("cost_usd", summary.columns)
+            self.assertEqual(float(summary.iloc[0]["cost_usd"]), 0.012)
+
     def test_skips_existing_leaderboard_folder(self):
         """A pre-existing `leaderboard` subdir under output_dir must not be
         treated as a provider (hardcoded skip in the leaderboard code)."""

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,54 @@
+import unittest
+
+
+class TestPricingResolver(unittest.TestCase):
+    def test_resolves_default_stt_provider_pricing(self):
+        from calibrate_agent.pricing import resolve_pricing
+
+        pricing = resolve_pricing("stt", "openai")
+
+        self.assertEqual(pricing["billing_unit"], "minute")
+        self.assertEqual(pricing["model"], "gpt-4o-transcribe")
+        self.assertEqual(pricing["price_per_minute_usd"], 0.006)
+        self.assertEqual(pricing["pricing_source"], "calibrate_default")
+
+    def test_resolves_explicit_stt_model_pricing(self):
+        from calibrate_agent.pricing import resolve_pricing
+
+        pricing = resolve_pricing("stt", "google", model="chirp_2")
+
+        self.assertEqual(pricing["billing_unit"], "minute")
+        self.assertEqual(pricing["model"], "chirp_2")
+        self.assertEqual(pricing["price_per_minute_usd"], 0.016)
+
+    def test_resolves_supported_stt_provider_defaults_with_pricing(self):
+        from calibrate_agent.pricing import resolve_pricing
+        from calibrate_agent.utils import STT_PROVIDER_MODELS
+
+        providers_without_per_minute_pricing = {"gemini"}
+        for provider, model in STT_PROVIDER_MODELS.items():
+            if provider in providers_without_per_minute_pricing:
+                continue
+            with self.subTest(provider=provider):
+                pricing = resolve_pricing("stt", provider)
+                self.assertEqual(pricing["model"], model)
+                self.assertIsInstance(pricing["price_per_minute_usd"], float)
+
+    def test_provider_lookup_is_case_insensitive_for_canonical_model(self):
+        from calibrate_agent.pricing import resolve_pricing
+
+        pricing = resolve_pricing("stt", "OpenAI", model="gpt-4o-transcribe")
+
+        self.assertEqual(pricing["model"], "gpt-4o-transcribe")
+        self.assertEqual(pricing["price_per_minute_usd"], 0.006)
+
+    def test_unknown_provider_returns_none(self):
+        from calibrate_agent.pricing import resolve_pricing
+
+        self.assertIsNone(resolve_pricing("stt", "unknown"))
+
+    def test_unsupported_component_raises(self):
+        from calibrate_agent.pricing import resolve_pricing
+
+        with self.assertRaises(ValueError):
+            resolve_pricing("tts", "openai")

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -10,7 +10,6 @@ class TestPricingResolver(unittest.TestCase):
         self.assertEqual(pricing["billing_unit"], "minute")
         self.assertEqual(pricing["model"], "gpt-4o-transcribe")
         self.assertEqual(pricing["price_per_minute_usd"], 0.006)
-        self.assertEqual(pricing["pricing_source"], "calibrate_default")
 
     def test_resolves_explicit_stt_model_pricing(self):
         from calibrate_agent.pricing import resolve_pricing


### PR DESCRIPTION
## Summary

Adds duration-based estimated cost metrics to STT evaluations.

- Records `audio_duration_seconds` for each transcription result.
- Adds provider/model pricing lookup through bundled pricing data.
- Calculates total audio duration and estimated cost per provider.
- Adds a `cost` object to each provider's `metrics.json`.
- Adds scalar cost columns to the STT leaderboard:
  - `audio_minutes`
  - `cost_per_minute_usd`
  - `cost_usd`
- Includes pricing, duration, evaluation, leaderboard, and packaging tests.
- Documents the new STT output fields.

This PR is for the ongoing changes in track and compare costs for STT/LLM/TTS providers [Here](https://github.com/ARTPARK-SAHAI-ORG/calibrate-frontend/issues/118) 

## Example cost output

```json
{
  "cost": {
    "provider": "openai",
    "pricing_model": "gpt-4o-transcribe",
    "currency": "USD",
    "billing_unit": "minute",
    "total_seconds": 120.0,
    "total_minutes": 2.0,
    "pricing_source": "calibrate_default",
    "price_per_minute_usd": 0.006,
    "estimated_total_cost_usd": 0.012
  }
}