### PR TITLE
Add pipecat-pipeline STT engine (real-time transport + TTFS)

### DIFF
--- a/calibrate_agent/_env.py
+++ b/calibrate_agent/_env.py
@@ -39,6 +39,23 @@ STT_PARALLELISM_DEFAULTS = {
 }
 
 
+def resolve_stt_max_concurrency(engine, max_concurrency=None):
+    """Resolve per-provider clip concurrency (the ``CALIBRATE_STT_MAX_CONCURRENCY``
+    knob) for an STT run.
+
+    An explicit (non-None) value wins; else the env var if set; else the
+    per-engine default in ``STT_PARALLELISM_DEFAULTS`` (unknown engines fall back
+    to ``direct``). Single-provider callers use this directly so they don't touch
+    the across-providers knob they have no use for.
+    """
+    if max_concurrency is not None:
+        return max_concurrency
+    _mp_default, mc_default = STT_PARALLELISM_DEFAULTS.get(
+        engine, STT_PARALLELISM_DEFAULTS["direct"]
+    )
+    return env_int("CALIBRATE_STT_MAX_CONCURRENCY", mc_default)
+
+
 def resolve_stt_parallelism(engine, max_parallel=None, max_concurrency=None):
     """Resolve ``(max_parallel, max_concurrency)`` for an STT benchmark run.
 
@@ -47,7 +64,7 @@ def resolve_stt_parallelism(engine, max_parallel=None, max_concurrency=None):
     if set, else the per-engine default in ``STT_PARALLELISM_DEFAULTS`` (unknown
     engines fall back to the ``direct`` defaults).
     """
-    mp_default, mc_default = STT_PARALLELISM_DEFAULTS.get(
+    mp_default, _mc_default = STT_PARALLELISM_DEFAULTS.get(
         engine, STT_PARALLELISM_DEFAULTS["direct"]
     )
     resolved_parallel = (
@@ -55,9 +72,4 @@ def resolve_stt_parallelism(engine, max_parallel=None, max_concurrency=None):
         if max_parallel is not None
         else env_int("CALIBRATE_STT_MAX_PARALLEL", mp_default)
     )
-    resolved_concurrency = (
-        max_concurrency
-        if max_concurrency is not None
-        else env_int("CALIBRATE_STT_MAX_CONCURRENCY", mc_default)
-    )
-    return resolved_parallel, resolved_concurrency
+    return resolved_parallel, resolve_stt_max_concurrency(engine, max_concurrency)

--- a/calibrate_agent/_env.py
+++ b/calibrate_agent/_env.py
@@ -25,3 +25,39 @@ def env_int(name: str, default: int) -> int:
         return int(raw)
     except ValueError:
         return default
+
+
+# Per-engine parallelism fallback defaults for the STT benchmark, as
+# ``(max_parallel, max_concurrency)``. The pipeline engine reports TTFS — a
+# wall-clock latency measured on the shared event loop — so it defaults to no
+# contention (one provider, one clip at a time) to keep that number clean. The
+# direct engine has no latency metric, so it defaults to parallel for
+# throughput. Precedence when resolving: explicit CLI flag > env var > these.
+STT_PARALLELISM_DEFAULTS = {
+    "pipeline": (1, 1),
+    "direct": (2, 4),
+}
+
+
+def resolve_stt_parallelism(engine, max_parallel=None, max_concurrency=None):
+    """Resolve ``(max_parallel, max_concurrency)`` for an STT benchmark run.
+
+    An explicit (non-None) value always wins. Otherwise the env var
+    (``CALIBRATE_STT_MAX_PARALLEL`` / ``CALIBRATE_STT_MAX_CONCURRENCY``) is used
+    if set, else the per-engine default in ``STT_PARALLELISM_DEFAULTS`` (unknown
+    engines fall back to the ``direct`` defaults).
+    """
+    mp_default, mc_default = STT_PARALLELISM_DEFAULTS.get(
+        engine, STT_PARALLELISM_DEFAULTS["direct"]
+    )
+    resolved_parallel = (
+        max_parallel
+        if max_parallel is not None
+        else env_int("CALIBRATE_STT_MAX_PARALLEL", mp_default)
+    )
+    resolved_concurrency = (
+        max_concurrency
+        if max_concurrency is not None
+        else env_int("CALIBRATE_STT_MAX_CONCURRENCY", mc_default)
+    )
+    return resolved_parallel, resolved_concurrency

--- a/calibrate_agent/cli.py
+++ b/calibrate_agent/cli.py
@@ -257,6 +257,26 @@ Examples:
             "$CALIBRATE_STT_MAX_PARALLEL)."
         ),
     )
+    stt_parser.add_argument(
+        "--engine",
+        type=str,
+        default="pipeline",
+        choices=["direct", "pipeline"],
+        help=(
+            "Transcription engine: 'pipeline' (default; streams through a real "
+            "pipecat agent pipeline at real-time pace, also reporting TTFS "
+            "latency) or 'direct' (faster; per-provider SDK, no latency)."
+        ),
+    )
+    stt_parser.add_argument(
+        "--max-concurrency",
+        type=int,
+        default=env_int("CALIBRATE_STT_MAX_CONCURRENCY", 4),
+        help=(
+            "Concurrent clips per provider, both engines (default: 4, or "
+            "$CALIBRATE_STT_MAX_CONCURRENCY)."
+        ),
+    )
 
     # ── TTS ───────────────────────────────────────────────────────
     # `calibrate-agent tts` with no args → interactive UI
@@ -601,6 +621,8 @@ Examples:
             if args.skip_llm_judges:
                 argv.append("--skip-llm-judges")
             argv.extend(["--max-parallel", str(args.max_parallel)])
+            argv.extend(["--engine", args.engine])
+            argv.extend(["--max-concurrency", str(args.max_concurrency)])
 
             sys.argv = argv
             asyncio.run(stt_benchmark_main())

