### PR TITLE
Steer OpenAI STT output language via prompt

### DIFF
--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -234,11 +234,16 @@ async def transcribe_openai_streaming(audio_path: Path, language: str) -> str:
     audio_file = load_audio(audio_path, as_file=True)
 
     # Supplying the input language (ISO-639-1) improves accuracy and latency
-    # per the OpenAI transcription docs.
+    # per the OpenAI transcription docs. For the gpt-4o transcribe models the
+    # `language` param is only a soft hint, so we also steer the output language
+    # via `prompt` — OpenAI's own recommended workaround for the model emitting
+    # the wrong script (e.g. Urdu for English/Hindi audio).
+    # https://developers.openai.com/api/docs/guides/speech-to-text
     stream = await client.audio.transcriptions.create(
         model=STT_PROVIDER_MODELS["openai"],
         file=audio_file,
         language=lang_code,
+        prompt=f"Transcribe the audio in {language.capitalize()}.",
         response_format="text",
         stream=True,
     )

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -664,6 +664,12 @@ class TestTranscribeOpenAIStreaming(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["transcript"], "hello world")
         # OpenAI STT expects an ISO-639-1 code — "hi" for hindi.
         self.assertEqual(create.await_args.kwargs["language"], "hi")
+        # The gpt-4o models treat `language` as a soft hint, so we also steer
+        # the output language via `prompt` to stop it emitting the wrong script.
+        self.assertEqual(
+            create.await_args.kwargs["prompt"],
+            "Transcribe the audio in Hindi.",
+        )
 
 
 class TestTranscribeGemini(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## What
- gpt-4o-transcribe treats the `language` param as a soft hint, so it can emit the wrong script (e.g. Urdu for English/Hindi audio) even with `language=en`.
- Pass a language-aware `prompt` alongside `language` in `transcribe_openai_streaming` — OpenAI's recommended workaround to steer output language.

## Notes
- Steers strongly but no OpenAI param guarantees correct script for gpt-4o models; `whisper-1` honors `language` as a hard constraint if stray output persists.