### PR TITLE
Make STT LLM judge opt-in; run Sarvam judges by default

### DIFF
--- a/calibrate_agent/cli.py
+++ b/calibrate_agent/cli.py
@@ -234,11 +234,11 @@ Examples:
         help="Path to dataset JSON (list of {id, gt, pred}). Required with --eval-only.",
     )
     stt_parser.add_argument(
-        "--sarvam-judges",
+        "--skip-sarvam",
         action="store_true",
         help=(
-            "Also compute Sarvam LLM judges: intent & entity preservation "
-            "and LLM-WER/CER. Off by default; enabling it runs extra "
+            "Skip the Sarvam LLM judges (intent & entity preservation and "
+            "LLM-WER/CER). They run by default; passing this skips the extra "
             "per-row LLM judges."
         ),
     )
@@ -540,8 +540,8 @@ Examples:
             argv.extend(["-o", args.output_dir])
             if args.config:
                 argv.extend(["--config", args.config])
-            if args.sarvam_judges:
-                argv.append("--sarvam-judges")
+            if args.skip_sarvam:
+                argv.append("--skip-sarvam")
 
             sys.argv = argv
             asyncio.run(stt_benchmark_main())
@@ -565,8 +565,8 @@ Examples:
                 argv.extend(["-s", args.save_dir])
             if args.config:
                 argv.extend(["--config", args.config])
-            if args.sarvam_judges:
-                argv.append("--sarvam-judges")
+            if args.skip_sarvam:
+                argv.append("--skip-sarvam")
 
             sys.argv = argv
             asyncio.run(stt_benchmark_main())

--- a/calibrate_agent/stt/benchmark.py
+++ b/calibrate_agent/stt/benchmark.py
@@ -96,8 +96,8 @@ async def run(
         overwrite: Overwrite existing results instead of resuming from checkpoint (default: False)
         max_parallel: Maximum number of providers to run in parallel (default: 2)
         judge_evaluators: Optional list of evaluator dicts (each with ``name``,
-            ``system_prompt``, ``judge_model``, ``type``, ...). When omitted
-            the implicit default STT evaluator runs.
+            ``system_prompt``, ``judge_model``, ``type``, ...). When omitted no
+            LLM judge runs and only WER/CER are reported.
         run_sarvam_judges: When True, also run the Sarvam intent/entity judge
             (loads a normalizer model + makes per-row judge calls). Off by
             default.

--- a/calibrate_agent/stt/benchmark.py
+++ b/calibrate_agent/stt/benchmark.py
@@ -77,7 +77,7 @@ async def run(
     overwrite: bool = False,
     max_parallel: int = MAX_PARALLEL_PROVIDERS,
     judge_evaluators: list[dict] = None,
-    run_sarvam_judges: bool = False,
+    run_sarvam_judges: bool = True,
 ) -> dict:
     """
     Run STT evaluation for one or more providers and generate a leaderboard.
@@ -98,9 +98,9 @@ async def run(
         judge_evaluators: Optional list of evaluator dicts (each with ``name``,
             ``system_prompt``, ``judge_model``, ``type``, ...). When omitted no
             LLM judge runs and only WER/CER are reported.
-        run_sarvam_judges: When True, also run the Sarvam intent/entity judge
-            (loads a normalizer model + makes per-row judge calls). Off by
-            default.
+        run_sarvam_judges: Run the Sarvam intent/entity judge (default True;
+            loads a normalizer model + makes per-row judge calls). Set to False
+            to skip it.
 
     Returns:
         dict: Results summary with status and output paths
@@ -246,11 +246,11 @@ async def main():
         help="Path to optional JSON config file with an `evaluators` list",
     )
     parser.add_argument(
-        "--sarvam-judges",
+        "--skip-sarvam",
         action="store_true",
         help=(
-            "Also compute Sarvam LLM judges: intent & entity preservation "
-            "and LLM-WER/CER. Off by default; enabling it runs extra "
+            "Skip the Sarvam LLM judges (intent & entity preservation and "
+            "LLM-WER/CER). They run by default; passing this skips the extra "
             "per-row LLM judges."
         ),
     )
@@ -316,7 +316,7 @@ async def main():
             output_dir=args.output_dir,
             judge_evaluators=judge_evaluators,
             language=args.language,
-            run_sarvam_judges=args.sarvam_judges,
+            run_sarvam_judges=not args.skip_sarvam,
         )
 
         print(f"\n\033[92m{'='*60}\033[0m")
@@ -362,7 +362,7 @@ async def main():
             ignore_retry=args.ignore_retry,
             overwrite=args.overwrite,
             judge_evaluators=judge_evaluators,
-            run_sarvam_judges=args.sarvam_judges,
+            run_sarvam_judges=not args.skip_sarvam,
         )
 
         # Print summary

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -1303,6 +1303,10 @@ async def _score_and_write_results(
     ``run_sarvam_judges`` is False it is skipped entirely — no normalizer model
     is loaded, no judge calls are made, and the ``sarvam_*`` columns/metrics are
     omitted.
+
+    Each judge is isolated: if any judge raises, the failure is logged and that
+    judge's columns/metrics are dropped, but WER/CER and any judges that
+    succeeded are still written.
     """
     wer_results = get_wer_score(gt_transcripts, pred_transcripts, language=language)
     _log(f"WER: {wer_results['score']}", to_terminal=False)
