### PR TITLE
Add --eval-only mode to TTS

### DIFF
--- a/calibrate_agent/cli.py
+++ b/calibrate_agent/cli.py
@@ -277,6 +277,17 @@ Examples:
         default=None,
         help="Path to optional JSON config file with judge settings (model, prompt)",
     )
+    tts_parser.add_argument(
+        "--eval-only",
+        action="store_true",
+        help="Skip synthesis and run the audio judge directly on a dataset of (text, audio_path) pairs",
+    )
+    tts_parser.add_argument(
+        "--dataset",
+        type=str,
+        default=None,
+        help="Path to dataset JSON (list of {id, text, audio_path}). Required with --eval-only.",
+    )
 
     # ── LLM tests ───────────────────────────────────────────────
     # `calibrate-agent llm` with no args → interactive UI
@@ -560,8 +571,25 @@ Examples:
             _launch_ink_ui("stt")
 
     elif args.component == "tts":
-        # If provider is given, run evaluation directly; otherwise launch interactive UI
-        if args.provider is not None:
+        # eval-only: skip synthesis and run the audio judge on a dataset.
+        # provider given → run synthesis + evaluators.
+        # neither: launch interactive UI.
+        if args.eval_only:
+            from calibrate_agent.tts.benchmark import main as tts_benchmark_main
+
+            if not args.dataset:
+                print("\033[31mError: --dataset is required with --eval-only\033[0m")
+                sys.exit(1)
+
+            argv = ["calibrate-agent", "--eval-only", "--dataset", args.dataset]
+            argv.extend(["-l", args.language])
+            argv.extend(["-o", args.output_dir])
+            if args.config:
+                argv.extend(["--config", args.config])
+
+            sys.argv = argv
+            asyncio.run(tts_benchmark_main())
+        elif args.provider is not None:
             from calibrate_agent.tts.benchmark import main as tts_benchmark_main
 
             providers = args.provider

--- a/calibrate_agent/cli.py
+++ b/calibrate_agent/cli.py
@@ -280,16 +280,15 @@ Examples:
     tts_parser.add_argument(
         "--eval-only",
         action="store_true",
-        help="Skip synthesis and run the audio judge directly on a dataset of (text, audio_path) pairs",
+        help="Skip synthesis and run the audio judge on a prior run's audio (see --dataset)",
     )
     tts_parser.add_argument(
         "--dataset",
         type=str,
         default=None,
         help=(
-            "Source for --eval-only: a prior run dir (its results.csv is read), "
-            "a CSV with id/text/audio_path columns, or a JSON list of "
-            "{id, text, audio_path}. Required with --eval-only."
+            "Prior TTS run directory (e.g. ./out/run/openai) whose results.csv "
+            "is read directly. Required with --eval-only."
         ),
     )
 
@@ -586,7 +585,6 @@ Examples:
                 sys.exit(1)
 
             argv = ["calibrate-agent", "--eval-only", "--dataset", args.dataset]
-            argv.extend(["-l", args.language])
             argv.extend(["-o", args.output_dir])
             if args.config:
                 argv.extend(["--config", args.config])

--- a/calibrate_agent/cli.py
+++ b/calibrate_agent/cli.py
@@ -286,7 +286,11 @@ Examples:
         "--dataset",
         type=str,
         default=None,
-        help="Path to dataset JSON (list of {id, text, audio_path}). Required with --eval-only.",
+        help=(
+            "Source for --eval-only: a prior run dir (its results.csv is read), "
+            "a CSV with id/text/audio_path columns, or a JSON list of "
+            "{id, text, audio_path}. Required with --eval-only."
+        ),
     )
 
     # ── LLM tests ───────────────────────────────────────────────

--- a/calibrate_agent/tts/__init__.py
+++ b/calibrate_agent/tts/__init__.py
@@ -32,10 +32,19 @@ from calibrate_agent.tts.benchmark import run
 # Single provider evaluation
 from calibrate_agent.tts.eval import run_single_provider_eval as run_single
 
+# Eval-only (skip synthesis, judge pre-generated audio)
+from calibrate_agent.tts.eval import run_eval_only
+
 # Leaderboard generation
 from calibrate_agent.tts.leaderboard import generate_leaderboard
 
 # Validation utilities
 from calibrate_agent.tts.eval import validate_tts_input_file
 
-__all__ = ["run", "run_single", "generate_leaderboard", "validate_tts_input_file"]
+__all__ = [
+    "run",
+    "run_single",
+    "run_eval_only",
+    "generate_leaderboard",
+    "validate_tts_input_file",
+]

--- a/calibrate_agent/tts/benchmark.py
+++ b/calibrate_agent/tts/benchmark.py
@@ -23,6 +23,7 @@ from typing import Literal
 from calibrate_agent.tts.eval import (
     TTS_LANGUAGES,
     TTS_PROVIDERS,
+    run_eval_only,
     run_single_provider_eval,
     validate_tts_input_file,
 )
@@ -142,8 +143,18 @@ async def main():
         "--provider",
         type=str,
         nargs="+",
