### PR TITLE
Add --max-parallel CLI flag (env-configurable across-provider concurrency)

### DIFF
--- a/calibrate_agent/_env.py
+++ b/calibrate_agent/_env.py
@@ -1,0 +1,27 @@
+"""Tiny environment-variable helpers.
+
+Deliberately stdlib-only (imports just ``os``): both the CLI argument parser
+(``calibrate_agent.cli``) and the library benchmark modules import from here.
+The CLI must build its parser *without* importing the heavy
+``calibrate_agent.utils`` module — that shifts scipy/numpy init order and trips a
+scipy ``_CopyMode`` incompatibility in the voice path — so this module must never
+grow a non-stdlib import.
+"""
+
+import os
+
+
+def env_int(name: str, default: int) -> int:
+    """Read an int from env var ``name``, falling back to ``default``.
+
+    Used for benchmark concurrency knobs so they can be tuned via the
+    environment (e.g. in CI / .env) without a code change; the hardcoded
+    ``default`` is the fallback when the var is unset or not a valid int.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default

--- a/calibrate_agent/cli.py
+++ b/calibrate_agent/cli.py
@@ -26,6 +26,23 @@ from importlib.metadata import version as get_version
 from dotenv import find_dotenv, load_dotenv
 
 
+def _env_int(name: str, default: int) -> int:
+    """Read an int from env var ``name``, falling back to ``default``.
+
+    Local to the CLI (uses only ``os``) so building the argument parser doesn't
+    import the heavy ``calibrate_agent.utils`` module — importing it here shifts
+    scipy/numpy init order and trips a scipy ``_CopyMode`` incompatibility in the
+    voice path. ``calibrate_agent.utils.env_int`` is the same helper for library code.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
 def _args_to_argv(args, exclude_keys=None, flag_mapping=None):
     """Convert argparse namespace to sys.argv format.
 
@@ -242,6 +259,15 @@ Examples:
             "per-row LLM judges."
         ),
     )
+    stt_parser.add_argument(
+        "--max-parallel",
+        type=int,
+        default=_env_int("CALIBRATE_STT_MAX_PARALLEL", 2),
+        help=(
+            "Number of providers to evaluate in parallel (default: 2, or "
+            "$CALIBRATE_STT_MAX_PARALLEL)."
+        ),
+    )
 
     # ── TTS ───────────────────────────────────────────────────────
     # `calibrate-agent tts` with no args → interactive UI
@@ -264,6 +290,15 @@ Examples:
     tts_parser.add_argument("-d", "--debug", action="store_true")
     tts_parser.add_argument("-dc", "--debug_count", type=int, default=5)
     tts_parser.add_argument("--overwrite", action="store_true")
+    tts_parser.add_argument(
+        "--max-parallel",
+        type=int,
+        default=_env_int("CALIBRATE_TTS_MAX_PARALLEL", 2),
+        help=(
+            "Number of providers to evaluate in parallel (default: 2, or "
+            "$CALIBRATE_TTS_MAX_PARALLEL)."
+        ),
+    )
     tts_parser.add_argument(
         "--leaderboard",
         action="store_true",
@@ -328,6 +363,15 @@ Examples:
         type=int,
         default=None,
         help="Number of test cases to evaluate in parallel per model",
+    )
+    llm_parser.add_argument(
+        "--max-parallel",
+        type=int,
+        default=_env_int("CALIBRATE_LLM_MAX_PARALLEL", 2),
+        help=(
+            "Number of models to evaluate in parallel (default: 2, or "
+            "$CALIBRATE_LLM_MAX_PARALLEL)."
+        ),
     )
     llm_parser.add_argument(
         "-d",
@@ -567,6 +611,7 @@ Examples:
                 argv.extend(["--config", args.config])
             if args.skip_sarvam:
                 argv.append("--skip-sarvam")
+            argv.extend(["--max-parallel", str(args.max_parallel)])
 
             sys.argv = argv
             asyncio.run(stt_benchmark_main())
@@ -606,6 +651,7 @@ Examples:
                 argv.append("--overwrite")
             if args.config:
                 argv.extend(["--config", args.config])
+            argv.extend(["--max-parallel", str(args.max_parallel)])
 
             sys.argv = argv
             asyncio.run(tts_benchmark_main())
@@ -706,6 +752,7 @@ Examples:
                             output_dir=args.output_dir,
                             models=_models,
                             evaluators=_config.get("evaluators"),
+                            max_parallel=args.max_parallel,
                             test_parallel=args.parallel,
                             overwrite=args.overwrite,
                         )
@@ -745,6 +792,7 @@ Examples:
                 argv.extend(["-p", args.provider])
                 if getattr(args, "parallel", None) is not None:
                     argv.extend(["-n", str(args.parallel)])
+                argv.extend(["--max-parallel", str(args.max_parallel)])
                 if getattr(args, "overwrite", False):
                     argv.append("--overwrite")
                 if getattr(args, "debug", False):

--- a/calibrate_agent/cli.py
+++ b/calibrate_agent/cli.py
@@ -25,22 +25,11 @@ import json
 from importlib.metadata import version as get_version
 from dotenv import find_dotenv, load_dotenv
 
-
-def _env_int(name: str, default: int) -> int:
-    """Read an int from env var ``name``, falling back to ``default``.
-
-    Local to the CLI (uses only ``os``) so building the argument parser doesn't
-    import the heavy ``calibrate_agent.utils`` module — importing it here shifts
-    scipy/numpy init order and trips a scipy ``_CopyMode`` incompatibility in the
-    voice path. ``calibrate_agent.utils.env_int`` is the same helper for library code.
-    """
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-    try:
-        return int(raw)
-    except ValueError:
-        return default
+# ``calibrate_agent._env`` is stdlib-only (imports just ``os``), so this import is
+# safe at parser-build time — unlike ``calibrate_agent.utils``, which pulls in
+# scipy/numpy/pipecat and trips a scipy ``_CopyMode`` incompatibility in the
+# voice path if imported here.
+from calibrate_agent._env import env_int
 
 
 def _args_to_argv(args, exclude_keys=None, flag_mapping=None):
@@ -262,7 +251,7 @@ Examples:
     stt_parser.add_argument(
         "--max-parallel",
         type=int,
-        default=_env_int("CALIBRATE_STT_MAX_PARALLEL", 2),
+        default=env_int("CALIBRATE_STT_MAX_PARALLEL", 2),
         help=(
             "Number of providers to evaluate in parallel (default: 2, or "
             "$CALIBRATE_STT_MAX_PARALLEL)."
@@ -293,7 +282,7 @@ Examples:
     tts_parser.add_argument(
         "--max-parallel",
         type=int,
-        default=_env_int("CALIBRATE_TTS_MAX_PARALLEL", 2),
+        default=env_int("CALIBRATE_TTS_MAX_PARALLEL", 2),
         help=(
             "Number of providers to evaluate in parallel (default: 2, or "
             "$CALIBRATE_TTS_MAX_PARALLEL)."
@@ -367,7 +356,7 @@ Examples:
     llm_parser.add_argument(
         "--max-parallel",
         type=int,
-        default=_env_int("CALIBRATE_LLM_MAX_PARALLEL", 2),
+        default=env_int("CALIBRATE_LLM_MAX_PARALLEL", 2),
         help=(
             "Number of models to evaluate in parallel (default: 2, or "
             "$CALIBRATE_LLM_MAX_PARALLEL)."

--- a/calibrate_agent/llm/benchmark.py
+++ b/calibrate_agent/llm/benchmark.py
@@ -29,7 +29,8 @@ from os.path import exists, join
 from calibrate_agent.llm.run_tests import display_label, run_model_tests
 from calibrate_agent.llm.tests_leaderboard import generate_leaderboard
 from calibrate_agent.llm._output import print_benchmark_summary
-from calibrate_agent.utils import StreamTee, apply_debug_limit, env_int
+from calibrate_agent._env import env_int
+from calibrate_agent.utils import StreamTee, apply_debug_limit
 
 # Maximum number of models to run in parallel
 MAX_PARALLEL_MODELS = 2

--- a/calibrate_agent/llm/benchmark.py
+++ b/calibrate_agent/llm/benchmark.py
@@ -29,7 +29,7 @@ from os.path import exists, join
 from calibrate_agent.llm.run_tests import display_label, run_model_tests
 from calibrate_agent.llm.tests_leaderboard import generate_leaderboard
 from calibrate_agent.llm._output import print_benchmark_summary
-from calibrate_agent.utils import StreamTee, apply_debug_limit
+from calibrate_agent.utils import StreamTee, apply_debug_limit, env_int
 
 # Maximum number of models to run in parallel
 MAX_PARALLEL_MODELS = 2
@@ -156,6 +156,15 @@ async def main():
         help="Number of test cases to evaluate in parallel per model",
     )
     parser.add_argument(
+        "--max-parallel",
+        type=int,
+        default=env_int("CALIBRATE_LLM_MAX_PARALLEL", MAX_PARALLEL_MODELS),
+        help=(
+            "Number of models to evaluate in parallel (default: 2, or "
+            "$CALIBRATE_LLM_MAX_PARALLEL)."
+        ),
+    )
+    parser.add_argument(
         "--overwrite",
         action="store_true",
         help="Force a clean run instead of resuming completed test cases from a prior results.json",
@@ -223,6 +232,7 @@ async def main():
             models=models,
             provider=args.provider,
             output_dir=args.output_dir,
+            max_parallel=args.max_parallel,
             test_parallel=args.parallel,
             overwrite=args.overwrite,
         )

--- a/calibrate_agent/stt/benchmark.py
+++ b/calibrate_agent/stt/benchmark.py
@@ -33,7 +33,8 @@ from calibrate_agent.stt.eval import (
     STT_LANGUAGES,
 )
 from calibrate_agent.stt.leaderboard import generate_leaderboard
-from calibrate_agent.utils import StreamTee, env_int
+from calibrate_agent._env import env_int
+from calibrate_agent.utils import StreamTee
 
 
 # Maximum number of providers to run in parallel

--- a/calibrate_agent/stt/benchmark.py
+++ b/calibrate_agent/stt/benchmark.py
@@ -33,7 +33,7 @@ from calibrate_agent.stt.eval import (
     STT_LANGUAGES,
 )
 from calibrate_agent.stt.leaderboard import generate_leaderboard
-from calibrate_agent.utils import StreamTee
+from calibrate_agent.utils import StreamTee, env_int
 
 
 # Maximum number of providers to run in parallel
@@ -254,6 +254,15 @@ async def main():
             "per-row LLM judges."
         ),
     )
+    parser.add_argument(
+        "--max-parallel",
+        type=int,
+        default=env_int("CALIBRATE_STT_MAX_PARALLEL", MAX_PARALLEL_PROVIDERS),
+        help=(
+            "Number of providers to evaluate in parallel (default: 2, or "
+            "$CALIBRATE_STT_MAX_PARALLEL)."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -363,6 +372,7 @@ async def main():
             overwrite=args.overwrite,
             judge_evaluators=judge_evaluators,
             run_sarvam_judges=not args.skip_sarvam,
+            max_parallel=args.max_parallel,
         )
 
         # Print summary

--- a/calibrate_agent/tts/benchmark.py
+++ b/calibrate_agent/tts/benchmark.py
@@ -28,7 +28,7 @@ from calibrate_agent.tts.eval import (
     validate_tts_input_file,
 )
 from calibrate_agent.tts.leaderboard import generate_leaderboard
-from calibrate_agent.utils import StreamTee
+from calibrate_agent.utils import StreamTee, env_int
 
 # Maximum number of providers to run in parallel
 MAX_PARALLEL_PROVIDERS = 2
@@ -205,6 +205,15 @@ async def main():
         default=None,
         help="Path to optional JSON config file with an `evaluators` list",
     )
+    parser.add_argument(
+        "--max-parallel",
+        type=int,
+        default=env_int("CALIBRATE_TTS_MAX_PARALLEL", MAX_PARALLEL_PROVIDERS),
+        help=(
+            "Number of providers to evaluate in parallel (default: 2, or "
+            "$CALIBRATE_TTS_MAX_PARALLEL)."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -314,6 +323,7 @@ async def main():
             debug_count=args.debug_count,
             overwrite=args.overwrite,
             judge_evaluators=judge_evaluators,
+            max_parallel=args.max_parallel,
         )
 
         # Print summary

--- a/calibrate_agent/tts/benchmark.py
+++ b/calibrate_agent/tts/benchmark.py
@@ -28,7 +28,8 @@ from calibrate_agent.tts.eval import (
     validate_tts_input_file,
 )
 from calibrate_agent.tts.leaderboard import generate_leaderboard
-from calibrate_agent.utils import StreamTee, env_int
+from calibrate_agent._env import env_int
+from calibrate_agent.utils import StreamTee
 
 # Maximum number of providers to run in parallel
 MAX_PARALLEL_PROVIDERS = 2

--- a/calibrate_agent/utils.py
+++ b/calibrate_agent/utils.py
@@ -24,6 +24,22 @@ from pipecat.transcriptions.language import Language
 current_context: ContextVar[str] = ContextVar("current_context", default="UNKNOWN")
 
 
+def env_int(name: str, default: int) -> int:
+    """Read an int from env var ``name``, falling back to ``default``.
+
+    Used for benchmark concurrency knobs so they can be tuned via the
+    environment (e.g. in CI / .env) without a code change; the hardcoded
+    ``default`` is the fallback when the var is unset or not a valid int.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
 def patch_langfuse_trace(trace_name: str):
     from pipecat.utils.tracing import service_decorators
 