@@ -1310,26 +1314,39 @@ async def _score_and_write_results(
     cer_results = get_cer_score(gt_transcripts, pred_transcripts, language=language)
     _log(f"CER: {cer_results['score']}", to_terminal=False)
 
+    # Each judge below runs independently and is isolated: a failure in one
+    # (Sarvam intent/entity, Sarvam LLM-WER/CER, or the LLM judge) is logged and
+    # that judge's columns/metrics are omitted, but WER/CER and any judges that
+    # succeeded are still written.
+
     # Intent + entity preservation and LLM-WER/CER run by default; setting
     # ``run_sarvam_judges`` to False skips loading the normalizer model and the
     # per-row judge calls.
     intent_entity_results = None
     llm_wer_results = None
     if run_sarvam_judges:
-        intent_entity_results = await get_intent_entity_score(
-            gt_transcripts, pred_transcripts, language=language
-        )
-        _log(
-            f"Sarvam Intent Score: {intent_entity_results['intent']:.4f}  Sarvam Entity Score: {intent_entity_results['entity']:.4f}",
-            to_terminal=False,
-        )
-        llm_wer_results = await get_llm_wer_cer_score(
-            gt_transcripts, pred_transcripts, language=language
-        )
-        _log(
-            f"Sarvam LLM WER: {llm_wer_results['llm_wer']:.4f}  Sarvam LLM CER: {llm_wer_results['llm_cer']:.4f}",
-            to_terminal=False,
-        )
+        try:
+            intent_entity_results = await get_intent_entity_score(
+                gt_transcripts, pred_transcripts, language=language
+            )
+            _log(
+                f"Sarvam Intent Score: {intent_entity_results['intent']:.4f}  Sarvam Entity Score: {intent_entity_results['entity']:.4f}",
+                to_terminal=False,
+            )
+        except Exception as e:
+            intent_entity_results = None
+            _log(f"Sarvam intent/entity judge failed, skipping: {e}")
+        try:
+            llm_wer_results = await get_llm_wer_cer_score(
+                gt_transcripts, pred_transcripts, language=language
+            )
+            _log(
+                f"Sarvam LLM WER: {llm_wer_results['llm_wer']:.4f}  Sarvam LLM CER: {llm_wer_results['llm_cer']:.4f}",
+                to_terminal=False,
+            )
+        except Exception as e:
+            llm_wer_results = None
+            _log(f"Sarvam LLM-WER/CER judge failed, skipping: {e}")
 
     # The LLM judge is opt-in for STT: when no evaluators are passed we report
     # WER/CER only and skip the judge entirely (no evaluator config, no judge
@@ -1339,15 +1356,22 @@ async def _score_and_write_results(
     if _evaluators:
         require_unique_evaluator_names(_evaluators)
         write_evaluator_config(evaluator_config_dir, _evaluators)
-        llm_results = await get_llm_judge_score(
-            gt_transcripts,
-            pred_transcripts,
-            evaluators=_evaluators,
-        )
-        for name, score_dict in llm_results["scores"].items():
-            _log(f"  {name}: {score_dict['mean']:.4f}")
+        try:
+            llm_results = await get_llm_judge_score(
+                gt_transcripts,
+                pred_transcripts,
+                evaluators=_evaluators,
+            )
+            for name, score_dict in llm_results["scores"].items():
+                _log(f"  {name}: {score_dict['mean']:.4f}")
+        except Exception as e:
+            llm_results = None
+            _log(f"LLM judge failed, skipping evaluator columns: {e}")
 
-    _evaluators_by_name = {ev["name"]: ev for ev in _evaluators}
+    # Only surface evaluator columns for judges that actually produced results.
+    _evaluators_by_name = (
+        {ev["name"]: ev for ev in _evaluators} if llm_results is not None else {}
+    )
 
     metrics_data = {
         "wer": wer_results["score"],

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -1101,7 +1101,7 @@ async def run_single_provider_eval(
     ignore_retry: bool,
     overwrite: bool,
     judge_evaluators: list[dict] = None,
-    run_sarvam_judges: bool = False,
+    run_sarvam_judges: bool = True,
 ) -> dict:
     """Run STT evaluation for a single provider."""
     provider_output_dir = join(output_dir, provider)
@@ -1290,7 +1290,7 @@ async def _score_and_write_results(
     evaluator_config_dir: str,
     judge_evaluators: list[dict] = None,
     language: str = "english",
-    run_sarvam_judges: bool = False,
+    run_sarvam_judges: bool = True,
 ) -> dict:
     """Run WER/CER (and optional LLM-judge evaluators) over (gt, pred) pairs.
 
@@ -1299,9 +1299,10 @@ async def _score_and_write_results(
     is empty/omitted, no judge runs, no evaluator config is written, and the
     evaluator columns/metrics are omitted. Returns the metrics_data dict.
 
-    When ``run_sarvam_judges`` is False (the default) the Sarvam intent/entity
-    judge is skipped entirely — no normalizer model is loaded, no judge calls
-    are made, and the ``sarvam_*`` columns/metrics are omitted.
+    The Sarvam intent/entity judge runs by default. When
+    ``run_sarvam_judges`` is False it is skipped entirely — no normalizer model
+    is loaded, no judge calls are made, and the ``sarvam_*`` columns/metrics are
+    omitted.
     """
     wer_results = get_wer_score(gt_transcripts, pred_transcripts, language=language)
     _log(f"WER: {wer_results['score']}", to_terminal=False)
@@ -1309,8 +1310,8 @@ async def _score_and_write_results(
     cer_results = get_cer_score(gt_transcripts, pred_transcripts, language=language)
     _log(f"CER: {cer_results['score']}", to_terminal=False)
 
-    # Intent + entity preservation and LLM-WER/CER are opt-in via
-    # ``run_sarvam_judges``; skipping avoids loading the normalizer model and the
+    # Intent + entity preservation and LLM-WER/CER run by default; setting
+    # ``run_sarvam_judges`` to False skips loading the normalizer model and the
     # per-row judge calls.
     intent_entity_results = None
     llm_wer_results = None
@@ -1427,7 +1428,7 @@ async def run_eval_only(
     output_dir: str,
     judge_evaluators: list[dict] = None,
     language: str = "english",
-    run_sarvam_judges: bool = False,
+    run_sarvam_judges: bool = True,
 ) -> dict:
     """Run evaluators only on a pre-existing dataset of (gt, pred) pairs.
 
@@ -1441,9 +1442,9 @@ async def run_eval_only(
             LLM judge runs and only WER/CER are reported.
         language: Language of the dataset, used to normalize text before the
             intent/entity judge. Defaults to ``english``.
-        run_sarvam_judges: When True, also run the Sarvam intent/entity judge.
-            Off by default — leaving it off skips the normalizer model load and
-            the judge calls entirely.
+        run_sarvam_judges: Run the Sarvam intent/entity judge (default True).
+            Setting it to False skips the normalizer model load and the judge
+            calls entirely.
 
     Returns:
         dict with status, metrics, and output_dir.
@@ -1494,7 +1495,7 @@ def format_metrics_summary(metrics: dict, prefix: str = "") -> str:
     shared by the single-provider, multi-provider, and eval-only paths.
 
     The Sarvam judge fields are only included when present in ``metrics``
-    (i.e. when ``--sarvam-judges`` was enabled for the run).
+    (i.e. unless ``--skip-sarvam`` was passed for the run).
     """
     parts = [
         f"WER={metrics.get('wer', 0):.4f}",
@@ -1587,11 +1588,11 @@ async def main():
         help="Overwrite existing results instead of resuming from last checkpoint",
     )
     parser.add_argument(
-        "--sarvam-judges",
+        "--skip-sarvam",
         action="store_true",
         help=(
-            "Also compute Sarvam LLM judges: intent & entity preservation "
-            "and LLM-WER/CER. Off by default; enabling it runs extra "
+            "Skip the Sarvam LLM judges (intent & entity preservation and "
+            "LLM-WER/CER). They run by default; passing this skips the extra "
             "per-row LLM judges."
         ),
     )
@@ -1636,7 +1637,7 @@ async def main():
         debug_count=args.debug_count,
         ignore_retry=args.ignore_retry,
         overwrite=args.overwrite,
-        run_sarvam_judges=args.sarvam_judges,
+        run_sarvam_judges=not args.skip_sarvam,
     )
 
     # Print summary

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -40,7 +40,6 @@ from calibrate_agent.stt.metrics import (
 )
 from calibrate_agent.judges import (
     is_rating,
-    DEFAULT_STT_EVALUATOR,
     require_unique_evaluator_names,
     write_evaluator_config,
 )
@@ -1293,11 +1292,12 @@ async def _score_and_write_results(
     language: str = "english",
     run_sarvam_judges: bool = False,
 ) -> dict:
-    """Run WER + LLM-judge evaluators over (gt, pred) pairs and write outputs.
+    """Run WER/CER (and optional LLM-judge evaluators) over (gt, pred) pairs.
 
-    Writes ``results.csv`` and ``metrics.json`` under ``output_dir`` and the
-    resolved evaluator config under ``evaluator_config_dir``. Returns the
-    metrics_data dict.
+    Writes ``results.csv`` and ``metrics.json`` under ``output_dir``. WER and
+    CER are always computed. The LLM judge is opt-in: when ``judge_evaluators``
+    is empty/omitted, no judge runs, no evaluator config is written, and the
+    evaluator columns/metrics are omitted. Returns the metrics_data dict.
 
     When ``run_sarvam_judges`` is False (the default) the Sarvam intent/entity
     judge is skipped entirely — no normalizer model is loaded, no judge calls
@@ -1330,16 +1330,21 @@ async def _score_and_write_results(
             to_terminal=False,
         )
 
-    _evaluators = judge_evaluators if judge_evaluators else [DEFAULT_STT_EVALUATOR]
-    require_unique_evaluator_names(_evaluators)
-    write_evaluator_config(evaluator_config_dir, _evaluators)
-    llm_results = await get_llm_judge_score(
-        gt_transcripts,
-        pred_transcripts,
-        evaluators=_evaluators,
-    )
-    for name, score_dict in llm_results["scores"].items():
-        _log(f"  {name}: {score_dict['mean']:.4f}")
+    # The LLM judge is opt-in for STT: when no evaluators are passed we report
+    # WER/CER only and skip the judge entirely (no evaluator config, no judge
+    # calls, no evaluator columns/metrics).
+    _evaluators = list(judge_evaluators) if judge_evaluators else []
+    llm_results = None
+    if _evaluators:
+        require_unique_evaluator_names(_evaluators)
+        write_evaluator_config(evaluator_config_dir, _evaluators)
+        llm_results = await get_llm_judge_score(
+            gt_transcripts,
+            pred_transcripts,
+            evaluators=_evaluators,
+        )
+        for name, score_dict in llm_results["scores"].items():
+            _log(f"  {name}: {score_dict['mean']:.4f}")
 
     _evaluators_by_name = {ev["name"]: ev for ev in _evaluators}
 
@@ -1353,8 +1358,9 @@ async def _score_and_write_results(
     if llm_wer_results is not None:
         metrics_data["sarvam_llm_wer"] = llm_wer_results["llm_wer"]
         metrics_data["sarvam_llm_cer"] = llm_wer_results["llm_cer"]
-    for name, score_dict in llm_results["scores"].items():
-        metrics_data[name] = score_dict
+    if llm_results is not None:
+        for name, score_dict in llm_results["scores"].items():
+            metrics_data[name] = score_dict
 
     ie_per_row = (
         intent_entity_results["per_row"]
@@ -1366,6 +1372,9 @@ async def _score_and_write_results(
         if llm_wer_results is not None
         else [None] * len(ids)
     )
+    llm_per_row = (
+        llm_results["per_row"] if llm_results is not None else [None] * len(ids)
+    )
 
     data = []
     for _id, gt_text, pred_text, wer, cer, ie_row, llm_wer_row, llm_row in zip(
@@ -1376,7 +1385,7 @@ async def _score_and_write_results(
         cer_results["per_row"],
         ie_per_row,
         llm_wer_per_row,
-        llm_results["per_row"],
+        llm_per_row,
     ):
         row = {
             "id": _id,
@@ -1428,8 +1437,8 @@ async def run_eval_only(
     Args:
         dataset_path: Path to a JSON file with a list of {"id", "gt", "pred"} rows.
         output_dir: Directory to write results and metrics.
-        judge_evaluators: Optional list of evaluator dicts. Defaults to the
-            built-in STT evaluator when omitted.
+        judge_evaluators: Optional list of evaluator dicts. When omitted, no
+            LLM judge runs and only WER/CER are reported.
         language: Language of the dataset, used to normalize text before the
             intent/entity judge. Defaults to ``english``.
         run_sarvam_judges: When True, also run the Sarvam intent/entity judge.

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -1351,7 +1351,7 @@ async def _score_and_write_results(
     # The LLM judge is opt-in for STT: when no evaluators are passed we report
     # WER/CER only and skip the judge entirely (no evaluator config, no judge
     # calls, no evaluator columns/metrics).
-    _evaluators = list(judge_evaluators) if judge_evaluators else []
+    _evaluators = judge_evaluators or []
     llm_results = None
     if _evaluators:
         require_unique_evaluator_names(_evaluators)

--- a/calibrate_agent/stt/metrics.py
+++ b/calibrate_agent/stt/metrics.py
@@ -24,7 +24,7 @@ from calibrate_agent.langfuse import observe, langfuse, langfuse_enabled
 # NOTE: ``calibrate_agent.stt.sarvam_intent_entity`` is imported lazily inside the
 # intent/entity functions below — importing it eagerly pulls in transformers,
 # indic-nlp, and joblib, which we want to avoid unless intent/entity scoring is
-# actually requested (it's opt-in via ``--sarvam-judges``).
+# actually requested (it runs by default unless ``--skip-sarvam`` is passed).
 
 # Re-export for existing imports
 DEFAULT_STT_JUDGE_MODEL = DEFAULT_TEXT_JUDGE_MODEL

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -304,6 +304,13 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                     pred_transcripts=["hello", "world"],
                     output_dir=str(out),
                     evaluator_config_dir=str(out),
+                    judge_evaluators=[
+                        {
+                            "name": "semantic_match",
+                            "system_prompt": "match",
+                            "judge_model": "openai/gpt-4.1",
+                        }
+                    ],
                     run_sarvam_judges=True,
                 )
 
@@ -413,9 +420,16 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                     pred_transcripts=["hello", "world"],
                     output_dir=str(out),
                     evaluator_config_dir=str(out),
+                    judge_evaluators=[
+                        {
+                            "name": "semantic_match",
+                            "system_prompt": "match",
+                            "judge_model": "openai/gpt-4.1",
+                        }
+                    ],
                 )
 
-            # Default: the judge is never invoked and no sarvam_* keys appear.
+            # Default: the Sarvam judge is never invoked and no sarvam_* keys appear.
             ie_mock.assert_not_awaited()
             self.assertNotIn("sarvam_intent_score", metrics)
             self.assertNotIn("sarvam_entity_score", metrics)
@@ -425,6 +439,32 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             # WER/CER and the judge column are still written.
             self.assertIn("wer", metrics)
             self.assertIn("semantic_match", metrics)
+
+    async def test_no_llm_judge_when_no_evaluators(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        judge_mock = AsyncMock()
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            with patch.object(stt_eval, "get_llm_judge_score", judge_mock):
+                metrics = await stt_eval._score_and_write_results(
+                    ids=["1", "2"],
+                    gt_transcripts=["hello", "world"],
+                    pred_transcripts=["hello", "goodbye"],
+                    output_dir=str(out),
+                    evaluator_config_dir=str(out),
+                )
+
+            # No evaluators passed: the LLM judge is never invoked, no evaluator
+            # config is written, and only WER/CER are reported.
+            judge_mock.assert_not_awaited()
+            self.assertIn("wer", metrics)
+            self.assertIn("cer", metrics)
+            self.assertNotIn("semantic_match", metrics)
+            self.assertFalse((out / "config.json").exists())
+            df = pd.read_csv(out / "results.csv")
+            self.assertEqual(set(df.columns), {"id", "gt", "pred", "wer", "cer"})
+            self.assertEqual(len(df), 2)
 
     async def test_rating_evaluator_writes_numeric_score(self):
         from calibrate_agent.stt import eval as stt_eval

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -488,6 +488,97 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             self.assertIn("wer", metrics)
             self.assertIn("semantic_match", metrics)
 
+    async def test_llm_judge_failure_still_writes_wer_cer_and_sarvam(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            with patch.object(
+                stt_eval,
+                "get_llm_judge_score",
+                AsyncMock(side_effect=RuntimeError("judge boom")),
+            ), patch.object(
+                stt_eval, "get_intent_entity_score", _fake_intent_entity(1, 1.0)
+            ), patch.object(
+                stt_eval, "get_llm_wer_cer_score", _fake_llm_wer(0.05, 0.03)
+            ):
+                metrics = await stt_eval._score_and_write_results(
+                    ids=["1", "2"],
+                    gt_transcripts=["hello", "world"],
+                    pred_transcripts=["hello", "world"],
+                    output_dir=str(out),
+                    evaluator_config_dir=str(out),
+                    judge_evaluators=[
+                        {
+                            "name": "semantic_match",
+                            "system_prompt": "match",
+                            "judge_model": "openai/gpt-4.1",
+                        }
+                    ],
+                )
+
+            # LLM judge failed: WER/CER and the Sarvam judges survive; the
+            # evaluator columns/metrics are dropped and nothing crashes.
+            self.assertIn("wer", metrics)
+            self.assertIn("cer", metrics)
+            self.assertIn("sarvam_intent_score", metrics)
+            self.assertIn("sarvam_llm_wer", metrics)
+            self.assertNotIn("semantic_match", metrics)
+            df = pd.read_csv(out / "results.csv")
+            self.assertNotIn("semantic_match", df.columns)
+            self.assertIn("sarvam_intent_score", df.columns)
+            self.assertEqual(len(df), 2)
+
+    async def test_sarvam_failure_still_writes_wer_cer_and_evaluator(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+            return {
+                "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
+                "score": 1.0,
+                "per_row": [
+                    {"semantic_match": {"match": True, "reasoning": "ok"}}
+                    for _ in refs
+                ],
+            }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            with patch.object(
+                stt_eval, "get_llm_judge_score", AsyncMock(side_effect=fake_judge)
+            ), patch.object(
+                stt_eval,
+                "get_intent_entity_score",
+                AsyncMock(side_effect=RuntimeError("intent boom")),
+            ), patch.object(
+                stt_eval, "get_llm_wer_cer_score", _fake_llm_wer(0.05, 0.03)
+            ):
+                metrics = await stt_eval._score_and_write_results(
+                    ids=["1", "2"],
+                    gt_transcripts=["hello", "world"],
+                    pred_transcripts=["hello", "world"],
+                    output_dir=str(out),
+                    evaluator_config_dir=str(out),
+                    judge_evaluators=[
+                        {
+                            "name": "semantic_match",
+                            "system_prompt": "match",
+                            "judge_model": "openai/gpt-4.1",
+                        }
+                    ],
+                )
+
+            # One Sarvam judge failed: WER/CER, the evaluator, and the other
+            # Sarvam judge (LLM-WER/CER) all survive; only intent/entity drops.
+            self.assertIn("wer", metrics)
+            self.assertIn("semantic_match", metrics)
+            self.assertIn("sarvam_llm_wer", metrics)
+            self.assertNotIn("sarvam_intent_score", metrics)
+            df = pd.read_csv(out / "results.csv")
+            self.assertIn("semantic_match", df.columns)
+            self.assertNotIn("sarvam_intent_score", df.columns)
+            self.assertIn("sarvam_llm_wer", df.columns)
+
     async def test_no_llm_judge_when_no_evaluators(self):
         from calibrate_agent.stt import eval as stt_eval
 

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -395,7 +395,54 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(df.iloc[0]["sarvam_entity_score"], 0.25)
             self.assertEqual(df.iloc[0]["sarvam_llm_wer"], 0.4)
 
-    async def test_intent_entity_skipped_by_default(self):
+    async def test_sarvam_judges_run_by_default(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+            return {
+                "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
+                "score": 1.0,
+                "per_row": [
+                    {"semantic_match": {"match": True, "reasoning": "ok"}}
+                    for _ in refs
+                ],
+            }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            with patch.object(
+                stt_eval, "get_llm_judge_score", AsyncMock(side_effect=fake_judge)
+            ), patch.object(
+                stt_eval, "get_intent_entity_score", _fake_intent_entity(1, 1.0)
+            ), patch.object(
+                stt_eval, "get_llm_wer_cer_score", _fake_llm_wer(0.05, 0.03)
+            ):
+                metrics = await stt_eval._score_and_write_results(
+                    ids=["1", "2"],
+                    gt_transcripts=["hello", "world"],
+                    pred_transcripts=["hello", "world"],
+                    output_dir=str(out),
+                    evaluator_config_dir=str(out),
+                    judge_evaluators=[
+                        {
+                            "name": "semantic_match",
+                            "system_prompt": "match",
+                            "judge_model": "openai/gpt-4.1",
+                        }
+                    ],
+                )
+
+            # Default: the Sarvam judges run and their metrics/columns appear.
+            self.assertIn("sarvam_intent_score", metrics)
+            self.assertIn("sarvam_entity_score", metrics)
+            self.assertIn("sarvam_llm_wer", metrics)
+            df = pd.read_csv(out / "results.csv")
+            self.assertIn("sarvam_intent_score", df.columns)
+            self.assertIn("sarvam_entity_score", df.columns)
+            self.assertIn("wer", metrics)
+            self.assertIn("semantic_match", metrics)
+
+    async def test_sarvam_judges_skipped_when_disabled(self):
         from calibrate_agent.stt import eval as stt_eval
 
         async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
@@ -427,9 +474,10 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                             "judge_model": "openai/gpt-4.1",
                         }
                     ],
+                    run_sarvam_judges=False,
                 )
 
-            # Default: the Sarvam judge is never invoked and no sarvam_* keys appear.
+            # Disabled: the Sarvam judge is never invoked and no sarvam_* keys appear.
             ie_mock.assert_not_awaited()
             self.assertNotIn("sarvam_intent_score", metrics)
             self.assertNotIn("sarvam_entity_score", metrics)
@@ -453,6 +501,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                     pred_transcripts=["hello", "goodbye"],
                     output_dir=str(out),
                     evaluator_config_dir=str(out),
+                    run_sarvam_judges=False,
                 )
 
             # No evaluators passed: the LLM judge is never invoked, no evaluator
@@ -508,6 +557,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                     output_dir=str(out),
                     evaluator_config_dir=str(out),
                     judge_evaluators=[rating],
+                    run_sarvam_judges=False,
                 )
             df = pd.read_csv(out / "results.csv")
             self.assertEqual(df.iloc[0]["accuracy"], 4)
@@ -547,6 +597,7 @@ class TestSTTRunEvalOnly(unittest.IsolatedAsyncioTestCase):
                 result = await stt_eval.run_eval_only(
                     dataset_path=str(ds_path),
                     output_dir=str(out),
+                    run_sarvam_judges=False,
                 )
 
             self.assertEqual(result["status"], "completed")

--- a/tests/stt/test_eval_extra.py
+++ b/tests/stt/test_eval_extra.py
@@ -727,6 +727,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
                             "judge_model": "openai/gpt-4.1",
                         }
                     ],
+                    run_sarvam_judges=False,
                 )
             self.assertEqual(result["wer"], 0.1)
             self.assertEqual(result["cer"], 0.2)
@@ -770,7 +771,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
             self.assertIn("sarvam_llm_cer", df.columns)
             self.assertIn("sarvam_llm_wer_reasoning", df.columns)
 
-    async def test_sarvam_llm_wer_absent_by_default(self):
+    async def test_sarvam_llm_wer_absent_when_disabled(self):
         from calibrate_agent.stt import eval as E
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -787,6 +788,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
                     pred_transcripts=["x"],
                     output_dir=tmp,
                     evaluator_config_dir=tmp,
+                    run_sarvam_judges=False,
                 )
             llm_wer_mock.assert_not_called()
             self.assertNotIn("sarvam_llm_wer", result)
@@ -816,6 +818,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
                 output_dir=tmp,
                 evaluator_config_dir=tmp,
                 judge_evaluators=[rating_ev],
+                run_sarvam_judges=False,
             )
 
 
@@ -849,7 +852,9 @@ class TestRunEvalOnly(unittest.IsolatedAsyncioTestCase):
                          {"semantic_match": {"match": True, "reasoning": "ok"}},
                      ],
                  })):
