### PR TITLE
Use Cartesia ink-2 STT for English; keep ink-whisper for Hindi/Kannada

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,6 +388,13 @@ pre-commit hook on `main`.
   "master" but the repo and all CI configs use `main`.
 - **Don't add comments unless the why is non-obvious.** The codebase follows
   the rule from the global guidelines: comments explain *why*, not *what*.
+- **Keep comments concise and write them for a fresh reader.** One or two lines
+  is usually enough. A comment should state the fact a newcomer needs to
+  understand the code — not narrate the task, the conversation, or the reasoning
+  that led there. Don't restate what the code plainly says, don't list every
+  call site or provider, and don't recap the decision history. If the "why"
+  needs more than a couple of lines, it belongs in a docstring or this file, not
+  an inline block.
 - **Prefer editing existing files** over creating new ones — especially in
   `stt/`, `tts/`, and `llm/`, where the structure is mirrored 1-to-1 in
   `tests/`.

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -536,8 +536,7 @@ async def transcribe_cartesia(audio_path: Path, language: str) -> str:
             "encoding": "pcm_s16le",  # Audio encoding format (required)
             "sample_rate": 16000,  # Audio sample rate (required)
         }
-        # min_volume / max_silence_duration_secs are ink-whisper-only tuning
-        # params; ink-2 does its own turn detection and rejects them.
+        # min_volume / max_silence_duration_secs are ink-whisper-only; ink-2 rejects them.
         if model == "ink-whisper":
             ws_kwargs["min_volume"] = 0.15
             ws_kwargs["max_silence_duration_secs"] = 0.3

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -27,6 +27,7 @@ from calibrate_agent.utils import (
     get_stt_language_code,
     validate_stt_language,
     STT_PROVIDER_MODELS,
+    get_stt_model,
     get_gemini_api_key,
     provider_log as _log,
     provider_log_file as _current_log_file,
@@ -524,19 +525,25 @@ async def transcribe_cartesia(audio_path: Path, language: str) -> str:
         raise ValueError("CARTESIA_API_KEY environment variable not set")
 
     lang_code = get_stt_language_code(language, "cartesia")
+    model = get_stt_model("cartesia", language)
 
     client = AsyncCartesia(api_key=api_key)
 
     try:
+        ws_kwargs = {
+            "model": model,  # Model (required)
+            "language": lang_code,  # Language of your audio (required)
+            "encoding": "pcm_s16le",  # Audio encoding format (required)
+            "sample_rate": 16000,  # Audio sample rate (required)
+        }
+        # min_volume / max_silence_duration_secs are ink-whisper-only tuning
+        # params; ink-2 does its own turn detection and rejects them.
+        if model == "ink-whisper":
+            ws_kwargs["min_volume"] = 0.15
+            ws_kwargs["max_silence_duration_secs"] = 0.3
+
         # Create websocket connection with voice activity detection
-        ws = await client.stt.websocket(
-            model=STT_PROVIDER_MODELS["cartesia"],  # Model (required)
-            language=lang_code,  # Language of your audio (required)
-            encoding="pcm_s16le",  # Audio encoding format (required)
-            sample_rate=16000,  # Audio sample rate (required)
-            min_volume=0.15,  # Volume threshold for voice activity detection
-            max_silence_duration_secs=0.3,  # Maximum silence duration before endpointing
-        )
+        ws = await client.stt.websocket(**ws_kwargs)
 
         # Simulate streaming audio data (replace with your audio source)
         async def audio_stream():

--- a/calibrate_agent/utils.py
+++ b/calibrate_agent/utils.py
@@ -1807,13 +1807,8 @@ STT_PROVIDER_MODELS = {
     "sarvam": "saaras:v3",
 }
 
-# Per-language STT model OVERRIDES, mirroring TTS_PROVIDER_VOICES_BY_LANGUAGE. A
-# (provider, language) entry here wins over the provider's STT_PROVIDER_MODELS
-# default; languages without an entry fall back to it. Both the live agent
-# (create_stt_service) and the benchmark (calibrate_agent/stt/eval.py) resolve
-# through get_stt_model() so they can't drift. Cartesia's ink-2 is its fastest,
-# most accurate streaming model but is English-only, so only english overrides to
-# it; hindi/kannada stay on the multilingual ink-whisper default.
+# Per-language STT model overrides, resolved through get_stt_model() (mirrors
+# TTS_PROVIDER_VOICES_BY_LANGUAGE / get_tts_voice). Cartesia's ink-2 is English-only.
 STT_PROVIDER_MODELS_BY_LANGUAGE = {
     "cartesia": {
         "english": "ink-2",
@@ -1822,13 +1817,8 @@ STT_PROVIDER_MODELS_BY_LANGUAGE = {
 
 
 def get_stt_model(provider: str, language: str) -> str:
-    """Return the default STT model for a provider + language.
-
-    A per-language override in STT_PROVIDER_MODELS_BY_LANGUAGE wins; otherwise the
-    provider's language-agnostic default in STT_PROVIDER_MODELS. Shared by
-    create_stt_service and calibrate_agent/stt/eval.py so the live agent and
-    benchmark pick the same model.
-    """
+    """Return the STT model for a provider + language: a per-language override in
+    STT_PROVIDER_MODELS_BY_LANGUAGE if present, else STT_PROVIDER_MODELS."""
     override = STT_PROVIDER_MODELS_BY_LANGUAGE.get(provider, {}).get(language)
     if override is not None:
         return override

--- a/calibrate_agent/utils.py
+++ b/calibrate_agent/utils.py
@@ -1807,6 +1807,33 @@ STT_PROVIDER_MODELS = {
     "sarvam": "saaras:v3",
 }
 
+# Per-language STT model OVERRIDES, mirroring TTS_PROVIDER_VOICES_BY_LANGUAGE. A
+# (provider, language) entry here wins over the provider's STT_PROVIDER_MODELS
+# default; languages without an entry fall back to it. Both the live agent
+# (create_stt_service) and the benchmark (calibrate_agent/stt/eval.py) resolve
+# through get_stt_model() so they can't drift. Cartesia's ink-2 is its fastest,
+# most accurate streaming model but is English-only, so only english overrides to
+# it; hindi/kannada stay on the multilingual ink-whisper default.
+STT_PROVIDER_MODELS_BY_LANGUAGE = {
+    "cartesia": {
+        "english": "ink-2",
+    },
+}
+
+
+def get_stt_model(provider: str, language: str) -> str:
+    """Return the default STT model for a provider + language.
+
+    A per-language override in STT_PROVIDER_MODELS_BY_LANGUAGE wins; otherwise the
+    provider's language-agnostic default in STT_PROVIDER_MODELS. Shared by
+    create_stt_service and calibrate_agent/stt/eval.py so the live agent and
+    benchmark pick the same model.
+    """
+    override = STT_PROVIDER_MODELS_BY_LANGUAGE.get(provider, {}).get(language)
+    if override is not None:
+        return override
+    return STT_PROVIDER_MODELS[provider]
+
 TTS_PROVIDER_MODELS = {
     "gemini": "gemini-3.1-flash-tts-preview",
     "cartesia": "sonic-3.5",
@@ -1885,7 +1912,7 @@ def create_stt_service(
             api_key=os.getenv("CARTESIA_API_KEY"),
             settings=CartesiaSTTService.Settings(
                 language=stt_language,
-                model=STT_PROVIDER_MODELS[provider],
+                model=get_stt_model(provider, language),
             ),
         )
     elif provider == "smallest":

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -911,5 +911,65 @@ class TestTranscribeGemini(unittest.IsolatedAsyncioTestCase):
                 await stt_eval.transcribe_gemini(Path("/tmp/x.wav"), "english")
 
 
+class TestTranscribeCartesia(unittest.IsolatedAsyncioTestCase):
+    """The Cartesia model is per-language (ink-2 for english, ink-whisper for
+    hindi/kannada) and the ink-whisper-only tuning params must not leak to ink-2."""
+
+    def _patch(self, stt_eval, ws_kwargs_sink):
+        async def fake_receive():
+            yield {"type": "transcript", "text": "hello", "is_final": True}
+            yield {"type": "done"}
+
+        ws = MagicMock()
+        ws.send = AsyncMock()
+        ws.receive = MagicMock(side_effect=lambda: fake_receive())
+        ws.close = AsyncMock()
+
+        async def fake_websocket(**kwargs):
+            ws_kwargs_sink.update(kwargs)
+            return ws
+
+        client = MagicMock()
+        client.stt.websocket = AsyncMock(side_effect=fake_websocket)
+        client.close = AsyncMock()
+
+        return (
+            patch.dict("os.environ", {"CARTESIA_API_KEY": "sk-fake"}),
+            patch.object(stt_eval, "AsyncCartesia", return_value=client),
+            patch.object(stt_eval, "load_audio", return_value=b"\x00\x00" * 1600),
+        )
+
+    async def test_english_uses_ink2_without_whisper_params(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        sink = {}
+        for p in self._patch(stt_eval, sink):
+            p.start()
+        try:
+            result = await stt_eval.transcribe_cartesia(Path("/tmp/x.wav"), "english")
+        finally:
+            patch.stopall()
+
+        self.assertEqual(result["transcript"], "hello")
+        self.assertEqual(sink["model"], "ink-2")
+        self.assertNotIn("min_volume", sink)
+        self.assertNotIn("max_silence_duration_secs", sink)
+
+    async def test_hindi_uses_ink_whisper_with_params(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        sink = {}
+        for p in self._patch(stt_eval, sink):
+            p.start()
+        try:
+            await stt_eval.transcribe_cartesia(Path("/tmp/x.wav"), "hindi")
+        finally:
+            patch.stopall()
+
+        self.assertEqual(sink["model"], "ink-whisper")
+        self.assertEqual(sink["min_volume"], 0.15)
+        self.assertEqual(sink["max_silence_duration_secs"], 0.3)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_utils_factories.py
+++ b/tests/test_utils_factories.py
@@ -59,21 +59,29 @@ class TestCreateSTTService(unittest.TestCase):
                 create_stt_service(prov, "english")
 
     def test_stt_models_come_from_shared_constant(self):
-        """Every provider's model in create_stt_service must come from
-        utils.STT_PROVIDER_MODELS — the SAME dict calibrate_agent/stt/eval.py reads —
-        so the live agent and the benchmark can't drift apart."""
-        from calibrate_agent.utils import create_stt_service, STT_PROVIDER_MODELS
+        """Every provider's model in create_stt_service must come from the same
+        resolver (get_stt_model over STT_PROVIDER_MODELS[_BY_LANGUAGE]) that
+        calibrate_agent/stt/eval.py reads — for every language — so the live agent
+        and the benchmark can't drift apart. Models are per-language: an override
+        in STT_PROVIDER_MODELS_BY_LANGUAGE wins, else the default."""
+        from calibrate_agent.utils import (
+            create_stt_service,
+            STT_PROVIDER_MODELS,
+            get_stt_model,
+        )
 
-        for prov, expected in STT_PROVIDER_MODELS.items():
+        for prov in STT_PROVIDER_MODELS:
             if prov in BENCHMARK_ONLY_PROVIDERS:
                 continue
-            with patch.dict(os.environ, ALL_KEYS), \
-                    patch(STT_SERVICE_TARGETS[prov]) as svc:
-                create_stt_service(prov, "english")
-                self.assertEqual(
-                    svc.Settings.call_args.kwargs["model"], expected,
-                    f"{prov}: STT model default drifted from STT_PROVIDER_MODELS",
-                )
+            for language in ("english", "hindi", "kannada"):
+                with patch.dict(os.environ, ALL_KEYS), \
+                        patch(STT_SERVICE_TARGETS[prov]) as svc:
+                    create_stt_service(prov, language)
+                    self.assertEqual(
+                        svc.Settings.call_args.kwargs["model"],
+                        get_stt_model(prov, language),
+                        f"{prov}/{language}: STT model drifted from get_stt_model",
+                    )
 
         # Guard against a new provider entering the constant without matching
         # parity coverage here (benchmark-only providers excepted).
@@ -82,6 +90,17 @@ class TestCreateSTTService(unittest.TestCase):
             {"deepgram", "openai", "groq", "google", "cartesia",
              "elevenlabs", "smallest", "sarvam"},
         )
+
+    def test_cartesia_stt_model_is_per_language(self):
+        """Cartesia uses English-only ink-2 for english but stays on the
+        multilingual ink-whisper for hindi/kannada."""
+        from calibrate_agent.utils import get_stt_model
+
+        self.assertEqual(get_stt_model("cartesia", "english"), "ink-2")
+        self.assertEqual(get_stt_model("cartesia", "hindi"), "ink-whisper")
+        self.assertEqual(get_stt_model("cartesia", "kannada"), "ink-whisper")
+        # A provider with no override falls back to its flat default.
+        self.assertEqual(get_stt_model("deepgram", "english"), "nova-3")
 
     def test_sarvam_stt_transcribes(self):
         """Sarvam STT must use saaras:v3 with mode="transcribe" so pipecat routes


### PR DESCRIPTION
## What
- Route Cartesia STT per-language: English uses the new `ink-2` (fastest/most accurate streaming model, but English-only); Hindi/Kannada stay on the multilingual `ink-whisper`.
- Add `STT_PROVIDER_MODELS_BY_LANGUAGE` + `get_stt_model()` resolver (mirrors `get_tts_voice`), read by both the live agent and the benchmark so they can't drift.
- Gate `min_volume` / `max_silence_duration_secs` to `ink-whisper` only — `ink-2` does its own turn detection and rejects them.

## Notes
- Smoke-tested against the live Cartesia API: English→ink-2 and Kannada→ink-whisper both return; ink-2 succeeds without the tuning params.
- Existing English Cartesia `results.csv` (from ink-whisper runs) won't auto-invalidate — use `--overwrite` to re-benchmark English on ink-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)