-        required=True,
-        help="TTS provider(s) to use for evaluation (space-separated for multiple)",
+        help="TTS provider(s) to use for evaluation (space-separated for multiple). Not required with --eval-only.",
+    )
+    parser.add_argument(
+        "--eval-only",
+        action="store_true",
+        help="Skip synthesis and run the audio judge directly on a dataset of (text, audio_path) pairs",
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        default=None,
+        help="Path to dataset JSON (list of {id, text, audio_path}). Required with --eval-only.",
     )
     parser.add_argument(
         "-l",
@@ -157,8 +168,7 @@ async def main():
         "-i",
         "--input",
         type=str,
-        required=True,
-        help="Path to the input CSV file containing the texts to synthesize",
+        help="Path to the input CSV file containing the texts to synthesize. Not required with --eval-only.",
     )
     parser.add_argument(
         "-o",
@@ -197,6 +207,63 @@ async def main():
 
     providers = args.provider
 
+    # Load evaluators from optional config file (shared by both flows)
+    judge_evaluators = None
+    if args.config:
+        import json as _json
+
+        with open(args.config) as _f:
+            _cfg = _json.load(_f)
+        judge_evaluators = _cfg.get("evaluators")
+
+    # Eval-only mode owns ``output_dir/logs`` itself via the provider_log
+    # contextvar, so we don't set up a benchmark-level StreamTee here —
+    # otherwise both writers would target the same path (and the eval-only
+    # ``os.remove`` of that path would unlink the active handle on POSIX or
+    # raise PermissionError on Windows).
+    if args.eval_only:
+        if not args.dataset:
+            print("\033[31mError: --dataset is required with --eval-only\033[0m")
+            sys.exit(1)
+
+        os.makedirs(args.output_dir, exist_ok=True)
+
+        print("\n\033[91mTTS Eval-Only\033[0m\n")
+        print(f"Dataset: {args.dataset}")
+        print(f"Output: {args.output_dir}")
+        print("")
+
+        result = await run_eval_only(
+            dataset_path=args.dataset,
+            output_dir=args.output_dir,
+            judge_evaluators=judge_evaluators,
+        )
+
+        print(f"\n\033[92m{'='*60}\033[0m")
+        print(f"\033[92mSummary\033[0m")
+        print(f"\033[92m{'='*60}\033[0m\n")
+
+        if result.get("status") == "error":
+            print(f"  \033[31mError - {result.get('error')}\033[0m")
+            sys.exit(1)
+
+        metrics = result.get("metrics", {})
+        # Evaluator entries are dicts carrying a ``type`` field.
+        judge_str = ", ".join(
+            f"{k}={v['mean']:.2f}"
+            for k, v in metrics.items()
+            if isinstance(v, dict) and "type" in v
+        )
+        print(f"  {judge_str}")
+        return
+
+    if not providers:
+        print("\033[31mError: --provider is required (omit only with --eval-only)\033[0m")
+        sys.exit(1)
+    if not args.input:
+        print("\033[31mError: --input is required (omit only with --eval-only)\033[0m")
+        sys.exit(1)
+
     # Validate all providers
     for provider in providers:
         if provider not in TTS_PROVIDERS:
@@ -234,14 +301,6 @@ async def main():
         print(f"Input: {args.input}")
         print(f"Output: {args.output_dir}")
         print("")
-
-        # Load evaluators from optional config file
-        judge_evaluators = None
-        if args.config:
-            import json as _json
-            with open(args.config) as _f:
-                _cfg = _json.load(_f)
-            judge_evaluators = _cfg.get("evaluators")
 
         result = await run(
             input=args.input,

--- a/calibrate_agent/tts/benchmark.py
+++ b/calibrate_agent/tts/benchmark.py
@@ -154,7 +154,11 @@ async def main():
         "--dataset",
         type=str,
         default=None,
-        help="Path to dataset JSON (list of {id, text, audio_path}). Required with --eval-only.",
+        help=(
+            "Source for --eval-only: a prior run dir (its results.csv is read), "
+            "a CSV with id/text/audio_path columns, or a JSON list of "
+            "{id, text, audio_path}. Required with --eval-only."
+        ),
     )
     parser.add_argument(
         "-l",

--- a/calibrate_agent/tts/benchmark.py
+++ b/calibrate_agent/tts/benchmark.py
@@ -148,16 +148,15 @@ async def main():
     parser.add_argument(
         "--eval-only",
         action="store_true",
-        help="Skip synthesis and run the audio judge directly on a dataset of (text, audio_path) pairs",
+        help="Skip synthesis and run the audio judge on a prior run's audio (see --dataset)",
     )
     parser.add_argument(
         "--dataset",
         type=str,
         default=None,
         help=(
-            "Source for --eval-only: a prior run dir (its results.csv is read), "
-            "a CSV with id/text/audio_path columns, or a JSON list of "
-            "{id, text, audio_path}. Required with --eval-only."
+            "Prior TTS run directory (e.g. ./out/run/openai) whose results.csv "
+            "is read directly. Required with --eval-only."
         ),
     )
     parser.add_argument(

--- a/calibrate_agent/tts/eval.py
+++ b/calibrate_agent/tts/eval.py
@@ -943,6 +943,144 @@ async def run_single_provider_eval(
         _current_log_file.reset(token)
 
 
+def validate_tts_eval_only_dataset(dataset_path: str) -> tuple[bool, str, list[dict]]:
+    """Validate a TTS eval-only dataset JSON file.
+
+    Expected format: a JSON list of objects with ``id``, ``text`` and
+    ``audio_path`` fields. ``audio_path`` may be absolute or relative to the
+    dataset file's directory; each is resolved to an absolute path and checked
+    to exist. The resolved path is written back into the returned rows.
+
+    Returns:
+        tuple[bool, str, list[dict]]: (is_valid, error_message, parsed_rows)
+    """
+    if not exists(dataset_path):
+        return False, f"Dataset file does not exist: {dataset_path}", []
+
+    try:
+        with open(dataset_path) as f:
+            data = json.load(f)
+    except Exception as e:
+        return False, f"Failed to parse dataset JSON: {e}", []
+
+    if not isinstance(data, list):
+        return False, "Dataset must be a JSON list of objects", []
+
+    required = {"id", "text", "audio_path"}
+    dataset_dir = os.path.dirname(os.path.abspath(dataset_path))
+    for i, row in enumerate(data):
+        if not isinstance(row, dict):
+            return False, f"Row {i} is not an object", []
+        missing = required - row.keys()
+        if missing:
+            return (
+                False,
+                f"Row {i} missing required fields: {sorted(missing)}. Each row needs 'id', 'text', 'audio_path'.",
+                [],
+            )
+        audio_path = row["audio_path"]
+        if not os.path.isabs(audio_path):
+            audio_path = join(dataset_dir, audio_path)
+        if not exists(audio_path):
+            return False, f"Row {i} audio file does not exist: {audio_path}", []
+        row["audio_path"] = audio_path
+
+    return True, "", data
+
+
+async def run_eval_only(
+    dataset_path: str,
+    output_dir: str,
+    judge_evaluators: list[dict] = None,
+) -> dict:
+    """Run the TTS audio judge only, on a pre-existing dataset of
+    (text, audio_path) pairs. Skips synthesis. Writes ``metrics.json`` and
+    ``results.csv`` directly under ``output_dir``.
+
+    Args:
+        dataset_path: Path to a JSON file with a list of {"id", "text",
+            "audio_path"} rows.
+        output_dir: Directory to write results and metrics.
+        judge_evaluators: Optional list of evaluator dicts. Defaults to the
+            built-in TTS evaluator (``DEFAULT_TTS_EVALUATOR``) when omitted.
+
+    Returns:
+        dict with status, metrics, and output_dir.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+
+    log_save_path = join(output_dir, "logs")
+    if exists(log_save_path):
+        os.remove(log_save_path)
+
+    token = _current_log_file.set(log_save_path)
+    try:
+        _log("--------------------------------")
+        _log("\033[33mRunning TTS eval-only on dataset\033[0m")
+        _log(f"Dataset: {dataset_path}")
+
+        is_valid, error_msg, rows = validate_tts_eval_only_dataset(dataset_path)
+        if not is_valid:
+            _log(f"\033[31mError: {error_msg}\033[0m")
+            return {"status": "error", "error": error_msg}
+
+        ids = [r["id"] for r in rows]
+        texts = [str(r["text"]) for r in rows]
+        audio_paths = [r["audio_path"] for r in rows]
+
+        _evaluators = judge_evaluators if judge_evaluators else [DEFAULT_TTS_EVALUATOR]
+        require_unique_evaluator_names(_evaluators)
+        write_evaluator_config(output_dir, _evaluators)
+
+        llm_judge_results = await get_tts_llm_judge_score(
+            audio_paths,
+            texts,
+            evaluators=_evaluators,
+        )
+        for name, score_dict in llm_judge_results["scores"].items():
+            _log(f"  {name}: {score_dict['mean']:.4f}")
+
+        _evaluators_by_name = {ev["name"]: ev for ev in _evaluators}
+
+        metrics_data = {}
+        for name, score_dict in llm_judge_results["scores"].items():
+            metrics_data[name] = score_dict
+
+        with open(join(output_dir, "metrics.json"), "w") as f:
+            json.dump(metrics_data, f, indent=4)
+
+        data = []
+        for _id, text, audio_path, llm_row in zip(
+            ids,
+            texts,
+            audio_paths,
+            llm_judge_results["per_row"],
+        ):
+            row = {
+                "id": _id,
+                "text": text,
+                "audio_path": audio_path,
+            }
+            for name, ev in _evaluators_by_name.items():
+                ev_result = llm_row[name]
+                if is_rating(ev):
+                    row[name] = ev_result["score"]
+                else:
+                    row[name] = bool(ev_result["match"])
+                row[f"{name}_reasoning"] = ev_result["reasoning"]
+            data.append(row)
+
+        pd.DataFrame(data).to_csv(join(output_dir, "results.csv"), index=False)
+
+        return {
+            "status": "completed",
+            "metrics": metrics_data,
+            "output_dir": output_dir,
+        }
+    finally:
+        _current_log_file.reset(token)
+
+
 async def main():
     """CLI entry point for single-provider TTS evaluation.
 

--- a/calibrate_agent/tts/eval.py
+++ b/calibrate_agent/tts/eval.py
@@ -1020,8 +1020,8 @@ def validate_tts_eval_only_dataset(run_dir: str) -> tuple[bool, str, list[dict]]
         candidates = [audio_path]
         if not os.path.isabs(audio_path):
             candidates.append(
-            join(run_dir, TTS_AUDIO_SUBDIR, os.path.basename(audio_path))
-        )
+                join(run_dir, TTS_AUDIO_SUBDIR, os.path.basename(audio_path))
+            )
         resolved = next((os.path.abspath(c) for c in candidates if exists(c)), None)
         if resolved is None:
             return False, f"Row {i} audio file does not exist: {audio_path}", []

--- a/calibrate_agent/tts/eval.py
+++ b/calibrate_agent/tts/eval.py
@@ -1043,6 +1043,17 @@ async def run_eval_only(
     Returns:
         dict with status, metrics, and output_dir.
     """
+    # Refuse to write results back into the run dir being judged — that would
+    # overwrite its results.csv/metrics.json (losing the run's ttfb column).
+    if os.path.abspath(output_dir) == os.path.abspath(dataset_path):
+        return {
+            "status": "error",
+            "error": (
+                f"--output-dir must differ from the run dir being judged: {dataset_path}. "
+                "Choose a different -o so the run's results.csv/metrics.json aren't overwritten."
+            ),
+        }
+
     os.makedirs(output_dir, exist_ok=True)
 
     log_save_path = join(output_dir, "logs")

--- a/calibrate_agent/tts/eval.py
+++ b/calibrate_agent/tts/eval.py
@@ -1028,9 +1028,9 @@ async def run_eval_only(
     output_dir: str,
     judge_evaluators: list[dict] = None,
 ) -> dict:
-    """Run the TTS audio judge only, on a pre-existing dataset of
-    (text, audio_path) pairs. Skips synthesis. Writes ``metrics.json`` and
-    ``results.csv`` directly under ``output_dir``.
+    """Run the TTS audio judge only, on a prior run's audio. Skips synthesis
+    and reads the run directory's ``results.csv`` directly. Writes
+    ``metrics.json`` and ``results.csv`` under ``output_dir``.
 
     Args:
         dataset_path: A prior TTS run directory (e.g. ``./out/run/openai``)

--- a/calibrate_agent/tts/eval.py
+++ b/calibrate_agent/tts/eval.py
@@ -943,47 +943,111 @@ async def run_single_provider_eval(
         _current_log_file.reset(token)
 
 
-def validate_tts_eval_only_dataset(dataset_path: str) -> tuple[bool, str, list[dict]]:
-    """Validate a TTS eval-only dataset JSON file.
+def _resolve_eval_only_audio_path(audio_path: str, source_dir: str) -> str | None:
+    """Resolve a dataset row's ``audio_path`` to an existing file, or None.
 
-    Expected format: a JSON list of objects with ``id``, ``text`` and
-    ``audio_path`` fields. ``audio_path`` may be absolute or relative to the
-    dataset file's directory; each is resolved to an absolute path and checked
-    to exist. The resolved path is written back into the returned rows.
+    A TTS run's ``results.csv`` stores ``audio_path`` relative to the CWD at
+    run time (e.g. ``./out/run/openai/audios/row_1.wav``), while a hand-written
+    JSON dataset typically stores paths relative to the dataset file. To make
+    both "just work" — and to survive being pointed at from a different CWD —
+    each path is tried against several candidates and the first that exists
+    wins. The final ``{source_dir}/audios/{basename}`` candidate matches the
+    fixed run layout (``results.csv`` sits next to an ``audios/`` folder), so a
+    run directory resolves regardless of CWD.
+    """
+    candidates = [audio_path]
+    if not os.path.isabs(audio_path):
+        candidates.append(join(source_dir, audio_path))
+        candidates.append(join(source_dir, "audios", os.path.basename(audio_path)))
+    for candidate in candidates:
+        if exists(candidate):
+            return os.path.abspath(candidate)
+    return None
+
+
+def validate_tts_eval_only_dataset(dataset_path: str) -> tuple[bool, str, list[dict]]:
+    """Validate a TTS eval-only dataset and resolve its audio paths.
+
+    ``dataset_path`` may be any of:
+
+    - a **directory** from a prior TTS run (e.g. ``./out/run/openai``) — its
+      ``results.csv`` is read directly, no transformation needed;
+    - a **CSV** file with ``id``, ``text`` and ``audio_path`` columns (a run's
+      ``results.csv`` qualifies; extra columns like ``ttfb`` are ignored);
+    - a **JSON** file: a list of objects with ``id``, ``text`` and
+      ``audio_path`` fields.
+
+    Each ``audio_path`` is resolved to an existing absolute path (see
+    :func:`_resolve_eval_only_audio_path`) and written back into the returned
+    rows.
 
     Returns:
         tuple[bool, str, list[dict]]: (is_valid, error_message, parsed_rows)
     """
     if not exists(dataset_path):
-        return False, f"Dataset file does not exist: {dataset_path}", []
-
-    try:
-        with open(dataset_path) as f:
-            data = json.load(f)
-    except Exception as e:
-        return False, f"Failed to parse dataset JSON: {e}", []
-
-    if not isinstance(data, list):
-        return False, "Dataset must be a JSON list of objects", []
+        return False, f"Dataset path does not exist: {dataset_path}", []
 
     required = {"id", "text", "audio_path"}
-    dataset_dir = os.path.dirname(os.path.abspath(dataset_path))
-    for i, row in enumerate(data):
-        if not isinstance(row, dict):
-            return False, f"Row {i} is not an object", []
-        missing = required - row.keys()
+
+    # A directory is treated as a run output dir: read its results.csv.
+    if os.path.isdir(dataset_path):
+        csv_path = join(dataset_path, "results.csv")
+        if not exists(csv_path):
+            return (
+                False,
+                f"No results.csv found in directory: {dataset_path}. "
+                "Point --dataset at a provider run dir, its results.csv, or a JSON dataset.",
+                [],
+            )
+        dataset_path = csv_path
+
+    source_dir = os.path.dirname(os.path.abspath(dataset_path))
+
+    if dataset_path.lower().endswith(".csv"):
+        try:
+            df = pd.read_csv(dataset_path)
+        except Exception as e:
+            return False, f"Failed to read dataset CSV: {e}", []
+        missing = required - set(df.columns)
         if missing:
             return (
                 False,
-                f"Row {i} missing required fields: {sorted(missing)}. Each row needs 'id', 'text', 'audio_path'.",
+                f"CSV missing required columns: {sorted(missing)}. "
+                f"Found columns: {list(df.columns)}.",
                 [],
             )
-        audio_path = row["audio_path"]
-        if not os.path.isabs(audio_path):
-            audio_path = join(dataset_dir, audio_path)
-        if not exists(audio_path):
-            return False, f"Row {i} audio file does not exist: {audio_path}", []
-        row["audio_path"] = audio_path
+        data = [
+            {"id": r["id"], "text": r["text"], "audio_path": r["audio_path"]}
+            for _, r in df[["id", "text", "audio_path"]].iterrows()
+        ]
+    else:
+        try:
+            with open(dataset_path) as f:
+                data = json.load(f)
+        except Exception as e:
+            return False, f"Failed to parse dataset JSON: {e}", []
+        if not isinstance(data, list):
+            return False, "Dataset must be a JSON list of objects", []
+        for i, row in enumerate(data):
+            if not isinstance(row, dict):
+                return False, f"Row {i} is not an object", []
+            row_missing = required - row.keys()
+            if row_missing:
+                return (
+                    False,
+                    f"Row {i} missing required fields: {sorted(row_missing)}. "
+                    "Each row needs 'id', 'text', 'audio_path'.",
+                    [],
+                )
+
+    if not data:
+        return False, f"Dataset is empty: {dataset_path}", []
+
+    for i, row in enumerate(data):
+        resolved = _resolve_eval_only_audio_path(str(row["audio_path"]), source_dir)
+        if resolved is None:
+            return False, f"Row {i} audio file does not exist: {row['audio_path']}", []
+        row["audio_path"] = resolved
 
     return True, "", data
 
@@ -998,8 +1062,10 @@ async def run_eval_only(
     ``results.csv`` directly under ``output_dir``.
 
     Args:
-        dataset_path: Path to a JSON file with a list of {"id", "text",
-            "audio_path"} rows.
+        dataset_path: A prior TTS run directory (its ``results.csv`` is read),
+            a CSV with ``id``/``text``/``audio_path`` columns, or a JSON file
+            with a list of {"id", "text", "audio_path"} rows. See
+            :func:`validate_tts_eval_only_dataset`.
         output_dir: Directory to write results and metrics.
         judge_evaluators: Optional list of evaluator dicts. Defaults to the
             built-in TTS evaluator (``DEFAULT_TTS_EVALUATOR``) when omitted.

--- a/calibrate_agent/tts/eval.py
+++ b/calibrate_agent/tts/eval.py
@@ -943,113 +943,58 @@ async def run_single_provider_eval(
         _current_log_file.reset(token)
 
 
-def _resolve_eval_only_audio_path(audio_path: str, source_dir: str) -> str | None:
-    """Resolve a dataset row's ``audio_path`` to an existing file, or None.
+def validate_tts_eval_only_dataset(run_dir: str) -> tuple[bool, str, list[dict]]:
+    """Validate a TTS run directory for eval-only and resolve its audio paths.
 
-    A TTS run's ``results.csv`` stores ``audio_path`` relative to the CWD at
-    run time (e.g. ``./out/run/openai/audios/row_1.wav``), while a hand-written
-    JSON dataset typically stores paths relative to the dataset file. To make
-    both "just work" — and to survive being pointed at from a different CWD —
-    each path is tried against several candidates and the first that exists
-    wins. The final ``{source_dir}/audios/{basename}`` candidate matches the
-    fixed run layout (``results.csv`` sits next to an ``audios/`` folder), so a
-    run directory resolves regardless of CWD.
-    """
-    candidates = [audio_path]
-    if not os.path.isabs(audio_path):
-        candidates.append(join(source_dir, audio_path))
-        candidates.append(join(source_dir, "audios", os.path.basename(audio_path)))
-    for candidate in candidates:
-        if exists(candidate):
-            return os.path.abspath(candidate)
-    return None
-
-
-def validate_tts_eval_only_dataset(dataset_path: str) -> tuple[bool, str, list[dict]]:
-    """Validate a TTS eval-only dataset and resolve its audio paths.
-
-    ``dataset_path`` may be any of:
-
-    - a **directory** from a prior TTS run (e.g. ``./out/run/openai``) — its
-      ``results.csv`` is read directly, no transformation needed;
-    - a **CSV** file with ``id``, ``text`` and ``audio_path`` columns (a run's
-      ``results.csv`` qualifies; extra columns like ``ttfb`` are ignored);
-    - a **JSON** file: a list of objects with ``id``, ``text`` and
-      ``audio_path`` fields.
-
-    Each ``audio_path`` is resolved to an existing absolute path (see
-    :func:`_resolve_eval_only_audio_path`) and written back into the returned
-    rows.
+    ``run_dir`` is a prior TTS run's output directory (e.g. ``./out/run/openai``)
+    containing a ``results.csv`` with ``id``, ``text`` and ``audio_path``
+    columns — no transformation needed. Extra columns (e.g. ``ttfb``) are
+    ignored. Each ``audio_path`` is resolved to an existing absolute path,
+    tried as given (relative to the CWD) and, as a fallback, under
+    ``{run_dir}/audios/{basename}`` (the fixed run layout) so it resolves
+    regardless of the CWD.
 
     Returns:
         tuple[bool, str, list[dict]]: (is_valid, error_message, parsed_rows)
     """
-    if not exists(dataset_path):
-        return False, f"Dataset path does not exist: {dataset_path}", []
+    if not exists(run_dir):
+        return False, f"Dataset directory does not exist: {run_dir}", []
+    if not os.path.isdir(run_dir):
+        return False, f"--dataset must be a run directory, got a file: {run_dir}", []
 
-    required = {"id", "text", "audio_path"}
+    csv_path = join(run_dir, "results.csv")
+    if not exists(csv_path):
+        return False, f"No results.csv found in directory: {run_dir}", []
 
-    # A directory is treated as a run output dir: read its results.csv.
-    if os.path.isdir(dataset_path):
-        csv_path = join(dataset_path, "results.csv")
-        if not exists(csv_path):
-            return (
-                False,
-                f"No results.csv found in directory: {dataset_path}. "
-                "Point --dataset at a provider run dir, its results.csv, or a JSON dataset.",
-                [],
-            )
-        dataset_path = csv_path
+    try:
+        df = pd.read_csv(csv_path)
+    except Exception as e:
+        return False, f"Failed to read results.csv: {e}", []
 
-    source_dir = os.path.dirname(os.path.abspath(dataset_path))
+    missing = {"id", "text", "audio_path"} - set(df.columns)
+    if missing:
+        return (
+            False,
+            f"results.csv missing required columns: {sorted(missing)}. "
+            f"Found columns: {list(df.columns)}.",
+            [],
+        )
 
-    if dataset_path.lower().endswith(".csv"):
-        try:
-            df = pd.read_csv(dataset_path)
-        except Exception as e:
-            return False, f"Failed to read dataset CSV: {e}", []
-        missing = required - set(df.columns)
-        if missing:
-            return (
-                False,
-                f"CSV missing required columns: {sorted(missing)}. "
-                f"Found columns: {list(df.columns)}.",
-                [],
-            )
-        data = [
-            {"id": r["id"], "text": r["text"], "audio_path": r["audio_path"]}
-            for _, r in df[["id", "text", "audio_path"]].iterrows()
-        ]
-    else:
-        try:
-            with open(dataset_path) as f:
-                data = json.load(f)
-        except Exception as e:
-            return False, f"Failed to parse dataset JSON: {e}", []
-        if not isinstance(data, list):
-            return False, "Dataset must be a JSON list of objects", []
-        for i, row in enumerate(data):
-            if not isinstance(row, dict):
-                return False, f"Row {i} is not an object", []
-            row_missing = required - row.keys()
-            if row_missing:
-                return (
-                    False,
-                    f"Row {i} missing required fields: {sorted(row_missing)}. "
-                    "Each row needs 'id', 'text', 'audio_path'.",
-                    [],
-                )
+    if len(df) == 0:
+        return False, f"results.csv is empty: {csv_path}", []
 
-    if not data:
-        return False, f"Dataset is empty: {dataset_path}", []
-
-    for i, row in enumerate(data):
-        resolved = _resolve_eval_only_audio_path(str(row["audio_path"]), source_dir)
+    rows = []
+    for i, r in df[["id", "text", "audio_path"]].iterrows():
+        audio_path = str(r["audio_path"])
+        candidates = [audio_path]
+        if not os.path.isabs(audio_path):
+            candidates.append(join(run_dir, "audios", os.path.basename(audio_path)))
+        resolved = next((os.path.abspath(c) for c in candidates if exists(c)), None)
         if resolved is None:
-            return False, f"Row {i} audio file does not exist: {row['audio_path']}", []
-        row["audio_path"] = resolved
+            return False, f"Row {i} audio file does not exist: {audio_path}", []
+        rows.append({"id": r["id"], "text": r["text"], "audio_path": resolved})
 
-    return True, "", data
+    return True, "", rows
 
 
 async def run_eval_only(
@@ -1062,9 +1007,8 @@ async def run_eval_only(
     ``results.csv`` directly under ``output_dir``.
 
     Args:
-        dataset_path: A prior TTS run directory (its ``results.csv`` is read),
-            a CSV with ``id``/``text``/``audio_path`` columns, or a JSON file
-            with a list of {"id", "text", "audio_path"} rows. See
+        dataset_path: A prior TTS run directory (e.g. ``./out/run/openai``)
+            whose ``results.csv`` is read directly. See
             :func:`validate_tts_eval_only_dataset`.
         output_dir: Directory to write results and metrics.
         judge_evaluators: Optional list of evaluator dicts. Defaults to the

--- a/calibrate_agent/tts/eval.py
+++ b/calibrate_agent/tts/eval.py
@@ -777,6 +777,94 @@ TTS_LANGUAGES = [
 ]
 
 
+async def _score_and_write_results(
+    ids: list,
+    texts: list[str],
+    audio_paths: list[str],
+    output_dir: str,
+    evaluator_config_dir: str,
+    judge_evaluators: list[dict] = None,
+    ttfb_values: list = None,
+) -> dict:
+    """Run the TTS audio judge over (audio_path, text) pairs and write outputs.
+
+    Writes ``metrics.json`` and ``results.csv`` under ``output_dir`` and the
+    resolved evaluator config under ``evaluator_config_dir``. Returns the
+    metrics_data dict.
+
+    When ``ttfb_values`` (aligned with ``ids``) is provided, a ``ttfb`` column
+    and TTFB percentile metrics are included; when None (eval-only, where
+    nothing is synthesized) both are omitted.
+    """
+    _log("Running evaluators...")
+    _evaluators = judge_evaluators if judge_evaluators else [DEFAULT_TTS_EVALUATOR]
+    require_unique_evaluator_names(_evaluators)
+    write_evaluator_config(evaluator_config_dir, _evaluators)
+    llm_judge_results = await get_tts_llm_judge_score(
+        audio_paths,
+        texts,
+        evaluators=_evaluators,
+    )
+    for name, score_dict in llm_judge_results["scores"].items():
+        _log(f"  {name}: {score_dict['mean']:.4f}")
+
+    # Map evaluator name → evaluator dict (for per-row value extraction).
+    _evaluators_by_name = {ev["name"]: ev for ev in _evaluators}
+
+    # Each evaluator gets one entry keyed by its name. The value is the full
+    # per-criterion dict (``type``, ``mean``, plus ``scale_min``/``scale_max``
+    # for ratings). Downstream consumers (leaderboard, summary print, UI)
+    # detect evaluators as dict values that carry a ``type`` field.
+    metrics_data = {}
+    for name, score_dict in llm_judge_results["scores"].items():
+        metrics_data[name] = score_dict
+
+    # TTFB percentile metrics (filter out None/NaN values). Only for the
+    # synthesis path — eval-only passes ttfb_values=None.
+    if ttfb_values is not None:
+        valid_ttfb = [
+            t
+            for t in ttfb_values
+            if t is not None and not (isinstance(t, float) and np.isnan(t))
+        ]
+        ttfb_pct = _latency_percentiles(valid_ttfb)
+        if ttfb_pct is not None:
+            metrics_data["ttfb"] = {
+                "p50": float(ttfb_pct["p50"]),
+                "p95": float(ttfb_pct["p95"]),
+                "p99": float(ttfb_pct["p99"]),
+                "count": ttfb_pct["count"],
+            }
+
+    metrics_save_path = join(output_dir, "metrics.json")
+    with open(metrics_save_path, "w") as f:
+        json.dump(metrics_data, f, indent=4)
+    _log(f"Metrics saved to: {metrics_save_path}")
+
+    ttfb_iter = ttfb_values if ttfb_values is not None else [None] * len(ids)
+    data = []
+    for _id, text, audio_path, ttfb, llm_row in zip(
+        ids, texts, audio_paths, ttfb_iter, llm_judge_results["per_row"]
+    ):
+        row = {"id": _id, "text": text, "audio_path": audio_path}
+        if ttfb_values is not None:
+            row["ttfb"] = ttfb
+        for name, ev in _evaluators_by_name.items():
+            ev_result = llm_row[name]
+            if is_rating(ev):
+                row[name] = ev_result["score"]
+            else:
+                row[name] = bool(ev_result["match"])
+            row[f"{name}_reasoning"] = ev_result["reasoning"]
+        data.append(row)
+
+    results_csv_path = join(output_dir, "results.csv")
+    pd.DataFrame(data).to_csv(results_csv_path, index=False)
+    _log(f"Results saved to: {results_csv_path}")
+
+    return metrics_data
+
+
 async def run_single_provider_eval(
     provider: str,
     language: str,
@@ -859,79 +947,17 @@ async def run_single_provider_eval(
                 "error": "No results found",
             }
 
-        # Run evaluators
-        _log("Running evaluators...")
-        _evaluators = judge_evaluators if judge_evaluators else [DEFAULT_TTS_EVALUATOR]
-        require_unique_evaluator_names(_evaluators)
-        write_evaluator_config(output_dir, _evaluators)
-        llm_judge_results = await get_tts_llm_judge_score(
-            all_audio_paths,
-            all_texts,
-            evaluators=_evaluators,
+        # Run evaluators, write metrics.json + results.csv (evaluator config
+        # goes to the parent output_dir, shared across providers).
+        metrics_data = await _score_and_write_results(
+            ids=all_ids,
+            texts=all_texts,
+            audio_paths=all_audio_paths,
+            output_dir=provider_output_dir,
+            evaluator_config_dir=output_dir,
+            judge_evaluators=judge_evaluators,
+            ttfb_values=all_ttfb,
         )
-        for name, score_dict in llm_judge_results["scores"].items():
-            _log(f"  {name}: {score_dict['mean']:.4f}")
-
-        # Map evaluator name → evaluator dict (for per-row value extraction)
-        _evaluators_by_name = {ev["name"]: ev for ev in _evaluators}
-
-        # Each evaluator gets one entry keyed by its name. The value is the
-        # full per-criterion dict (``type``, ``mean``, plus ``scale_min``/
-        # ``scale_max`` for ratings). Downstream consumers (leaderboard,
-        # summary print, UI) detect evaluators as dict values that carry a
-        # ``type`` field.
-        metrics_data = {}
-        for name, score_dict in llm_judge_results["scores"].items():
-            metrics_data[name] = score_dict
-
-        # Add ttfb percentile metrics (filter out None/NaN values)
-        valid_ttfb = [
-            t
-            for t in all_ttfb
-            if t is not None and not (isinstance(t, float) and np.isnan(t))
-        ]
-        ttfb_pct = _latency_percentiles(valid_ttfb)
-        if ttfb_pct is not None:
-            metrics_data["ttfb"] = {
-                "p50": float(ttfb_pct["p50"]),
-                "p95": float(ttfb_pct["p95"]),
-                "p99": float(ttfb_pct["p99"]),
-                "count": ttfb_pct["count"],
-            }
-
-        # Save metrics
-        metrics_save_path = join(provider_output_dir, "metrics.json")
-        with open(metrics_save_path, "w") as f:
-            json.dump(metrics_data, f, indent=4)
-
-        _log(f"Metrics saved to: {metrics_save_path}")
-
-        # Update results CSV with evaluator scores
-        data = []
-        for _id, text, audio_path, ttfb, llm_row in zip(
-            all_ids,
-            all_texts,
-            all_audio_paths,
-            all_ttfb,
-            llm_judge_results["per_row"],
-        ):
-            row = {
-                "id": _id,
-                "text": text,
-                "audio_path": audio_path,
-                "ttfb": ttfb,
-            }
-            for name, ev in _evaluators_by_name.items():
-                ev_result = llm_row[name]
-                if is_rating(ev):
-                    row[name] = ev_result["score"]
-                else:
-                    row[name] = bool(ev_result["match"])
-                row[f"{name}_reasoning"] = ev_result["reasoning"]
-            data.append(row)
-
-        pd.DataFrame(data).to_csv(results_csv_path, index=False)
-        _log(f"Results saved to: {results_csv_path}")
 
         return {
             "provider": provider,
@@ -1038,49 +1064,18 @@ async def run_eval_only(
         texts = [str(r["text"]) for r in rows]
         audio_paths = [r["audio_path"] for r in rows]
 
-        _evaluators = judge_evaluators if judge_evaluators else [DEFAULT_TTS_EVALUATOR]
-        require_unique_evaluator_names(_evaluators)
-        write_evaluator_config(output_dir, _evaluators)
-
-        llm_judge_results = await get_tts_llm_judge_score(
-            audio_paths,
-            texts,
-            evaluators=_evaluators,
+        # No synthesis here, so no TTFB: ttfb_values=None omits the column and
+        # the percentile metrics. Metrics + results + evaluator config all land
+        # in ``output_dir``.
+        metrics_data = await _score_and_write_results(
+            ids=ids,
+            texts=texts,
+            audio_paths=audio_paths,
+            output_dir=output_dir,
+            evaluator_config_dir=output_dir,
+            judge_evaluators=judge_evaluators,
+            ttfb_values=None,
         )
-        for name, score_dict in llm_judge_results["scores"].items():
-            _log(f"  {name}: {score_dict['mean']:.4f}")
-
-        _evaluators_by_name = {ev["name"]: ev for ev in _evaluators}
-
-        metrics_data = {}
-        for name, score_dict in llm_judge_results["scores"].items():
-            metrics_data[name] = score_dict
-
-        with open(join(output_dir, "metrics.json"), "w") as f:
-            json.dump(metrics_data, f, indent=4)
-
-        data = []
-        for _id, text, audio_path, llm_row in zip(
-            ids,
-            texts,
-            audio_paths,
-            llm_judge_results["per_row"],
-        ):
-            row = {
-                "id": _id,
-                "text": text,
-                "audio_path": audio_path,
-            }
-            for name, ev in _evaluators_by_name.items():
-                ev_result = llm_row[name]
-                if is_rating(ev):
-                    row[name] = ev_result["score"]
-                else:
-                    row[name] = bool(ev_result["match"])
-                row[f"{name}_reasoning"] = ev_result["reasoning"]
-            data.append(row)
-
-        pd.DataFrame(data).to_csv(join(output_dir, "results.csv"), index=False)
 
         return {
             "status": "completed",

--- a/calibrate_agent/tts/eval.py
+++ b/calibrate_agent/tts/eval.py
@@ -51,6 +51,11 @@ from calibrate_agent.langfuse import (
 from calibrate_agent.rate_limit import SARVAM_TTS_STREAMING_LIMITER
 
 
+# Subdirectory (under a run's output dir) where synthesized audio is written.
+# Single-sourced: the synthesis path writes here and eval-only reads from here.
+TTS_AUDIO_SUBDIR = "audios"
+
+
 # =============================================================================
 # TTS Provider API Methods
 # =============================================================================
@@ -595,7 +600,7 @@ async def run_tts_eval(
     else:
         processed_ids = set()
 
-    audio_output_dir = join(output_dir, "audios")
+    audio_output_dir = join(output_dir, TTS_AUDIO_SUBDIR)
     os.makedirs(audio_output_dir, exist_ok=True)
 
     success_count = 0
@@ -1014,7 +1019,9 @@ def validate_tts_eval_only_dataset(run_dir: str) -> tuple[bool, str, list[dict]]
         audio_path = str(r["audio_path"])
         candidates = [audio_path]
         if not os.path.isabs(audio_path):
-            candidates.append(join(run_dir, "audios", os.path.basename(audio_path)))
+            candidates.append(
+            join(run_dir, TTS_AUDIO_SUBDIR, os.path.basename(audio_path))
+        )
         resolved = next((os.path.abspath(c) for c in candidates if exists(c)), None)
         if resolved is None:
             return False, f"Row {i} audio file does not exist: {audio_path}", []

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -273,6 +273,40 @@ class TestMainDispatch(unittest.TestCase):
                     "-d", "--overwrite",
                 ])
 
+    def test_tts_eval_only_no_dataset_exits(self):
+        with self.assertRaises(SystemExit):
+            self._run_with_argv(["calibrate_agent", "tts", "--eval-only"])
+
+    def test_tts_eval_only_success(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("calibrate_agent.tts.benchmark.main", AsyncMock(return_value=None)):
+                self._run_with_argv([
+                    "calibrate_agent", "tts", "--eval-only", "--dataset", tmp,
+                    "-o", str(Path(tmp) / "out"),
+                ])
+
+    def test_tts_eval_only_forwards_dataset_and_config(self):
+        captured = {}
+
+        async def fake_main():
+            captured["argv"] = list(sys.argv)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "cfg.json"
+            cfg.write_text("{}")
+            with patch("calibrate_agent.tts.benchmark.main",
+                       AsyncMock(side_effect=fake_main)):
+                self._run_with_argv([
+                    "calibrate_agent", "tts", "--eval-only", "--dataset", tmp,
+                    "-o", str(Path(tmp) / "out"), "-c", str(cfg),
+                ])
+
+        self.assertIn("--eval-only", captured["argv"])
+        self.assertIn(tmp, captured["argv"])
+        self.assertIn("--config", captured["argv"])
+        # Language is not forwarded to the eval-only path (judge ignores it).
+        self.assertNotIn("-l", captured["argv"])
+
     def test_llm_no_config_launches_ui(self):
         from calibrate_agent import cli
         with patch.object(cli, "_launch_ink_ui") as mock:

--- a/tests/tts/test_benchmark.py
+++ b/tests/tts/test_benchmark.py
@@ -1,0 +1,89 @@
+"""
+Tests for calibrate_agent/tts/benchmark.py main() — focused on the eval-only
+dispatch branch (skip synthesis, run the audio judge on a prior run dir).
+
+Run with:
+    python -m pytest tests/tts/test_benchmark.py -v
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch, AsyncMock
+
+
+class TestTTSBenchmarkEvalOnly(unittest.IsolatedAsyncioTestCase):
+    async def _run_main(self, argv_extra):
+        from calibrate_agent.tts import benchmark
+
+        argv = ["calibrate-agent", "--eval-only"] + argv_extra
+        with patch.object(sys, "argv", argv):
+            await benchmark.main()
+
+    async def test_no_dataset_exits(self):
+        with self.assertRaises(SystemExit):
+            await self._run_main([])
+
+    async def test_success_calls_run_eval_only(self):
+        captured = {}
+
+        async def fake_run_eval_only(*, dataset_path, output_dir, judge_evaluators):
+            captured["dataset_path"] = dataset_path
+            captured["output_dir"] = output_dir
+            captured["judge_evaluators"] = judge_evaluators
+            return {
+                "status": "completed",
+                "metrics": {"quality": {"type": "binary", "mean": 0.9}},
+                "output_dir": output_dir,
+            }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "out")
+            with patch(
+                "calibrate_agent.tts.benchmark.run_eval_only",
+                AsyncMock(side_effect=fake_run_eval_only),
+            ):
+                await self._run_main(["--dataset", tmp, "-o", out])
+
+        self.assertEqual(captured["dataset_path"], tmp)
+        self.assertEqual(captured["output_dir"], out)
+        # No config passed → evaluators default to None.
+        self.assertIsNone(captured["judge_evaluators"])
+
+    async def test_config_forwards_evaluators(self):
+        captured = {}
+
+        async def fake_run_eval_only(*, dataset_path, output_dir, judge_evaluators):
+            captured["judge_evaluators"] = judge_evaluators
+            return {"status": "completed", "metrics": {}, "output_dir": output_dir}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "cfg.json"
+            cfg.write_text('{"evaluators": [{"name": "q", "system_prompt": "p"}]}')
+            with patch(
+                "calibrate_agent.tts.benchmark.run_eval_only",
+                AsyncMock(side_effect=fake_run_eval_only),
+            ):
+                await self._run_main(
+                    ["--dataset", tmp, "-o", os.path.join(tmp, "out"), "-c", str(cfg)]
+                )
+
+        self.assertEqual(captured["judge_evaluators"], [{"name": "q", "system_prompt": "p"}])
+
+    async def test_error_result_exits(self):
+        async def fake_run_eval_only(*, dataset_path, output_dir, judge_evaluators):
+            return {"status": "error", "error": "boom"}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch(
+                "calibrate_agent.tts.benchmark.run_eval_only",
+                AsyncMock(side_effect=fake_run_eval_only),
+            ):
+                with self.assertRaises(SystemExit):
+                    await self._run_main(["--dataset", tmp, "-o", os.path.join(tmp, "out")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tts/test_eval.py
+++ b/tests/tts/test_eval.py
@@ -485,6 +485,17 @@ class TestTTSValidateEvalOnlyDataset(unittest.TestCase):
             self.assertFalse(ok)
             self.assertIn("audio file does not exist", err)
 
+    def test_empty_results_csv(self):
+        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pd.DataFrame(columns=["id", "text", "audio_path"]).to_csv(
+                os.path.join(tmp, "results.csv"), index=False
+            )
+            ok, err, rows = validate_tts_eval_only_dataset(tmp)
+            self.assertFalse(ok)
+            self.assertIn("empty", err)
+
 
 class TestTTSRunEvalOnly(unittest.IsolatedAsyncioTestCase):
     async def test_runs_on_run_directory(self):

--- a/tests/tts/test_eval.py
+++ b/tests/tts/test_eval.py
@@ -537,6 +537,22 @@ class TestTTSRunEvalOnly(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["status"], "error")
         self.assertIn("does not exist", result["error"])
 
+    async def test_output_dir_same_as_run_dir_rejected(self):
+        """Judging a run into its own dir would clobber its results.csv."""
+        from calibrate_agent.tts import eval as tts_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_run_dir(tmp, extra_cols={"ttfb": 1.0})
+            result = await tts_eval.run_eval_only(
+                dataset_path=run_dir,
+                output_dir=os.path.join(run_dir, ""),  # same dir, trailing slash
+            )
+            self.assertEqual(result["status"], "error")
+            self.assertIn("must differ", result["error"])
+            # The original run's results.csv is untouched (ttfb column intact).
+            df = pd.read_csv(os.path.join(run_dir, "results.csv"))
+            self.assertIn("ttfb", df.columns)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tts/test_eval.py
+++ b/tests/tts/test_eval.py
@@ -465,6 +465,68 @@ class TestTTSValidateEvalOnlyDataset(unittest.TestCase):
             self.assertFalse(ok)
             self.assertIn("audio file does not exist", err)
 
+    def test_reads_run_results_csv(self):
+        """A run's results.csv is accepted directly (columns id/text/audio_path,
+        extra ttfb ignored; audio_path resolved via the {dir}/audios/ layout)."""
+        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audios = os.path.join(tmp, "audios")
+            os.makedirs(audios)
+            _write_wav(os.path.join(audios, "row_1.wav"))
+            csv_path = os.path.join(tmp, "results.csv")
+            pd.DataFrame(
+                [
+                    {
+                        "id": "row_1",
+                        "text": "hello world",
+                        # Stored relative to a *different* cwd — must still resolve
+                        # via the {csv_dir}/audios/{basename} fallback.
+                        "audio_path": "./out/run/openai/audios/row_1.wav",
+                        "ttfb": 1.23,
+                    }
+                ]
+            ).to_csv(csv_path, index=False)
+
+            ok, err, rows = validate_tts_eval_only_dataset(csv_path)
+            self.assertTrue(ok, err)
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["audio_path"], os.path.join(audios, "row_1.wav"))
+
+    def test_reads_run_directory(self):
+        """Pointing at a run directory reads its results.csv with no transform."""
+        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audios = os.path.join(tmp, "audios")
+            os.makedirs(audios)
+            _write_wav(os.path.join(audios, "row_1.wav"))
+            pd.DataFrame(
+                [{"id": "row_1", "text": "hi", "audio_path": "audios/row_1.wav"}]
+            ).to_csv(os.path.join(tmp, "results.csv"), index=False)
+
+            ok, err, rows = validate_tts_eval_only_dataset(tmp)
+            self.assertTrue(ok, err)
+            self.assertEqual(rows[0]["audio_path"], os.path.join(audios, "row_1.wav"))
+
+    def test_directory_without_results_csv(self):
+        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
+
+        with tempfile.TemporaryDirectory() as tmp:
+            ok, err, rows = validate_tts_eval_only_dataset(tmp)
+            self.assertFalse(ok)
+            self.assertIn("No results.csv", err)
+
+    def test_csv_missing_columns(self):
+        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
+
+        with tempfile.TemporaryDirectory() as tmp:
+            csv_path = os.path.join(tmp, "results.csv")
+            pd.DataFrame([{"id": "1", "text": "hi"}]).to_csv(csv_path, index=False)
+            ok, err, rows = validate_tts_eval_only_dataset(csv_path)
+            self.assertFalse(ok)
+            self.assertIn("missing required columns", err)
+
 
 class TestTTSRunEvalOnly(unittest.IsolatedAsyncioTestCase):
     async def test_runs_judge_on_dataset(self):
@@ -519,6 +581,52 @@ class TestTTSRunEvalOnly(unittest.IsolatedAsyncioTestCase):
             self.assertNotIn("ttfb", df.columns)
             self.assertIn("quality", df.columns)
             self.assertIn("quality_reasoning", df.columns)
+
+    async def test_runs_on_run_directory(self):
+        """End-to-end: point run_eval_only at a run dir, no dataset transform."""
+        from calibrate_agent.tts import eval as tts_eval
+
+        async def fake_judge(audio_paths, texts, evaluators=None, fallback_model=None):
+            return {
+                "scores": {"quality": {"type": "binary", "mean": 1.0}},
+                "score": 1.0,
+                "per_row": [{"quality": {"match": True, "reasoning": "ok"}}],
+            }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = os.path.join(tmp, "openai")
+            os.makedirs(os.path.join(run_dir, "audios"))
+            _write_wav(os.path.join(run_dir, "audios", "row_1.wav"))
+            pd.DataFrame(
+                [
+                    {
+                        "id": "row_1",
+                        "text": "hello world",
+                        "audio_path": "audios/row_1.wav",
+                        "ttfb": 1.0,
+                    }
+                ]
+            ).to_csv(os.path.join(run_dir, "results.csv"), index=False)
+            out = os.path.join(tmp, "eval")
+
+            with patch.object(
+                tts_eval, "get_tts_llm_judge_score", AsyncMock(side_effect=fake_judge)
+            ):
+                result = await tts_eval.run_eval_only(
+                    dataset_path=run_dir,
+                    output_dir=out,
+                    judge_evaluators=[
+                        {
+                            "name": "quality",
+                            "system_prompt": "judge quality",
+                            "judge_model": "openai/gpt-4.1",
+                            "type": "binary",
+                        }
+                    ],
+                )
+
+            self.assertEqual(result["status"], "completed")
+            self.assertTrue(os.path.exists(os.path.join(out, "results.csv")))
 
     async def test_invalid_dataset_returns_error(self):
         from calibrate_agent.tts import eval as tts_eval

--- a/tests/tts/test_eval.py
+++ b/tests/tts/test_eval.py
@@ -383,5 +383,153 @@ class TestSynthesizeGemini(unittest.IsolatedAsyncioTestCase):
                 await tts_eval.synthesize_gemini("hi", "english", "/tmp/out.wav")
 
 
+import json
+
+
+def _write_wav(path: str) -> None:
+    """Write a tiny valid WAV file so eval-only validation's existence check passes."""
+    with wave.open(path, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(16000)
+        wf.writeframes(b"\x00\x00" * 100)
+
+
+class TestTTSValidateEvalOnlyDataset(unittest.TestCase):
+    def test_valid_relative_paths_resolved(self):
+        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
+
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_wav(os.path.join(tmp, "a.wav"))
+            _write_wav(os.path.join(tmp, "b.wav"))
+            ds = os.path.join(tmp, "ds.json")
+            with open(ds, "w") as f:
+                json.dump(
+                    [
+                        {"id": "1", "text": "hello", "audio_path": "a.wav"},
+                        {"id": "2", "text": "world", "audio_path": "b.wav"},
+                    ],
+                    f,
+                )
+            ok, err, rows = validate_tts_eval_only_dataset(ds)
+            self.assertTrue(ok, err)
+            self.assertEqual(len(rows), 2)
+            # Relative paths resolved to absolute against the dataset dir.
+            self.assertTrue(os.path.isabs(rows[0]["audio_path"]))
+            self.assertEqual(rows[0]["audio_path"], os.path.join(tmp, "a.wav"))
+
+    def test_missing_file(self):
+        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
+
+        ok, err, rows = validate_tts_eval_only_dataset("/nope.json")
+        self.assertFalse(ok)
+        self.assertEqual(rows, [])
+        self.assertIn("does not exist", err)
+
+    def test_not_a_list(self):
+        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
+
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump({"id": "1", "text": "hi", "audio_path": "a.wav"}, f)
+            path = f.name
+        try:
+            ok, err, rows = validate_tts_eval_only_dataset(path)
+            self.assertFalse(ok)
+            self.assertIn("list", err)
+        finally:
+            os.remove(path)
+
+    def test_missing_fields(self):
+        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
+
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump([{"id": "1", "text": "hi"}], f)
+            path = f.name
+        try:
+            ok, err, rows = validate_tts_eval_only_dataset(path)
+            self.assertFalse(ok)
+            self.assertIn("missing required fields", err)
+        finally:
+            os.remove(path)
+
+    def test_audio_file_absent(self):
+        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
+
+        with tempfile.TemporaryDirectory() as tmp:
+            ds = os.path.join(tmp, "ds.json")
+            with open(ds, "w") as f:
+                json.dump(
+                    [{"id": "1", "text": "hi", "audio_path": "missing.wav"}], f
+                )
+            ok, err, rows = validate_tts_eval_only_dataset(ds)
+            self.assertFalse(ok)
+            self.assertIn("audio file does not exist", err)
+
+
+class TestTTSRunEvalOnly(unittest.IsolatedAsyncioTestCase):
+    async def test_runs_judge_on_dataset(self):
+        from calibrate_agent.tts import eval as tts_eval
+
+        async def fake_judge(audio_paths, texts, evaluators=None, fallback_model=None):
+            return {
+                "scores": {"quality": {"type": "binary", "mean": 0.5}},
+                "score": 0.5,
+                "per_row": [
+                    {"quality": {"match": True, "reasoning": "ok"}},
+                    {"quality": {"match": False, "reasoning": "no"}},
+                ],
+            }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_wav(os.path.join(tmp, "a.wav"))
+            _write_wav(os.path.join(tmp, "b.wav"))
+            ds = os.path.join(tmp, "ds.json")
+            with open(ds, "w") as f:
+                json.dump(
+                    [
+                        {"id": "1", "text": "hello", "audio_path": "a.wav"},
+                        {"id": "2", "text": "world", "audio_path": "b.wav"},
+                    ],
+                    f,
+                )
+            out = os.path.join(tmp, "out")
+
+            with patch.object(
+                tts_eval, "get_tts_llm_judge_score", AsyncMock(side_effect=fake_judge)
+            ):
+                result = await tts_eval.run_eval_only(
+                    dataset_path=ds,
+                    output_dir=out,
+                    judge_evaluators=[
+                        {
+                            "name": "quality",
+                            "system_prompt": "judge quality",
+                            "judge_model": "openai/gpt-4.1",
+                            "type": "binary",
+                        }
+                    ],
+                )
+
+            self.assertEqual(result["status"], "completed")
+            self.assertIn("quality", result["metrics"])
+            self.assertTrue(os.path.exists(os.path.join(out, "metrics.json")))
+            self.assertTrue(os.path.exists(os.path.join(out, "results.csv")))
+            # No ttfb column in eval-only results.
+            df = pd.read_csv(os.path.join(out, "results.csv"))
+            self.assertNotIn("ttfb", df.columns)
+            self.assertIn("quality", df.columns)
+            self.assertIn("quality_reasoning", df.columns)
+
+    async def test_invalid_dataset_returns_error(self):
+        from calibrate_agent.tts import eval as tts_eval
+
+        result = await tts_eval.run_eval_only(
+            dataset_path="/nonexistent.json",
+            output_dir=tempfile.mkdtemp(),
+        )
+        self.assertEqual(result["status"], "error")
+        self.assertIn("does not exist", result["error"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tts/test_eval.py
+++ b/tests/tts/test_eval.py
@@ -383,9 +383,6 @@ class TestSynthesizeGemini(unittest.IsolatedAsyncioTestCase):
                 await tts_eval.synthesize_gemini("hi", "english", "/tmp/out.wav")
 
 
-import json
-
-
 def _write_wav(path: str) -> None:
     """Write a tiny valid WAV file so eval-only validation's existence check passes."""
     with wave.open(path, "wb") as wf:
@@ -395,119 +392,68 @@ def _write_wav(path: str) -> None:
         wf.writeframes(b"\x00\x00" * 100)
 
 
+def _make_run_dir(tmp: str, audio_path: str = "audios/row_1.wav", extra_cols: dict = None) -> str:
+    """Create a minimal TTS run dir (results.csv + audios/row_1.wav) under ``tmp``."""
+    run_dir = os.path.join(tmp, "openai")
+    os.makedirs(os.path.join(run_dir, "audios"))
+    _write_wav(os.path.join(run_dir, "audios", "row_1.wav"))
+    row = {"id": "row_1", "text": "hello world", "audio_path": audio_path}
+    if extra_cols:
+        row.update(extra_cols)
+    pd.DataFrame([row]).to_csv(os.path.join(run_dir, "results.csv"), index=False)
+    return run_dir
+
+
 class TestTTSValidateEvalOnlyDataset(unittest.TestCase):
-    def test_valid_relative_paths_resolved(self):
-        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
-
-        with tempfile.TemporaryDirectory() as tmp:
-            _write_wav(os.path.join(tmp, "a.wav"))
-            _write_wav(os.path.join(tmp, "b.wav"))
-            ds = os.path.join(tmp, "ds.json")
-            with open(ds, "w") as f:
-                json.dump(
-                    [
-                        {"id": "1", "text": "hello", "audio_path": "a.wav"},
-                        {"id": "2", "text": "world", "audio_path": "b.wav"},
-                    ],
-                    f,
-                )
-            ok, err, rows = validate_tts_eval_only_dataset(ds)
-            self.assertTrue(ok, err)
-            self.assertEqual(len(rows), 2)
-            # Relative paths resolved to absolute against the dataset dir.
-            self.assertTrue(os.path.isabs(rows[0]["audio_path"]))
-            self.assertEqual(rows[0]["audio_path"], os.path.join(tmp, "a.wav"))
-
-    def test_missing_file(self):
-        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
-
-        ok, err, rows = validate_tts_eval_only_dataset("/nope.json")
-        self.assertFalse(ok)
-        self.assertEqual(rows, [])
-        self.assertIn("does not exist", err)
-
-    def test_not_a_list(self):
-        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
-
-        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
-            json.dump({"id": "1", "text": "hi", "audio_path": "a.wav"}, f)
-            path = f.name
-        try:
-            ok, err, rows = validate_tts_eval_only_dataset(path)
-            self.assertFalse(ok)
-            self.assertIn("list", err)
-        finally:
-            os.remove(path)
-
-    def test_missing_fields(self):
-        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
-
-        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
-            json.dump([{"id": "1", "text": "hi"}], f)
-            path = f.name
-        try:
-            ok, err, rows = validate_tts_eval_only_dataset(path)
-            self.assertFalse(ok)
-            self.assertIn("missing required fields", err)
-        finally:
-            os.remove(path)
-
-    def test_audio_file_absent(self):
-        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
-
-        with tempfile.TemporaryDirectory() as tmp:
-            ds = os.path.join(tmp, "ds.json")
-            with open(ds, "w") as f:
-                json.dump(
-                    [{"id": "1", "text": "hi", "audio_path": "missing.wav"}], f
-                )
-            ok, err, rows = validate_tts_eval_only_dataset(ds)
-            self.assertFalse(ok)
-            self.assertIn("audio file does not exist", err)
-
-    def test_reads_run_results_csv(self):
-        """A run's results.csv is accepted directly (columns id/text/audio_path,
-        extra ttfb ignored; audio_path resolved via the {dir}/audios/ layout)."""
-        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
-
-        with tempfile.TemporaryDirectory() as tmp:
-            audios = os.path.join(tmp, "audios")
-            os.makedirs(audios)
-            _write_wav(os.path.join(audios, "row_1.wav"))
-            csv_path = os.path.join(tmp, "results.csv")
-            pd.DataFrame(
-                [
-                    {
-                        "id": "row_1",
-                        "text": "hello world",
-                        # Stored relative to a *different* cwd — must still resolve
-                        # via the {csv_dir}/audios/{basename} fallback.
-                        "audio_path": "./out/run/openai/audios/row_1.wav",
-                        "ttfb": 1.23,
-                    }
-                ]
-            ).to_csv(csv_path, index=False)
-
-            ok, err, rows = validate_tts_eval_only_dataset(csv_path)
-            self.assertTrue(ok, err)
-            self.assertEqual(len(rows), 1)
-            self.assertEqual(rows[0]["audio_path"], os.path.join(audios, "row_1.wav"))
-
     def test_reads_run_directory(self):
         """Pointing at a run directory reads its results.csv with no transform."""
         from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
 
         with tempfile.TemporaryDirectory() as tmp:
-            audios = os.path.join(tmp, "audios")
-            os.makedirs(audios)
-            _write_wav(os.path.join(audios, "row_1.wav"))
-            pd.DataFrame(
-                [{"id": "row_1", "text": "hi", "audio_path": "audios/row_1.wav"}]
-            ).to_csv(os.path.join(tmp, "results.csv"), index=False)
-
-            ok, err, rows = validate_tts_eval_only_dataset(tmp)
+            run_dir = _make_run_dir(tmp)
+            ok, err, rows = validate_tts_eval_only_dataset(run_dir)
             self.assertTrue(ok, err)
-            self.assertEqual(rows[0]["audio_path"], os.path.join(audios, "row_1.wav"))
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(
+                rows[0]["audio_path"], os.path.join(run_dir, "audios", "row_1.wav")
+            )
+
+    def test_extra_columns_ignored_and_cwd_independent(self):
+        """A ttfb column is ignored; an audio_path stored relative to a different
+        cwd still resolves via the {run_dir}/audios/{basename} fallback."""
+        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
+
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_run_dir(
+                tmp,
+                audio_path="./out/run/openai/audios/row_1.wav",
+                extra_cols={"ttfb": 1.23},
+            )
+            ok, err, rows = validate_tts_eval_only_dataset(run_dir)
+            self.assertTrue(ok, err)
+            self.assertEqual(
+                rows[0]["audio_path"], os.path.join(run_dir, "audios", "row_1.wav")
+            )
+
+    def test_path_does_not_exist(self):
+        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
+
+        ok, err, rows = validate_tts_eval_only_dataset("/nope")
+        self.assertFalse(ok)
+        self.assertEqual(rows, [])
+        self.assertIn("does not exist", err)
+
+    def test_rejects_a_file(self):
+        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            ok, err, rows = validate_tts_eval_only_dataset(path)
+            self.assertFalse(ok)
+            self.assertIn("must be a run directory", err)
+        finally:
+            os.remove(path)
 
     def test_directory_without_results_csv(self):
         from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
@@ -517,71 +463,30 @@ class TestTTSValidateEvalOnlyDataset(unittest.TestCase):
             self.assertFalse(ok)
             self.assertIn("No results.csv", err)
 
-    def test_csv_missing_columns(self):
+    def test_results_csv_missing_columns(self):
         from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
 
         with tempfile.TemporaryDirectory() as tmp:
-            csv_path = os.path.join(tmp, "results.csv")
-            pd.DataFrame([{"id": "1", "text": "hi"}]).to_csv(csv_path, index=False)
-            ok, err, rows = validate_tts_eval_only_dataset(csv_path)
+            pd.DataFrame([{"id": "1", "text": "hi"}]).to_csv(
+                os.path.join(tmp, "results.csv"), index=False
+            )
+            ok, err, rows = validate_tts_eval_only_dataset(tmp)
             self.assertFalse(ok)
             self.assertIn("missing required columns", err)
 
-
-class TestTTSRunEvalOnly(unittest.IsolatedAsyncioTestCase):
-    async def test_runs_judge_on_dataset(self):
-        from calibrate_agent.tts import eval as tts_eval
-
-        async def fake_judge(audio_paths, texts, evaluators=None, fallback_model=None):
-            return {
-                "scores": {"quality": {"type": "binary", "mean": 0.5}},
-                "score": 0.5,
-                "per_row": [
-                    {"quality": {"match": True, "reasoning": "ok"}},
-                    {"quality": {"match": False, "reasoning": "no"}},
-                ],
-            }
+    def test_audio_file_absent(self):
+        from calibrate_agent.tts.eval import validate_tts_eval_only_dataset
 
         with tempfile.TemporaryDirectory() as tmp:
-            _write_wav(os.path.join(tmp, "a.wav"))
-            _write_wav(os.path.join(tmp, "b.wav"))
-            ds = os.path.join(tmp, "ds.json")
-            with open(ds, "w") as f:
-                json.dump(
-                    [
-                        {"id": "1", "text": "hello", "audio_path": "a.wav"},
-                        {"id": "2", "text": "world", "audio_path": "b.wav"},
-                    ],
-                    f,
-                )
-            out = os.path.join(tmp, "out")
+            pd.DataFrame(
+                [{"id": "1", "text": "hi", "audio_path": "audios/missing.wav"}]
+            ).to_csv(os.path.join(tmp, "results.csv"), index=False)
+            ok, err, rows = validate_tts_eval_only_dataset(tmp)
+            self.assertFalse(ok)
+            self.assertIn("audio file does not exist", err)
 
-            with patch.object(
-                tts_eval, "get_tts_llm_judge_score", AsyncMock(side_effect=fake_judge)
-            ):
-                result = await tts_eval.run_eval_only(
-                    dataset_path=ds,
-                    output_dir=out,
-                    judge_evaluators=[
-                        {
-                            "name": "quality",
-                            "system_prompt": "judge quality",
-                            "judge_model": "openai/gpt-4.1",
-                            "type": "binary",
-                        }
-                    ],
-                )
 
-            self.assertEqual(result["status"], "completed")
-            self.assertIn("quality", result["metrics"])
-            self.assertTrue(os.path.exists(os.path.join(out, "metrics.json")))
-            self.assertTrue(os.path.exists(os.path.join(out, "results.csv")))
-            # No ttfb column in eval-only results.
-            df = pd.read_csv(os.path.join(out, "results.csv"))
-            self.assertNotIn("ttfb", df.columns)
-            self.assertIn("quality", df.columns)
-            self.assertIn("quality_reasoning", df.columns)
-
+class TestTTSRunEvalOnly(unittest.IsolatedAsyncioTestCase):
     async def test_runs_on_run_directory(self):
         """End-to-end: point run_eval_only at a run dir, no dataset transform."""
         from calibrate_agent.tts import eval as tts_eval
@@ -594,19 +499,7 @@ class TestTTSRunEvalOnly(unittest.IsolatedAsyncioTestCase):
             }
 
         with tempfile.TemporaryDirectory() as tmp:
-            run_dir = os.path.join(tmp, "openai")
-            os.makedirs(os.path.join(run_dir, "audios"))
-            _write_wav(os.path.join(run_dir, "audios", "row_1.wav"))
-            pd.DataFrame(
-                [
-                    {
-                        "id": "row_1",
-                        "text": "hello world",
-                        "audio_path": "audios/row_1.wav",
-                        "ttfb": 1.0,
-                    }
-                ]
-            ).to_csv(os.path.join(run_dir, "results.csv"), index=False)
+            run_dir = _make_run_dir(tmp, extra_cols={"ttfb": 1.0})
             out = os.path.join(tmp, "eval")
 
             with patch.object(
@@ -626,13 +519,19 @@ class TestTTSRunEvalOnly(unittest.IsolatedAsyncioTestCase):
                 )
 
             self.assertEqual(result["status"], "completed")
-            self.assertTrue(os.path.exists(os.path.join(out, "results.csv")))
+            self.assertIn("quality", result["metrics"])
+            self.assertTrue(os.path.exists(os.path.join(out, "metrics.json")))
+            df = pd.read_csv(os.path.join(out, "results.csv"))
+            # No ttfb column in eval-only results; evaluator columns present.
+            self.assertNotIn("ttfb", df.columns)
+            self.assertIn("quality", df.columns)
+            self.assertIn("quality_reasoning", df.columns)
 
     async def test_invalid_dataset_returns_error(self):
         from calibrate_agent.tts import eval as tts_eval
 
         result = await tts_eval.run_eval_only(
-            dataset_path="/nonexistent.json",
+            dataset_path="/nonexistent",
             output_dir=tempfile.mkdtemp(),
         )
         self.assertEqual(result["status"], "error")


### PR DESCRIPTION
## What
- TTS was the only eval command without an `--eval-only` path; this adds one — skip synthesis and run the audio judge on pre-generated audio.
- Dataset is a JSON list of `{id, text, audio_path}` (audio_path resolved relative to the dataset file). Mirrors STT/LLM/sim.
- Wired through `tts/eval.py` (`validate_tts_eval_only_dataset` + `run_eval_only`), `tts/benchmark.py`, `cli.py`, and exported from `tts/__init__.py`.

## Notes
- No TTFB is reported in this mode (nothing is synthesized).
- Unlike STT, `run_eval_only` takes no `language` arg — the TTS audio judge doesn't use one, so it'd be a dead param. CLI still accepts `-l` for symmetry but ignores it here.
- Scoped tests pass (`tests/tts/`, `tests/test_cli.py` — 98 passed); CI runs the full suite.