--- a/calibrate_agent/cli.py
+++ b/calibrate_agent/cli.py
@@ -251,10 +251,10 @@ Examples:
     stt_parser.add_argument(
         "--max-parallel",
         type=int,
-        default=env_int("CALIBRATE_STT_MAX_PARALLEL", 2),
+        default=None,
         help=(
-            "Number of providers to evaluate in parallel (default: 2, or "
-            "$CALIBRATE_STT_MAX_PARALLEL)."
+            "Number of providers to evaluate in parallel (default: pipeline 1, "
+            "direct 2; or $CALIBRATE_STT_MAX_PARALLEL)."
         ),
     )
     stt_parser.add_argument(
@@ -271,10 +271,11 @@ Examples:
     stt_parser.add_argument(
         "--max-concurrency",
         type=int,
-        default=env_int("CALIBRATE_STT_MAX_CONCURRENCY", 4),
+        default=None,
         help=(
-            "Concurrent clips per provider, both engines (default: 4, or "
-            "$CALIBRATE_STT_MAX_CONCURRENCY)."
+            "Concurrent clips per provider, both engines (default: pipeline 1, "
+            "direct 4; or $CALIBRATE_STT_MAX_CONCURRENCY). Pipeline defaults to "
+            "1 to keep TTFS latency uncontended."
         ),
     )
 
@@ -620,9 +621,14 @@ Examples:
                 argv.extend(["--config", args.config])
             if args.skip_llm_judges:
                 argv.append("--skip-llm-judges")
-            argv.extend(["--max-parallel", str(args.max_parallel)])
+            # Only forward the parallelism knobs when the user set them
+            # explicitly; otherwise let the benchmark resolve the per-engine
+            # default (pipeline 1/1, direct 2/4).
+            if args.max_parallel is not None:
+                argv.extend(["--max-parallel", str(args.max_parallel)])
+            if args.max_concurrency is not None:
+                argv.extend(["--max-concurrency", str(args.max_concurrency)])
             argv.extend(["--engine", args.engine])
-            argv.extend(["--max-concurrency", str(args.max_concurrency)])
 
             sys.argv = argv
             asyncio.run(stt_benchmark_main())

--- a/calibrate_agent/stt/benchmark.py
+++ b/calibrate_agent/stt/benchmark.py
@@ -81,7 +81,8 @@ async def run(
     """
     Run STT evaluation for one or more providers and generate a leaderboard.
 
-    Evaluates providers in parallel (max 2 by default), then generates a comparison leaderboard.
+    Evaluates providers in parallel (per-engine default: pipeline 1, direct 2),
+    then generates a comparison leaderboard.
 
     Args:
         providers: List of STT providers to evaluate

--- a/calibrate_agent/stt/benchmark.py
+++ b/calibrate_agent/stt/benchmark.py
@@ -33,12 +33,8 @@ from calibrate_agent.stt.eval import (
     STT_LANGUAGES,
 )
 from calibrate_agent.stt.leaderboard import generate_leaderboard
-from calibrate_agent._env import env_int
+from calibrate_agent._env import resolve_stt_parallelism
 from calibrate_agent.utils import StreamTee
-
-
-# Maximum number of providers to run in parallel
-MAX_PARALLEL_PROVIDERS = 2
 
 
 async def run(
@@ -76,11 +72,11 @@ async def run(
     debug_count: int = 5,
     ignore_retry: bool = False,
     overwrite: bool = False,
-    max_parallel: int = MAX_PARALLEL_PROVIDERS,
+    max_parallel: int = None,
     judge_evaluators: list[dict] = None,
     run_llm_judges: bool = True,
     engine: str = "pipeline",
-    max_concurrency: int = 4,
+    max_concurrency: int = None,
 ) -> dict:
     """
     Run STT evaluation for one or more providers and generate a leaderboard.
@@ -97,7 +93,8 @@ async def run(
         debug_count: Number of audio files to run in debug mode (default: 5)
         ignore_retry: Skip retry if not all audios are processed
         overwrite: Overwrite existing results instead of resuming from checkpoint (default: False)
-        max_parallel: Maximum number of providers to run in parallel (default: 2)
+        max_parallel: Providers to run in parallel. ``None`` resolves per engine
+            (pipeline 1, direct 2) via ``resolve_stt_parallelism``.
         judge_evaluators: Optional list of evaluator dicts (each with ``name``,
             ``system_prompt``, ``judge_model``, ``type``, ...). When omitted no
             LLM judge runs and only WER/CER are reported.
@@ -118,6 +115,9 @@ async def run(
         ...     output_dir="./out"
         ... ))
     """
+    max_parallel, max_concurrency = resolve_stt_parallelism(
+        engine, max_parallel, max_concurrency
+    )
     results = {}
     semaphore = asyncio.Semaphore(max_parallel)
 
@@ -262,10 +262,10 @@ async def main():
     parser.add_argument(
         "--max-parallel",
         type=int,
-        default=env_int("CALIBRATE_STT_MAX_PARALLEL", MAX_PARALLEL_PROVIDERS),
+        default=None,
         help=(
-            "Number of providers to evaluate in parallel (default: 2, or "
-            "$CALIBRATE_STT_MAX_PARALLEL)."
+            "Number of providers to evaluate in parallel (default: pipeline 1, "
+            "direct 2; or $CALIBRATE_STT_MAX_PARALLEL)."
         ),
     )
     parser.add_argument(
@@ -282,10 +282,11 @@ async def main():
     parser.add_argument(
         "--max-concurrency",
         type=int,
-        default=env_int("CALIBRATE_STT_MAX_CONCURRENCY", 4),
+        default=None,
         help=(
-            "Concurrent clips per provider, both engines (default: 4, or "
-            "$CALIBRATE_STT_MAX_CONCURRENCY)."
+            "Concurrent clips per provider, both engines (default: pipeline 1, "
+            "direct 4; or $CALIBRATE_STT_MAX_CONCURRENCY). Pipeline defaults to "
+            "1 to keep TTFS latency uncontended."
         ),
     )
 

--- a/calibrate_agent/stt/benchmark.py
+++ b/calibrate_agent/stt/benchmark.py
@@ -79,6 +79,8 @@ async def run(
     max_parallel: int = MAX_PARALLEL_PROVIDERS,
     judge_evaluators: list[dict] = None,
     run_llm_judges: bool = True,
+    engine: str = "pipeline",
+    max_concurrency: int = 4,
 ) -> dict:
     """
     Run STT evaluation for one or more providers and generate a leaderboard.
@@ -134,6 +136,8 @@ async def run(
                 overwrite=overwrite,
                 judge_evaluators=judge_evaluators,
                 run_llm_judges=run_llm_judges,
+                engine=engine,
+                max_concurrency=max_concurrency,
             )
             return (provider, result)
 
@@ -264,6 +268,26 @@ async def main():
             "$CALIBRATE_STT_MAX_PARALLEL)."
         ),
     )
