### PR TITLE
Fix STT language coverage (all 13 languages + Google Sindhi)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,6 +382,17 @@ For any function block you add or modify:
 This is not optional — every PR is gated by the test suite in CI and by the
 pre-commit hook on `main`.
 
+### When the user asks "how do I test this?"
+
+Answer with the **single specific command they should run locally** for the
+change at hand — the exact `uv run …` / `calibrate-agent …` invocation, with the
+real flags, dataset path, and provider filled in (use `examples/` datasets when
+one fits). Do **not** give a tiered "here are the options" answer or a menu of
+fast-vs-thorough choices. One concrete, copy-pasteable command (a second line
+only if a follow-up command is genuinely needed, e.g. inspecting the output
+file). If a real run needs API keys or a dataset the user must supply, say so in
+one line, but still give the exact command.
+
 ## Things to keep in mind
 
 - **Default branch is `main`**, not `master`. Some early conversations used

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -27,6 +27,7 @@ from calibrate_agent.utils import (
     get_stt_language_code,
     validate_stt_language,
     STT_PROVIDER_MODELS,
+    google_stt_model_and_location,
     get_gemini_api_key,
     provider_log as _log,
     provider_log_file as _current_log_file,
@@ -385,13 +386,7 @@ async def transcribe_google(audio_path: Path, language: str) -> str:
 
     lang_code = get_stt_language_code(language, "google")
 
-    # Use chirp_2 model and asia-southeast1 region for Sindhi
-    if language.lower() == "sindhi":
-        model = "chirp_2"
-        region = "asia-southeast1"
-    else:
-        model = STT_PROVIDER_MODELS["google"]
-        region = "us"
+    model, region = google_stt_model_and_location(language)
 
     result = await asyncio.wait_for(
         asyncio.to_thread(

--- a/calibrate_agent/utils.py
+++ b/calibrate_agent/utils.py
@@ -1640,35 +1640,62 @@ def validate_tts_language(language: str, provider: str) -> None:
 # =============================================================================
 
 
+# Base pipecat ``Language`` enum per language name, used by the STT factory
+# (create_stt_service) and the pipeline benchmark engine. Mirrors the coverage of
+# the direct-path ``get_stt_language_code`` maps so both engines support the same
+# 13 languages. Sarvam takes India-regional (``*_IN``) variants; every other
+# provider takes the base enum and pipecat's per-service layer translates it.
+_STT_LANGUAGE_ENUMS = {
+    "english": Language.EN,
+    "hindi": Language.HI,
+    "kannada": Language.KN,
+    "bengali": Language.BN,
+    "malayalam": Language.ML,
+    "marathi": Language.MR,
+    "odia": Language.OR,
+    "punjabi": Language.PA,
+    "tamil": Language.TA,
+    "telugu": Language.TE,
+    "gujarati": Language.GU,
+    "sindhi": Language.SD,
+    "maithili": Language.MAI,
+}
+
+_SARVAM_STT_LANGUAGE_ENUMS = {
+    "english": Language.EN_IN,
+    "hindi": Language.HI_IN,
+    "kannada": Language.KN_IN,
+    "bengali": Language.BN_IN,
+    "malayalam": Language.ML_IN,
+    "marathi": Language.MR_IN,
+    "odia": Language.OR_IN,
+    "punjabi": Language.PA_IN,
+    "tamil": Language.TA_IN,
+    "telugu": Language.TE_IN,
+    "gujarati": Language.GU_IN,
+    "sindhi": Language.SD_IN,
+    "maithili": Language.MAI_IN,
+}
+
+
 def get_stt_language(
-    language: Literal["english", "hindi", "kannada"],
+    language: str,
     provider: str,
 ) -> Language:
     """Get the appropriate Language enum for STT based on language and provider.
 
     Args:
-        language: The language name (english, hindi, kannada)
+        language: The language name (e.g. english, hindi, tamil — any of the 13
+            supported STT languages).
         provider: The STT provider name
 
     Returns:
-        The appropriate Language enum value
+        The appropriate Language enum value (falls back to English for an
+        unknown language, matching the direct-path code maps' defaults).
     """
-    # Sarvam uses regional language codes
-    if provider == "sarvam":
-        if language == "kannada":
-            return Language.KN_IN
-        elif language == "hindi":
-            return Language.HI_IN
-        else:
-            return Language.EN_IN
-
-    # Default language codes
-    if language == "kannada":
-        return Language.KN
-    elif language == "hindi":
-        return Language.HI
-    else:
-        return Language.EN
+    language = language.lower()
+    table = _SARVAM_STT_LANGUAGE_ENUMS if provider == "sarvam" else _STT_LANGUAGE_ENUMS
+    return table.get(language, table["english"])
 
 
 def get_tts_language(
@@ -1904,12 +1931,20 @@ def create_stt_service(
             ),
         )
     elif provider == "google":
+        # Sindhi is only served by chirp_2 in asia-southeast1 (mirrors the
+        # direct-path transcribe_google special-case in stt/eval.py).
+        if str(language).lower() == "sindhi":
+            google_model = model or "chirp_2"
+            google_location = "asia-southeast1"
+        else:
+            google_model = model or STT_PROVIDER_MODELS[provider]
+            google_location = "us"
         return GoogleSTTService(
             sample_rate=16000,
-            location="us",
+            location=google_location,
             settings=GoogleSTTService.Settings(
                 languages=[stt_language],
-                model=model or STT_PROVIDER_MODELS[provider],
+                model=google_model,
             ),
             credentials_path=os.getenv("GOOGLE_APPLICATION_CREDENTIALS"),
         )

--- a/calibrate_agent/utils.py
+++ b/calibrate_agent/utils.py
@@ -1834,6 +1834,22 @@ STT_PROVIDER_MODELS = {
     "sarvam": "saaras:v3",
 }
 
+
+def google_stt_model_and_location(
+    language: str, model: str | None = None
+) -> tuple[str, str]:
+    """Return the Google STT (model, location) for a language.
+
+    Sindhi is only served by ``chirp_2`` in ``asia-southeast1``; every other
+    language uses the default model in ``us``. Single source of truth shared by
+    the live-agent factory (``create_stt_service``) and the direct-path
+    benchmark (``stt/eval.py`` ``transcribe_google``) so the two can't drift.
+    """
+    if str(language).lower() == "sindhi":
+        return model or "chirp_2", "asia-southeast1"
+    return model or STT_PROVIDER_MODELS["google"], "us"
+
+
 TTS_PROVIDER_MODELS = {
     "gemini": "gemini-3.1-flash-tts-preview",
     "cartesia": "sonic-3.5",
@@ -1931,14 +1947,7 @@ def create_stt_service(
             ),
         )
     elif provider == "google":
-        # Sindhi is only served by chirp_2 in asia-southeast1 (mirrors the
-        # direct-path transcribe_google special-case in stt/eval.py).
-        if str(language).lower() == "sindhi":
-            google_model = model or "chirp_2"
-            google_location = "asia-southeast1"
-        else:
-            google_model = model or STT_PROVIDER_MODELS[provider]
-            google_location = "us"
+        google_model, google_location = google_stt_model_and_location(language, model)
         return GoogleSTTService(
             sample_rate=16000,
             location=google_location,

--- a/tests/stt/test_language_mapping.py
+++ b/tests/stt/test_language_mapping.py
@@ -1,0 +1,76 @@
+"""Tests for get_stt_language 13-language coverage + Google Sindhi routing."""
+
+import os
+import unittest
+from unittest.mock import patch
+
+
+STT_LANGUAGES = [
+    "english", "hindi", "kannada", "bengali", "malayalam", "marathi",
+    "odia", "punjabi", "tamil", "telugu", "gujarati", "sindhi", "maithili",
+]
+
+
+class TestGetSTTLanguage(unittest.TestCase):
+    def test_all_13_languages_map_to_a_language_enum(self):
+        from calibrate_agent.utils import get_stt_language
+        from pipecat.transcriptions.language import Language
+
+        for lang in STT_LANGUAGES:
+            self.assertIsInstance(get_stt_language(lang, "deepgram"), Language)
+            self.assertIsInstance(get_stt_language(lang, "sarvam"), Language)
+
+    def test_non_english_does_not_fall_back_to_english(self):
+        from calibrate_agent.utils import get_stt_language
+        from pipecat.transcriptions.language import Language
+
+        # The bug this fixes: tamil/telugu/etc. used to become English.
+        self.assertEqual(get_stt_language("tamil", "deepgram"), Language.TA)
+        self.assertEqual(get_stt_language("telugu", "deepgram"), Language.TE)
+        self.assertEqual(get_stt_language("bengali", "deepgram"), Language.BN)
+        self.assertNotEqual(
+            get_stt_language("tamil", "deepgram"),
+            get_stt_language("english", "deepgram"),
+        )
+
+    def test_sarvam_uses_regional_variants(self):
+        from calibrate_agent.utils import get_stt_language
+        from pipecat.transcriptions.language import Language
+
+        self.assertEqual(get_stt_language("tamil", "sarvam"), Language.TA_IN)
+        self.assertEqual(get_stt_language("hindi", "sarvam"), Language.HI_IN)
+
+    def test_unknown_language_falls_back_to_english(self):
+        from calibrate_agent.utils import get_stt_language
+        from pipecat.transcriptions.language import Language
+
+        self.assertEqual(get_stt_language("klingon", "deepgram"), Language.EN)
+        self.assertEqual(get_stt_language("klingon", "sarvam"), Language.EN_IN)
+
+
+class TestGoogleSindhiRouting(unittest.TestCase):
+    ALL_KEYS = {"GOOGLE_APPLICATION_CREDENTIALS": "/creds.json"}
+
+    def test_sindhi_uses_chirp2_asia_southeast1(self):
+        from calibrate_agent.utils import create_stt_service
+
+        target = "pipecat.services.google.stt.GoogleSTTService"
+        with patch.dict(os.environ, self.ALL_KEYS), patch(target) as svc:
+            create_stt_service("google", "sindhi")
+        self.assertEqual(svc.call_args.kwargs["location"], "asia-southeast1")
+        self.assertEqual(svc.Settings.call_args.kwargs["model"], "chirp_2")
+
+    def test_non_sindhi_uses_default_model_and_us(self):
+        from calibrate_agent.utils import create_stt_service, STT_PROVIDER_MODELS
+
+        target = "pipecat.services.google.stt.GoogleSTTService"
+        with patch.dict(os.environ, self.ALL_KEYS), patch(target) as svc:
+            create_stt_service("google", "hindi")
+        self.assertEqual(svc.call_args.kwargs["location"], "us")
+        self.assertEqual(
+            svc.Settings.call_args.kwargs["model"], STT_PROVIDER_MODELS["google"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/stt/test_language_mapping.py
+++ b/tests/stt/test_language_mapping.py
@@ -48,6 +48,24 @@ class TestGetSTTLanguage(unittest.TestCase):
         self.assertEqual(get_stt_language("klingon", "sarvam"), Language.EN_IN)
 
 
+class TestGoogleModelAndLocation(unittest.TestCase):
+    def test_sindhi_vs_default(self):
+        from calibrate_agent.utils import (
+            google_stt_model_and_location,
+            STT_PROVIDER_MODELS,
+        )
+
+        self.assertEqual(
+            google_stt_model_and_location("sindhi"), ("chirp_2", "asia-southeast1")
+        )
+        self.assertEqual(
+            google_stt_model_and_location("hindi"),
+            (STT_PROVIDER_MODELS["google"], "us"),
+        )
+        # Explicit model override wins for non-Sindhi.
+        self.assertEqual(google_stt_model_and_location("hindi", "chirp_3"), ("chirp_3", "us"))
+
+
 class TestGoogleSindhiRouting(unittest.TestCase):
     ALL_KEYS = {"GOOGLE_APPLICATION_CREDENTIALS": "/creds.json"}
 


### PR DESCRIPTION
## What
- `get_stt_language` only mapped english/hindi/kannada and silently fell back to English for the other 10 languages — so `create_stt_service` (used by both the live agent and the benchmarks) transcribed e.g. Tamil audio as English. Now maps all 13 STT languages to the correct pipecat `Language` enums (Sarvam uses `*_IN` regional variants).
- Route Google **Sindhi** to `chirp_2` / `asia-southeast1`, matching the direct-path `transcribe_google` special-case.
- Doc tweak: CLAUDE.md note to answer "how do I test this?" with one concrete local command.

## Notes
- Standalone fix — benefits the live voice agent directly (correct language selection), and is a prerequisite for the pipeline STT engine (separate PR).
- Tests: 13-language mapping (incl. Sarvam regional variants + unknown-language fallback) and Google Sindhi vs. non-Sindhi routing. 11 passed with the existing factory tests.