-                result = await E.run_eval_only(str(ds), str(out))
+                result = await E.run_eval_only(
+                    str(ds), str(out), run_sarvam_judges=False
+                )
         self.assertEqual(result["status"], "completed")
 
 
@@ -928,6 +933,7 @@ class TestRunSingleProviderEval(unittest.IsolatedAsyncioTestCase):
                     debug_count=5,
                     ignore_retry=False,
                     overwrite=True,
+                    run_sarvam_judges=False,
                 )
             self.assertEqual(result["status"], "completed")
 
@@ -990,6 +996,7 @@ class TestRunSingleProviderEval(unittest.IsolatedAsyncioTestCase):
                     debug_count=1,
                     ignore_retry=True,
                     overwrite=False,
+                    run_sarvam_judges=False,
                 )
             self.assertEqual(result["status"], "completed")
 

--- a/tests/stt/test_eval_extra.py
+++ b/tests/stt/test_eval_extra.py
@@ -720,6 +720,13 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
                     pred_transcripts=["x", "y"],
                     output_dir=tmp,
                     evaluator_config_dir=tmp,
+                    judge_evaluators=[
+                        {
+                            "name": "semantic_match",
+                            "system_prompt": "match",
+                            "judge_model": "openai/gpt-4.1",
+                        }
+                    ],
                 )
             self.assertEqual(result["wer"], 0.1)
             self.assertEqual(result["cer"], 0.2)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -243,7 +243,7 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
 
             self.assertEqual(mock_eval.call_args.kwargs["language"], "hindi")
 
