### PR TITLE
Clarify agent connection contract with a diagram

### DIFF
--- a/docs/core-concepts/agent-connections.mdx
+++ b/docs/core-concepts/agent-connections.mdx
@@ -15,7 +15,9 @@ If you already have a deployed agent, you can connect it to Calibrate and run ev
 Calibrate does not need to understand your whole agent. It needs a single HTTP
 endpoint that follows one contract:
 
-- **Request** — Calibrate `POST`s the conversation so far as a `messages` array.
+- **Request** — Calibrate sends a `POST` request whose body has a `messages`
+  array: the conversation so far, in OpenAI chat message format (each message is
+  a `{ "role", "content" }` object).
 - **Response** — your endpoint returns a JSON object with the agent's reply: a
   `response` string, and optionally `tool_calls`.
 
@@ -57,8 +59,9 @@ re-implemented or mocked.
 
 ### Request format
 
-Calibrate `POST`s to your endpoint with the full conversation history in
-chronological order:
+Calibrate sends a `POST` request to your endpoint. The body carries the full
+conversation history in chronological order, using the OpenAI chat message
+format:
 
 ```json
 {

--- a/docs/core-concepts/agent-connections.mdx
+++ b/docs/core-concepts/agent-connections.mdx
@@ -15,47 +15,10 @@ If you already have a deployed agent, you can connect it to Calibrate and run ev
 Calibrate does not need to understand your whole agent. It needs a single HTTP
 endpoint that follows one contract:
 
-- **Request** — Calibrate sends a `POST` request whose body has a `messages`
-  array: the conversation so far, in OpenAI chat message format (each message is
-  a `{ "role", "content" }` object).
-- **Response** — your endpoint returns a JSON object with the agent's reply: a
-  `response` string, and optionally `tool_calls`.
-
-Your agent does **not** have to be OpenAI-compatible, and you do **not** have to
-expose your production pipeline — all the custom preprocessing, routing,
-retrieval, and output formatting your agent does can stay exactly as it is.
-
-The insight is that however custom your agent's API looks on the outside, it
-almost always ends in an LLM call over a `messages` list. That LLM call is what
-Calibrate evaluates. So the job is just to expose *that inner call* as a thin
-endpoint Calibrate can reach:
-
-```mermaid
-flowchart LR
-    subgraph prod["Your production agent — any custom shape"]
-        direction TB
-        IN["Custom inputs<br/>(x1, x2, x3)"] --> PRE["Preprocess"]
-        PRE --> MSG["Build messages"]
-        MSG --> CORE["llm_inference(messages)"]
-        CORE --> POST["Transform output"]
-        POST --> OUT["Your agent's response"]
-    end
-
-    subgraph hook["Calibrate hook — thin wrapper"]
-        direction TB
-        REQ["messages<br/>(from Calibrate)"] --> CORE2["llm_inference(messages)"]
-        CORE2 --> RESP["{ response }"]
-    end
-
-    CORE -.->|"chat.completions"| LLM[("LLM / OpenAI-compatible API")]
-    CORE2 -.->|"chat.completions"| LLM
-    Cal["Calibrate"] ==>|"POST { messages }"| REQ
-    RESP ==>|"{ response }"| Cal
-```
-
-Both paths call the **same** `llm_inference(messages)` function, so the endpoint
-Calibrate tests is exactly the model logic your agent ships — nothing is
-re-implemented or mocked.
+- **Request** — Calibrate sends a `POST` request with the conversation history as a `messages`
+  array in the OpenAI chat message format.
+- **Response** — your endpoint returns a JSON object with the agent's reply as a
+  `response` string, and/or its tool calls as a `tool_calls` array.
 
 ### Request format
 
@@ -119,10 +82,10 @@ results view for review only, and never affects whether a test passes or fails:
   `tool_calls` field.
 </Warning>
 
-### Wrap your existing LLM call
+### Add a Calibrate endpoint to your agent
 
-Concretely, pull the model call out of your agent handler into a reusable
-function, then expose a second route that calls it directly.
+The change to your codebase: pull the model call out of your agent handler into a
+reusable function, then expose a new route that calls it directly.
 
 **Before** — the LLM call is buried inside your request handler:
 

--- a/docs/core-concepts/agent-connections.mdx
+++ b/docs/core-concepts/agent-connections.mdx
@@ -12,17 +12,16 @@ If you already have a deployed agent, you can connect it to Calibrate and run ev
 
 ## How the connection works
 
-Calibrate does not need to understand your whole agent. It only needs a single
-HTTP endpoint that speaks a simple **text-in / text-out** contract:
+Calibrate does not need to understand your whole agent. It needs a single HTTP
+endpoint that follows one contract:
 
-- **In** — a `messages` array (the conversation so far).
-- **Out** — a JSON object with a `response` text field (and optionally
-  `tool_calls`).
+- **Request** — Calibrate `POST`s the conversation so far as a `messages` array.
+- **Response** — your endpoint returns a JSON object with the agent's reply: a
+  `response` string, and optionally `tool_calls`.
 
-That's the entire contract. Your agent does **not** have to be
-OpenAI-compatible, and you do **not** have to expose your production pipeline —
-all the custom preprocessing, routing, retrieval, and output formatting your
-agent does can stay exactly as it is.
+Your agent does **not** have to be OpenAI-compatible, and you do **not** have to
+expose your production pipeline — all the custom preprocessing, routing,
+retrieval, and output formatting your agent does can stay exactly as it is.
 
 The insight is that however custom your agent's API looks on the outside, it
 almost always ends in an LLM call over a `messages` list. That LLM call is what
@@ -55,6 +54,67 @@ flowchart LR
 Both paths call the **same** `llm_inference(messages)` function, so the endpoint
 Calibrate tests is exactly the model logic your agent ships — nothing is
 re-implemented or mocked.
+
+### Request format
+
+Calibrate `POST`s to your endpoint with the full conversation history in
+chronological order:
+
+```json
+{
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Namaste! Main aapki kaise madad kar sakti hoon?"
+    },
+    { "role": "user", "content": "Meri beti ka vaccination schedule kya hai?" }
+  ]
+}
+```
+
+### Response format
+
+By default, your endpoint returns a `response` field containing the agent's text
+reply:
+
+```json
+{
+  "response": "Aapki beti ka agla vaccination 14 weeks pe hai — OPV aur DPT ke liye."
+}
+```
+
+If your agent also returns tool calls, expand the body to include a `tool_calls`
+array — each item has a `tool` name and an `arguments` object:
+
+```json
+{
+  "response": "Aapki beti ka agla vaccination 14 weeks pe hai — OPV aur DPT ke liye.",
+  "tool_calls": [
+    { "tool": "get_schedule", "arguments": { "child_age_weeks": 14 } }
+  ]
+}
+```
+
+Each tool call may also include an optional `output` field — the result the tool
+returned when your agent ran it. It can be any JSON value, is shown in the
+results view for review only, and never affects whether a test passes or fails:
+
+```json
+{
+  "tool_calls": [
+    {
+      "tool": "get_schedule",
+      "arguments": { "child_age_weeks": 14 },
+      "output": { "next_visit_weeks": 14, "vaccines": ["OPV", "DPT"] }
+    }
+  ]
+}
+```
+
+<Warning>
+  Your endpoint's output **must** include either a `response` field or a
+  `tool_calls` field.
+</Warning>
 
 ### Wrap your existing LLM call
 
@@ -114,9 +174,8 @@ def calibrate_test(body):
     return {"response": llm_inference(body["messages"])}
 ```
 
