### PR TITLE
Fix agent skills install docs: add per-agent --agent flag and restart note

### DIFF
--- a/docs/agents/skills.mdx
+++ b/docs/agents/skills.mdx
@@ -15,11 +15,30 @@ automated scores are trustworthy.
 
 ## Install
 
-Install every Calibrate skill with a single command:
+Install every Calibrate skill with one command. Pass `--agent` to target your
+specific coding agent — without it, the command defaults to whichever agent it
+detects, which may not be the one you want:
 
-```bash
-npx skills add dalmia/calibrate-skills
+<CodeGroup>
+```bash Claude Code
+npx skills add dalmia/calibrate-skills --agent claude-code -g
 ```
+
+```bash Cursor
+npx skills add dalmia/calibrate-skills --agent cursor -g
+```
+
+```bash Windsurf
+npx skills add dalmia/calibrate-skills --agent windsurf -g
+```
+
+```bash Codex
+npx skills add dalmia/calibrate-skills --agent codex -g
+```
+</CodeGroup>
+
+The `-g` flag installs globally (available in all projects). After installing,
+**restart your coding agent session** for the new skills to appear.
 
 You also need the Calibrate CLI (which the skills drive) and an API key:
 


### PR DESCRIPTION
## Summary
- Added per-agent install commands (`--agent claude-code`, `cursor`, `windsurf`, `codex`) in a `CodeGroup` block
- Explained that omitting `--agent` defaults to the detected agent, which may be wrong
- Added note to restart the coding agent session after installing for skills to appear

## Test plan
- [ ] Verify the `CodeGroup` renders correctly in Mintlify preview
- [ ] Confirm each tab shows the correct `--agent` flag for its agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)