### PR TITLE
Push synced docs to main via bypass-listed GitHub App token

### DIFF
--- a/.github/workflows/sync-api-spec.yml
+++ b/.github/workflows/sync-api-spec.yml
@@ -28,8 +28,17 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Checkout Python SDK reference
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The sync-api-spec workflow pushes generated docs directly to \`main\` (\`git push origin HEAD:main\`). The repo ruleset on \`main\` requires changes go through a PR, and \`GITHUB_TOKEN\` pushes are evaluated as \`github-actions[bot]\` — which has no bypass — so the push failed with GH013 on every trigger (manual, schedule, and backend \`repository_dispatch\` alike).

Repo-level rulesets can't grant bypass to the built-in GitHub Actions integration (org-only, and org rulesets need GitHub Team). A GitHub App on the bypass list *is* allowed.

## Change

- Mint a token from a bypass-listed GitHub App (\`SYNC_APP_ID\` / \`SYNC_APP_PRIVATE_KEY\` secrets) via \`actions/create-github-app-token\`.
- Check out with that token so \`git push origin HEAD:main\` is attributed to the App and bypasses the PR rule.

## Required setup (done outside this PR)

- GitHub App created under the org with **Contents: Read & write**, installed on \`calibrate\`.
- App added to the \`main\` ruleset's **bypass list**.
- Repo secrets \`SYNC_APP_ID\` and \`SYNC_APP_PRIVATE_KEY\` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)