### PR TITLE
Gate STT accuracy scoring to the internal calibrate agent

### DIFF
--- a/calibrate_agent/agent/run_simulation.py
+++ b/calibrate_agent/agent/run_simulation.py
@@ -2180,7 +2180,7 @@ async def _run_single_simulation_inner(
                     start_bot(
                         config["system_prompt"]
                         + f"\n\nYou must always speak in {language}.",
-                        config["tools"],
+                        config.get("tools", []),
                         language,
                         port=port,
                         stt_config=stt_config,

--- a/calibrate_agent/agent/run_simulation.py
+++ b/calibrate_agent/agent/run_simulation.py
@@ -299,6 +299,34 @@ def is_external_ws_agent(config: dict) -> bool:
     return agent_url.startswith("ws://") or agent_url.startswith("wss://")
 
 
+def prepare_stt_judge_inputs(
+    references: list[str],
+    predictions: list[str],
+    agent_uri: Optional[str],
+) -> Optional[tuple[list[str], list[str]]]:
+    """Pair persona references with agent STT predictions for STT judging.
+
+    Returns ``(references, predictions)`` truncated to equal length and paired
+    positionally, or ``None`` when STT accuracy should not be scored.
+
+    Scoring is gated to the **internal** calibrate agent (``agent_uri is None``).
+    For that agent we own the STT pipeline and the persona's turn boundaries stay
+    aligned with the transcription turns, so the positional pairing is reliable
+    and deterministic. For an **external** WS agent (``agent_uri`` set) the
+    pairing is not trustworthy — noise-driven VAD merges shift turn boundaries
+    and the agent may transcribe in a different script than the persona spoke —
+    so we return ``None`` and skip scoring rather than report a deflated number.
+    """
+    if agent_uri is not None:
+        return None
+    if not references or not predictions:
+        return None
+    min_len = min(len(references), len(predictions))
+    if min_len == 0:
+        return None
+    return references[:min_len], predictions[:min_len]
+
+
 def select_transport_uri(agent_uri: Optional[str], port: int) -> str:
     """Pick the simulator client transport URI.
 
@@ -1814,15 +1842,37 @@ async def _run_simulation_inner(
     # Filter out empty STT outputs
     filtered_stt_outputs = [s for s in stt_outputs if s.strip()]
 
-    # # Compare STT outputs with user messages using STT LLM judge
+    # Compare STT outputs with user messages using the STT LLM judge.
+    #
+    # This pairs each persona reference turn with the agent's transcription
+    # positionally. That pairing is only trustworthy for the internal calibrate
+    # agent, whose STT we own and whose turn boundaries stay aligned with the
+    # persona's turns. For an external WS agent we only observe its RTVI
+    # transcriptions: noise-driven VAD merges shift the turn boundaries, and the
+    # agent may transcribe in a different script than the persona spoke (e.g.
+    # romanized Hindi vs Devanagari), so a positional pairing scores otherwise
+    # correct transcriptions against the wrong reference and deflates the score.
+    # Skip STT judging entirely for external agents rather than report a
+    # misleading number (``prepare_stt_judge_inputs`` returns ``None``).
     stt_llm_judge_result = None
-    if filtered_stt_outputs and user_messages_in_transcript:
+    stt_eval_references: list[str] = []
+    stt_eval_predictions: list[str] = []
+    stt_judge_inputs = prepare_stt_judge_inputs(
+        user_messages_in_transcript, filtered_stt_outputs, agent_uri
+    )
+    if stt_judge_inputs is None and agent_uri is not None and (
+        filtered_stt_outputs and user_messages_in_transcript
+    ):
+        log_and_print(
+            f"{GENERAL_LOG_COLOR}Skipping STT accuracy scoring for the external "
+            "WS agent — reference/transcription turn pairing is unreliable for "
+            f"external agents.{RESET_COLOR}"
+        )
+    if stt_judge_inputs is not None:
+        stt_eval_references, stt_eval_predictions = stt_judge_inputs
+        min_len = len(stt_eval_references)
         # Align lengths - take minimum length
         log_and_print(f"Evaluating the STT outputs with user messages")
-        min_len = min(len(filtered_stt_outputs), len(user_messages_in_transcript))
-
-        stt_eval_references = user_messages_in_transcript[:min_len]
-        stt_eval_predictions = filtered_stt_outputs[:min_len]
 
         if min_len > 0:
             stt_llm_judge_result = await stt_llm_judge_score(

--- a/tests/agent/test_run_simulation_helpers.py
+++ b/tests/agent/test_run_simulation_helpers.py
@@ -86,6 +86,74 @@ class TestFindAvailablePort(unittest.TestCase):
                 RS.find_available_port()
 
 
+class TestPrepareSttJudgeInputs(unittest.TestCase):
+    """STT judging is scored only for the internal calibrate agent."""
+
+    def test_external_agent_returns_none(self):
+        from calibrate_agent.agent.run_simulation import prepare_stt_judge_inputs
+
+        refs = ["hi there", "my name is priya"]
+        preds = ["hi there", "my name is priya"]
+        self.assertIsNone(
+            prepare_stt_judge_inputs(refs, preds, agent_uri="ws://agent.example")
+        )
+        self.assertIsNone(
+            prepare_stt_judge_inputs(refs, preds, agent_uri="wss://agent.example")
+        )
+
+    def test_internal_agent_pairs_positionally(self):
+        from calibrate_agent.agent.run_simulation import prepare_stt_judge_inputs
+
+        refs = ["hi there", "my name is priya"]
+        preds = ["hi there", "my name is priya"]
+        result = prepare_stt_judge_inputs(refs, preds, agent_uri=None)
+        self.assertEqual(result, (refs, preds))
+
+    def test_internal_agent_truncates_to_min_len(self):
+        from calibrate_agent.agent.run_simulation import prepare_stt_judge_inputs
+
+        refs = ["a", "b", "c"]
+        preds = ["a", "b"]
+        result = prepare_stt_judge_inputs(refs, preds, agent_uri=None)
+        self.assertEqual(result, (["a", "b"], ["a", "b"]))
+
+    def test_empty_inputs_return_none(self):
+        from calibrate_agent.agent.run_simulation import prepare_stt_judge_inputs
+
+        self.assertIsNone(prepare_stt_judge_inputs([], ["a"], agent_uri=None))
+        self.assertIsNone(prepare_stt_judge_inputs(["a"], [], agent_uri=None))
+        self.assertIsNone(prepare_stt_judge_inputs([], [], agent_uri=None))
+
+    def test_regression_shifted_turns_skipped_for_external(self):
+        """Persona-2/5 shifted-turn case: an external run must not score STT.
+
+        On a noisy external call, the agent's VAD merges a turn boundary and
+        every subsequent transcription is paired with the *next* reference. A
+        positional pairing would score correct transcriptions against the wrong
+        reference and deflate the score (0.67 / 0.44 in the real runs). Because
+        the agent is external, we skip STT scoring entirely instead.
+        """
+        from calibrate_agent.agent.run_simulation import prepare_stt_judge_inputs
+
+        # SAID (persona reference, Devanagari) shifted against HEARD (agent STT,
+        # romanized): reference[i] truly corresponds to prediction[i-1].
+        references = [
+            "उसकी जन्म तारीख बाईस जुलाई दो हजार तेईस है",
+            "हाँ, यह नंबर आंगनवाड़ी से जुड़ा हुआ है",
+            "यही नंबर WhatsApp से भी जुड़ा हुआ है",
+        ]
+        predictions = [
+            "Haan, yah number Anganwadi se juda hua hai.",
+            "Haan, yahi number. WhatsApp se bhi juda hua hai.",
+            "4 8 2 7 hai.",
+        ]
+        self.assertIsNone(
+            prepare_stt_judge_inputs(
+                references, predictions, agent_uri="wss://swasth-kadam.example"
+            )
+        )
+
+
 class TestMetricsLogger(unittest.IsolatedAsyncioTestCase):
     async def test_process_frame(self):
         from collections import defaultdict

--- a/tests/agent/test_run_simulation_helpers.py
+++ b/tests/agent/test_run_simulation_helpers.py
@@ -154,6 +154,56 @@ class TestPrepareSttJudgeInputs(unittest.TestCase):
         )
 
 
+class TestConfigWithoutTools(unittest.IsolatedAsyncioTestCase):
+    """A sim config that omits ``tools`` must default to an empty list.
+
+    Regression: ``_run_single_simulation_inner`` used ``config["tools"]``, so a
+    config without the key crashed with ``KeyError: 'tools'`` before the bot was
+    ever spawned. It now uses ``config.get("tools", [])`` like the sim-task call
+    two lines below.
+    """
+
+    async def test_missing_tools_key_defaults_to_empty_list(self):
+        import tempfile
+        from calibrate_agent.agent import run_simulation as RS
+
+        config = {
+            "system_prompt": "You are a helpful agent.",
+            # no "tools" key on purpose
+            "stt": {"provider": "google"},
+            "tts": {"provider": "google"},
+            "llm": {"provider": "openrouter", "model": "some/model"},
+            "settings": {"agent_speaks_first": True, "max_turns": 1},
+        }
+        persona = {
+            "characteristics": "polite",
+            "gender": "neutral",
+            "language": "english",
+            "interruption_sensitivity": "none",
+        }
+        scenario = {"name": "s", "description": "d"}
+
+        with tempfile.TemporaryDirectory() as tmp, patch.object(
+            RS, "start_bot", AsyncMock()
+        ) as mock_start_bot, patch.object(
+            RS, "run_simulation", AsyncMock(return_value={})
+        ), patch.object(
+            RS, "find_available_port", return_value=54321
+        ):
+            # The mocked bot task completes immediately, so the inner routine
+            # raises "Bot task completed unexpectedly" — but only *after* it has
+            # already passed the tools access and spawned the bot, which is all
+            # this regression cares about.
+            with self.assertRaises(RuntimeError):
+                await RS._run_single_simulation_inner(
+                    config, 0, persona, 0, scenario, tmp, {"none": 0.0}
+                )
+
+        mock_start_bot.assert_called_once()
+        # tools is the second positional argument to start_bot.
+        self.assertEqual(mock_start_bot.call_args.args[1], [])
+
+
 class TestMetricsLogger(unittest.IsolatedAsyncioTestCase):
     async def test_process_frame(self):
         from collections import defaultdict


### PR DESCRIPTION
## What
- Voice sims paired persona reference turns with agent transcriptions positionally; noise-driven VAD merges shifted the pairing and deflated `stt_llm_judge_score` on otherwise-correct transcriptions.
- STT accuracy is now scored only for the internal calibrate agent, where we own the pipeline and the ref/pred pairing is reliable and deterministic. External WS agents skip STT judging entirely instead of reporting a misleading number.
- Extracted the gate + positional pairing into a testable `prepare_stt_judge_inputs()` helper, with a persona-2/5 shifted-turn regression test.

## Notes
- Text-alignment was ruled out: on cross-script data (Devanagari persona text vs romanized STT) the correct pairing scores lower than the wrong one, so edit-distance/DTW can't fix it.
- External runs now report no STT score at all (not a corrected one). Follow-up if needed: timing-based alignment or whole-conversation semantic scoring.
- The flaky `form_completed` judge on the same runs is untouched.