-    async def test_main_eval_only_intent_entity_off_by_default(self):
+    async def test_main_eval_only_intent_entity_on_by_default(self):
         from calibrate_agent.stt import benchmark as B
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -259,9 +259,9 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
                  patch.object(B, "run_eval_only", mock_eval):
                 await B.main()
 
-            self.assertFalse(mock_eval.call_args.kwargs["run_sarvam_judges"])
+            self.assertTrue(mock_eval.call_args.kwargs["run_sarvam_judges"])
 
-    async def test_main_eval_only_forwards_intent_entity_flag(self):
+    async def test_main_eval_only_skip_sarvam_flag(self):
         from calibrate_agent.stt import benchmark as B
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -273,12 +273,12 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
             fake_result = {"status": "completed", "metrics": {"wer": 0.1}}
             mock_eval = AsyncMock(return_value=fake_result)
             argv = ["b.py", "--eval-only", "--dataset", str(ds),
-                    "-o", str(out), "--sarvam-judges"]
+                    "-o", str(out), "--skip-sarvam"]
             with patch.object(sys, "argv", argv), \
                  patch.object(B, "run_eval_only", mock_eval):
                 await B.main()
 
-            self.assertTrue(mock_eval.call_args.kwargs["run_sarvam_judges"])
+            self.assertFalse(mock_eval.call_args.kwargs["run_sarvam_judges"])
 
     async def test_main_eval_only_error(self):
         from calibrate_agent.stt import benchmark as B