+    parser.add_argument(
+        "--engine",
+        type=str,
+        default="pipeline",
+        choices=["direct", "pipeline"],
+        help=(
+            "Transcription engine: 'pipeline' (default; streams through a real "
+            "pipecat agent pipeline at real-time pace, also reporting TTFS "
+            "latency) or 'direct' (faster; per-provider SDK, no latency)."
+        ),
+    )
+    parser.add_argument(
+        "--max-concurrency",
+        type=int,
+        default=env_int("CALIBRATE_STT_MAX_CONCURRENCY", 4),
+        help=(
+            "Concurrent clips per provider, both engines (default: 4, or "
+            "$CALIBRATE_STT_MAX_CONCURRENCY)."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -374,6 +398,8 @@ async def main():
             judge_evaluators=judge_evaluators,
             run_llm_judges=not args.skip_llm_judges,
             max_parallel=args.max_parallel,
+            engine=args.engine,
+            max_concurrency=args.max_concurrency,
         )
 
         # Print summary

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -29,6 +29,7 @@ from calibrate_agent.utils import (
     validate_stt_language,
     STT_PROVIDER_MODELS,
     google_stt_model_and_location,
+    create_stt_service,
     get_gemini_api_key,
     provider_log as _log,
     provider_log_file as _current_log_file,
@@ -40,7 +41,10 @@ from calibrate_agent.stt.metrics import (
     get_intent_entity_score,
     get_llm_wer_cer_score,
     get_semantic_wer_score,
+    get_ttfs_stats,
 )
+from calibrate_agent.stt.pipeline_eval import transcribe_via_pipeline
+from calibrate_agent._env import env_int
 from calibrate_agent.judges import (
     is_rating,
     require_unique_evaluator_names,
@@ -937,12 +941,142 @@ async def transcribe_audio(
 # =============================================================================
 
 
+@backoff.on_exception(backoff.expo, Exception, max_tries=3, factor=2)
+@observe(name="stt", capture_input=False, capture_output=False)
+async def transcribe_audio_pipeline(
+    audio_path: Path,
+    reference: str,
+    provider: str,
+    language: str,
+    unique_id: str,
+) -> dict:
+    """Transcribe one clip by streaming it through a real pipecat pipeline.
+
+    The "pipeline" engine: feeds the WAV at real-time pace through the same
+    ``create_stt_service`` the live agent deploys, so the benchmark reflects the
+    shipped STT config and also captures TTFS latency (speech-stop -> final
+    transcript). Contrast with ``transcribe_audio`` (the "direct" engine), which
+    calls each provider SDK directly.
+
+    Returns ``{"transcript": str, "ttfs": float | None}``.
+    """
+    # Sarvam's streaming endpoint is rate-limited per account; honour the same
+    # limiter the direct engine uses so concurrent clips don't blow the cap.
+    if provider == "sarvam":
+        await SARVAM_STT_STREAMING_LIMITER.acquire()
+
+    pcm = load_audio(audio_path, raw_pcm=True)
+    stt_service = create_stt_service(provider, language)
+    output = await transcribe_via_pipeline(pcm, stt_service)
+
+    transcript = output["transcript"].strip()
+    ttfs = output["ttfs"]
+
+    if langfuse_enabled and langfuse:
+        input_audio_media = create_langfuse_audio_media(audio_path)
+        langfuse.update_current_trace(
+            input={
+                "audio": input_audio_media,
+                "reference": reference,
+                "language": language,
+                "provider": provider,
+            },
+            output=transcript,
+            metadata={
+                "provider": provider,
+                "language": language,
+                "reference": reference,
+                "ttfs": ttfs,
+                "engine": "pipeline",
+            },
+            session_id=unique_id,
+        )
+
+    return {"transcript": transcript, "ttfs": ttfs}
+
+
+async def _run_stt_eval_concurrent(
+    gt_data: List[Dict],
+    audio_dir: Path,
+    provider: str,
+    language: str,
+    results_csv_path: Path,
+    max_concurrency: int,
+    transcribe_fn,
+    with_ttfs: bool,
+) -> int:
+    """Transcribe clips with bounded concurrency, writing rows as they complete.
+
+    Shared by both engines: ``transcribe_fn`` is the per-clip coroutine
+    (``transcribe_audio`` for direct, ``transcribe_audio_pipeline`` for pipeline)
+    and ``with_ttfs`` adds the ``ttfs`` column (pipeline only). Up to
+    ``max_concurrency`` clips run at once (for pipeline each is a 1x real-time
+    pipeline, so concurrency keeps a large run tractable); each result is written
+    to ``results.csv`` under a lock (resumable, skip-processed). A failed clip is
+    logged and left unwritten for the outer retry loop / no-progress fill,
+    without a gather-wide cancel.
+    """
+    if exists(results_csv_path):
+        existing_df = pd.read_csv(results_csv_path)
+        results = existing_df.to_dict("records")
+        processed_ids = set(existing_df["id"].tolist())
+    else:
+        results = []
+        processed_ids = set()
+
+    pending = [g for g in gt_data if g["id"] not in processed_ids]
+    if not pending:
+        return 0
+
+    unique_id = str(uuid.uuid4())
+    semaphore = asyncio.Semaphore(max_concurrency)
+    write_lock = asyncio.Lock()
+    success_count = 0
+
+    async def worker(index: int, gt_info: Dict) -> None:
+        nonlocal success_count
+        async with semaphore:
+            audio_path = audio_dir / f"{gt_info['id']}.wav"
+            _log("--------------------------------")
+            _log(f"Processing audio [{index}/{len(pending)}]: {audio_path.name}")
+            try:
+                output = await transcribe_fn(
+                    audio_path, gt_info["gt"], provider, language, unique_id
+                )
+            except Exception as e:
+                # Don't raise: leave this id unprocessed so the retry loop can
+                # re-attempt it (and eventually fill an empty transcript) without
+                # cancelling the other in-flight clips.
+                _log(f"\033[91mFailed to transcribe {audio_path}: {e}\033[0m")
+                return
+
+            transcript = output["transcript"]
+            _log(f"\033[33mTranscript: {transcript}\033[0m")
+            async with write_lock:
+                if transcript:
+                    success_count += 1
+                row = _stt_result_row(
+                    gt_info["id"], gt_info["gt"], transcript, audio_dir
+                )
+                if with_ttfs:
+                    row["ttfs"] = output.get("ttfs")
+                results.append(row)
+                pd.DataFrame(results).to_csv(results_csv_path, index=False)
+
+    await asyncio.gather(
+        *(worker(i + 1, gt_info) for i, gt_info in enumerate(pending))
+    )
+    return success_count
+
+
 async def run_stt_eval(
     gt_data: List[Dict],
     audio_dir: Path,
     provider: str,
     language: str,
     results_csv_path: Path,
+    engine: str = "pipeline",
+    max_concurrency: int = 4,
 ) -> int:
     """Process audio files and save results immediately to CSV.
 
@@ -952,53 +1086,26 @@ async def run_stt_eval(
         provider: STT provider name
         language: Language code
         results_csv_path: Path to save results CSV
+        engine: ``"direct"`` (per-provider SDK calls) or ``"pipeline"`` (stream
+            through a real pipecat agent pipeline, capturing TTFS latency).
+        max_concurrency: Concurrent clips per provider (applies to both engines).
 
     Returns:
         Number of files successfully transcribed (non-empty) in this run.
     """
-    # Load existing results to skip already processed files
-    if exists(results_csv_path):
-        existing_df = pd.read_csv(results_csv_path)
-        results = existing_df.to_dict("records")
-        processed_ids = set(existing_df["id"].tolist())
-    else:
-        results = []
-        processed_ids = set()
-
-    success_count = 0
-
-    unique_id = str(uuid.uuid4())
-
-    for i, gt_info in enumerate(gt_data):
-        # Skip if already processed
-        if gt_info["id"] in processed_ids:
-            continue
-
-        audio_path = audio_dir / f"{gt_info['id']}.wav"
-
-        _log(f"--------------------------------")
-        _log(f"Processing audio [{i + 1}/{len(gt_data)}]: {audio_path.name}")
-
-        try:
-            output = await transcribe_audio(
-                audio_path, gt_info["gt"], provider, language, unique_id
-            )
-            transcript = output["transcript"]
-            _log(f"\033[33mTranscript: {transcript}\033[0m")
-            if transcript:
-                success_count += 1
-        except Exception as e:
-            _log(f"\033[91mFailed to transcribe {audio_path}: {e}\033[0m")
-            raise
-
-        # Save immediately after each file
-        results.append(
-            _stt_result_row(gt_info["id"], gt_info["gt"], transcript, audio_dir)
-        )
-        pd.DataFrame(results).to_csv(results_csv_path, index=False)
-
-    return success_count
-
+    transcribe_fn = (
+        transcribe_audio_pipeline if engine == "pipeline" else transcribe_audio
+    )
+    return await _run_stt_eval_concurrent(
+        gt_data,
+        audio_dir,
+        provider,
+        language,
+        results_csv_path,
+        max_concurrency,
+        transcribe_fn=transcribe_fn,
+        with_ttfs=(engine == "pipeline"),
+    )
 
 def validate_stt_input_dir(input_dir: str, input_file_name: str) -> tuple[bool, str]:
     """Validate STT input directory structure.
@@ -1158,6 +1265,8 @@ async def run_single_provider_eval(
     overwrite: bool,
     judge_evaluators: list[dict] = None,
     run_llm_judges: bool = True,
+    engine: str = "pipeline",
+    max_concurrency: int = 4,
 ) -> dict:
     """Run STT evaluation for a single provider."""
     provider_output_dir = join(output_dir, provider)
@@ -1266,6 +1375,8 @@ async def run_single_provider_eval(
                 provider=provider,
                 language=language,
                 results_csv_path=results_csv_path,
+                engine=engine,
+                max_concurrency=max_concurrency,
             )
 
             if ignore_retry:
@@ -1290,6 +1401,14 @@ async def run_single_provider_eval(
             model=_default_stt_model(provider, language),
         )
 
+        # TTFS latency is only produced by the pipeline engine; NaN/absent -> None.
+        if "ttfs" in results_df.columns:
+            all_ttfs = [
+                None if pd.isna(v) else float(v) for v in results_df["ttfs"].tolist()
+            ]
+        else:
+            all_ttfs = [None] * len(all_ids)
+
         _log(f"gt_transcripts: {all_gt_transcripts}", to_terminal=False)
         _log(f"pred_transcripts: {all_pred_transcripts}", to_terminal=False)
 
@@ -1307,6 +1426,7 @@ async def run_single_provider_eval(
             run_llm_judges=run_llm_judges,
             audio_durations=audio_durations,
             cost_metrics=cost_metrics,
+            ttfs_values=all_ttfs,
         )
 
         return {
@@ -1365,6 +1485,7 @@ async def _score_and_write_results(
     run_llm_judges: bool = True,
     cost_metrics: dict | None = None,
     audio_durations: list[float | None] | None = None,
+    ttfs_values: list = None,
 ) -> dict:
     """Run WER/CER (and optional LLM-judge evaluators) over (gt, pred) pairs.
 
@@ -1480,6 +1601,15 @@ async def _score_and_write_results(
     if cost_metrics:
         metrics_data["cost"] = cost_metrics
 
+    # TTFS latency (pipeline engine only). Emitted as a {p50,p95,p99,mean} dict
+    # so read_leaderboard_metrics fans it into ttfs_p50/ttfs_p95/ttfs_p99 columns.
+    ttfs_per_row = ttfs_values if ttfs_values is not None else [None] * len(ids)
+    has_ttfs = any(v is not None for v in ttfs_per_row)
+    if has_ttfs:
+        ttfs_stats = get_ttfs_stats(ttfs_per_row)
+        if ttfs_stats is not None:
+            metrics_data["ttfs"] = ttfs_stats
+
     ie_per_row = (
         intent_entity_results["per_row"]
         if intent_entity_results is not None
@@ -1512,6 +1642,7 @@ async def _score_and_write_results(
         pred_text,
         wer,
         cer,
+        ttfs_row,
         ie_row,
         llm_wer_row,
         semantic_wer_row,
@@ -1523,6 +1654,7 @@ async def _score_and_write_results(
         pred_transcripts,
         wer_results["per_row"],
         cer_results["per_row"],
+        ttfs_per_row,
         ie_per_row,
         llm_wer_per_row,
         semantic_wer_per_row,
@@ -1538,6 +1670,8 @@ async def _score_and_write_results(
         }
         if duration is not None and not pd.isna(duration):
             row["audio_duration_seconds"] = duration
+        if has_ttfs:
+            row["ttfs"] = ttfs_row
         if ie_row is not None:
             row["sarvam_intent_score"] = int(ie_row["intent_score"])
             row["sarvam_intent_reasoning"] = ie_row["intent_explanation"]
@@ -1667,6 +1801,10 @@ def format_metrics_summary(metrics: dict, prefix: str = "") -> str:
     ):
         if key in metrics:
             parts.append(f"{label}={metrics[key]:.4f}")
+    # TTFS latency (pipeline engine only) — a {p50,p95,p99,mean} dict.
+    ttfs = metrics.get("ttfs")
+    if isinstance(ttfs, dict) and "p50" in ttfs:
+        parts.append(f"TTFS p50={ttfs['p50']:.2f}s p95={ttfs['p95']:.2f}s")
     # Evaluator entries are dicts carrying a ``type`` field; that's the marker
     # we use to pick them out from other top-level metrics.
     parts.extend(
@@ -1757,6 +1895,26 @@ async def main():
             "They all run by default; passing this reports WER/CER only."
         ),
     )
+    parser.add_argument(
+        "--engine",
+        type=str,
+        default="pipeline",
+        choices=["direct", "pipeline"],
+        help=(
+            "Transcription engine: 'pipeline' (default; streams through a real "
+            "pipecat agent pipeline at real-time pace, also reporting TTFS "
+            "latency) or 'direct' (faster; per-provider SDK, no latency)."
+        ),
+    )
+    parser.add_argument(
+        "--max-concurrency",
+        type=int,
+        default=env_int("CALIBRATE_STT_MAX_CONCURRENCY", 4),
+        help=(
+            "Concurrent clips per provider, both engines (default: 4, or "
+            "$CALIBRATE_STT_MAX_CONCURRENCY)."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -1799,6 +1957,8 @@ async def main():
         ignore_retry=args.ignore_retry,
         overwrite=args.overwrite,
         run_llm_judges=not args.skip_llm_judges,
+        engine=args.engine,
+        max_concurrency=args.max_concurrency,
     )
 
     # Print summary

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -44,7 +44,7 @@ from calibrate_agent.stt.metrics import (
     get_ttfs_stats,
 )
 from calibrate_agent.stt.pipeline_eval import transcribe_via_pipeline
-from calibrate_agent._env import resolve_stt_parallelism
+from calibrate_agent._env import resolve_stt_max_concurrency
 from calibrate_agent.judges import (
     is_rating,
     require_unique_evaluator_names,
@@ -1095,9 +1095,7 @@ async def run_stt_eval(
     Returns:
         Number of files successfully transcribed (non-empty) in this run.
     """
-    _, max_concurrency = resolve_stt_parallelism(
-        engine, max_concurrency=max_concurrency
-    )
+    max_concurrency = resolve_stt_max_concurrency(engine, max_concurrency)
     transcribe_fn = (
         transcribe_audio_pipeline if engine == "pipeline" else transcribe_audio
     )

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -1603,7 +1603,11 @@ async def _score_and_write_results(
 
     # TTFS latency (pipeline engine only). Emitted as a {p50,p95,p99,mean} dict
     # so read_leaderboard_metrics fans it into ttfs_p50/ttfs_p95/ttfs_p99 columns.
-    ttfs_per_row = ttfs_values if ttfs_values is not None else [None] * len(ids)
+    ttfs_per_row = list(ttfs_values) if ttfs_values is not None else [None] * len(ids)
+    if len(ttfs_per_row) < len(ids):
+        ttfs_per_row.extend([None] * (len(ids) - len(ttfs_per_row)))
+    elif len(ttfs_per_row) > len(ids):
+        ttfs_per_row = ttfs_per_row[: len(ids)]
     has_ttfs = any(v is not None for v in ttfs_per_row)
     if has_ttfs:
         ttfs_stats = get_ttfs_stats(ttfs_per_row)

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -44,7 +44,7 @@ from calibrate_agent.stt.metrics import (
     get_ttfs_stats,
 )
 from calibrate_agent.stt.pipeline_eval import transcribe_via_pipeline
-from calibrate_agent._env import env_int
+from calibrate_agent._env import resolve_stt_parallelism
 from calibrate_agent.judges import (
     is_rating,
     require_unique_evaluator_names,
@@ -1076,7 +1076,7 @@ async def run_stt_eval(
     language: str,
     results_csv_path: Path,
     engine: str = "pipeline",
-    max_concurrency: int = 4,
+    max_concurrency: int = None,
 ) -> int:
     """Process audio files and save results immediately to CSV.
 
@@ -1088,11 +1088,16 @@ async def run_stt_eval(
         results_csv_path: Path to save results CSV
         engine: ``"direct"`` (per-provider SDK calls) or ``"pipeline"`` (stream
             through a real pipecat agent pipeline, capturing TTFS latency).
-        max_concurrency: Concurrent clips per provider (applies to both engines).
+        max_concurrency: Concurrent clips per provider (both engines). ``None``
+            resolves per engine (pipeline 1, direct 4) via
+            ``resolve_stt_parallelism``.
 
     Returns:
         Number of files successfully transcribed (non-empty) in this run.
     """
+    _, max_concurrency = resolve_stt_parallelism(
+        engine, max_concurrency=max_concurrency
+    )
     transcribe_fn = (
         transcribe_audio_pipeline if engine == "pipeline" else transcribe_audio
     )
@@ -1266,9 +1271,13 @@ async def run_single_provider_eval(
     judge_evaluators: list[dict] = None,
     run_llm_judges: bool = True,
     engine: str = "pipeline",
-    max_concurrency: int = 4,
+    max_concurrency: int = None,
 ) -> dict:
-    """Run STT evaluation for a single provider."""
+    """Run STT evaluation for a single provider.
+
+    ``max_concurrency=None`` is forwarded to ``run_stt_eval``, which resolves the
+    per-engine default (pipeline 1, direct 4).
+    """
     provider_output_dir = join(output_dir, provider)
 
     # ``exist_ok=True`` keeps this safe when the same provider folder is
@@ -1913,10 +1922,11 @@ async def main():
     parser.add_argument(
         "--max-concurrency",
         type=int,
-        default=env_int("CALIBRATE_STT_MAX_CONCURRENCY", 4),
+        default=None,
         help=(
-            "Concurrent clips per provider, both engines (default: 4, or "
-            "$CALIBRATE_STT_MAX_CONCURRENCY)."
+            "Concurrent clips per provider, both engines (default: pipeline 1, "
+            "direct 4; or $CALIBRATE_STT_MAX_CONCURRENCY). Pipeline defaults to "
+            "1 to keep TTFS latency uncontended."
         ),
     )
 

--- a/calibrate_agent/stt/metrics.py
+++ b/calibrate_agent/stt/metrics.py
@@ -364,7 +364,7 @@ def get_ttfs_stats(ttfs_values: List[Optional[float]]) -> Optional[dict]:
     simply omits TTFS from ``metrics.json``. Percentiles use linear
     interpolation (numpy's default), matching pipecat's stt-benchmark.
     """
-    values = sorted(v for v in ttfs_values if v is not None)
+    values = [v for v in ttfs_values if v is not None]
     if not values:
         return None
     arr = np.array(values, dtype=float)

--- a/calibrate_agent/stt/metrics.py
+++ b/calibrate_agent/stt/metrics.py
@@ -352,6 +352,30 @@ async def get_semantic_wer_score(
     return {"semantic_wer": float(pooled), "per_row": per_row}
 
 
+def get_ttfs_stats(ttfs_values: List[Optional[float]]) -> Optional[dict]:
+    """Aggregate per-clip TTFS latencies into percentile stats.
+
+    TTFS (time-to-final-segment) is the speech-stop -> final-transcript latency
+    captured by the pipeline engine (``None`` for clips that produced no
+    transcript / no TTFB metric, and for every clip under the direct engine).
+
+    Returns ``{"p50", "p95", "p99", "mean"}`` in seconds over the non-None
+    values, or ``None`` when there are none — so the direct engine (all None)
+    simply omits TTFS from ``metrics.json``. Percentiles use linear
+    interpolation (numpy's default), matching pipecat's stt-benchmark.
+    """
+    values = sorted(v for v in ttfs_values if v is not None)
+    if not values:
+        return None
+    arr = np.array(values, dtype=float)
+    return {
+        "p50": float(np.percentile(arr, 50)),
+        "p95": float(np.percentile(arr, 95)),
+        "p99": float(np.percentile(arr, 99)),
+        "mean": float(np.mean(arr)),
+    }
+
+
 def get_wer_score(
     references: List[str], predictions: List[str], language: str = "english"
 ) -> dict:

--- a/calibrate_agent/stt/pipeline_eval.py
+++ b/calibrate_agent/stt/pipeline_eval.py
@@ -1,0 +1,301 @@
+"""Pipecat-pipeline STT engine for the benchmark.
+
+This is the "real agent pipeline" transcription path: instead of calling each
+provider's SDK directly (see ``transcribe_*`` in ``stt/eval.py``), a WAV is
+streamed **at real-time pace** through a minimal pipecat pipeline
+
+    [SyntheticAudioInputTransport] -> [VADProcessor(Silero)] -> [STTService]
+
+using the exact same ``create_stt_service`` factory the live voice agent runs
+(``calibrate_agent/utils.py``). This makes the benchmark test the STT config we
+actually deploy, and lets us harvest pipecat's own speech-stop -> final-transcript
+latency (``TTFBMetricsData``, branded "TTFS") the same way pipecat's published
+per-service P99 numbers are measured (https://github.com/pipecat-ai/stt-benchmark).
+
+Mirrors pipecat's stt-benchmark methodology on our pinned pipecat 1.0.0:
+- audio is pushed as 20 ms ``InputAudioRawFrame`` chunks with a real-time sleep
+  between them, then a trailing-silence tail so VAD fires ``UserStoppedSpeaking``
+  and streaming services flush their final segment;
+- Silero VAD (``stop_secs=0.2``) matches the live agent (``agent/bot.py``);
+- on ``VADUserStoppedSpeakingFrame`` the pipecat ``STTService`` starts its TTFB
+  timer at the corrected speech-end time and stops it on the finalized
+  ``TranscriptionFrame`` (or after ``stt_ttfb_timeout``), emitting a
+  ``MetricsFrame(TTFBMetricsData)`` we collect.
+"""
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Optional
+
+from pipecat.frames.frames import (
+    InputAudioRawFrame,
+    MetricsFrame,
+    TranscriptionFrame,
+)
+from pipecat.metrics.metrics import TTFBMetricsData
+from pipecat.observers.base_observer import BaseObserver, FramePushed
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.runner import PipelineRunner
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.transports.base_input import BaseInputTransport
+from pipecat.transports.base_transport import TransportParams
+from pipecat.processors.audio.vad_processor import VADProcessor
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.audio.vad.vad_analyzer import VADParams
+from pipecat.services.stt_service import STTService
+
+# 16 kHz, 16-bit mono PCM — matches the live agent's audio_in_sample_rate and
+# what every ``create_stt_service`` provider is configured for.
+SAMPLE_RATE = 16000
+# Match the live agent's VAD (agent/bot.py). stop_secs MUST be set or the
+# pipecat STTService skips TTFB measurement entirely.
+VAD_STOP_SECS = 0.2
+# 20 ms audio chunks, like pipecat's stt-benchmark synthetic transport.
+CHUNK_MS = 20
+# Leading silence streamed BEFORE the real audio. A streaming STT service (e.g.
+# Deepgram) opens its websocket on the pipeline StartFrame; if we start pushing
+# speech immediately, the first ~0.5s can be dropped before the socket is ready,
+# truncating the opening words. Feeding silence first absorbs that connect time
+# (and lets Silero VAD warm up), just like a real mic has a moment of room tone
+# before the user speaks. TTFS is unaffected — it's anchored at speech-stop.
+LEAD_SILENCE_SECONDS = 1.0
+# How long to keep feeding trailing silence waiting for a transcript before
+# giving up, and how much extra silence to send after the first transcript to
+# let streaming services flush late segments.
+MAX_SILENCE_SECONDS = 10.0
+POST_TRANSCRIPTION_SILENCE_SECONDS = 2.0
+# Overall guard so a wedged provider can't hang a benchmark run forever.
+PIPELINE_RUN_TIMEOUT_SECONDS = 120.0
+
+
+class SyntheticAudioInputTransport(BaseInputTransport):
+    """Feeds a pre-loaded PCM buffer into a pipeline at real-time (1x) pace.
+
+    Emulates a live microphone: pushes ``InputAudioRawFrame``s in ``CHUNK_MS``
+    steps sleeping one chunk-duration between them, then a trailing-silence tail
+    (so VAD detects end-of-speech and streaming STT flushes) until
+    ``transcription_received`` fires or ``MAX_SILENCE_SECONDS`` elapses.
+    """
+
+    def __init__(
+        self,
+        pcm: bytes,
+        transcription_received: asyncio.Event,
+        sample_rate: int = SAMPLE_RATE,
+        chunk_ms: int = CHUNK_MS,
+        max_silence_seconds: float = MAX_SILENCE_SECONDS,
+        post_transcription_silence_seconds: float = POST_TRANSCRIPTION_SILENCE_SECONDS,
+        lead_silence_seconds: float = LEAD_SILENCE_SECONDS,
+    ):
+        super().__init__(
+            TransportParams(
+                audio_in_enabled=True,
+                audio_in_passthrough=True,
+                audio_in_sample_rate=sample_rate,
+            )
+        )
+        self._pcm = pcm
+        self._transcription_received = transcription_received
+        self._chunk_sample_rate = sample_rate
+        self._chunk_ms = chunk_ms
+        # 2 bytes/sample (16-bit).
+        self._chunk_size = int(sample_rate * chunk_ms / 1000) * 2
+        self._max_silence_seconds = max_silence_seconds
+        self._post_transcription_silence_seconds = post_transcription_silence_seconds
+        self._lead_silence_seconds = lead_silence_seconds
+        self._audio_complete = asyncio.Event()
+        self._pump_task: Optional[asyncio.Task] = None
+
+    async def start(self, frame):
+        await super().start(frame)
+        # Real transports call this from their connect handler; a synthetic
+        # source has no connection, so mark ready as soon as the pipeline starts.
+        await self.set_transport_ready(frame)
+
+    async def set_transport_ready(self, frame):
+        await super().set_transport_ready(frame)
+        if self._pump_task is None:
+            self._pump_task = self.create_task(self._pump_audio())
+
+    async def stop(self, frame):
+        await self._cancel_pump_task()
+        await super().stop(frame)
+
+    async def cancel(self, frame):
+        await self._cancel_pump_task()
+        await super().cancel(frame)
+
+    async def _cancel_pump_task(self):
+        if self._pump_task is not None:
+            await self.cancel_task(self._pump_task)
+            self._pump_task = None
+
+    async def wait_for_audio_complete(self, timeout: float) -> None:
+        """Wait until the real (non-silence) audio has been fully streamed."""
+        try:
+            await asyncio.wait_for(self._audio_complete.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            pass
+
+    def _make_frame(self, chunk: bytes) -> InputAudioRawFrame:
+        return InputAudioRawFrame(
+            audio=chunk, sample_rate=self._chunk_sample_rate, num_channels=1
+        )
+
+    async def _pump_audio(self):
+        sleep_time = self._chunk_ms / 1000.0
+        silence = bytes(self._chunk_size)
+
+        # Lead-in silence: let the STT service's websocket connect (and VAD warm
+        # up) before the first real speech, so the opening words aren't dropped.
+        for _ in range(int(self._lead_silence_seconds / sleep_time)):
+            await self.push_audio_frame(self._make_frame(silence))
+            await asyncio.sleep(sleep_time)
+
+        # Stream the real audio at 1x wall-clock.
+        for offset in range(0, len(self._pcm), self._chunk_size):
+            chunk = self._pcm[offset : offset + self._chunk_size]
+            if chunk:
+                await self.push_audio_frame(self._make_frame(chunk))
+                await asyncio.sleep(sleep_time)
+
+        self._audio_complete.set()
+
+        # Trailing silence: keep VAD/STT fed until we have a transcript (plus a
+        # short post-transcript window for late streaming segments).
+        silence_start = time.monotonic()
+        post_deadline: Optional[float] = None
+        while True:
+            now = time.monotonic()
+            if now - silence_start >= self._max_silence_seconds:
+                break
+            if self._transcription_received.is_set():
+                if post_deadline is None:
+                    post_deadline = now + self._post_transcription_silence_seconds
+                elif now >= post_deadline:
+                    break
+            await self.push_audio_frame(self._make_frame(silence))
+            await asyncio.sleep(sleep_time)
+
+
+class _STTOutputCollector(BaseObserver):
+    """Harvests final transcript text and TTFS latency from the STT service.
+
+    Passive: reads frames the STT service pushes. Concatenates
+    ``TranscriptionFrame`` text (services may segment long audio into several)
+    and captures the ``TTFBMetricsData`` value pipecat's STTService emits for the
+    speech-stop -> final-transcript interval. Sets ``transcription_received`` on
+    the first non-empty transcript so the transport can wind down its silence tail.
+    """
+
+    def __init__(self, transcription_received: asyncio.Event):
+        super().__init__()
+        self._transcription_received = transcription_received
+        self._parts: list[str] = []
+        self.ttfs: Optional[float] = None
+
+    async def on_push_frame(self, data: FramePushed):
+        if not isinstance(data.source, STTService):
+            return
+        frame = data.frame
+        if isinstance(frame, TranscriptionFrame):
+            text = (frame.text or "").strip()
+            if text:
+                self._parts.append(text)
+                self._transcription_received.set()
+        elif isinstance(frame, MetricsFrame):
+            for item in getattr(frame, "data", []) or []:
+                if isinstance(item, TTFBMetricsData) and item.value:
+                    # Last non-zero wins (final-segment latency).
+                    self.ttfs = float(item.value)
+
+    @property
+    def transcript(self) -> str:
+        return " ".join(self._parts).strip()
+
+
+def _default_vad_analyzer():
+    """Silero VAD tuned to match the live agent (agent/bot.py)."""
+    return SileroVADAnalyzer(params=VADParams(stop_secs=VAD_STOP_SECS))
+
+
+async def transcribe_via_pipeline(
+    audio_pcm: bytes,
+    stt_service: STTService,
+    run_timeout: float = PIPELINE_RUN_TIMEOUT_SECONDS,
+    vad_analyzer=None,
+    max_silence_seconds: float = MAX_SILENCE_SECONDS,
+    post_transcription_silence_seconds: float = POST_TRANSCRIPTION_SILENCE_SECONDS,
+) -> dict:
+    """Transcribe one clip by streaming it through a real pipecat pipeline.
+
+    Args:
+        audio_pcm: 16 kHz, 16-bit mono PCM bytes (e.g. ``load_audio(path, raw_pcm=True)``).
+        stt_service: A pipecat ``STTService`` (from ``create_stt_service``). One
+            fresh service per call — pipecat services are single-pipeline-lifecycle.
+        run_timeout: Hard cap on the whole run.
+        vad_analyzer: VAD analyzer to use. Defaults to Silero (``stop_secs=0.2``),
+            matching the live agent. Injectable so tests can drive VAD
+            deterministically without loading the Silero model.
+        max_silence_seconds: How long to feed trailing silence waiting for a
+            transcript before giving up.
+        post_transcription_silence_seconds: Extra silence after the first
+            transcript to let streaming services flush late segments.
+
+    Returns:
+        ``{"transcript": str, "ttfs": float | None}`` — ``ttfs`` is the
+        speech-stop -> final-transcript latency in seconds (None if the provider
+        emitted no TTFB metric, e.g. an empty/silent clip).
+    """
+    transcription_received = asyncio.Event()
+    transport = SyntheticAudioInputTransport(
+        audio_pcm,
+        transcription_received,
+        max_silence_seconds=max_silence_seconds,
+        post_transcription_silence_seconds=post_transcription_silence_seconds,
+    )
+    vad = VADProcessor(vad_analyzer=vad_analyzer or _default_vad_analyzer())
+    collector = _STTOutputCollector(transcription_received)
+
+    pipeline = Pipeline([transport, vad, stt_service])
+    task = PipelineTask(
+        pipeline,
+        params=PipelineParams(
+            enable_metrics=True,
+            audio_in_sample_rate=SAMPLE_RATE,
+            audio_out_sample_rate=SAMPLE_RATE,
+        ),
+        observers=[collector],
+    )
+    runner = PipelineRunner(handle_sigint=False)
+    run_task = asyncio.create_task(runner.run(task))
+
+    try:
+        # Wait for the real audio to finish streaming, then for a transcript
+        # (bounded by the transport's own silence-tail window).
+        await transport.wait_for_audio_complete(timeout=run_timeout)
+        try:
+            await asyncio.wait_for(
+                transcription_received.wait(),
+                timeout=max_silence_seconds + post_transcription_silence_seconds + 1.0,
+            )
+        except asyncio.TimeoutError:
+            pass
+        # Give the post-transcription silence window time to collect the TTFB
+        # metric and any late segments, then end the pipeline.
+        await asyncio.sleep(post_transcription_silence_seconds + 0.5)
+    finally:
+        # Graceful drain (queues an EndFrame that propagates through the
+        # transport, cancelling its audio pump), then hard-cancel on timeout.
+        await task.stop_when_done()
+        try:
+            await asyncio.wait_for(run_task, timeout=run_timeout)
+        except asyncio.TimeoutError:
+            await task.cancel()
+            try:
+                await run_task
+            except asyncio.CancelledError:
+                pass
+
+    return {"transcript": collector.transcript, "ttfs": collector.ttfs}

--- a/tests/stt/test_eval_extra.py
+++ b/tests/stt/test_eval_extra.py
@@ -1019,6 +1019,7 @@ class TestRunStteval(unittest.IsolatedAsyncioTestCase):
                     provider="deepgram",
                     language="english",
                     results_csv_path=str(results_csv),
+                    engine="direct",
                 )
 
             self.assertEqual(count, 1)
@@ -1128,6 +1129,7 @@ class TestRunSingleProviderEval(unittest.IsolatedAsyncioTestCase):
                     ignore_retry=True,
                     overwrite=False,
                     run_llm_judges=False,
+                    engine="direct",
                 )
             self.assertEqual(result["status"], "completed")
 

--- a/tests/stt/test_pipeline_engine_wiring.py
+++ b/tests/stt/test_pipeline_engine_wiring.py
@@ -1,0 +1,259 @@
+"""Tests for wiring the pipeline STT engine into the benchmark.
+
+Covers the parts that make ``--engine pipeline`` work end-to-end without a real
+pipeline or API keys:
+- ``get_stt_language`` full 13-language coverage (+ Sarvam regional variants),
+- ``get_ttfs_stats`` percentile aggregation,
+- ``run_stt_eval(engine="pipeline")`` routing, TTFS column, concurrency & resume,
+- ``_score_and_write_results`` threading TTFS into metrics.json + results.csv.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pandas as pd
+
+
+STT_LANGUAGES = [
+    "english", "hindi", "kannada", "bengali", "malayalam", "marathi",
+    "odia", "punjabi", "tamil", "telugu", "gujarati", "sindhi", "maithili",
+]
+
+
+class TestGetSTTLanguageCoverage(unittest.TestCase):
+    def test_all_13_languages_map_distinctly(self):
+        from calibrate_agent.utils import get_stt_language
+        from pipecat.transcriptions.language import Language
+
+        for lang in STT_LANGUAGES:
+            base = get_stt_language(lang, "deepgram")
+            sarvam = get_stt_language(lang, "sarvam")
+            self.assertIsInstance(base, Language)
+            self.assertIsInstance(sarvam, Language)
+
+        # Non-English languages must NOT silently fall back to English.
+        self.assertNotEqual(
+            get_stt_language("tamil", "deepgram"),
+            get_stt_language("english", "deepgram"),
+        )
+        self.assertEqual(get_stt_language("tamil", "sarvam"), Language.TA_IN)
+        self.assertEqual(get_stt_language("tamil", "deepgram"), Language.TA)
+
+    def test_unknown_language_falls_back_to_english(self):
+        from calibrate_agent.utils import get_stt_language
+        from pipecat.transcriptions.language import Language
+
+        self.assertEqual(get_stt_language("klingon", "deepgram"), Language.EN)
+        self.assertEqual(get_stt_language("klingon", "sarvam"), Language.EN_IN)
+
+
+class TestGetTTFSStats(unittest.TestCase):
+    def test_percentiles_ignore_none(self):
+        from calibrate_agent.stt.metrics import get_ttfs_stats
+
+        stats = get_ttfs_stats([0.2, 0.4, None, 0.6, 0.8, None])
+        self.assertAlmostEqual(stats["p50"], 0.5)
+        self.assertAlmostEqual(stats["mean"], 0.5)
+        self.assertGreaterEqual(stats["p99"], stats["p95"])
+        self.assertGreaterEqual(stats["p95"], stats["p50"])
+
+    def test_all_none_returns_none(self):
+        from calibrate_agent.stt.metrics import get_ttfs_stats
+
+        self.assertIsNone(get_ttfs_stats([None, None]))
+        self.assertIsNone(get_ttfs_stats([]))
+
+
+def _fake_judge():
+    async def judge(refs, preds, evaluators=None, fallback_model=None):
+        return {
+            "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
+            "score": 1.0,
+            "per_row": [
+                {"semantic_match": {"match": True, "reasoning": "ok"}} for _ in refs
+            ],
+        }
+
+    return AsyncMock(side_effect=judge)
+
+
+class TestScoreAndWriteTTFS(unittest.IsolatedAsyncioTestCase):
+    async def test_ttfs_in_metrics_and_results(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            with patch.object(stt_eval, "get_llm_judge_score", _fake_judge()):
+                metrics = await stt_eval._score_and_write_results(
+                    ids=["a", "b", "c"],
+                    gt_transcripts=["hi", "there", "world"],
+                    pred_transcripts=["hi", "there", "world"],
+                    output_dir=str(out),
+                    evaluator_config_dir=str(out),
+                    ttfs_values=[0.3, 0.5, None],
+                )
+
+            self.assertIn("ttfs", metrics)
+            self.assertEqual(set(metrics["ttfs"]), {"p50", "p95", "p99", "mean"})
+            df = pd.read_csv(out / "results.csv")
+            self.assertIn("ttfs", df.columns)
+
+    async def test_direct_engine_omits_ttfs(self):
+        """All-None TTFS (direct engine) leaves ttfs out entirely."""
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            with patch.object(stt_eval, "get_llm_judge_score", _fake_judge()):
+                metrics = await stt_eval._score_and_write_results(
+                    ids=["a", "b"],
+                    gt_transcripts=["hi", "there"],
+                    pred_transcripts=["hi", "there"],
+                    output_dir=str(out),
+                    evaluator_config_dir=str(out),
+                    ttfs_values=[None, None],
+                )
+
+            self.assertNotIn("ttfs", metrics)
+            df = pd.read_csv(out / "results.csv")
+            self.assertNotIn("ttfs", df.columns)
+
+
+class TestRunSTTEvalDirectRouting(unittest.IsolatedAsyncioTestCase):
+    async def test_direct_engine_concurrent_writes_no_ttfs(self):
+        """Direct engine routes through the shared concurrent runner: writes all
+        rows (respecting max_concurrency) and emits no ttfs column."""
+        from calibrate_agent.stt import eval as stt_eval
+
+        async def fake_direct(audio_path, reference, provider, language, uid):
+            stem = Path(audio_path).stem
+            return {"transcript": f"pred_{stem}"}  # no ttfs key for direct
+
+        gt_data = [{"id": i, "gt": str(i)} for i in (1, 2, 3)]
+        with tempfile.TemporaryDirectory() as tmp:
+            csv_path = Path(tmp) / "results.csv"
+            with patch.object(
+                stt_eval, "transcribe_audio", AsyncMock(side_effect=fake_direct)
+            ):
+                n = await stt_eval.run_stt_eval(
+                    gt_data=gt_data,
+                    audio_dir=Path(tmp),
+                    provider="deepgram",
+                    language="english",
+                    results_csv_path=csv_path,
+                    engine="direct",
+                    max_concurrency=3,
+                )
+            self.assertEqual(n, 3)
+            df = pd.read_csv(csv_path)
+            self.assertEqual(len(df), 3)
+            self.assertNotIn("ttfs", df.columns)
+
+
+class TestRunSTTEvalPipelineRouting(unittest.IsolatedAsyncioTestCase):
+    async def test_pipeline_engine_writes_transcript_and_ttfs(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            # id is the wav stem; echo a per-id transcript + latency.
+            stem = Path(audio_path).stem
+            return {"transcript": f"pred_{stem}", "ttfs": 0.1 * int(stem)}
+
+        gt_data = [{"id": 1, "gt": "one"}, {"id": 2, "gt": "two"}]
+        with tempfile.TemporaryDirectory() as tmp:
+            csv_path = Path(tmp) / "results.csv"
+            with patch.object(
+                stt_eval,
+                "transcribe_audio_pipeline",
+                AsyncMock(side_effect=fake_transcribe),
+            ):
+                n = await stt_eval.run_stt_eval(
+                    gt_data=gt_data,
+                    audio_dir=Path(tmp),
+                    provider="deepgram",
+                    language="tamil",
+                    results_csv_path=csv_path,
+                    engine="pipeline",
+                    max_concurrency=2,
+                )
+
+            self.assertEqual(n, 2)
+            df = pd.read_csv(csv_path).sort_values("id").reset_index(drop=True)
+            self.assertEqual(list(df["pred"]), ["pred_1", "pred_2"])
+            self.assertIn("ttfs", df.columns)
+            self.assertEqual(len(df), 2)
+
+    async def test_pipeline_engine_resumes_and_skips_processed(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        gt_data = [{"id": 1, "gt": "one"}, {"id": 2, "gt": "two"}]
+        with tempfile.TemporaryDirectory() as tmp:
+            csv_path = Path(tmp) / "results.csv"
+            # Pre-seed id=1 as already processed.
+            pd.DataFrame(
+                [{"id": 1, "gt": "one", "pred": "pred_1", "ttfs": 0.1}]
+            ).to_csv(csv_path, index=False)
+
+            calls = []
+
+            async def fake_transcribe(audio_path, reference, provider, language, uid):
+                stem = Path(audio_path).stem
+                calls.append(stem)
+                return {"transcript": f"pred_{stem}", "ttfs": 0.2}
+
+            with patch.object(
+                stt_eval,
+                "transcribe_audio_pipeline",
+                AsyncMock(side_effect=fake_transcribe),
+            ):
+                await stt_eval.run_stt_eval(
+                    gt_data=gt_data,
+                    audio_dir=Path(tmp),
+                    provider="deepgram",
+                    language="hindi",
+                    results_csv_path=csv_path,
+                    engine="pipeline",
+                )
+
+            # Only id=2 should have been transcribed (id=1 skipped).
+            self.assertEqual(calls, ["2"])
+            df = pd.read_csv(csv_path)
+            self.assertEqual(len(df), 2)
+
+    async def test_pipeline_engine_failure_left_for_retry(self):
+        """A failing clip is not written (raises no gather-wide cancel)."""
+        from calibrate_agent.stt import eval as stt_eval
+
+        gt_data = [{"id": 1, "gt": "one"}, {"id": 2, "gt": "two"}]
+
+        async def fake_transcribe(audio_path, reference, provider, language, uid):
+            stem = Path(audio_path).stem
+            if stem == "1":
+                raise RuntimeError("boom")
+            return {"transcript": f"pred_{stem}", "ttfs": 0.2}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            csv_path = Path(tmp) / "results.csv"
+            with patch.object(
+                stt_eval,
+                "transcribe_audio_pipeline",
+                AsyncMock(side_effect=fake_transcribe),
+            ):
+                n = await stt_eval.run_stt_eval(
+                    gt_data=gt_data,
+                    audio_dir=Path(tmp),
+                    provider="deepgram",
+                    language="english",
+                    results_csv_path=csv_path,
+                    engine="pipeline",
+                )
+
+            self.assertEqual(n, 1)  # only id=2 succeeded
+            df = pd.read_csv(csv_path)
+            self.assertEqual(list(df["id"]), [2])  # id=1 left unwritten
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/stt/test_pipeline_engine_wiring.py
+++ b/tests/stt/test_pipeline_engine_wiring.py
@@ -100,6 +100,26 @@ class TestScoreAndWriteTTFS(unittest.IsolatedAsyncioTestCase):
             df = pd.read_csv(out / "results.csv")
             self.assertIn("ttfs", df.columns)
 
+    async def test_shorter_ttfs_list_does_not_drop_rows(self):
+        """A ttfs list shorter than ids is padded, not silently truncated via zip."""
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            with patch.object(stt_eval, "get_llm_judge_score", _fake_judge()):
+                metrics = await stt_eval._score_and_write_results(
+                    ids=["a", "b", "c"],
+                    gt_transcripts=["hi", "there", "world"],
+                    pred_transcripts=["hi", "there", "world"],
+                    output_dir=str(out),
+                    evaluator_config_dir=str(out),
+                    ttfs_values=[0.3],  # shorter than the 3 ids
+                )
+
+            self.assertIn("ttfs", metrics)
+            df = pd.read_csv(out / "results.csv")
+            self.assertEqual(len(df), 3)  # all rows written, none dropped
+
     async def test_direct_engine_omits_ttfs(self):
         """All-None TTFS (direct engine) leaves ttfs out entirely."""
         from calibrate_agent.stt import eval as stt_eval

--- a/tests/stt/test_pipeline_eval.py
+++ b/tests/stt/test_pipeline_eval.py
@@ -1,0 +1,179 @@
+"""Integration tests for the pipecat-pipeline STT engine (stt/pipeline_eval.py).
+
+These run a REAL pipecat pipeline on the pinned pipecat 1.0.0 — no provider API
+keys and no Silero model needed. A deterministic RMS-based fake ``VADAnalyzer``
+drives the pipecat VAD state machine, and a minimal in-pipeline fake
+``STTService`` emits a finalized ``TranscriptionFrame`` at end-of-speech — which
+exercises the base STTService's real TTFB machinery, so we assert both transcript
+collection and TTFS latency harvesting work end-to-end.
+
+Run with:
+    python -m unittest tests.stt.test_pipeline_eval -v
+"""
+
+import asyncio
+import math
+import struct
+import unittest
+
+from pipecat.audio.vad.vad_analyzer import VADAnalyzer, VADParams
+from pipecat.frames.frames import (
+    Frame,
+    TranscriptionFrame,
+    VADUserStoppedSpeakingFrame,
+)
+from pipecat.observers.base_observer import FramePushed
+from pipecat.processors.frame_processor import FrameDirection
+from pipecat.services.stt_service import STTService
+
+from calibrate_agent.stt.pipeline_eval import (
+    SAMPLE_RATE,
+    SyntheticAudioInputTransport,
+    transcribe_via_pipeline,
+    _STTOutputCollector,
+)
+
+# Short silence windows keep the real-time-paced tests fast.
+FAST = dict(max_silence_seconds=0.6, post_transcription_silence_seconds=0.2)
+
+
+def _tone_pcm(seconds: float, freq: float = 220.0) -> bytes:
+    n = int(SAMPLE_RATE * seconds)
+    out = bytearray()
+    for i in range(n):
+        val = int(0.6 * 32767 * math.sin(2 * math.pi * freq * i / SAMPLE_RATE))
+        out += struct.pack("<h", val)
+    return bytes(out)
+
+
+class _RMSVADAnalyzer(VADAnalyzer):
+    """Deterministic VAD: loud frames -> speech, silence -> quiet. No model.
+
+    Implements only the two abstract hooks; the base class runs the real
+    STARTING/SPEAKING/STOPPING/QUIET state machine, so this genuinely exercises
+    the same VAD path Silero would, just with a trivial confidence function.
+    """
+
+    def __init__(self):
+        super().__init__(
+            params=VADParams(
+                confidence=0.5, start_secs=0.05, stop_secs=0.1, min_volume=0.0
+            )
+        )
+
+    def num_frames_required(self) -> int:
+        return int(SAMPLE_RATE * 0.02)  # 20 ms frames
+
+    def voice_confidence(self, buffer: bytes) -> float:
+        if not buffer:
+            return 0.0
+        count = len(buffer) // 2
+        samples = struct.unpack(f"<{count}h", buffer[: count * 2])
+        rms = math.sqrt(sum(s * s for s in samples) / count) / 32768.0
+        return 1.0 if rms > 0.05 else 0.0
+
+
+class _FakeSTTService(STTService):
+    """Emits a fixed transcript when VAD reports the user stopped speaking."""
+
+    def __init__(self, text: str = "hello world", **kwargs):
+        super().__init__(stt_ttfb_timeout=0.3, **kwargs)
+        self._text = text
+
+    def can_generate_metrics(self) -> bool:
+        # Real provider services (Deepgram, Cartesia, ...) override this to True;
+        # required for the base STTService to emit TTFB metrics.
+        return True
+
+    async def run_stt(self, audio: bytes):
+        return
+        yield  # pragma: no cover - makes this an async generator
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+        if isinstance(frame, VADUserStoppedSpeakingFrame):
+            await self.push_frame(
+                TranscriptionFrame(
+                    user_id="", text=self._text, timestamp="", finalized=True
+                )
+            )
+
+
+class TestPipelineEngine(unittest.IsolatedAsyncioTestCase):
+    async def test_pipeline_produces_transcript_and_ttfs(self):
+        result = await transcribe_via_pipeline(
+            _tone_pcm(seconds=0.6),
+            _FakeSTTService(text="hello world"),
+            vad_analyzer=_RMSVADAnalyzer(),
+            **FAST,
+        )
+        self.assertEqual(result["transcript"], "hello world")
+        # VAD fired -> STTService opened+closed its TTFB window -> latency harvested.
+        self.assertIsNotNone(result["ttfs"])
+        self.assertGreaterEqual(result["ttfs"], 0.0)
+        self.assertLess(result["ttfs"], 5.0)
+
+    async def test_pipeline_empty_on_pure_silence(self):
+        """Silence never trips VAD, so no transcript and no TTFS (not a crash)."""
+        result = await transcribe_via_pipeline(
+            bytes(int(SAMPLE_RATE * 0.4) * 2),  # 0.4s of 16-bit silence
+            _FakeSTTService(text="should not appear"),
+            vad_analyzer=_RMSVADAnalyzer(),
+            **FAST,
+        )
+        self.assertEqual(result["transcript"], "")
+        self.assertIsNone(result["ttfs"])
+
+
+class TestOutputCollector(unittest.IsolatedAsyncioTestCase):
+    async def test_collector_concatenates_segments(self):
+        ev = asyncio.Event()
+        collector = _STTOutputCollector(ev)
+        stt = _FakeSTTService()
+
+        async def push(text):
+            await collector.on_push_frame(
+                FramePushed(
+                    source=stt,
+                    destination=stt,
+                    frame=TranscriptionFrame(user_id="", text=text, timestamp=""),
+                    direction=FrameDirection.DOWNSTREAM,
+                    timestamp=0,
+                )
+            )
+
+        await push("part one")
+        await push("part two")
+        self.assertEqual(collector.transcript, "part one part two")
+        self.assertTrue(ev.is_set())
+
+    async def test_collector_ignores_non_stt_sources(self):
+        """Frames not sourced from an STTService are ignored."""
+        ev = asyncio.Event()
+        collector = _STTOutputCollector(ev)
+
+        class _NotStt:
+            pass
+
+        await collector.on_push_frame(
+            FramePushed(
+                source=_NotStt(),
+                destination=_NotStt(),
+                frame=TranscriptionFrame(user_id="", text="ignore me", timestamp=""),
+                direction=FrameDirection.DOWNSTREAM,
+                timestamp=0,
+            )
+        )
+        self.assertEqual(collector.transcript, "")
+        self.assertFalse(ev.is_set())
+
+
+class TestTransport(unittest.TestCase):
+    def test_transport_chunk_size(self):
+        """20 ms at 16 kHz 16-bit = 640 bytes/chunk."""
+        t = SyntheticAudioInputTransport(b"", asyncio.Event())
+        self.assertEqual(t._chunk_size, 640)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from calibrate_agent._env import env_int
+from calibrate_agent._env import env_int, resolve_stt_parallelism
 
 
 class TestEnvInt:
@@ -24,6 +24,43 @@ class TestEnvInt:
         monkeypatch.setenv("CALIBRATE_TEST_INT", "-1")
         assert env_int("CALIBRATE_TEST_INT", 2) == -1
 
+class TestResolveSTTParallelism:
+    def _clear(self, monkeypatch):
+        monkeypatch.delenv("CALIBRATE_STT_MAX_PARALLEL", raising=False)
+        monkeypatch.delenv("CALIBRATE_STT_MAX_CONCURRENCY", raising=False)
+
+    def test_pipeline_default_is_one_one(self, monkeypatch):
+        self._clear(monkeypatch)
+        assert resolve_stt_parallelism("pipeline") == (1, 1)
+
+    def test_direct_default_is_two_four(self, monkeypatch):
+        self._clear(monkeypatch)
+        assert resolve_stt_parallelism("direct") == (2, 4)
+
+    def test_unknown_engine_falls_back_to_direct(self, monkeypatch):
+        self._clear(monkeypatch)
+        assert resolve_stt_parallelism("banana") == (2, 4)
+
+    def test_explicit_values_win_over_everything(self, monkeypatch):
+        monkeypatch.setenv("CALIBRATE_STT_MAX_PARALLEL", "9")
+        monkeypatch.setenv("CALIBRATE_STT_MAX_CONCURRENCY", "9")
+        # Explicit args beat both env and the per-engine default.
+        assert resolve_stt_parallelism("pipeline", 3, 5) == (3, 5)
+
+    def test_env_overrides_engine_default(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("CALIBRATE_STT_MAX_PARALLEL", "6")
+        monkeypatch.setenv("CALIBRATE_STT_MAX_CONCURRENCY", "8")
+        # No explicit args → env wins over the pipeline (1, 1) default.
+        assert resolve_stt_parallelism("pipeline") == (6, 8)
+
+    def test_partial_explicit_leaves_other_to_default(self, monkeypatch):
+        self._clear(monkeypatch)
+        # Only concurrency given explicitly; parallel falls to pipeline default.
+        assert resolve_stt_parallelism("pipeline", max_concurrency=5) == (1, 5)
+
+
+class TestEnvStdlibOnly:
     def test_stays_stdlib_only(self):
         """The module must stay stdlib-only so the CLI can import it at
         parser-build time without dragging in scipy/numpy/pipecat (which trips a

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
-from calibrate_agent._env import env_int, resolve_stt_parallelism
+from calibrate_agent._env import (
+    env_int,
+    resolve_stt_max_concurrency,
+    resolve_stt_parallelism,
+)
 
 
 class TestEnvInt:
@@ -58,6 +62,32 @@ class TestResolveSTTParallelism:
         self._clear(monkeypatch)
         # Only concurrency given explicitly; parallel falls to pipeline default.
         assert resolve_stt_parallelism("pipeline", max_concurrency=5) == (1, 5)
+
+
+class TestResolveSTTMaxConcurrency:
+    def _clear(self, monkeypatch):
+        monkeypatch.delenv("CALIBRATE_STT_MAX_PARALLEL", raising=False)
+        monkeypatch.delenv("CALIBRATE_STT_MAX_CONCURRENCY", raising=False)
+
+    def test_per_engine_default(self, monkeypatch):
+        self._clear(monkeypatch)
+        assert resolve_stt_max_concurrency("pipeline") == 1
+        assert resolve_stt_max_concurrency("direct") == 4
+
+    def test_explicit_wins(self, monkeypatch):
+        monkeypatch.setenv("CALIBRATE_STT_MAX_CONCURRENCY", "9")
+        assert resolve_stt_max_concurrency("pipeline", 3) == 3
+
+    def test_env_overrides_default(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("CALIBRATE_STT_MAX_CONCURRENCY", "7")
+        assert resolve_stt_max_concurrency("pipeline") == 7
+
+    def test_ignores_the_parallel_env_var(self, monkeypatch):
+        self._clear(monkeypatch)
+        # A single-provider resolve must not be swayed by the across-providers knob.
+        monkeypatch.setenv("CALIBRATE_STT_MAX_PARALLEL", "99")
+        assert resolve_stt_max_concurrency("pipeline") == 1
 
 
 class TestEnvStdlibOnly:


### PR DESCRIPTION
## What
- Add `transcribe_via_pipeline`: streams a WAV through a real pipecat pipeline (synthetic real-time transport → Silero VAD → `STTService` via `create_stt_service`) instead of calling provider SDKs directly, mirroring the live agent.
- Harvests per-clip TTFS latency (speech-stop → final transcript) from pipecat's `TTFBMetricsData`, for every provider.
- Add integration tests that exercise the full pipeline on pipecat 1.0.0 with no API keys (fake VAD + fake `STTService`); 5/5 green in ~4s.

## Notes
- Engine only — not yet wired into `run_stt_eval` or the CLI; accuracy scoring (WER/CER/judge/intent-entity) is unchanged and downstream, so it applies identically once wired.
- Known follow-up before wiring: `create_stt_service`/`get_stt_language` only map english/hindi/kannada and silently fall back to English for the other 10 languages — must extend to full 13-language coverage (parity with the direct path's `get_stt_language_code`). Also missing vs direct: Google Sindhi region special-case, Sarvam stream rate limiter, `@backoff` retry, Langfuse audio tracing.
- Real-time 1× pacing makes runs take ~clip-duration per file; bounded concurrency (planned in wiring) mitigates it.
- Absolute latency numbers still need validation against a real keyed provider run.