### PR TITLE
Show all named request examples on SDK & CLI reference pages

### DIFF
--- a/docs/core-concepts/agent-connections.mdx
+++ b/docs/core-concepts/agent-connections.mdx
@@ -38,6 +38,8 @@ format:
 }
 ```
 
+The request may also carry an optional `model` field. Calibrate adds it only when you [benchmark across models](#enable-benchmarking-across-models), so your endpoint knows which model to run for that request. Handle it only if your agent is set up to switch models from that input; otherwise ignore it.
+
 ### Response format
 
 By default, your endpoint returns a `response` field containing the agent's text
@@ -169,6 +171,8 @@ Fill in the following:
 
 2. **Headers** (optional) — Add any headers your agent needs for authentication or custom metadata (e.g. `Authorization: Bearer YOUR_API_KEY`). Click **+ Add header** to add multiple headers.
 
+3. **Support benchmarking different models** (optional) — Turn this on if your agent can switch LLMs from the request `model` field, then pick your **Model provider**. The provider sets the format Calibrate sends in `model`: for OpenRouter it's provider-prefixed (e.g. `openai/gpt-4.1`), for OpenAI it's bare (e.g. `gpt-4.1`). In the API/SDK this is the `benchmark_provider` field on the agent config. See [Enable benchmarking across models](#enable-benchmarking-across-models) for the full flow.
+
 The request and response formats your endpoint must follow are described in
 [How the connection works](#how-the-connection-works) above.
 
@@ -229,7 +233,7 @@ When enabled:
 }
 ```
 
