### PR TITLE
Reframe docs pitch: AI agents (text or voice), not voice-only

### DIFF
--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Overview"
-description: "Give your AI coding agents the tools and knowledge to evaluate voice agents on Calibrate through skills, MCP, CLI, or API"
+description: "Give your AI coding agents the tools and knowledge to evaluate AI agents on Calibrate through skills, MCP, CLI, or API"
 ---
 
 Calibrate meets your AI coding agent where it already works — Claude Code,

--- a/docs/agents/skills.mdx
+++ b/docs/agents/skills.mdx
@@ -4,7 +4,7 @@ description: "Install evaluation expertise into your AI coding agent — one com
 ---
 
 Agent skills are modular knowledge packages that teach your AI coding agent how
-to evaluate voice agents on Calibrate. They follow the open
+to evaluate AI agents on Calibrate. They follow the open
 [Agent Skills](https://agentskills.io) standard, so they work with Claude Code,
 Cursor, Codex, Windsurf, and other compatible agents.
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -5,7 +5,7 @@ description: "Command-line interface for evaluating AI agents"
 
 <Note>
   This is the **local** toolkit (`calibrate-agent`) for benchmarking STT, TTS,
-  and LLM providers and running voice-agent simulations on your own machine. For
+  and LLM providers and running agent simulations on your own machine. For
   the hosted CLI that runs agent tests against your deployed agents, see the
   [CLI](/cli/calibrate/overview) tab.
 </Note>

--- a/docs/core-concepts/agents.mdx
+++ b/docs/core-concepts/agents.mdx
@@ -5,9 +5,9 @@ description: "Create AI agents to evaluate and improve"
 
 An agent is a core building block of Calibrate. Agents can:
 
-- Process voice conversations using Speech To Text (STT) and Text To Speech (TTS)
 - Respond intelligently using LLM models following the instructions given to them
 - Use tools for structured data extraction
+- Process voice conversations using Speech To Text (STT) and Text To Speech (TTS)
 
 <Tip>
   Already have a deployed agent? You can connect it to Calibrate via its HTTP

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -3,7 +3,7 @@ title: "Introduction"
 description: "Learn about Calibrate and how to get started."
 ---
 
-[Calibrate](https://calibrate.artpark.ai) is an open-source evaluation framework for voice agents.
+[Calibrate](https://calibrate.artpark.ai) is an open-source evaluation platform for AI agents — text or voice.
 
 <iframe
   className="w-full aspect-video rounded-xl"
@@ -13,34 +13,28 @@ description: "Learn about Calibrate and how to get started."
   allowFullScreen
 ></iframe>
 
-Testing voice agents manually is slow, inconsistent, and doesn't scale. Voice agents require multiple components to work well together:
+Testing AI agents manually is slow, inconsistent, and doesn't scale. An agent has to reason about the user's intent against the context and purpose of the conversation, call the right tools with the right arguments in the right order, and generate the right next-turn response — turn after turn. Voice agents add more moving parts on top: transcribing speech accurately, producing natural-sounding replies, detecting turn ends, handling interruptions, keeping latency low, and coping with multiple languages, accents, and code-switching.
 
-- Transcribing the user's speech accurately and efficiently
-- Reasoning about the user's response against the context and purpose of the conversation
-- Calling the right tools with the right arguments in the right order
-- Generating the right next turn response
-- Producing natural-sounding speech back to the user
-- Detecting if the user has completed speaking or has taken a pause before speaking again
-- Handling interruptions by the user while the agent is speaking
-- Keeping the turnaround time low
-- Handling multiple languages, accents, dialects and code-switching
+There is no simple way to evaluate each of these across every provider on your own dataset. Even when individual pieces work well, it is hard to tell whether the agent as a whole will behave in production. This leads to many teams deploying with a lot of uncertainty and risk, and their users having to deal with poor experiences.
 
-and a lot more.
+Calibrate solves this by letting you evaluate the whole agent, whichever pieces it uses:
 
-There is no simple way to evaluate each component across all the providers on your own dataset. Even if individual components work well, it is hard to tell if the agent as a whole will work as expected when you deploy it to production. This leads to many teams deploying their agents with a lot of uncertainty and risk with their users having to deal with poor experiences.
+- `Text agents (LLMs)`: Evaluate the response quality and tool calling of your LLMs for multi-turn conversations, define custom evaluators, and find the best LLM for your agent
+- `Voice agents (STT & TTS)`: Benchmark speech-to-text and text-to-speech providers (Google, Sarvam, ElevenLabs and more) on your dataset across 10+ indic languages, using metrics optimised for agentic use cases
+- `Simulations`: Simulate realistic conversations using user personas and scenarios to surface failure modes — including interruptions — before you deploy
+- `Human alignment`: Collect human labels and iteratively align your LLM judges to them, so you can automate monitoring reliably
 
-Calibrate solves this problem by letting you evaluate your entire voice agent stack:
-
-- `Speech to Text (STT)`: Benchmark multiple providers (Google, Sarvam, ElevenLabs and more) on your dataset across 10+ indic languages using metrics optimised for agentic use cases
-- `Text to Speech (TTS)`: Benchmark generated speech by multiple providers automatically using an Audio LLM Judge across 10+ indic languages
-- `Text to Text (LLMs)`: Evaluate the response quality and tool calling of your LLMs for multi-turn conversations and find the best LLM for your agent
-- `Simulations`: Simulate realistic conversations using realistic user personas and scenarios to test failure modes for your agent including interruptions
-
-Calibrate helps you continuously improve your agent, ensure a bug never repeats itself and deploy your agent with confidence.
+Calibrate helps you continuously improve your agent, ensure a bug never repeats itself, and deploy with confidence.
 
 ## Get started
 
 <CardGroup cols={2}>
+  <Card title="LLM tests" icon="brain" href="/quickstart/text-to-text">
+    Create test suites that verify model responses and tool calling behavior
+  </Card>
+  <Card title="Simulations" icon="comments" href="/quickstart/simulations">
+    Simulate agent conversations with customizable personas and scenarios
+  </Card>
   <Card
     title="Speech to Text"
     icon="microphone"
@@ -48,18 +42,12 @@ Calibrate helps you continuously improve your agent, ensure a bug never repeats 
   >
     Compare transcription accuracy across multiple providers on your dataset
   </Card>
-  <Card title="LLM tests" icon="brain" href="/quickstart/text-to-text">
-    Create test suites that verify model responses and tool calling behavior
-  </Card>
   <Card
     title="Text to Speech"
     icon="volume-high"
     href="/quickstart/text-to-speech"
   >
     Benchmark generated audio quality across multiple providers
-  </Card>
-  <Card title="Simulations" icon="comments" href="/quickstart/simulations">
-    Simulate agent conversations with customizable personas and scenarios
   </Card>
 </CardGroup>
 

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -13,7 +13,22 @@ description: "Learn about Calibrate and how to get started."
   allowFullScreen
 ></iframe>
 
-Testing AI agents manually is slow, inconsistent, and doesn't scale. An agent has to reason about the user's intent against the context and purpose of the conversation, call the right tools with the right arguments in the right order, and generate the right next-turn response — turn after turn. Voice agents add more moving parts on top: transcribing speech accurately, producing natural-sounding replies, detecting turn ends, handling interruptions, keeping latency low, and coping with multiple languages, accents, and code-switching.
+Testing AI agents manually is slow, inconsistent, and doesn't scale. Every agent has to get several things right, turn after turn:
+
+- Reasoning about the user's intent against the context and purpose of the conversation
+- Calling the right tools with the right arguments in the right order
+- Generating the right next-turn response
+
+If you're building a **voice agent**, there are further challenges on top:
+
+- Transcribing the user's speech accurately and efficiently
+- Producing natural-sounding speech back to the user
+- Detecting when the user has finished speaking or has only paused
+- Handling interruptions while the agent is speaking
+- Keeping the turnaround time low
+- Handling multiple languages, accents, dialects and code-switching
+
+and a lot more.
 
 There is no simple way to evaluate each of these across every provider on your own dataset. Even when individual pieces work well, it is hard to tell whether the agent as a whole will behave in production. This leads to many teams deploying with a lot of uncertainty and risk, and their users having to deal with poor experiences.
 

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -17,7 +17,10 @@ Testing AI agents manually is slow, inconsistent, and doesn't scale. Every agent
 
 - Reasoning about the user's intent against the context and purpose of the conversation
 - Calling the right tools with the right arguments in the right order
-- Generating the right next-turn response
+- Generating the right response
+- Handling multiple languages and code-switching
+
+It can be hard to even define what "the right response" means.
 
 If you're building a **voice agent**, there are further challenges on top:
 
@@ -26,7 +29,7 @@ If you're building a **voice agent**, there are further challenges on top:
 - Detecting when the user has finished speaking or has only paused
 - Handling interruptions while the agent is speaking
 - Keeping the turnaround time low
-- Handling multiple languages, accents, dialects and code-switching
+- Handling varying accents and dialects
 
 and a lot more.
 
@@ -72,8 +75,17 @@ Calibrate helps you continuously improve your agent, ensure a bug never repeats 
   <Card title="Core Concepts" icon="book" href="/core-concepts/speech-to-text">
     Understand how Calibrate helps you evaluate effectively
   </Card>
-  <Card title="CLI" icon="terminal" href="/cli/overview">
-    Run evaluations from the command line
+  <Card title="Agents" icon="robot" href="/agents/overview">
+    Give your AI coding agent the skills to evaluate on Calibrate
+  </Card>
+  <Card title="CLI" icon="terminal" href="/cli/calibrate/overview">
+    Drive the full evaluation loop from your terminal
+  </Card>
+  <Card title="Python SDK" icon="python" href="/sdk/overview">
+    Script agents, tests, runs, and benchmarks from Python
+  </Card>
+  <Card title="MCP" icon="server" href="/mcp/overview">
+    Give your coding agent native Calibrate tools over MCP
   </Card>
   <Card title="Integrations" icon="plug" href="/integrations/stt">
     See all supported providers for different components


### PR DESCRIPTION
## What
- Landing page described Calibrate as a framework "for voice agents"; the website, SDK, calibrate-cli, and MCP server all position it as a general AI-agent platform with voice as one pillar. Reframed the pitch to "AI agents — text or voice".
- Added the Human alignment pillar (align LLM judges to human labels), which the intro omitted entirely, so the four pillars now match the website.
- Swapped "voice agents" → "AI agents" in three meta descriptions and reordered agent-capability bullets so LLM/tools lead.

## Notes
- Docs-only. Genuinely voice-specific pages (outbound-voice, TTS concepts) left untouched.