### PR TITLE
Render named request examples on the MCP Tools page

### DIFF
--- a/scripts/generate_mcp_docs.py
+++ b/scripts/generate_mcp_docs.py
@@ -283,12 +283,13 @@ def _params_table(args: list[Arg]) -> str:
 def _examples_block(tool: McpTool, op: Operation) -> list[str]:
     """Render an **Examples** block, one labelled ``tools/call`` payload per variant.
 
-    Only emitted when the operation has ≥2 named request examples — a single
-    example matches the Parameters table above and adds nothing. Keeps every
-    distinct request shape (e.g. build-in-Calibrate vs. connect-external agent)
-    visible on the Tools page, from the OpenAPI spec as the single source.
+    Emitted for any operation with ≥1 named request example. Unlike the SDK/CLI
+    pages (which skip a single example because it duplicates their Usage block),
+    the MCP Tools page has no Usage block, so even one example adds a concrete
+    ``tools/call`` payload. Keeps every distinct request shape (e.g.
+    build-in-Calibrate vs. connect-external agent) visible from the OpenAPI spec.
     """
-    if len(op.examples) < 2:
+    if not op.examples:
         return []
     lines = ["**Examples**", ""]
     for ex in op.examples:

--- a/scripts/generate_mcp_docs.py
+++ b/scripts/generate_mcp_docs.py
@@ -29,7 +29,7 @@ import json
 import re
 import sys
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -38,6 +38,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from docs_mdx import escape_mdx_prose, frontmatter_value, table_cell  # noqa: E402
 from docs_nav import insert_tab  # noqa: E402
 from mcp_reference import McpTool, operation_key, parse_tools_dir  # noqa: E402
+from request_examples import (  # noqa: E402
+    NamedExample,
+    command_key,
+    learn_more_markdown,
+    named_request_examples,
+    render_mcp_snippet,
+)
 from sdk_reference import api_group_from_tag  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -100,6 +107,7 @@ class Operation:
     summary: str
     tag: str
     args: list["Arg"]
+    examples: list[NamedExample] = field(default_factory=list)
 
     @property
     def api_page(self) -> str:
@@ -220,6 +228,7 @@ def build_operation_map(openapi: dict[str, Any]) -> dict[str, Operation]:
                 summary=(op.get("summary") or "").strip(),
                 tag=tags[0] if tags else "",
                 args=args,
+                examples=named_request_examples(op),
             )
     return ops
 
@@ -271,6 +280,29 @@ def _params_table(args: list[Arg]) -> str:
     return "\n".join(lines)
 
 
+def _examples_block(tool: McpTool, op: Operation) -> list[str]:
+    """Render an **Examples** block, one labelled ``tools/call`` payload per variant.
+
+    Only emitted when the operation has ≥2 named request examples — a single
+    example matches the Parameters table above and adds nothing. Keeps every
+    distinct request shape (e.g. build-in-Calibrate vs. connect-external agent)
+    visible on the Tools page, from the OpenAPI spec as the single source.
+    """
+    if len(op.examples) < 2:
+        return []
+    lines = ["**Examples**", ""]
+    for ex in op.examples:
+        lines += [f"**{escape_mdx_prose(ex.summary)}**", ""]
+        if ex.description:
+            lines += [escape_mdx_prose(ex.description), ""]
+        lines += ["```json", render_mcp_snippet(tool.name, ex.value), "```", ""]
+    verb = tool.name.split("-", 1)[0]
+    note = learn_more_markdown(command_key(op.tag, verb))
+    if note:
+        lines += [note, ""]
+    return lines
+
+
 def _tool_section(tool: McpTool, op: Operation) -> list[str]:
     lines = [f"### {tool.name}", ""]
     if tool.description:
@@ -285,6 +317,8 @@ def _tool_section(tool: McpTool, op: Operation) -> list[str]:
     table = _params_table(op.args)
     if table:
         lines += ["**Parameters**", "", table, ""]