-You then point Calibrate at `POST /calibrate/test`. The sections below cover the
-exact request and response formats, how to add authentication, and how to verify
-the connection.
+You then point Calibrate at `POST /calibrate/test`, add any authentication
+headers your agent requires, and verify the connection — both covered below.
 
 ## Create an agent connection
 
@@ -145,70 +204,8 @@ Fill in the following:
 
 2. **Headers** (optional) — Add any headers your agent needs for authentication or custom metadata (e.g. `Authorization: Bearer YOUR_API_KEY`). Click **+ Add header** to add multiple headers.
 
-## Expected request format
-
-Calibrate will `POST` to your agent URL with this body:
-
-```json
-{
-  "messages": [
-    {
-      "role": "assistant",
-      "content": "Namaste! Main aapki kaise madad kar sakti hoon?"
-    },
-    { "role": "user", "content": "Meri beti ka vaccination schedule kya hai?" }
-  ]
-}
-```
-
-The `messages` array contains the full conversation history in chronological order.
-
-## Expected response format
-
-By default, your agent must respond with a `response` field containing its text reply:
-
-```json
-{
-  "response": "Aapki beti ka agla vaccination 14 weeks pe hai — OPV aur DPT ke liye."
-}
-```
-
-If your agent also returns tool calls, the expected output format expands to include `tool_calls`:
-
-```json
-{
-  "response": "Aapki beti ka agla vaccination 14 weeks pe hai — OPV aur DPT ke liye.",
-  "tool_calls": [
-    { "tool": "get_schedule", "arguments": { "child_age_weeks": 14 } }
-  ]
-}
-```
-
-- `response` — The agent's text reply
-- `tool_calls` — An array of tool invocations, each with a `tool` name and `arguments` object
-
-Each tool call may also include an optional `output` field — the result the
-tool returned when your agent ran it. It can be any JSON value:
-
-```json
-{
-  "tool_calls": [
-    {
-      "tool": "get_schedule",
-      "arguments": { "child_age_weeks": 14 },
-      "output": { "next_visit_weeks": 14, "vaccines": ["OPV", "DPT"] }
-    }
-  ]
-}
-```
-
-`output` is optional and shown in the results view for review only — it never
-affects whether a test passes or fails.
-
-<Warning>
-  Your agent's output **must** include either a `response` field or a
-  `tool_calls` field
-</Warning>
+The request and response formats your endpoint must follow are described in
+[How the connection works](#how-the-connection-works) above.
 
 ## Verify your connection
 

--- a/docs/core-concepts/agent-connections.mdx
+++ b/docs/core-concepts/agent-connections.mdx
@@ -82,7 +82,7 @@ results view for review only, and never affects whether a test passes or fails:
   `tool_calls` field.
 </Warning>
 
-### Add a Calibrate endpoint to your agent
+### Add a Calibrate endpoint
 
 Pull the model call out of your agent handler into a reusable function, then add
 a route that calls it directly. Your existing agent logic stays untouched:
@@ -102,8 +102,7 @@ def calibrate_test(body):
     return {"response": llm_inference(body["messages"])}
 ```
 
-Point Calibrate at `POST /calibrate/test`, add any auth headers your agent needs,
-and verify the connection — covered below.
+Point Calibrate at the new endpoint `POST /calibrate/test`, add any auth headers your agent needs, and verify the connection as shown below.
 
 ## Create an agent connection
 

--- a/docs/core-concepts/agent-connections.mdx
+++ b/docs/core-concepts/agent-connections.mdx
@@ -84,20 +84,58 @@ results view for review only, and never affects whether a test passes or fails:
 
 ### Add a Calibrate endpoint
 
-Pull the model call out of your agent handler into a reusable function, then add
-a route that calls it directly. Your existing agent logic stays untouched:
+The change to your codebase: pull the model call out of your agent handler into a
+reusable function, then expose a new route that calls it directly.
+
+**Before** — the LLM call is buried inside your request handler:
 
 ```python
-def llm_inference(messages):               # extract your existing model call
+def inference(x1, x2, x3):
+    y1 = preprocess(x1)
+    y2 = preprocess(x2)
+    y3 = preprocess(x3)
+
+    messages = [
+        {"role": "user", "content": "..."},
+        {"role": "assistant", "content": "..."},
+        {"role": "user", "content": "..."},
+    ]
+
+    response = client.chat.completions.create(messages=messages)  # buried here
+    return transform(response)
+
+@app.get("/agent")
+def agent():
+    return inference(x1, x2, x3)
+```
+
+**After** — the LLM call is modularized and re-used by a thin Calibrate route:
+
+```python
+def llm_inference(messages):
+    """The core model call — reused by both your agent and Calibrate."""
     response = client.chat.completions.create(messages=messages)
     return response.choices[0].message.content
 
-@app.get("/agent")                         # your agent — unchanged behavior
-def agent(x1, x2, x3):
-    messages = build_messages(preprocess(x1, x2, x3))
-    return transform(llm_inference(messages))
+def inference(x1, x2, x3):
+    y1 = preprocess(x1)
+    y2 = preprocess(x2)
+    y3 = preprocess(x3)
 
-@app.post("/calibrate/test")               # new: the endpoint Calibrate calls
+    messages = [
+        {"role": "user", "content": "..."},
+        {"role": "assistant", "content": "..."},
+        {"role": "user", "content": "..."},
+    ]
+
+    response = llm_inference(messages)   # same call, now shared
+    return transform(response)
+
+@app.get("/agent")
+def agent():
+    return inference(x1, x2, x3)
+
+@app.post("/calibrate/test")           # the endpoint you connect to Calibrate
 def calibrate_test(body):
     return {"response": llm_inference(body["messages"])}
 ```

--- a/docs/core-concepts/agent-connections.mdx
+++ b/docs/core-concepts/agent-connections.mdx
@@ -10,6 +10,114 @@ If you already have a deployed agent, you can connect it to Calibrate and run ev
   Calibrate, see [Core Concepts: Agents](/core-concepts/agents) instead.
 </Tip>
 
+## How the connection works
+
+Calibrate does not need to understand your whole agent. It only needs a single
+HTTP endpoint that speaks a simple **text-in / text-out** contract:
+
+- **In** — a `messages` array (the conversation so far).
+- **Out** — a JSON object with a `response` text field (and optionally
+  `tool_calls`).
+
+That's the entire contract. Your agent does **not** have to be
+OpenAI-compatible, and you do **not** have to expose your production pipeline —
+all the custom preprocessing, routing, retrieval, and output formatting your
+agent does can stay exactly as it is.
+
+The insight is that however custom your agent's API looks on the outside, it
+almost always ends in an LLM call over a `messages` list. That LLM call is what
+Calibrate evaluates. So the job is just to expose *that inner call* as a thin
+endpoint Calibrate can reach:
+
+```mermaid
+flowchart LR
+    subgraph prod["Your production agent — any custom shape"]
+        direction TB
+        IN["Custom inputs<br/>(x1, x2, x3)"] --> PRE["Preprocess"]
+        PRE --> MSG["Build messages"]
+        MSG --> CORE["llm_inference(messages)"]
+        CORE --> POST["Transform output"]
+        POST --> OUT["Your agent's response"]
+    end
+
+    subgraph hook["Calibrate hook — thin wrapper"]
+        direction TB
+        REQ["messages<br/>(from Calibrate)"] --> CORE2["llm_inference(messages)"]
+        CORE2 --> RESP["{ response }"]
+    end
+
+    CORE -.->|"chat.completions"| LLM[("LLM / OpenAI-compatible API")]
+    CORE2 -.->|"chat.completions"| LLM
+    Cal["Calibrate"] ==>|"POST { messages }"| REQ
+    RESP ==>|"{ response }"| Cal
+```
+
+Both paths call the **same** `llm_inference(messages)` function, so the endpoint
+Calibrate tests is exactly the model logic your agent ships — nothing is
+re-implemented or mocked.
+
+### Wrap your existing LLM call
+
+Concretely, pull the model call out of your agent handler into a reusable
+function, then expose a second route that calls it directly.
+
+**Before** — the LLM call is buried inside your request handler:
+
+```python
+def inference(x1, x2, x3):
+    y1 = preprocess(x1)
+    y2 = preprocess(x2)
+    y3 = preprocess(x3)
+
+    messages = [
+        {"role": "user", "content": "..."},
+        {"role": "assistant", "content": "..."},
+        {"role": "user", "content": "..."},
+    ]
+
+    response = client.chat.completions.create(messages=messages)  # buried here
+    return transform(response)
+
+@app.get("/agent")
+def agent():
+    return inference(x1, x2, x3)
+```
+
+**After** — the LLM call is modularized and re-used by a thin Calibrate route:
+
+```python
+def llm_inference(messages):
+    """The core model call — reused by both your agent and Calibrate."""
+    response = client.chat.completions.create(messages=messages)
+    return response.choices[0].message.content
+
+def inference(x1, x2, x3):
+    y1 = preprocess(x1)
+    y2 = preprocess(x2)
+    y3 = preprocess(x3)
+
+    messages = [
+        {"role": "user", "content": "..."},
+        {"role": "assistant", "content": "..."},
+        {"role": "user", "content": "..."},
+    ]
+
+    response = llm_inference(messages)   # same call, now shared
+    return transform(response)
+
+@app.get("/agent")
+def agent():
+    return inference(x1, x2, x3)
+
+@app.post("/calibrate/test")           # the endpoint you connect to Calibrate
+def calibrate_test(body):
+    return {"response": llm_inference(body["messages"])}
+```
+
+You then point Calibrate at `POST /calibrate/test`. The sections below cover the
+exact request and response formats, how to add authentication, and how to verify
+the connection.
+
 ## Create an agent connection
 
 From the sidebar, click **Agents** → **New agent**. Select **Connect your existing agent**, give it a name, and click **Create**.

--- a/docs/core-concepts/agent-connections.mdx
+++ b/docs/core-concepts/agent-connections.mdx
@@ -84,64 +84,26 @@ results view for review only, and never affects whether a test passes or fails:
 
 ### Add a Calibrate endpoint to your agent
 
-The change to your codebase: pull the model call out of your agent handler into a
-reusable function, then expose a new route that calls it directly.
-
-**Before** — the LLM call is buried inside your request handler:
+Pull the model call out of your agent handler into a reusable function, then add
+a route that calls it directly. Your existing agent logic stays untouched:
 
 ```python
-def inference(x1, x2, x3):
-    y1 = preprocess(x1)
-    y2 = preprocess(x2)
-    y3 = preprocess(x3)
-
-    messages = [
-        {"role": "user", "content": "..."},
-        {"role": "assistant", "content": "..."},
-        {"role": "user", "content": "..."},
-    ]
-
-    response = client.chat.completions.create(messages=messages)  # buried here
-    return transform(response)
-
-@app.get("/agent")
-def agent():
-    return inference(x1, x2, x3)
-```
-
-**After** — the LLM call is modularized and re-used by a thin Calibrate route:
-
-```python
-def llm_inference(messages):
-    """The core model call — reused by both your agent and Calibrate."""
+def llm_inference(messages):               # extract your existing model call
     response = client.chat.completions.create(messages=messages)
     return response.choices[0].message.content
 
-def inference(x1, x2, x3):
-    y1 = preprocess(x1)
-    y2 = preprocess(x2)
-    y3 = preprocess(x3)
+@app.get("/agent")                         # your agent — unchanged behavior
+def agent(x1, x2, x3):
+    messages = build_messages(preprocess(x1, x2, x3))
+    return transform(llm_inference(messages))
 
-    messages = [
-        {"role": "user", "content": "..."},
-        {"role": "assistant", "content": "..."},
-        {"role": "user", "content": "..."},
-    ]
-
-    response = llm_inference(messages)   # same call, now shared
-    return transform(response)
-
-@app.get("/agent")
-def agent():
-    return inference(x1, x2, x3)
-
-@app.post("/calibrate/test")           # the endpoint you connect to Calibrate
+@app.post("/calibrate/test")               # new: the endpoint Calibrate calls
 def calibrate_test(body):
     return {"response": llm_inference(body["messages"])}
 ```
 
-You then point Calibrate at `POST /calibrate/test`, add any authentication
-headers your agent requires, and verify the connection — both covered below.
+Point Calibrate at `POST /calibrate/test`, add any auth headers your agent needs,
+and verify the connection — covered below.
 
 ## Create an agent connection
 


### PR DESCRIPTION
## What
- Add a "How the connection works" section to the agent connections doc: reframes the contract as simple text-in (`messages`) / text-out (`response`), and states the agent need not be OpenAI-compatible or expose its full pipeline.
- Add a Mermaid diagram showing the production path and the Calibrate hook sharing one `llm_inference(messages)` core.
- Add a before/after refactor showing how to expose that inner LLM call as a thin `/calibrate/test` endpoint.

## Notes
- Docs only; renders via Mintlify's native Mermaid support (no image assets committed). Not previewed live.