--- a/calibrate_agent/utils.py
+++ b/calibrate_agent/utils.py
@@ -24,22 +24,6 @@ from pipecat.transcriptions.language import Language
 current_context: ContextVar[str] = ContextVar("current_context", default="UNKNOWN")
 
 
-def env_int(name: str, default: int) -> int:
-    """Read an int from env var ``name``, falling back to ``default``.
-
-    Used for benchmark concurrency knobs so they can be tuned via the
-    environment (e.g. in CI / .env) without a code change; the hardcoded
-    ``default`` is the fallback when the var is unset or not a valid int.
-    """
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-    try:
-        return int(raw)
-    except ValueError:
-        return default
-
-
 def patch_langfuse_trace(trace_name: str):
     from pipecat.utils.tracing import service_decorators
 

--- a/tests/llm/test_benchmark.py
+++ b/tests/llm/test_benchmark.py
@@ -317,7 +317,14 @@ class TestBenchmarkDebugFlag(unittest.IsolatedAsyncioTestCase):
         captured = {}
 
         async def fake_run(
-            *, config, models, provider, output_dir, test_parallel=None, overwrite=False
+            *,
+            config,
+            models,
+            provider,
+            output_dir,
+            max_parallel=2,
+            test_parallel=None,
+            overwrite=False,
         ):
             captured["config"] = config
             captured["overwrite"] = overwrite

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from calibrate_agent._env import env_int
+
+
+class TestEnvInt:
+    def test_returns_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("CALIBRATE_TEST_INT", raising=False)
+        assert env_int("CALIBRATE_TEST_INT", 2) == 2
+
+    def test_parses_int_from_env(self, monkeypatch):
+        monkeypatch.setenv("CALIBRATE_TEST_INT", "7")
+        assert env_int("CALIBRATE_TEST_INT", 2) == 7
+
+    def test_falls_back_on_invalid_value(self, monkeypatch):
+        monkeypatch.setenv("CALIBRATE_TEST_INT", "not-a-number")
+        assert env_int("CALIBRATE_TEST_INT", 3) == 3
+
+    def test_empty_string_falls_back(self, monkeypatch):
+        monkeypatch.setenv("CALIBRATE_TEST_INT", "")
+        assert env_int("CALIBRATE_TEST_INT", 4) == 4
+
+    def test_negative_value_parsed(self, monkeypatch):
+        monkeypatch.setenv("CALIBRATE_TEST_INT", "-1")
+        assert env_int("CALIBRATE_TEST_INT", 2) == -1
+
+    def test_stays_stdlib_only(self):
+        """The module must stay stdlib-only so the CLI can import it at
+        parser-build time without dragging in scipy/numpy/pipecat (which trips a
+        scipy ``_CopyMode`` incompatibility in the voice path)."""
+        import ast
+        import calibrate_agent._env as env_mod
+
+        source = Path(env_mod.__file__).read_text()
+        imported = set()
+        for node in ast.walk(ast.parse(source)):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module.split(".")[0])
+
+        assert imported <= {"os"}, f"_env.py must stay stdlib-only, imports: {imported}"


### PR DESCRIPTION
## What
- STT, TTS, and LLM benchmarks already parallelized providers/models (default 2), but the value was only settable via the Python SDK. Expose it on the CLI as `--max-parallel` for all three.
- Each defaults from an env var with a hardcoded fallback: `CALIBRATE_STT_MAX_PARALLEL`, `CALIBRATE_TTS_MAX_PARALLEL`, `CALIBRATE_LLM_MAX_PARALLEL` (all 2).

## Notes
- Independent of the STT pipeline engine work (separate PR); this is engine-agnostic across-provider concurrency.
- `env_int` helper added to utils.py; the CLI uses a local `_env_int` (stdlib-only) so parser-build time doesn't import the heavy utils module — that import shifts scipy/numpy init order and trips a scipy `_CopyMode` error in the voice path.
- 124 tests pass (CLI + benchmark suites).