### PR TITLE
Docs: start new work in a new worktree when on main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 Guidance for Claude Code when working in this repository.
 
+> **⚠️ Start every new task in a new worktree when you're on `main`.** Before
+> beginning any new piece of work, check the current branch. If HEAD is on
+> `main`, create a dedicated worktree (and branch) for the task and do the work
+> there — never work or commit directly on `main`. If you're already on a
+> non-`main` branch/worktree scoped to the task, continue there.
+
 ## What this project is
 
 **Calibrate** (`calibrate-agent` on PyPI) is an open-source evaluation framework


### PR DESCRIPTION
## What changed

Adds a prominent callout to the top of `CLAUDE.md` instructing that any new task started while HEAD is on `main` must be done in a dedicated worktree (and branch), never directly on `main`. If already on a task-scoped non-`main` branch, continue there.

## Why

The repo already has a "if you're on `main`, branch first" rule buried in the committing/pushing section. Surfacing it at the top makes it the first thing seen when picking up new work, reducing the chance of accidentally working or committing directly on `main`.

## Notes for reviewer

Docs-only change — no code or test impact.