@@ -355,17 +355,17 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
             }
             mock_run = AsyncMock(return_value=fake_run_result)
 
-            # Default off.
+            # Default on.
             argv = ["b.py", "-p", "deepgram", "-i", str(base), "-o", str(out)]
             with patch.object(sys, "argv", argv), patch.object(B, "run", mock_run):
                 await B.main()
-            self.assertFalse(mock_run.call_args.kwargs["run_sarvam_judges"])
+            self.assertTrue(mock_run.call_args.kwargs["run_sarvam_judges"])
 
-            # Flag on.
-            argv.append("--sarvam-judges")
+            # Skip flag.
+            argv.append("--skip-sarvam")
             with patch.object(sys, "argv", argv), patch.object(B, "run", mock_run):
                 await B.main()
-            self.assertTrue(mock_run.call_args.kwargs["run_sarvam_judges"])
+            self.assertFalse(mock_run.call_args.kwargs["run_sarvam_judges"])
 
     async def test_main_error_provider_exits(self):
         from calibrate_agent.stt import benchmark as B

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -186,7 +186,7 @@ class TestMainDispatch(unittest.TestCase):
                     "-o", tmp,
                 ])
 
-    def test_stt_benchmark_forwards_sarvam_flag(self):
+    def test_stt_benchmark_forwards_skip_sarvam_flag(self):
         captured = {}
 
         async def fake_main():