-Depending on the provider you have selected, the format of the `model` field will be different. For example, if you have selected `OpenRouter`, the `model` field will be `openrouter/gpt-4.1`. If you have selected OpenAI, the `model` field will just be `gpt-4.1`.
+Depending on the provider you have selected, the format of the `model` field will be different. For example, if you have selected `OpenRouter`, the `model` field is provider-prefixed (e.g. `openai/gpt-4.1`). If you have selected OpenAI, the `model` field will just be `gpt-4.1`.
 
 3. When running a benchmark via **Compare models**, Calibrate will verify the connection for each selected model before starting the evaluation. See [this](/quickstart/text-to-text#verifying-agent-connection) for details.
 

--- a/scripts/fetch_public_openapi.py
+++ b/scripts/fetch_public_openapi.py
@@ -103,7 +103,6 @@ def _normalize_for_docs(spec: dict[str, Any], base_url: str) -> dict[str, Any]:
             if not isinstance(op, dict):
                 continue
             op["security"] = [{API_KEY_SCHEME: []}]
-            op.pop("x-codeSamples", None)
             params = op.get("parameters")
             if params:
                 op["parameters"] = [

--- a/scripts/generate_cli_docs.py
+++ b/scripts/generate_cli_docs.py
@@ -45,7 +45,12 @@ from docs_mdx import escape_mdx_prose as _escape_mdx_prose  # noqa: E402
 from docs_mdx import frontmatter_value as _frontmatter_value  # noqa: E402
 from docs_mdx import table_cell as _table_cell  # noqa: E402
 from docs_nav import insert_tab  # noqa: E402
-from sdk_reference import api_group_from_tag  # noqa: E402
+from request_examples import (  # noqa: E402
+    NamedExample,
+    named_request_examples,
+    render_cli_snippet,
+)
+from sdk_reference import api_group_from_tag, load_route_map  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DOCS_ROOT = REPO_ROOT / "docs"
@@ -140,22 +145,92 @@ def _synopsis_lines(cmd: CliCommand) -> list[str]:
     return []
 
 
-def _command_body(cmd: CliCommand) -> list[str]:
-    """Usage block + options table + examples for a single command."""
+def _command_key(command: str) -> str:
+    """Normalize a command path for matching a CLI command to an SDK route.
+
+    ``calibrate agents create`` -> ``agents create``; hyphens and underscores are
+    unified (Fern uses ``agent_tests``, Cobra ``agent-tests``) so the two naming
+    conventions — kept in lockstep by the backend overlays — compare equal.
+    """
+    parts = command.split()
+    tail = parts[1:] if parts and parts[0] == "calibrate" else parts
+    return " ".join(tail).replace("_", "-").lower()
+
+
+def _examples_by_command(openapi: dict) -> dict[str, list[NamedExample]]:
+    """Map each CLI command to its operation's ≥2 named request examples.
+
+    Reuses the Fern route map (path + SDK group/method) to bridge a CLI command
+    to its spec operation, since the SDK and CLI naming overlays are kept 1:1.
+    Best-effort: if the Fern overrides aren't available (they live in the backend
+    repo, present during the sync workflow), returns ``{}`` and the CLI pages
+    fall back to Cobra's own Examples block.
+    """
+    try:
+        routes = load_route_map(openapi=openapi)
+    except SystemExit:
+        return {}
+    result: dict[str, list[NamedExample]] = {}
+    for route in routes:
+        op = openapi.get("paths", {}).get(route.path, {}).get(route.http.lower(), {})
+        examples = named_request_examples(op) if isinstance(op, dict) else []
+        if len(examples) >= 2:
+            key = f"{route.sdk_group} {route.sdk_method}".replace("_", "-").lower()
+            result[key] = examples
+    return result
+
+
+def _spec_examples_block(cmd: CliCommand, examples: list[NamedExample]) -> list[str]:
+    """Render one labelled `bash` invocation per named request variant."""
+    options = parse_options(cmd.options)
+    lines = ["**Examples**", ""]
+    for example in examples:
+        lines += [
+            f"_{example.summary}_",
+            "",
+            "```bash",
+            render_cli_snippet(cmd.command, options, example.value),
+            "```",
+            "",
+        ]
+    return lines
+
+
+def _command_body(
+    cmd: CliCommand,
+    spec_examples: list[NamedExample] | None = None,
+) -> list[str]:
+    """Usage block + options table + examples for a single command.
+
+    When the spec supplies ≥2 named request examples for this command they
+    replace Cobra's single (often empty) Examples block, so distinct request
+    shapes stay visible on the CLI page.
+    """
     lines: list[str] = []
     if cmd.usage:
         lines += ["```bash", cmd.usage.strip(), "```", ""]
     table = _options_table(parse_options(cmd.options))
     if table:
         lines += ["**Options**", "", table, ""]
-    if cmd.examples:
+    if spec_examples:
+        lines += _spec_examples_block(cmd, spec_examples)
+    elif cmd.examples:
         lines += ["**Examples**", "", "```bash", cmd.examples.strip(), "```", ""]
     return lines
 
 
-def _subcommand_section(cmd: CliCommand) -> list[str]:
+def _subcommand_section(
+    cmd: CliCommand,
+    examples_by_command: dict[str, list[NamedExample]] | None = None,
+) -> list[str]:
     heading = cmd.short.strip() or cmd.subcommand
-    return [f"## {heading}", "", *_synopsis_lines(cmd), *_command_body(cmd)]
+    spec_examples = (examples_by_command or {}).get(_command_key(cmd.command))
+    return [
+        f"## {heading}",
+        "",
+        *_synopsis_lines(cmd),
+        *_command_body(cmd, spec_examples),
+    ]
 
 
 def _frontmatter(title: str, description: str) -> list[str]:
@@ -171,18 +246,30 @@ def _frontmatter(title: str, description: str) -> list[str]:
 
 
 def render_resource_page(
-    title: str, parent: CliCommand | None, subcommands: list[CliCommand]
+    title: str,
+    parent: CliCommand | None,
+    subcommands: list[CliCommand],
+    examples_by_command: dict[str, list[NamedExample]] | None = None,
 ) -> str:
     """A resource page — straight into one ## section per subcommand (no preamble)."""
     lines = _frontmatter(title, parent.short if parent else "")
     for cmd in subcommands:
-        lines += _subcommand_section(cmd)
+        lines += _subcommand_section(cmd, examples_by_command)
     return "\n".join(lines).rstrip("\n") + "\n"
 
 
-def render_leaf_page(title: str, cmd: CliCommand) -> str:
+def render_leaf_page(
+    title: str,
+    cmd: CliCommand,
+    examples_by_command: dict[str, list[NamedExample]] | None = None,
+) -> str:
     """A standalone command (no subcommands) rendered as a single page."""
-    lines = _frontmatter(title, cmd.short) + _synopsis_lines(cmd) + _command_body(cmd)
+    spec_examples = (examples_by_command or {}).get(_command_key(cmd.command))
+    lines = (
+        _frontmatter(title, cmd.short)
+        + _synopsis_lines(cmd)
+        + _command_body(cmd, spec_examples)
+    )
     return "\n".join(lines).rstrip("\n") + "\n"
 
 
@@ -385,6 +472,15 @@ def generate_cli_docs(
     tags = include_tags if include_tags is not None else api_tags(openapi_path)
     tag_by_key = {_match_key(t): t for t in tags} if tags is not None else None
 
+    # Spec-derived request examples, keyed by CLI command. Best-effort: a missing
+    # or unreadable spec just means Cobra's own Examples blocks are used.
+    examples_by_command: dict[str, list[NamedExample]] = {}
+    try:
+        spec = json.loads(Path(openapi_path).read_text(encoding="utf-8"))
+        examples_by_command = _examples_by_command(spec)
+    except (OSError, ValueError):
+        pass
+
     # Decide what to document first, WITHOUT writing anything.
     selected: list[str] = []
     matched_tags: set[str] = set()
@@ -412,9 +508,13 @@ def generate_cli_docs(
         title = resource_title(res)
         subs = _ordered_subs(entry["subs"], subcommand_order(entry["parent"]))
         if subs:
-            content = render_resource_page(title, entry["parent"], subs)
+            content = render_resource_page(
+                title, entry["parent"], subs, examples_by_command
+            )
         elif entry["parent"] is not None:
-            content = render_leaf_page(title, entry["parent"])
+            content = render_leaf_page(
+                title, entry["parent"], examples_by_command
+            )
         else:
             continue
         slug = resource_slug(res)

--- a/scripts/generate_cli_docs.py
+++ b/scripts/generate_cli_docs.py
@@ -47,6 +47,7 @@ from docs_mdx import table_cell as _table_cell  # noqa: E402
 from docs_nav import insert_tab  # noqa: E402
 from request_examples import (  # noqa: E402
     NamedExample,
+    learn_more_markdown,
     named_request_examples,
     render_cli_snippet,
 )
@@ -193,6 +194,9 @@ def _spec_examples_block(cmd: CliCommand, examples: list[NamedExample]) -> list[
             "```",
             "",
         ]
+    note = learn_more_markdown(_command_key(cmd.command))
+    if note:
+        lines += [note, ""]
     return lines
 
 

--- a/scripts/generate_sdk_docs.py
+++ b/scripts/generate_sdk_docs.py
@@ -8,6 +8,11 @@ from pathlib import Path
 from typing import Any
 
 from docs_nav import insert_tab
+from request_examples import (
+    NamedExample,
+    named_request_examples,
+    render_python_snippet,
+)
 from sdk_reference import (
     SdkMethodDoc,
     SdkRoute,
@@ -44,7 +49,35 @@ def _split_description(description: str) -> tuple[str, str]:
     return summary, body
 
 
-def render_method_page(route: SdkRoute, doc: SdkMethodDoc) -> str:
+def _render_examples_section(
+    route: SdkRoute, examples: list[NamedExample]
+) -> list[str]:
+    """Render an `## Examples` block, one labelled snippet per named variant.
+
+    Only emitted when the operation has ≥2 named request examples — a single
+    example is already the Usage block, so repeating it adds nothing. Keeps every
+    distinct request shape (build-in-Calibrate vs. connect-external) visible on
+    the SDK page instead of only Fern's first-example Usage snippet.
+    """
+    if len(examples) < 2:
+        return []
+    parts = ["## Examples\n\n"]
+    for example in examples:
+        parts.append(f"**{_mdx_escape(example.summary)}**\n\n")
+        if example.description:
+            parts.append(f"{_mdx_escape(example.description)}\n\n")
+        snippet = render_python_snippet(
+            route.sdk_group, route.sdk_method, example.value
+        )
+        parts.append(f"```python\n{snippet}\n```\n\n")
+    return parts
+
+
+def render_method_page(
+    route: SdkRoute,
+    doc: SdkMethodDoc,
+    examples: list[NamedExample] | None = None,
+) -> str:
     api_page = _mdx_escape(route.mintlify_api_page)
     api_callout = (
         f"See **{api_page}** in the "
@@ -70,6 +103,11 @@ def render_method_page(route: SdkRoute, doc: SdkMethodDoc) -> str:
         [
             "## Usage\n\n",
             f"```python\n{doc.usage_code.rstrip()}\n```\n\n",
+        ]
+    )
+    parts.extend(_render_examples_section(route, examples or []))
+    parts.extend(
+        [
             "## API endpoint\n\n",
             f"{api_callout}\n",
         ]
@@ -77,14 +115,25 @@ def render_method_page(route: SdkRoute, doc: SdkMethodDoc) -> str:
     return "".join(parts)
 
 
+def _examples_for_route(
+    route: SdkRoute, openapi: dict[str, Any]
+) -> list[NamedExample]:
+    op = openapi.get("paths", {}).get(route.path, {}).get(route.http.lower(), {})
+    return named_request_examples(op) if isinstance(op, dict) else []
+
+
 def write_sdk_pages(
     paired: list[tuple[SdkRoute, SdkMethodDoc]],
+    openapi: dict[str, Any],
 ) -> list[str]:
     written: list[str] = []
     for route, doc in paired:
         out = SDK_ROOT / route.sdk_group.replace("_", "-") / f"{route.sdk_method}.mdx"
         out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(render_method_page(route, doc), encoding="utf-8")
+        examples = _examples_for_route(route, openapi)
+        out.write_text(
+            render_method_page(route, doc, examples), encoding="utf-8"
+        )
         written.append(route.doc_slug)
     return written
 
@@ -166,7 +215,7 @@ def generate_sdk_docs(reference_path: Path, openapi: dict[str, Any]) -> list[str
     methods = parse_reference_file(reference_path)
     paired = routes_with_sdk_docs(routes, methods)
     copy_overview()
-    written = write_sdk_pages(paired)
+    written = write_sdk_pages(paired, openapi)
     update_docs_json(routes, paired)
     return ["sdk/overview", *written]
 

--- a/scripts/generate_sdk_docs.py
+++ b/scripts/generate_sdk_docs.py
@@ -10,6 +10,8 @@ from typing import Any
 from docs_nav import insert_tab
 from request_examples import (
     NamedExample,
+    command_key,
+    learn_more_markdown,
     named_request_examples,
     render_python_snippet,
 )
@@ -70,6 +72,9 @@ def _render_examples_section(
             route.sdk_group, route.sdk_method, example.value
         )
         parts.append(f"```python\n{snippet}\n```\n\n")
+    note = learn_more_markdown(command_key(route.sdk_group, route.sdk_method))
+    if note:
+        parts.append(f"{note}\n\n")
     return parts
 
 

--- a/scripts/request_examples.py
+++ b/scripts/request_examples.py
@@ -157,6 +157,33 @@ def _flag_for(field: str, options: list[Any]) -> str:
     return exact
 
 
+# Optional "learn more" pointer rendered under an operation's Examples section,
+# keyed by the normalized ``<group> <method>`` command (see ``command_key``).
+# Kept per-operation so a link only shows where it's relevant — the Examples
+# section itself is generic across any multi-example endpoint.
+LEARN_MORE_LINKS: dict[str, tuple[str, str]] = {
+    "agents create": ("Agent connections", "/core-concepts/agent-connections"),
+}
+
+
+def command_key(group: str, method: str) -> str:
+    """Normalize an SDK/CLI ``group``/``method`` pair to a lookup key.
+
+    Hyphens and underscores are unified and the result lowercased so the Fern
+    (``agent_tests``) and Cobra (``agent-tests``) naming conventions collide.
+    """
+    return f"{group} {method}".replace("_", "-").lower()
+
+
+def learn_more_markdown(key: str) -> str | None:
+    """Return a one-line Markdown "learn more" pointer for ``key``, or None."""
+    link = LEARN_MORE_LINKS.get(key)
+    if not link:
+        return None
+    label, url = link
+    return f"For more details, see [{label}]({url})."
+
+
 def render_cli_snippet(command: str, options: list[Any], value: Any) -> str:
     """Render one example body as a ``calibrate …`` invocation.
 

--- a/scripts/request_examples.py
+++ b/scripts/request_examples.py
@@ -1,0 +1,170 @@
+"""Render a route's *named* request-body examples as SDK / CLI snippets.
+
+The public OpenAPI spec carries one or more named request examples per operation
+(the backend declares them via FastAPI ``Body(openapi_examples=…)``). Fern and
+Speakeasy each feature only the *first* one, so an operation with genuinely
+distinct variants — e.g. building an agent inside Calibrate vs. connecting an
+external HTTP agent — loses that distinction on the generated SDK and CLI pages.
+
+These helpers re-render *every* named example straight from the same spec, so the
+SDK/CLI pages can show all variants with the OpenAPI spec as the single source of
+truth (no example body is hand-copied into the docs repo). They are intentionally
+generic: any operation that grows a second named example gets the treatment for
+free.
+
+Pure functions, no I/O — the generators own reading the spec and writing pages.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class NamedExample:
+    """One entry of an operation's request-body ``examples`` map."""
+
+    key: str          # the map key, e.g. "openai_compatible_connection"
+    summary: str      # human label; falls back to the key
+    description: str  # optional prose shown above the snippet
+    value: Any        # the example request body
+
+
+def named_request_examples(op: dict[str, Any]) -> list[NamedExample]:
+    """Extract the JSON request body's named ``examples`` from an operation.
+
+    Returns them in spec order. Empty when the op has no request body, no
+    ``examples`` map, or only entries missing a ``value`` — callers use the
+    count to decide whether a multi-variant section is worth rendering.
+    """
+    content = (op.get("requestBody") or {}).get("content") or {}
+    body = content.get("application/json") or {}
+    examples = body.get("examples") or {}
+    result: list[NamedExample] = []
+    for key, entry in examples.items():
+        if not isinstance(entry, dict) or "value" not in entry:
+            continue
+        result.append(
+            NamedExample(
+                key=key,
+                summary=(entry.get("summary") or key).strip(),
+                description=(entry.get("description") or "").strip(),
+                value=entry["value"],
+            )
+        )
+    return result
+
+
+def _py_literal(value: Any, indent: int = 0) -> str:
+    """Format a JSON-decoded value as a Python literal (double-quoted, indented).
+
+    Mirrors the style of Fern's own usage snippets (``True``/``None``,
+    double-quoted keys) so the generated Examples section reads identically to
+    the Usage block above it.
+    """
+    pad = "    " * indent
+    child = "    " * (indent + 1)
+    if isinstance(value, dict):
+        if not value:
+            return "{}"
+        items = list(value.items())
+        lines = ["{"]
+        for i, (k, v) in enumerate(items):
+            comma = "," if i < len(items) - 1 else ""
+            lines.append(f"{child}{json.dumps(k)}: {_py_literal(v, indent + 1)}{comma}")
+        lines.append(pad + "}")
+        return "\n".join(lines)
+    if isinstance(value, list):
+        if not value:
+            return "[]"
+        lines = ["["]
+        for i, item in enumerate(value):
+            comma = "," if i < len(value) - 1 else ""
+            lines.append(f"{child}{_py_literal(item, indent + 1)}{comma}")
+        lines.append(pad + "]")
+        return "\n".join(lines)
+    # bool must precede the numeric fallthrough — bool is a subclass of int.
+    if isinstance(value, bool):
+        return "True" if value else "False"
+    if value is None:
+        return "None"
+    return json.dumps(value)  # str -> double-quoted; int/float -> bare
+
+
+def render_python_snippet(sdk_group: str, sdk_method: str, value: Any) -> str:
+    """Render one example body as a ``client.<group>.<method>(…)`` call.
+
+    A top-level object becomes keyword arguments (one per line); anything else is
+    passed as a single positional argument.
+    """
+    call = f"client.{sdk_group}.{sdk_method}"
+    if not isinstance(value, dict):
+        return f"{call}({_py_literal(value)})"
+    if not value:
+        return f"{call}()"
+    lines = [f"{call}("]
+    for key, val in value.items():
+        lines.append(f"    {key}={_py_literal(val, 1)},")
+    lines.append(")")
+    return "\n".join(lines)
+
+
+def _cli_value(value: Any) -> str:
+    """Format one flag value for a shell command.
+
+    Objects/arrays are emitted as single-quoted compact JSON (the shape the
+    Speakeasy CLI expects for a JSON-string flag); scalars are shell-quoted.
+    """
+    if isinstance(value, (dict, list)):
+        return "'" + json.dumps(value, separators=(",", ":")) + "'"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return '""'
+    if isinstance(value, str):
+        return json.dumps(value)  # double-quoted, escaped
+    return json.dumps(value)
+
+
+def _flag_for(field: str, options: list[Any]) -> str:
+    """Resolve a body field name to its CLI flag using the command's options.
+
+    Prefers an exact ``--<field>`` long flag, then a long flag that starts with
+    or contains the field name (Speakeasy renames e.g. ``config`` to
+    ``--config-param``). Falls back to ``--<field>`` when nothing matches.
+    """
+    def long_flags(opt: Any) -> list[str]:
+        return [
+            token.strip()
+            for token in opt.flag.split(",")
+            if token.strip().startswith("--")
+        ]
+
+    exact = f"--{field}"
+    for opt in options:
+        if exact in long_flags(opt):
+            return exact
+    for opt in options:
+        for lf in long_flags(opt):
+            if lf[2:].startswith(field):
+                return lf
+    for opt in options:
+        for lf in long_flags(opt):
+            if field in lf[2:]:
+                return lf
+    return exact
+
+
+def render_cli_snippet(command: str, options: list[Any], value: Any) -> str:
+    """Render one example body as a ``calibrate …`` invocation.
+
+    ``command`` is the full command (``calibrate agents create``); ``options``
+    are the command's parsed flags (used to map body fields to flag names).
+    Non-object bodies are skipped by the caller, so this expects a dict.
+    """
+    parts = [command]
+    for field, val in value.items():
+        parts.append(f"{_flag_for(field, options)} {_cli_value(val)}")
+    return " \\\n  ".join(parts)

--- a/tests/test_fetch_public_openapi.py
+++ b/tests/test_fetch_public_openapi.py
@@ -130,12 +130,13 @@ def test_render_method_page_escapes_quotes_in_frontmatter() -> None:
     assert 'description: "Rename the agent to \\"production\\"."' in page
 
 
-def test_normalize_strips_x_code_samples(minimal_spec: dict) -> None:
-    minimal_spec["paths"]["/agents"]["get"]["x-codeSamples"] = [
-        {"lang": "python", "source": "from calibrate import Calibrate\n"}
-    ]
+def test_normalize_preserves_x_code_samples(minimal_spec: dict) -> None:
+    # Mintlify renders x-codeSamples as the request code panel, so the backend's
+    # per-operation samples must survive normalization into the docs spec.
+    samples = [{"lang": "python", "source": "from calibrate import Calibrate\n"}]
+    minimal_spec["paths"]["/agents"]["get"]["x-codeSamples"] = samples
     out = _normalize_for_docs(minimal_spec, TEST_BASE_URL)
-    assert "x-codeSamples" not in out["paths"]["/agents"]["get"]
+    assert out["paths"]["/agents"]["get"]["x-codeSamples"] == samples
 
 
 def test_render_templates_substitutes_base_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_generate_cli_docs.py
+++ b/tests/test_generate_cli_docs.py
@@ -436,3 +436,102 @@ def test_generate_fails_hard_on_unmatched_tag(tmp_path: Path, capsys) -> None:
     # nothing is written on failure — the docs are left untouched
     assert not (output_root / "widgets.mdx").exists()
     assert not (output_root / "overview.mdx").exists()
+
+
+# --------------------------------------------------------------------------- #
+# spec-derived request examples (connect-vs-create)
+# --------------------------------------------------------------------------- #
+def _spec_two_examples() -> dict:
+    return {
+        "paths": {
+            "/agents": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "examples": {
+                                    "build": {
+                                        "summary": "Agent within Calibrate",
+                                        "value": {"name": "Support Agent", "type": "agent"},
+                                    },
+                                    "connect": {
+                                        "summary": "Connect external agent",
+                                        "value": {
+                                            "name": "My Hosted Agent",
+                                            "type": "connection",
+                                            "config": {"agent_url": "https://x.example.com/v1"},
+                                        },
+                                    },
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        }
+    }
+
+
+def test_examples_by_command_maps_via_route_map() -> None:
+    overrides = {
+        "paths": {"/agents": {"post": {
+            "x-fern-sdk-group-name": "agents",
+            "x-fern-sdk-method-name": "create",
+        }}}
+    }
+    from sdk_reference import build_route_map
+
+    spec = _spec_two_examples()
+    spec["paths"]["/agents"]["post"]["tags"] = ["agents"]
+    # Route map bridges the CLI command to the op; key is the normalized command.
+    routes = build_route_map(overrides, spec)
+    assert routes  # sanity: the override resolves
+
+    # _examples_by_command loads overrides from disk; exercise the pure mapping
+    # by monkeypatching load_route_map to the in-memory route map.
+    import generate_cli_docs as gcd
+
+    orig = gcd.load_route_map
+    gcd.load_route_map = lambda openapi=None: routes
+    try:
+        mapping = gcd._examples_by_command(spec)
+    finally:
+        gcd.load_route_map = orig
+    assert set(mapping) == {"agents create"}
+    assert [e.summary for e in mapping["agents create"]] == [
+        "Agent within Calibrate",
+        "Connect external agent",
+    ]
+
+
+def test_subcommand_section_injects_spec_examples() -> None:
+    from cli_reference import CliCommand
+    from generate_cli_docs import _subcommand_section
+    from request_examples import named_request_examples
+
+    cmd = CliCommand(
+        command="calibrate agents create",
+        short="Create agent",
+        options="  --name string\n  --type type\n  -c, --config-param type",
+        examples="calibrate agents create",  # Cobra's minimal block
+    )
+    examples = named_request_examples(_spec_two_examples()["paths"]["/agents"]["post"])
+    section = "\n".join(_subcommand_section(cmd, {"agents create": examples}))
+    assert "_Agent within Calibrate_" in section
+    assert "_Connect external agent_" in section
+    assert "--config-param '{\"agent_url\":\"https://x.example.com/v1\"}'" in section
+    # Spec examples REPLACE Cobra's minimal block, not append to it.
+    assert section.count("**Examples**") == 1
+
+
+def test_subcommand_section_without_spec_examples_uses_cobra() -> None:
+    from cli_reference import CliCommand
+    from generate_cli_docs import _subcommand_section
+
+    cmd = CliCommand(
+        command="calibrate agents create",
+        short="Create agent",
+        examples="calibrate agents create --name X",
+    )
+    section = "\n".join(_subcommand_section(cmd, {}))
+    assert "calibrate agents create --name X" in section

--- a/tests/test_generate_cli_docs.py
+++ b/tests/test_generate_cli_docs.py
@@ -535,3 +535,18 @@ def test_subcommand_section_without_spec_examples_uses_cobra() -> None:
     )
     section = "\n".join(_subcommand_section(cmd, {}))
     assert "calibrate agents create --name X" in section
+
+
+def test_subcommand_section_includes_learn_more_link() -> None:
+    from cli_reference import CliCommand
+    from generate_cli_docs import _subcommand_section
+    from request_examples import named_request_examples
+
+    cmd = CliCommand(
+        command="calibrate agents create",
+        short="Create agent",
+        options="  --name string\n  -c, --config-param type",
+    )
+    examples = named_request_examples(_spec_two_examples()["paths"]["/agents"]["post"])
+    section = "\n".join(_subcommand_section(cmd, {"agents create": examples}))
+    assert "[Agent connections](/core-concepts/agent-connections)" in section

--- a/tests/test_generate_sdk_docs.py
+++ b/tests/test_generate_sdk_docs.py
@@ -74,3 +74,14 @@ def test_examples_for_route_reads_op() -> None:
     # Unknown route → no examples, no crash.
     missing = SdkRoute("GET", "/nope", "x", "y", "X", "T")
     assert _examples_for_route(missing, spec) == []
+
+
+def test_examples_section_includes_learn_more_link() -> None:
+    from request_examples import NamedExample
+
+    examples = [
+        NamedExample(key="build", summary="Build", description="", value={"name": "a"}),
+        NamedExample(key="connect", summary="Connect", description="", value={"name": "b"}),
+    ]
+    page = render_method_page(_ROUTE, _DOC, examples)
+    assert "[Agent connections](/core-concepts/agent-connections)" in page

--- a/tests/test_generate_sdk_docs.py
+++ b/tests/test_generate_sdk_docs.py
@@ -1,0 +1,76 @@
+"""Tests for the spec-examples section in scripts/generate_sdk_docs.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from generate_sdk_docs import _examples_for_route, render_method_page  # noqa: E402
+from request_examples import NamedExample  # noqa: E402
+from sdk_reference import SdkMethodDoc, SdkRoute  # noqa: E402
+
+_ROUTE = SdkRoute(
+    http="POST",
+    path="/agents",
+    sdk_group="agents",
+    sdk_method="create",
+    api_group="Agents",
+    title="Create agent",
+)
+_DOC = SdkMethodDoc(
+    sdk_group="agents",
+    sdk_method="create",
+    description="Create an agent.",
+    usage_code="client.agents.create(name=\"Support Agent\")\n",
+)
+
+
+def _examples(n: int) -> list[NamedExample]:
+    return [
+        NamedExample(key=f"k{i}", summary=f"Variant {i}", description="", value={"name": f"a{i}"})
+        for i in range(n)
+    ]
+
+
+def test_examples_section_renders_each_variant() -> None:
+    page = render_method_page(_ROUTE, _DOC, _examples(2))
+    assert "## Examples" in page
+    assert "**Variant 0**" in page and "**Variant 1**" in page
+    assert page.count("```python") == 3  # 1 Usage + 2 example snippets
+    # Ordered: Usage before Examples before the API-endpoint callout.
+    assert page.index("## Usage") < page.index("## Examples") < page.index("## API endpoint")
+
+
+def test_single_example_suppresses_section() -> None:
+    # One example is already the Usage block — no point repeating it.
+    assert "## Examples" not in render_method_page(_ROUTE, _DOC, _examples(1))
+    assert "## Examples" not in render_method_page(_ROUTE, _DOC, [])
+    assert "## Examples" not in render_method_page(_ROUTE, _DOC, None)
+
+
+def test_examples_for_route_reads_op() -> None:
+    spec = {
+        "paths": {
+            "/agents": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "examples": {
+                                    "a": {"summary": "A", "value": {"name": "x"}},
+                                    "b": {"summary": "B", "value": {"name": "y"}},
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    assert [e.summary for e in _examples_for_route(_ROUTE, spec)] == ["A", "B"]
+    # Unknown route → no examples, no crash.
+    missing = SdkRoute("GET", "/nope", "x", "y", "X", "T")
+    assert _examples_for_route(missing, spec) == []

--- a/tests/test_request_examples.py
+++ b/tests/test_request_examples.py
@@ -10,6 +10,8 @@ sys.path.insert(0, str(ROOT / "scripts"))
 
 from cli_reference import Option  # noqa: E402
 from request_examples import (  # noqa: E402
+    command_key,
+    learn_more_markdown,
     named_request_examples,
     render_cli_snippet,
     render_python_snippet,
@@ -105,3 +107,17 @@ def test_render_cli_snippet_falls_back_to_field_flag() -> None:
     # No matching option → `--<field>` fallback rather than dropping the field.
     snippet = render_cli_snippet("calibrate x y", [], {"foo": "bar"})
     assert snippet == 'calibrate x y \\\n  --foo "bar"'
+
+
+def test_command_key_normalizes() -> None:
+    assert command_key("agents", "create") == "agents create"
+    assert command_key("agent_tests", "run") == "agent-tests run"
+
+
+def test_learn_more_markdown() -> None:
+    note = learn_more_markdown("agents create")
+    assert note == (
+        "For more details, see [Agent connections](/core-concepts/agent-connections)."
+    )
+    # No pointer for operations without a configured link.
+    assert learn_more_markdown("tests create") is None

--- a/tests/test_request_examples.py
+++ b/tests/test_request_examples.py
@@ -1,0 +1,107 @@
+"""Tests for scripts/request_examples.py — spec examples → SDK/CLI snippets."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from cli_reference import Option  # noqa: E402
+from request_examples import (  # noqa: E402
+    named_request_examples,
+    render_cli_snippet,
+    render_python_snippet,
+)
+
+_OP_WITH_EXAMPLES = {
+    "requestBody": {
+        "content": {
+            "application/json": {
+                "examples": {
+                    "build": {
+                        "summary": "Agent within Calibrate",
+                        "description": "Build inside Calibrate.",
+                        "value": {"name": "Support Agent", "type": "agent"},
+                    },
+                    "connect": {
+                        "summary": "Connect external agent",
+                        "value": {
+                            "name": "My Hosted Agent",
+                            "type": "connection",
+                            "config": {"agent_url": "https://x.example.com/v1"},
+                        },
+                    },
+                }
+            }
+        }
+    }
+}
+
+
+def test_named_request_examples_extracts_in_order() -> None:
+    examples = named_request_examples(_OP_WITH_EXAMPLES)
+    assert [e.key for e in examples] == ["build", "connect"]
+    assert examples[0].summary == "Agent within Calibrate"
+    assert examples[0].description == "Build inside Calibrate."
+    # Missing summary falls back to the key; missing description is empty.
+    assert examples[1].summary == "Connect external agent"
+    assert examples[1].description == ""
+
+
+def test_named_request_examples_empty_when_absent() -> None:
+    assert named_request_examples({}) == []
+    assert named_request_examples({"requestBody": {"content": {}}}) == []
+    # Entries without a `value` are skipped.
+    op = {"requestBody": {"content": {"application/json": {"examples": {"x": {}}}}}}
+    assert named_request_examples(op) == []
+
+
+def test_render_python_snippet_kwargs_and_literals() -> None:
+    value = {
+        "name": "Support Agent",
+        "type": "agent",
+        "config": {
+            "settings": {"agent_speaks_first": False, "max_assistant_turns": 10},
+            "tags": [],
+        },
+    }
+    snippet = render_python_snippet("agents", "create", value)
+    assert snippet.startswith("client.agents.create(\n")
+    assert '    name="Support Agent",' in snippet
+    # JSON literals become Python literals, double-quoted keys, nested indent.
+    assert '"agent_speaks_first": False' in snippet
+    assert '"max_assistant_turns": 10' in snippet
+    assert '"tags": []' in snippet
+    assert snippet.endswith(")")
+
+
+def test_render_python_snippet_non_object_is_positional() -> None:
+    assert render_python_snippet("a", "b", "hi") == 'client.a.b("hi")'
+    assert render_python_snippet("a", "b", {}) == "client.a.b()"
+
+
+def test_render_cli_snippet_maps_fields_to_flags() -> None:
+    options = [
+        Option(flag="--name", type="string"),
+        Option(flag="--type", type="type=agent"),
+        Option(flag="-c, --config-param", type="type"),
+    ]
+    value = {
+        "name": "Support Agent",
+        "type": "connection",
+        "config": {"agent_url": "https://x.example.com/v1"},
+    }
+    snippet = render_cli_snippet("calibrate agents create", options, value)
+    assert snippet.startswith("calibrate agents create \\\n")
+    assert '--name "Support Agent"' in snippet
+    assert '--type "connection"' in snippet
+    # `config` resolves to the renamed `--config-param` flag; object → JSON string.
+    assert "--config-param '{\"agent_url\":\"https://x.example.com/v1\"}'" in snippet
+
+
+def test_render_cli_snippet_falls_back_to_field_flag() -> None:
+    # No matching option → `--<field>` fallback rather than dropping the field.
+    snippet = render_cli_snippet("calibrate x y", [], {"foo": "bar"})
+    assert snippet == 'calibrate x y \\\n  --foo "bar"'


### PR DESCRIPTION
## Why

Fern and Speakeasy each feature only the **first** request example, so `POST /agents` — which has two genuinely distinct variants (build an agent **inside Calibrate** vs. **connect** an external HTTP agent) — showed only one shape on the generated SDK and CLI pages. New users reading `sdk/agents/create` or `cli/calibrate/agents` never saw the second way to call it. (The API-reference page shows both via the `examples` dropdown; the SDK/CLI pages didn't.)

## What

New `scripts/request_examples.py` pulls an operation's **named request examples straight from the public OpenAPI spec** (already fetched into this repo) and renders each as an SDK call and a CLI invocation. The spec is the single source of truth — the backend's `Body(openapi_examples=…)` flows through untouched, so no example body is hand-copied here and nothing can drift.

- **SDK** (`generate_sdk_docs.py`): appends an `## Examples` section below Usage — one labelled Python snippet per variant — only when the op has ≥2 named examples.
- **CLI** (`generate_cli_docs.py`): maps each command to its op via the Fern route map (the SDK/CLI naming overlays are kept 1:1 by the backend) and replaces Cobra's single, often-empty Examples block with one labelled `calibrate …` invocation per variant. Best-effort: falls back to Cobra's own block if the route map/overrides aren't available during a build.

Generic by design — any endpoint that grows a second named example is covered automatically. Today only `agents create` qualifies.

## Rendered output (agents create)

SDK page gains a Python snippet for each of *Agent within Calibrate* and *Connect OpenAI-compatible agent*; CLI page gains the equivalent `calibrate agents create --name … --type … --config-param '{…}'` for each.

## Tests

- `tests/test_request_examples.py` — extraction, Python/CLI rendering, field→flag mapping, literal formatting.
- `tests/test_generate_sdk_docs.py` — section rendered for ≥2 examples, suppressed for 0/1.
- `tests/test_generate_cli_docs.py` — command→op mapping, spec examples replace Cobra's block, fallback when absent.

70 passed, 1 skipped locally (`test_request_examples`, `test_generate_sdk_docs`, `test_generate_cli_docs`, `test_sdk_reference`, `test_cli_reference`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)