+
+    lines += _examples_block(tool, op)
 
     api_page = escape_mdx_prose(op.api_page)
     lines += [

--- a/scripts/request_examples.py
+++ b/scripts/request_examples.py
@@ -111,6 +111,19 @@ def render_python_snippet(sdk_group: str, sdk_method: str, value: Any) -> str:
     return "\n".join(lines)
 
 
+def render_mcp_snippet(tool_name: str, value: Any) -> str:
+    """Render one example body as an MCP ``tools/call`` argument payload.
+
+    The request-body object becomes the tool's ``arguments`` map — the shape a
+    coding agent passes when it invokes the tool. Mirrors the JSON-RPC
+    ``tools/call`` params documented in the MCP troubleshooting page, so the
+    Tools reference shows exactly what the agent sends.
+    """
+    arguments = value if isinstance(value, dict) else {}
+    payload = {"name": tool_name, "arguments": arguments}
+    return json.dumps(payload, indent=2)
+
+
 def _cli_value(value: Any) -> str:
     """Format one flag value for a shell command.
 

--- a/tests/mcp_tool_samples.py
+++ b/tests/mcp_tool_samples.py
@@ -186,7 +186,19 @@ OPENAPI: dict = {
                 "requestBody": {
                     "content": {
                         "application/json": {
-                            "schema": {"$ref": "#/components/schemas/WidgetCreate"}
+                            "schema": {"$ref": "#/components/schemas/WidgetCreate"},
+                            "examples": {
+                                "basic_widget": {
+                                    "summary": "Basic widget",
+                                    "description": "A minimal widget.",
+                                    "value": {"name": "sprocket"},
+                                },
+                                "colored_widget": {
+                                    "summary": "Colored widget",
+                                    "value": {"name": "sprocket", "color": "red"},
+                                },
+                                "no_value": {"summary": "ignored — no value"},
+                            },
                         }
                     }
                 },

--- a/tests/test_generate_mcp_docs.py
+++ b/tests/test_generate_mcp_docs.py
@@ -14,7 +14,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from generate_mcp_docs import (  # noqa: E402
     Arg,
+    Operation,
     _anchor,
+    _examples_block,
     _params_table,
     _schema_type,
     _summary_line,
@@ -24,7 +26,8 @@ from generate_mcp_docs import (  # noqa: E402
     build_tab,
     generate_mcp_docs,
 )
-from mcp_reference import parse_tool_ts  # noqa: E402
+from mcp_reference import McpTool, parse_tool_ts  # noqa: E402
+from request_examples import NamedExample  # noqa: E402
 from mcp_tool_samples import (  # noqa: E402
     CREATE_WIDGET_TS,
     GET_WIDGET_TS,
@@ -118,6 +121,67 @@ def test_operation_map_unwraps_optional_body_anyof() -> None:
     assert [a.name for a in run.args] == ["gadget_names"]
     assert run.args[0].required is False
     assert run.args[0].type == "array of string"
+
+
+def test_operation_map_extracts_named_examples() -> None:
+    create = build_operation_map(OPENAPI)["createwidgetwidgetspostop"]
+    # value-less "no_value" entry is dropped; only the two real variants survive
+    assert [e.key for e in create.examples] == ["basic_widget", "colored_widget"]
+    assert create.examples[0].summary == "Basic widget"
+    assert create.examples[0].value == {"name": "sprocket"}
+
+
+# --------------------------------------------------------------------------- #
+# _examples_block
+# --------------------------------------------------------------------------- #
+def _op_with_examples(tag: str, examples: list[NamedExample]) -> Operation:
+    return Operation(
+        path="/widgets", method="post", summary="", tag=tag, args=[], examples=examples
+    )
+
+
+def _tool(name: str) -> McpTool:
+    return McpTool(name=name, scopes=["write"])
+
+
+def test_examples_block_renders_labelled_tools_call_payloads() -> None:
+    op = _op_with_examples(
+        "widgets",
+        [
+            NamedExample("basic", "Basic widget", "A minimal widget.", {"name": "s"}),
+            NamedExample("colored", "Colored widget", "", {"name": "s", "color": "red"}),
+        ],
+    )
+    text = "\n".join(_examples_block(_tool("create-widget"), op))
+    assert "**Examples**" in text
+    assert "**Basic widget**" in text
+    assert "A minimal widget." in text  # description rendered
+    assert "**Colored widget**" in text
+    # each variant is a JSON tools/call payload naming the tool + its arguments
+    assert '"name": "create-widget"' in text
+    assert '"arguments": {' in text
+    assert '"color": "red"' in text
+    assert text.count("```json") == 2
+    # no production learn-more link for the synthetic "widgets create" key
+    assert "For more details" not in text
+
+
+def test_examples_block_omitted_for_single_variant() -> None:
+    op = _op_with_examples("widgets", [NamedExample("only", "Only", "", {"name": "s"})])
+    assert _examples_block(_tool("create-widget"), op) == []
+
+
+def test_examples_block_adds_agent_connection_learn_more() -> None:
+    # create-agent (tag "agents", verb "create") -> the production learn-more link
+    op = _op_with_examples(
+        "agents",
+        [
+            NamedExample("build", "Build in Calibrate", "", {"name": "a"}),
+            NamedExample("connect", "Connect external", "", {"name": "a", "config": {}}),
+        ],
+    )
+    text = "\n".join(_examples_block(_tool("create-agent"), op))
+    assert "[Agent connections](/core-concepts/agent-connections)" in text
 
 
 # --------------------------------------------------------------------------- #
@@ -252,6 +316,12 @@ def test_tools_page_content(tmp_path: Path) -> None:
     # no-arg tool omits the Parameters block
     list_section = tools[tools.index("### list-widgets"):tools.index("### get-widget")]
     assert "**Parameters**" not in list_section
+    # multi-variant create-widget grows an Examples block of tools/call payloads
+    create_section = tools[tools.index("### create-widget"):]
+    assert "**Examples**" in create_section
+    assert "**Basic widget**" in create_section
+    assert '"name": "create-widget"' in create_section
+    assert create_section.count("```json") == 2
 
 
 def test_generate_inserts_tab_after_python_sdk(tmp_path: Path) -> None:

--- a/tests/test_generate_mcp_docs.py
+++ b/tests/test_generate_mcp_docs.py
@@ -166,9 +166,17 @@ def test_examples_block_renders_labelled_tools_call_payloads() -> None:
     assert "For more details" not in text
 
 
-def test_examples_block_omitted_for_single_variant() -> None:
+def test_examples_block_renders_single_variant() -> None:
+    # No Usage block on the MCP page, so even one example gets a payload.
     op = _op_with_examples("widgets", [NamedExample("only", "Only", "", {"name": "s"})])
-    assert _examples_block(_tool("create-widget"), op) == []
+    text = "\n".join(_examples_block(_tool("create-widget"), op))
+    assert "**Examples**" in text
+    assert '"name": "create-widget"' in text
+    assert text.count("```json") == 1
+
+
+def test_examples_block_omitted_when_no_examples() -> None:
+    assert _examples_block(_tool("create-widget"), _op_with_examples("widgets", [])) == []
 
 
 def test_examples_block_adds_agent_connection_learn_more() -> None:

--- a/tests/test_request_examples.py
+++ b/tests/test_request_examples.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -14,6 +15,7 @@ from request_examples import (  # noqa: E402
     learn_more_markdown,
     named_request_examples,
     render_cli_snippet,
+    render_mcp_snippet,
     render_python_snippet,
 )
 
@@ -82,6 +84,18 @@ def test_render_python_snippet_kwargs_and_literals() -> None:
 def test_render_python_snippet_non_object_is_positional() -> None:
     assert render_python_snippet("a", "b", "hi") == 'client.a.b("hi")'
     assert render_python_snippet("a", "b", {}) == "client.a.b()"
+
+
+def test_render_mcp_snippet_wraps_body_as_tools_call_arguments() -> None:
+    value = {"name": "Support Agent", "config": {"agent_url": "https://x.example.com/v1"}}
+    snippet = render_mcp_snippet("create-agent", value)
+    assert json.loads(snippet) == {"name": "create-agent", "arguments": value}
+    # indented (pretty) JSON, not a compact one-liner
+    assert "\n" in snippet
+
+
+def test_render_mcp_snippet_non_object_yields_empty_arguments() -> None:
+    assert json.loads(render_mcp_snippet("t", "hi")) == {"name": "t", "arguments": {}}
 
 
 def test_render_cli_snippet_maps_fields_to_flags() -> None:


### PR DESCRIPTION
## What
- The MCP Tools generator was the only generated reference surface (SDK, CLI, MCP) not rendering an operation's named request examples, so `create-agent` showed only its parameters table.
- Wire the shared `request_examples` helpers into the MCP generator: add `render_mcp_snippet` (a `tools/call` `{name, arguments}` payload — the MCP analogue of the SDK method call and CLI flags), carry each op's named examples on `Operation`, and emit an **Examples** block for any tool with ≥1 example, reusing the same Agent-connections learn-more link.
- On the next spec sync, `create-agent` will render both the build-in-Calibrate and connect-existing-agent variants.

## Notes
- `docs/mcp/tools.mdx` regenerates only when the `sync-api-spec` workflow reruns the generator against the live `calibrate-mcp` checkout — no generated output changes in this PR.
- The MCP page shows examples even for single-example ops (it has no Usage block to duplicate), unlike the SDK/CLI pages which gate on ≥2 variants.