@@ -206,12 +206,12 @@ class TestMainDispatch(unittest.TestCase):
                 self._run_with_argv([
                     "calibrate_agent", "stt", "-p", "deepgram",
                     "-i", str(base), "-o", str(base / "out"),
-                    "--sarvam-judges",
+                    "--skip-sarvam",
                 ])
 
-        self.assertIn("--sarvam-judges", captured["argv"])
+        self.assertIn("--skip-sarvam", captured["argv"])
 
-    def test_stt_benchmark_omits_sarvam_flag_by_default(self):
+    def test_stt_benchmark_omits_skip_sarvam_flag_by_default(self):
         captured = {}
 
         async def fake_main():
@@ -233,9 +233,9 @@ class TestMainDispatch(unittest.TestCase):
                     "-i", str(base), "-o", str(base / "out"),
                 ])
 
-        self.assertNotIn("--sarvam-judges", captured["argv"])
+        self.assertNotIn("--skip-sarvam", captured["argv"])
 
-    def test_stt_eval_only_forwards_sarvam_flag_and_language(self):
+    def test_stt_eval_only_forwards_skip_sarvam_flag_and_language(self):
         captured = {}
 
         async def fake_main():
@@ -248,10 +248,10 @@ class TestMainDispatch(unittest.TestCase):
                        AsyncMock(side_effect=fake_main)):
                 self._run_with_argv([
                     "calibrate_agent", "stt", "--eval-only", "--dataset", str(ds),
-                    "-o", tmp, "-l", "hindi", "--sarvam-judges",
+                    "-o", tmp, "-l", "hindi", "--skip-sarvam",
                 ])
 
-        self.assertIn("--sarvam-judges", captured["argv"])
+        self.assertIn("--skip-sarvam", captured["argv"])
         self.assertIn("hindi", captured["argv"])
 
     def test_tts_no_provider_launches_ui(self):


### PR DESCRIPTION
## What
- STT eval no longer runs an LLM judge when no evaluators are passed — it reports WER/CER only. Passing evaluators works as before.
- The Sarvam judges (intent/entity + LLM-WER/CER) now run by default; the CLI flag `--sarvam-judges` is replaced by `--skip-sarvam` to opt out.

## Notes
- Default-behavior change for both CLI and SDK: a bare `calibrate-agent stt -p <provider>` now emits WER/CER plus the Sarvam judges, and no semantic-match judge unless evaluators are supplied.
- TTS is unchanged — it still defaults to its judge since it has no WER-style metric.