### PR TITLE
Add semantic WER; unify STT judge flags into --skip-llm-judges

### DIFF
--- a/calibrate_agent/cli.py
+++ b/calibrate_agent/cli.py
@@ -240,12 +240,12 @@ Examples:
         help="Path to dataset JSON (list of {id, gt, pred}). Required with --eval-only.",
     )
     stt_parser.add_argument(
-        "--skip-sarvam",
+        "--skip-llm-judges",
         action="store_true",
         help=(
-            "Skip the Sarvam LLM judges (intent & entity preservation and "
-            "LLM-WER/CER). They run by default; passing this skips the extra "
-            "per-row LLM judges."
+            "Skip the extra LLM-based judges (Sarvam intent & entity "
+            "preservation, Sarvam LLM-WER/CER, and pipecat-style semantic WER). "
+            "They all run by default; passing this reports WER/CER only."
         ),
     )
     stt_parser.add_argument(
@@ -573,8 +573,8 @@ Examples:
             argv.extend(["-o", args.output_dir])
             if args.config:
                 argv.extend(["--config", args.config])
-            if args.skip_sarvam:
-                argv.append("--skip-sarvam")
+            if args.skip_llm_judges:
+                argv.append("--skip-llm-judges")
 
             sys.argv = argv
             asyncio.run(stt_benchmark_main())
@@ -598,8 +598,8 @@ Examples:
                 argv.extend(["-s", args.save_dir])
             if args.config:
                 argv.extend(["--config", args.config])
-            if args.skip_sarvam:
-                argv.append("--skip-sarvam")
+            if args.skip_llm_judges:
+                argv.append("--skip-llm-judges")
             argv.extend(["--max-parallel", str(args.max_parallel)])
 
             sys.argv = argv

--- a/calibrate_agent/stt/benchmark.py
+++ b/calibrate_agent/stt/benchmark.py
@@ -78,7 +78,7 @@ async def run(
     overwrite: bool = False,
     max_parallel: int = MAX_PARALLEL_PROVIDERS,
     judge_evaluators: list[dict] = None,
-    run_sarvam_judges: bool = True,
+    run_llm_judges: bool = True,
 ) -> dict:
     """
     Run STT evaluation for one or more providers and generate a leaderboard.
@@ -99,7 +99,7 @@ async def run(
         judge_evaluators: Optional list of evaluator dicts (each with ``name``,
             ``system_prompt``, ``judge_model``, ``type``, ...). When omitted no
             LLM judge runs and only WER/CER are reported.
-        run_sarvam_judges: Run the Sarvam intent/entity judge (default True;
+        run_llm_judges: Run the Sarvam intent/entity judge (default True;
             loads a normalizer model + makes per-row judge calls). Set to False
             to skip it.
 
@@ -133,7 +133,7 @@ async def run(
                 ignore_retry=ignore_retry,
                 overwrite=overwrite,
                 judge_evaluators=judge_evaluators,
-                run_sarvam_judges=run_sarvam_judges,
+                run_llm_judges=run_llm_judges,
             )
             return (provider, result)
 
@@ -247,12 +247,12 @@ async def main():
         help="Path to optional JSON config file with an `evaluators` list",
     )
     parser.add_argument(
-        "--skip-sarvam",
+        "--skip-llm-judges",
         action="store_true",
         help=(
-            "Skip the Sarvam LLM judges (intent & entity preservation and "
-            "LLM-WER/CER). They run by default; passing this skips the extra "
-            "per-row LLM judges."
+            "Skip the extra LLM-based judges (Sarvam intent & entity "
+            "preservation, Sarvam LLM-WER/CER, and pipecat-style semantic WER). "
+            "They all run by default; passing this reports WER/CER only."
         ),
     )
     parser.add_argument(
@@ -326,7 +326,7 @@ async def main():
             output_dir=args.output_dir,
             judge_evaluators=judge_evaluators,
             language=args.language,
-            run_sarvam_judges=not args.skip_sarvam,
+            run_llm_judges=not args.skip_llm_judges,
         )
 
         print(f"\n\033[92m{'='*60}\033[0m")
@@ -372,7 +372,7 @@ async def main():
             ignore_retry=args.ignore_retry,
             overwrite=args.overwrite,
             judge_evaluators=judge_evaluators,
-            run_sarvam_judges=not args.skip_sarvam,
+            run_llm_judges=not args.skip_llm_judges,
             max_parallel=args.max_parallel,
         )
 

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -1461,10 +1461,17 @@ async def _score_and_write_results(
             )
         if semantic_wer_row is not None:
             row["semantic_wer"] = float(semantic_wer_row["semantic_wer"])
-            row["semantic_wer_substitutions"] = semantic_wer_row["substitutions"]
-            row["semantic_wer_deletions"] = semantic_wer_row["deletions"]
-            row["semantic_wer_insertions"] = semantic_wer_row["insertions"]
-            row["semantic_wer_reference_words"] = semantic_wer_row["reference_words"]
+            row["semantic_wer_metadata"] = json.dumps(
+                {
+                    "substitutions": semantic_wer_row["substitutions"],
+                    "deletions": semantic_wer_row["deletions"],
+                    "insertions": semantic_wer_row["insertions"],
+                    "reference_words": semantic_wer_row["reference_words"],
+                    "normalized_reference": semantic_wer_row["normalized_reference"],
+                    "normalized_hypothesis": semantic_wer_row["normalized_hypothesis"],
+                },
+                ensure_ascii=False,
+            )
             row["semantic_wer_reasoning"] = semantic_wer_row["reasoning"]
         for name, ev in _evaluators_by_name.items():
             ev_result = llm_row[name]

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -38,6 +38,7 @@ from calibrate_agent.stt.metrics import (
     get_llm_judge_score,
     get_intent_entity_score,
     get_llm_wer_cer_score,
+    get_semantic_wer_score,
 )
 from calibrate_agent.judges import (
     is_rating,
@@ -1096,7 +1097,7 @@ async def run_single_provider_eval(
     ignore_retry: bool,
     overwrite: bool,
     judge_evaluators: list[dict] = None,
-    run_sarvam_judges: bool = True,
+    run_llm_judges: bool = True,
 ) -> dict:
     """Run STT evaluation for a single provider."""
     provider_output_dir = join(output_dir, provider)
@@ -1229,7 +1230,7 @@ async def run_single_provider_eval(
             evaluator_config_dir=output_dir,
             judge_evaluators=judge_evaluators,
             language=language,
-            run_sarvam_judges=run_sarvam_judges,
+            run_llm_judges=run_llm_judges,
         )
 
         return {
@@ -1285,7 +1286,7 @@ async def _score_and_write_results(
     evaluator_config_dir: str,
     judge_evaluators: list[dict] = None,
     language: str = "english",
-    run_sarvam_judges: bool = True,
+    run_llm_judges: bool = True,
 ) -> dict:
     """Run WER/CER (and optional LLM-judge evaluators) over (gt, pred) pairs.
 
@@ -1295,7 +1296,7 @@ async def _score_and_write_results(
     evaluator columns/metrics are omitted. Returns the metrics_data dict.
 
     The Sarvam intent/entity judge runs by default. When
-    ``run_sarvam_judges`` is False it is skipped entirely — no normalizer model
+    ``run_llm_judges`` is False it is skipped entirely — no normalizer model
     is loaded, no judge calls are made, and the ``sarvam_*`` columns/metrics are
     omitted.
 
@@ -1315,11 +1316,11 @@ async def _score_and_write_results(
     # succeeded are still written.
 
     # Intent + entity preservation and LLM-WER/CER run by default; setting
-    # ``run_sarvam_judges`` to False skips loading the normalizer model and the
+    # ``run_llm_judges`` to False skips loading the normalizer model and the
     # per-row judge calls.
     intent_entity_results = None
     llm_wer_results = None
-    if run_sarvam_judges:
+    if run_llm_judges:
         try:
             intent_entity_results = await get_intent_entity_score(
                 gt_transcripts, pred_transcripts, language=language
@@ -1342,6 +1343,21 @@ async def _score_and_write_results(
         except Exception as e:
             llm_wer_results = None
             _log(f"Sarvam LLM-WER/CER judge failed, skipping: {e}")
+
+    # Semantic WER (pipecat methodology) runs as part of the LLM judges group.
+    semantic_wer_results = None
+    if run_llm_judges:
+        try:
+            semantic_wer_results = await get_semantic_wer_score(
+                gt_transcripts, pred_transcripts
+            )
+            _log(
+                f"Semantic WER: {semantic_wer_results['semantic_wer']:.4f}",
+                to_terminal=False,
+            )
+        except Exception as e:
+            semantic_wer_results = None
+            _log(f"Semantic WER judge failed, skipping: {e}")
 
     # The LLM judge is opt-in for STT: when no evaluators are passed we report
     # WER/CER only and skip the judge entirely (no evaluator config, no judge
@@ -1378,6 +1394,8 @@ async def _score_and_write_results(
     if llm_wer_results is not None:
         metrics_data["sarvam_llm_wer"] = llm_wer_results["llm_wer"]
         metrics_data["sarvam_llm_cer"] = llm_wer_results["llm_cer"]
+    if semantic_wer_results is not None:
+        metrics_data["semantic_wer"] = semantic_wer_results["semantic_wer"]
     if llm_results is not None:
         for name, score_dict in llm_results["scores"].items():
             metrics_data[name] = score_dict
@@ -1395,9 +1413,24 @@ async def _score_and_write_results(
     llm_per_row = (
         llm_results["per_row"] if llm_results is not None else [None] * len(ids)
     )
+    semantic_wer_per_row = (
+        semantic_wer_results["per_row"]
+        if semantic_wer_results is not None
+        else [None] * len(ids)
+    )
 
     data = []
-    for _id, gt_text, pred_text, wer, cer, ie_row, llm_wer_row, llm_row in zip(
+    for (
+        _id,
+        gt_text,
+        pred_text,
+        wer,
+        cer,
+        ie_row,
+        llm_wer_row,
+        semantic_wer_row,
+        llm_row,
+    ) in zip(
         ids,
         gt_transcripts,
         pred_transcripts,
@@ -1405,6 +1438,7 @@ async def _score_and_write_results(
         cer_results["per_row"],
         ie_per_row,
         llm_wer_per_row,
+        semantic_wer_per_row,
         llm_per_row,
     ):
         row = {
@@ -1425,6 +1459,13 @@ async def _score_and_write_results(
             row["sarvam_llm_wer_reasoning"] = json.dumps(
                 llm_wer_row["segments"], ensure_ascii=False
             )
+        if semantic_wer_row is not None:
+            row["semantic_wer"] = float(semantic_wer_row["semantic_wer"])
+            row["semantic_wer_substitutions"] = semantic_wer_row["substitutions"]
+            row["semantic_wer_deletions"] = semantic_wer_row["deletions"]
+            row["semantic_wer_insertions"] = semantic_wer_row["insertions"]
+            row["semantic_wer_reference_words"] = semantic_wer_row["reference_words"]
+            row["semantic_wer_reasoning"] = semantic_wer_row["reasoning"]
         for name, ev in _evaluators_by_name.items():
             ev_result = llm_row[name]
             if is_rating(ev):
@@ -1447,7 +1488,7 @@ async def run_eval_only(
     output_dir: str,
     judge_evaluators: list[dict] = None,
     language: str = "english",
-    run_sarvam_judges: bool = True,
+    run_llm_judges: bool = True,
 ) -> dict:
     """Run evaluators only on a pre-existing dataset of (gt, pred) pairs.
 
@@ -1461,7 +1502,7 @@ async def run_eval_only(
             LLM judge runs and only WER/CER are reported.
         language: Language of the dataset, used to normalize text before the
             intent/entity judge. Defaults to ``english``.
-        run_sarvam_judges: Run the Sarvam intent/entity judge (default True).
+        run_llm_judges: Run the Sarvam intent/entity judge (default True).
             Setting it to False skips the normalizer model load and the judge
             calls entirely.
 
@@ -1497,7 +1538,7 @@ async def run_eval_only(
             evaluator_config_dir=output_dir,
             judge_evaluators=judge_evaluators,
             language=language,
-            run_sarvam_judges=run_sarvam_judges,
+            run_llm_judges=run_llm_judges,
         )
 
         return {
@@ -1514,13 +1555,14 @@ def format_metrics_summary(metrics: dict, prefix: str = "") -> str:
     shared by the single-provider, multi-provider, and eval-only paths.
 
     The Sarvam judge fields are only included when present in ``metrics``
-    (i.e. unless ``--skip-sarvam`` was passed for the run).
+    (i.e. unless ``--skip-llm-judges`` was passed for the run).
     """
     parts = [
         f"WER={metrics.get('wer', 0):.4f}",
         f"CER={metrics.get('cer', 0):.4f}",
     ]
     for key, label in (
+        ("semantic_wer", "Semantic WER"),
         ("sarvam_intent_score", "Sarvam Intent Score"),
         ("sarvam_entity_score", "Sarvam Entity Score"),
         ("sarvam_llm_wer", "Sarvam LLM WER"),
@@ -1607,12 +1649,12 @@ async def main():
         help="Overwrite existing results instead of resuming from last checkpoint",
     )
     parser.add_argument(
-        "--skip-sarvam",
+        "--skip-llm-judges",
         action="store_true",
         help=(
-            "Skip the Sarvam LLM judges (intent & entity preservation and "
-            "LLM-WER/CER). They run by default; passing this skips the extra "
-            "per-row LLM judges."
+            "Skip the extra LLM-based judges (Sarvam intent & entity "
+            "preservation, Sarvam LLM-WER/CER, and pipecat-style semantic WER). "
+            "They all run by default; passing this reports WER/CER only."
         ),
     )
 
@@ -1656,7 +1698,7 @@ async def main():
         debug_count=args.debug_count,
         ignore_retry=args.ignore_retry,
         overwrite=args.overwrite,
-        run_sarvam_judges=not args.skip_sarvam,
+        run_llm_judges=not args.skip_llm_judges,
     )
 
     # Print summary

--- a/calibrate_agent/stt/metrics.py
+++ b/calibrate_agent/stt/metrics.py
@@ -261,10 +261,11 @@ async def get_semantic_wer_score(
 ) -> dict:
     """Compute pipecat-style semantic WER over (reference, prediction) pairs.
 
-    One holistic LLM call per row (see ``stt/semantic_wer``): the model
-    normalizes, aligns, applies the semantic error check, and returns
-    substitution/deletion/insertion counts + the reference word count. WER is
-    computed here from those counts, exactly as pipecat's ``_calculate_wer``:
+    One judge call per row via pipecat's reason-then-tool loop (see
+    ``stt/semantic_wer``): the model normalizes, aligns, applies the semantic
+    error check, and commits substitution/deletion/insertion counts + the
+    reference word count through a ``calculate_wer`` tool call. WER is computed
+    here from those counts, exactly as pipecat's ``_calculate_wer``:
     per row ``(S + D + I) / reference_words`` and, at the dataset level, the
     length-weighted **pooled** WER ``ΣSDI / Σreference_words`` over the
     finite-WER rows only (``ref_words==0`` rows are ``inf`` and excluded from

--- a/calibrate_agent/stt/metrics.py
+++ b/calibrate_agent/stt/metrics.py
@@ -269,9 +269,12 @@ async def get_semantic_wer_score(
     length-weighted **pooled** WER ``ΣSDI / Σreference_words``.
 
     Unlike ``get_llm_wer_cer_score`` (Sarvam: deterministic difflib alignment +
-    per-segment equivalence forgiveness), the LLM does the entire count here.
-    No text normalization is applied upstream — the judge normalizes inline,
-    matching pipecat (which targets English).
+    per-segment equivalence forgiveness), the LLM does the entire count here and
+    normalizes inline (case, punctuation, contractions, numbers, …). The only
+    upstream step is Unicode NFC canonicalization in ``semantic_wer_judge`` — a
+    deviation from pipecat (English-only, no normalization) so Indic codepoint
+    variants don't count as spurious errors. No case/punctuation/Indic pass is
+    applied; that stays the judge's job.
 
     Returns:
         {

--- a/calibrate_agent/stt/metrics.py
+++ b/calibrate_agent/stt/metrics.py
@@ -319,7 +319,9 @@ async def get_semantic_wer_score(
         s = int(res.get("substitutions", 0))
         d = int(res.get("deletions", 0))
         i = int(res.get("insertions", 0))
-        ref_words = int(res.get("reference_words", 0))
+        # The judge always sets reference_words; default to 1 (not 0) only to
+        # stay consistent with its own default and pipecat's call site.
+        ref_words = int(res.get("reference_words", 1))
         errors = s + d + i
         if ref_words == 0:
             row_wer = 0.0 if errors == 0 else float("inf")

--- a/calibrate_agent/stt/metrics.py
+++ b/calibrate_agent/stt/metrics.py
@@ -24,7 +24,7 @@ from calibrate_agent.langfuse import observe, langfuse, langfuse_enabled
 # NOTE: ``calibrate_agent.stt.sarvam_intent_entity`` is imported lazily inside the
 # intent/entity functions below — importing it eagerly pulls in transformers,
 # indic-nlp, and joblib, which we want to avoid unless intent/entity scoring is
-# actually requested (it runs by default unless ``--skip-sarvam`` is passed).
+# actually requested (it runs by default unless ``--skip-llm-judges`` is passed).
 
 # Re-export for existing imports
 DEFAULT_STT_JUDGE_MODEL = DEFAULT_TEXT_JUDGE_MODEL
@@ -252,6 +252,91 @@ def _score_edit_metric(
     )
 
     return {"score": float(score), "per_row": per_row}
+
+
+async def get_semantic_wer_score(
+    references: List[str],
+    predictions: List[str],
+    model: Optional[str] = None,
+) -> dict:
+    """Compute pipecat-style semantic WER over (reference, prediction) pairs.
+
+    One holistic LLM call per row (see ``stt/semantic_wer``): the model
+    normalizes, aligns, applies the semantic error check, and returns
+    substitution/deletion/insertion counts + the reference word count. WER is
+    computed here from those counts, exactly as pipecat's ``_calculate_wer``:
+    per row ``(S + D + I) / reference_words`` and, at the dataset level, the
+    length-weighted **pooled** WER ``ΣSDI / Σreference_words``.
+
+    Unlike ``get_llm_wer_cer_score`` (Sarvam: deterministic difflib alignment +
+    per-segment equivalence forgiveness), the LLM does the entire count here.
+    No text normalization is applied upstream — the judge normalizes inline,
+    matching pipecat (which targets English).
+
+    Returns:
+        {
+            "semantic_wer": float,   # dataset-pooled WER
+            "per_row": [
+                {"semantic_wer": float, "substitutions": int, "deletions": int,
+                 "insertions": int, "reference_words": int,
+                 "normalized_reference": str, "normalized_hypothesis": str,
+                 "reasoning": str},
+                ...
+            ],
+        }
+
+    ``model`` defaults to ``DEFAULT_SEMANTIC_WER_MODEL`` when omitted; ``per_row``
+    order matches the input order.
+    """
+    if not references:
+        return {"semantic_wer": 0.0, "per_row": []}
+
+    from calibrate_agent.stt import semantic_wer as _semantic_wer
+    from calibrate_agent.stt.semantic_wer import DEFAULT_SEMANTIC_WER_MODEL
+
+    if model is None:
+        model = DEFAULT_SEMANTIC_WER_MODEL
+
+    coroutines = [
+        _semantic_wer.semantic_wer_judge(str(reference), str(prediction), model=model)
+        for reference, prediction in zip(references, predictions)
+    ]
+    results = await tqdm_asyncio.gather(
+        *coroutines,
+        desc="Running semantic WER judge",
+    )
+
+    total_errors = 0
+    total_ref_words = 0
+    per_row: List[dict] = []
+    for res in results:
+        s = int(res.get("substitutions", 0))
+        d = int(res.get("deletions", 0))
+        i = int(res.get("insertions", 0))
+        ref_words = int(res.get("reference_words", 0))
+        errors = s + d + i
+        if ref_words == 0:
+            row_wer = 0.0 if errors == 0 else float("inf")
+        else:
+            row_wer = errors / ref_words
+        per_row.append(
+            {
+                "semantic_wer": float(row_wer),
+                "substitutions": s,
+                "deletions": d,
+                "insertions": i,
+                "reference_words": ref_words,
+                "normalized_reference": res.get("normalized_reference", ""),
+                "normalized_hypothesis": res.get("normalized_hypothesis", ""),
+                "reasoning": res.get("reasoning", ""),
+            }
+        )
+        total_errors += errors
+        total_ref_words += ref_words
+
+    pooled = 0.0 if total_ref_words == 0 else total_errors / total_ref_words
+
+    return {"semantic_wer": float(pooled), "per_row": per_row}
 
 
 def get_wer_score(

--- a/calibrate_agent/stt/metrics.py
+++ b/calibrate_agent/stt/metrics.py
@@ -266,7 +266,9 @@ async def get_semantic_wer_score(
     substitution/deletion/insertion counts + the reference word count. WER is
     computed here from those counts, exactly as pipecat's ``_calculate_wer``:
     per row ``(S + D + I) / reference_words`` and, at the dataset level, the
-    length-weighted **pooled** WER ``ΣSDI / Σreference_words``.
+    length-weighted **pooled** WER ``ΣSDI / Σreference_words`` over the
+    finite-WER rows only (``ref_words==0`` rows are ``inf`` and excluded from
+    both sums, matching pipecat's ``compute_pooled_wer``).
 
     Unlike ``get_llm_wer_cer_score`` (Sarvam: deterministic difflib alignment +
     per-segment equivalence forgiveness), the LLM does the entire count here and
@@ -334,8 +336,13 @@ async def get_semantic_wer_score(
                 "reasoning": res.get("reasoning", ""),
             }
         )
-        total_errors += errors
-        total_ref_words += ref_words
+        # Pool only finite-WER rows, matching pipecat's compute_pooled_wer
+        # (``valid = [m for m in metrics if m.wer < inf]``). A ``ref_words==0``
+        # row with errors is ``inf`` and is excluded entirely — otherwise its
+        # errors would inflate the numerator with nothing in the denominator.
+        if row_wer != float("inf"):
+            total_errors += errors
+            total_ref_words += ref_words
 
     pooled = 0.0 if total_ref_words == 0 else total_errors / total_ref_words
 

--- a/calibrate_agent/stt/semantic_wer/__init__.py
+++ b/calibrate_agent/stt/semantic_wer/__init__.py
@@ -1,0 +1,24 @@
+"""Semantic WER — pipecat stt-benchmark methodology.
+
+An LLM (Claude by default, via OpenRouter) computes a semantically-forgiving WER
+in a single holistic call per (reference, hypothesis) pair: it normalizes, aligns,
+applies a "would an LLM agent respond differently?" error check, and reports
+substitution/deletion/insertion counts, from which WER is computed in Python.
+
+Distinct from ``stt/sarvam_llm_wer`` (deterministic difflib alignment + per-
+segment equivalence forgiveness). Runs by default as part of the LLM-judge
+group; disable the group with ``--skip-llm-judges``.
+
+Reference: https://github.com/pipecat-ai/stt-benchmark
+"""
+
+from .main import SemanticWERResponse, build_prompt, PROMPT_TEMPLATE
+from .judge import semantic_wer_judge, DEFAULT_SEMANTIC_WER_MODEL
+
+__all__ = [
+    "SemanticWERResponse",
+    "build_prompt",
+    "PROMPT_TEMPLATE",
+    "semantic_wer_judge",
+    "DEFAULT_SEMANTIC_WER_MODEL",
+]

--- a/calibrate_agent/stt/semantic_wer/__init__.py
+++ b/calibrate_agent/stt/semantic_wer/__init__.py
@@ -1,9 +1,13 @@
 """Semantic WER — pipecat stt-benchmark methodology.
 
 An LLM (Claude by default, via OpenRouter) computes a semantically-forgiving WER
-in a single holistic call per (reference, hypothesis) pair: it normalizes, aligns,
-applies a "would an LLM agent respond differently?" error check, and reports
-substitution/deletion/insertion counts, from which WER is computed in Python.
+per (reference, hypothesis) pair via pipecat's reason-then-tool loop: with the
+rules in a system message and the pair in a user message, it normalizes, aligns,
+applies a "would an LLM agent respond differently?" error check, writes its
+reasoning, then commits substitution/deletion/insertion counts through a
+``calculate_wer`` tool call. WER is computed in Python from those counts. The
+prompt and tool schema are pipecat's verbatim; only the transport (OpenRouter's
+OpenAI-compatible tool calling vs pipecat's native Anthropic SDK) differs.
 
 Distinct from ``stt/sarvam_llm_wer`` (deterministic difflib alignment + per-
 segment equivalence forgiveness). Runs by default as part of the LLM-judge
@@ -12,13 +16,21 @@ group; disable the group with ``--skip-llm-judges``.
 Reference: https://github.com/pipecat-ai/stt-benchmark
 """
 
-from .main import SemanticWERResponse, build_prompt, PROMPT_TEMPLATE
+from .main import (
+    SYSTEM_PROMPT,
+    PROMPT_TEMPLATE,
+    CALCULATE_WER_TOOL,
+    build_user_prompt,
+    build_prompt,
+)
 from .judge import semantic_wer_judge, DEFAULT_SEMANTIC_WER_MODEL
 
 __all__ = [
-    "SemanticWERResponse",
-    "build_prompt",
+    "SYSTEM_PROMPT",
     "PROMPT_TEMPLATE",
+    "CALCULATE_WER_TOOL",
+    "build_user_prompt",
+    "build_prompt",
     "semantic_wer_judge",
     "DEFAULT_SEMANTIC_WER_MODEL",
 ]

--- a/calibrate_agent/stt/semantic_wer/__init__.py
+++ b/calibrate_agent/stt/semantic_wer/__init__.py
@@ -18,19 +18,15 @@ Reference: https://github.com/pipecat-ai/stt-benchmark
 
 from .main import (
     SYSTEM_PROMPT,
-    PROMPT_TEMPLATE,
     CALCULATE_WER_TOOL,
     build_user_prompt,
-    build_prompt,
 )
 from .judge import semantic_wer_judge, DEFAULT_SEMANTIC_WER_MODEL
 
 __all__ = [
     "SYSTEM_PROMPT",
-    "PROMPT_TEMPLATE",
     "CALCULATE_WER_TOOL",
     "build_user_prompt",
-    "build_prompt",
     "semantic_wer_judge",
     "DEFAULT_SEMANTIC_WER_MODEL",
 ]

--- a/calibrate_agent/stt/semantic_wer/judge.py
+++ b/calibrate_agent/stt/semantic_wer/judge.py
@@ -42,6 +42,17 @@ DEFAULT_SEMANTIC_WER_MODEL = "anthropic/claude-sonnet-4.5"
 # Phase 2 requires the model to call calculate_wer (no free-form escape).
 _FORCE_WER_TOOL = {"type": "function", "function": {"name": "calculate_wer"}}
 
+# Cache the long, identical-every-row system prompt. Both phases and every row
+# share this exact prefix, so within the cache window rows are billed as cache
+# reads instead of full prompt tokens. OpenRouter forwards the Anthropic-style
+# breakpoint; providers without prompt caching simply ignore it.
+_CACHED_SYSTEM_MESSAGE = {
+    "role": "system",
+    "content": [
+        {"type": "text", "text": SYSTEM_PROMPT, "cache_control": {"type": "ephemeral"}}
+    ],
+}
+
 
 def _short_circuit(
     substitutions: int,
@@ -113,7 +124,7 @@ async def semantic_wer_judge(
     reason_resp = await client.chat.completions.create(
         model=model,
         messages=[
-            {"role": "system", "content": SYSTEM_PROMPT},
+            _CACHED_SYSTEM_MESSAGE,
             {"role": "user", "content": user_msg},
         ],
         temperature=0,
@@ -126,7 +137,7 @@ async def semantic_wer_judge(
     commit_resp = await client.chat.completions.create(
         model=model,
         messages=[
-            {"role": "system", "content": SYSTEM_PROMPT},
+            _CACHED_SYSTEM_MESSAGE,
             {"role": "user", "content": user_msg},
             {"role": "assistant", "content": reasoning},
             {"role": "user", "content": "Now call calculate_wer with your final counts."},

--- a/calibrate_agent/stt/semantic_wer/judge.py
+++ b/calibrate_agent/stt/semantic_wer/judge.py
@@ -1,25 +1,49 @@
-"""Holistic semantic-WER judge — one LLM call per (reference, hypothesis) pair.
+"""Semantic-WER judge — pipecat's reason-then-tool loop over OpenRouter.
 
-Mirrors pipecat's stt-benchmark semantic WER: the model normalizes, aligns,
-applies the semantic error check, and returns S/D/I + reference word counts,
-which ``get_semantic_wer_score`` turns into a WER. Routes through calibrate's
-OpenRouter + ``instructor`` client (same plumbing as the Sarvam LLM-WER and text
-judges).
+Mirrors pipecat's stt-benchmark ``SemanticWEREvaluator.evaluate``: a multi-turn
+tool-use loop where the model writes its free-form semantic reasoning and then
+commits the counts via a ``calculate_wer`` tool call, with the rules in a
+**system** message and the (reference, hypothesis) pair in a **user** message.
+The prompt and tool schema are pipecat's verbatim (``main.py``).
+
+The one transport difference from pipecat: calibrate stays on its OpenRouter
+(OpenAI-compatible) client rather than the native Anthropic SDK, so the
+Anthropic ``tool_use`` loop is expressed as OpenAI function-calling (same
+reason→commit shape, same tool contract). Seams: ``@backoff`` / ``@observe`` /
+``log_judge_io`` and a Unicode NFC pre-normalization of the inputs (for Indic
+scripts; pipecat targets English and normalizes nothing upstream).
 """
 
+import json
 import unicodedata
 
 import backoff
-import instructor
 
 from calibrate_agent.judges import _build_openrouter_client
 from calibrate_agent.langfuse import observe, langfuse, langfuse_enabled
 from calibrate_agent.utils import log_judge_io
-from calibrate_agent.stt.semantic_wer.main import SemanticWERResponse, build_prompt
+from calibrate_agent.stt.semantic_wer.main import (
+    SYSTEM_PROMPT,
+    CALCULATE_WER_TOOL,
+    build_user_prompt,
+)
 
 # pipecat's stt-benchmark judges with Claude; reached here via OpenRouter.
 # Overridable per call / via get_semantic_wer_score(model=...).
 DEFAULT_SEMANTIC_WER_MODEL = "anthropic/claude-sonnet-4.5"
+
+_MAX_TURNS = 10  # pipecat's safety limit
+
+# pipecat's Anthropic tool → OpenAI function-calling shape. The Anthropic
+# ``input_schema`` doubles as the OpenAI ``parameters`` object unchanged.
+_OPENAI_TOOL = {
+    "type": "function",
+    "function": {
+        "name": CALCULATE_WER_TOOL["name"],
+        "description": CALCULATE_WER_TOOL["description"],
+        "parameters": CALCULATE_WER_TOOL["input_schema"],
+    },
+}
 
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=5, factor=2)
@@ -29,40 +53,78 @@ async def semantic_wer_judge(
     prediction: str,
     model: str = DEFAULT_SEMANTIC_WER_MODEL,
 ) -> dict:
-    """Score one (reference, hypothesis) pair with the semantic-WER rubric.
+    """Score one (reference, hypothesis) pair with pipecat's tool-use loop.
 
-    Returns a dict matching :class:`SemanticWERResponse`
-    (``substitutions``, ``deletions``, ``insertions``, ``reference_words``,
-    ``normalized_reference``, ``normalized_hypothesis``, ``reasoning``).
+    Returns the ``calculate_wer`` counts plus reasoning:
+    ``substitutions``, ``deletions``, ``insertions``, ``reference_words``,
+    ``normalized_reference``, ``normalized_hypothesis``, ``reasoning``.
     """
-    # Canonicalize Unicode (NFC) before the judge sees the text. pipecat targets
-    # English and applies no upstream normalization, but this repo runs Indic
-    # scripts where visually identical strings can differ at the codepoint level
-    # (NFC vs NFD, nukta composition) — without this the LLM may count those as
-    # spurious substitutions. NFC only: lossless canonicalization, no case /
-    # punctuation stripping (the judge's inline STEP 1 handles the rest).
+    # Seam: NFC pre-normalization (see module docstring). Applied before the
+    # judge sees the text so Indic codepoint variants aren't counted as errors.
     reference = unicodedata.normalize("NFC", reference)
     prediction = unicodedata.normalize("NFC", prediction)
 
-    client = instructor.apatch(_build_openrouter_client())
+    client = _build_openrouter_client()
 
-    prompt = build_prompt(reference, prediction)
+    # System = pipecat's rules; user = pipecat's per-pair message.
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": build_user_prompt(reference, prediction)},
+    ]
 
-    response = await client.chat.completions.create(
-        model=model,
-        messages=[{"role": "user", "content": prompt}],
-        response_model=SemanticWERResponse,
-        temperature=0,
-        max_completion_tokens=8192,
-    )
+    tool_input = None
+    reasoning = ""
 
-    result = response.model_dump()
+    for _ in range(_MAX_TURNS):
+        response = await client.chat.completions.create(
+            model=model,
+            messages=messages,
+            tools=[_OPENAI_TOOL],
+            tool_choice="auto",
+            temperature=0,
+            max_tokens=4096,
+        )
+        message = response.choices[0].message
+        tool_calls = message.tool_calls or []
+
+        wer_call = next(
+            (tc for tc in tool_calls if tc.function.name == "calculate_wer"), None
+        )
+        if wer_call is not None:
+            # The assistant's free-form reasoning precedes the committed counts.
+            reasoning = message.content or ""
+            tool_input = json.loads(wer_call.function.arguments)
+            break
+
+        # Model reasoned without committing yet — feed its turn back and ask it
+        # to finish with the tool call (pipecat's loop likewise keeps going).
+        messages.append({"role": "assistant", "content": message.content or ""})
+        messages.append(
+            {"role": "user", "content": "Now call calculate_wer with your counts."}
+        )
+
+    if tool_input is None:
+        raise ValueError(
+            "semantic_wer_judge: model did not call calculate_wer within "
+            f"{_MAX_TURNS} turns"
+        )
+
+    result = {
+        "substitutions": int(tool_input.get("substitutions", 0)),
+        "deletions": int(tool_input.get("deletions", 0)),
+        "insertions": int(tool_input.get("insertions", 0)),
+        # pipecat defaults a missing reference_words to 1 at its call site.
+        "reference_words": int(tool_input.get("reference_words", 1)),
+        "normalized_reference": tool_input.get("normalized_reference") or "",
+        "normalized_hypothesis": tool_input.get("normalized_hypothesis") or "",
+        "reasoning": reasoning,
+    }
 
     log_judge_io(
         evaluator="semantic_wer",
         model=model,
-        system_prompt="",
-        user_input=prompt,
+        system_prompt=SYSTEM_PROMPT,
+        user_input=build_user_prompt(reference, prediction),
         output=result,
     )
 
@@ -70,11 +132,7 @@ async def semantic_wer_judge(
         langfuse.update_current_trace(
             input={"reference": reference, "prediction": prediction},
             output=result,
-            metadata={
-                "reference": reference,
-                "prediction": prediction,
-                "model": model,
-            },
+            metadata={"reference": reference, "prediction": prediction, "model": model},
         )
 
     return result

--- a/calibrate_agent/stt/semantic_wer/judge.py
+++ b/calibrate_agent/stt/semantic_wer/judge.py
@@ -145,7 +145,12 @@ async def semantic_wer_judge(
         tools=[_OPENAI_TOOL],
         tool_choice=_FORCE_WER_TOOL,
         temperature=0,
-        max_tokens=1024,
+        # Headroom for the tool-call JSON: it carries normalized_reference +
+        # normalized_hypothesis (the full texts) and an errors list, which for a
+        # long utterance can exceed a tight cap. A truncated call is unparseable
+        # and, at temperature 0, fails identically on every retry — so undersize
+        # here would deterministically drop the whole run's semantic WER.
+        max_tokens=4096,
     )
     message = commit_resp.choices[0].message
     wer_call = next(

--- a/calibrate_agent/stt/semantic_wer/judge.py
+++ b/calibrate_agent/stt/semantic_wer/judge.py
@@ -1,17 +1,24 @@
-"""Semantic-WER judge — pipecat's reason-then-tool loop over OpenRouter.
+"""Semantic-WER judge — two-phase reason-then-commit over OpenRouter.
 
-Mirrors pipecat's stt-benchmark ``SemanticWEREvaluator.evaluate``: a multi-turn
-tool-use loop where the model writes its free-form semantic reasoning and then
-commits the counts via a ``calculate_wer`` tool call, with the rules in a
-**system** message and the (reference, hypothesis) pair in a **user** message.
-The prompt and tool schema are pipecat's verbatim (``main.py``).
+Same rubric and tool contract as pipecat's stt-benchmark
+``SemanticWEREvaluator.evaluate`` (prompt + ``calculate_wer`` schema are
+pipecat's verbatim; see ``main.py``), but structured for reliability as two
+explicit calls per pair instead of pipecat's single auto tool-use loop:
 
-The one transport difference from pipecat: calibrate stays on its OpenRouter
-(OpenAI-compatible) client rather than the native Anthropic SDK, so the
-Anthropic ``tool_use`` loop is expressed as OpenAI function-calling (same
-reason→commit shape, same tool contract). Seams: ``@backoff`` / ``@observe`` /
-``log_judge_io`` and a Unicode NFC pre-normalization of the inputs (for Indic
-scripts; pipecat targets English and normalizes nothing upstream).
+  Phase 1 — with the rules in a **system** message and the (reference,
+            hypothesis) pair in a **user** message, the model reasons freely.
+            No tool is offered, so it can only produce text.
+  Phase 2 — the phase-1 reasoning is replayed and the model is *required* to
+            call ``calculate_wer`` (forced ``tool_choice``), committing the
+            counts.
+
+This guarantees termination in exactly two calls (no nudge loop, no
+runaway-retry worst case) at the cost of one extra call per row versus
+pipecat's single-call-usually loop. Transport is calibrate's OpenRouter
+(OpenAI-compatible) client, not the native Anthropic SDK. Seams: ``@backoff`` /
+``@observe`` / ``log_judge_io`` and a Unicode NFC pre-normalization of the
+inputs (for Indic scripts; pipecat targets English and normalizes nothing
+upstream).
 """
 
 import json
@@ -32,7 +39,8 @@ from calibrate_agent.stt.semantic_wer.main import (
 # Overridable per call / via get_semantic_wer_score(model=...).
 DEFAULT_SEMANTIC_WER_MODEL = "anthropic/claude-sonnet-4.5"
 
-_MAX_TURNS = 10  # pipecat's safety limit
+# Phase 2 requires the model to call calculate_wer (no free-form escape).
+_FORCE_WER_TOOL = {"type": "function", "function": {"name": "calculate_wer"}}
 
 
 def _short_circuit(
@@ -98,49 +106,44 @@ async def semantic_wer_judge(
         return _short_circuit(0, words, 0, words, reasoning="empty hypothesis")
 
     client = _build_openrouter_client()
+    user_msg = build_user_prompt(reference, prediction)
 
-    # System = pipecat's rules; user = pipecat's per-pair message.
-    messages = [
-        {"role": "system", "content": SYSTEM_PROMPT},
-        {"role": "user", "content": build_user_prompt(reference, prediction)},
-    ]
+    # Phase 1 — reason freely. No tool is offered, so the model can only write
+    # its NORMALIZE → ALIGN → SEMANTIC CHECK working out as text.
+    reason_resp = await client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": user_msg},
+        ],
+        temperature=0,
+        max_tokens=4096,
+    )
+    reasoning = reason_resp.choices[0].message.content or ""
 
-    tool_input = None
-    reasoning = ""
-
-    for _ in range(_MAX_TURNS):
-        response = await client.chat.completions.create(
-            model=model,
-            messages=messages,
-            tools=[_OPENAI_TOOL],
-            tool_choice="auto",
-            temperature=0,
-            max_tokens=4096,
-        )
-        message = response.choices[0].message
-        tool_calls = message.tool_calls or []
-
-        wer_call = next(
-            (tc for tc in tool_calls if tc.function.name == "calculate_wer"), None
-        )
-        if wer_call is not None:
-            # The assistant's free-form reasoning precedes the committed counts.
-            reasoning = message.content or ""
-            tool_input = json.loads(wer_call.function.arguments)
-            break
-
-        # Model reasoned without committing yet — feed its turn back and ask it
-        # to finish with the tool call (pipecat's loop likewise keeps going).
-        messages.append({"role": "assistant", "content": message.content or ""})
-        messages.append(
-            {"role": "user", "content": "Now call calculate_wer with your counts."}
-        )
-
-    if tool_input is None:
-        raise ValueError(
-            "semantic_wer_judge: model did not call calculate_wer within "
-            f"{_MAX_TURNS} turns"
-        )
+    # Phase 2 — replay the reasoning and REQUIRE the calculate_wer call, so the
+    # counts are always committed (no nudge loop, guaranteed to terminate).
+    commit_resp = await client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": user_msg},
+            {"role": "assistant", "content": reasoning},
+            {"role": "user", "content": "Now call calculate_wer with your final counts."},
+        ],
+        tools=[_OPENAI_TOOL],
+        tool_choice=_FORCE_WER_TOOL,
+        temperature=0,
+        max_tokens=1024,
+    )
+    message = commit_resp.choices[0].message
+    wer_call = next(
+        (tc for tc in (message.tool_calls or []) if tc.function.name == "calculate_wer"),
+        None,
+    )
+    if wer_call is None:
+        raise ValueError("semantic_wer_judge: forced calculate_wer call was not returned")
+    tool_input = json.loads(wer_call.function.arguments)
 
     result = {
         "substitutions": int(tool_input.get("substitutions", 0)),
@@ -157,7 +160,7 @@ async def semantic_wer_judge(
         evaluator="semantic_wer",
         model=model,
         system_prompt=SYSTEM_PROMPT,
-        user_input=build_user_prompt(reference, prediction),
+        user_input=user_msg,
         output=result,
     )
 

--- a/calibrate_agent/stt/semantic_wer/judge.py
+++ b/calibrate_agent/stt/semantic_wer/judge.py
@@ -7,6 +7,8 @@ OpenRouter + ``instructor`` client (same plumbing as the Sarvam LLM-WER and text
 judges).
 """
 
+import unicodedata
+
 import backoff
 import instructor
 
@@ -33,6 +35,15 @@ async def semantic_wer_judge(
     (``substitutions``, ``deletions``, ``insertions``, ``reference_words``,
     ``normalized_reference``, ``normalized_hypothesis``, ``reasoning``).
     """
+    # Canonicalize Unicode (NFC) before the judge sees the text. pipecat targets
+    # English and applies no upstream normalization, but this repo runs Indic
+    # scripts where visually identical strings can differ at the codepoint level
+    # (NFC vs NFD, nukta composition) — without this the LLM may count those as
+    # spurious substitutions. NFC only: lossless canonicalization, no case /
+    # punctuation stripping (the judge's inline STEP 1 handles the rest).
+    reference = unicodedata.normalize("NFC", reference)
+    prediction = unicodedata.normalize("NFC", prediction)
+
     client = instructor.apatch(_build_openrouter_client())
 
     prompt = build_prompt(reference, prediction)

--- a/calibrate_agent/stt/semantic_wer/judge.py
+++ b/calibrate_agent/stt/semantic_wer/judge.py
@@ -34,6 +34,25 @@ DEFAULT_SEMANTIC_WER_MODEL = "anthropic/claude-sonnet-4.5"
 
 _MAX_TURNS = 10  # pipecat's safety limit
 
+
+def _short_circuit(
+    substitutions: int,
+    deletions: int,
+    insertions: int,
+    reference_words: int,
+    reasoning: str,
+) -> dict:
+    """Deterministic empty-input result (no LLM call), pipecat's shape."""
+    return {
+        "substitutions": substitutions,
+        "deletions": deletions,
+        "insertions": insertions,
+        "reference_words": reference_words,
+        "normalized_reference": "",
+        "normalized_hypothesis": "",
+        "reasoning": reasoning,
+    }
+
 # pipecat's Anthropic tool → OpenAI function-calling shape. The Anthropic
 # ``input_schema`` doubles as the OpenAI ``parameters`` object unchanged.
 _OPENAI_TOOL = {
@@ -63,6 +82,20 @@ async def semantic_wer_judge(
     # judge sees the text so Indic codepoint variants aren't counted as errors.
     reference = unicodedata.normalize("NFC", reference)
     prediction = unicodedata.normalize("NFC", prediction)
+
+    # pipecat evaluate(): empty-input short-circuits, ported verbatim. These are
+    # deterministic — no LLM call — matching _empty_result / _no_reference_result
+    # / _no_hypothesis_result. get_semantic_wer_score turns these counts into the
+    # same per-row WER pipecat reports (0.0 / inf / 1.0 respectively).
+    if not reference.strip() and not prediction.strip():
+        return _short_circuit(0, 0, 0, 0, reasoning="empty reference and hypothesis")
+    if not reference.strip():
+        return _short_circuit(
+            0, 0, len(prediction.split()), 0, reasoning="empty reference"
+        )
+    if not prediction.strip():
+        words = len(reference.split())
+        return _short_circuit(0, words, 0, words, reasoning="empty hypothesis")
 
     client = _build_openrouter_client()
 

--- a/calibrate_agent/stt/semantic_wer/judge.py
+++ b/calibrate_agent/stt/semantic_wer/judge.py
@@ -1,0 +1,69 @@
+"""Holistic semantic-WER judge — one LLM call per (reference, hypothesis) pair.
+
+Mirrors pipecat's stt-benchmark semantic WER: the model normalizes, aligns,
+applies the semantic error check, and returns S/D/I + reference word counts,
+which ``get_semantic_wer_score`` turns into a WER. Routes through calibrate's
+OpenRouter + ``instructor`` client (same plumbing as the Sarvam LLM-WER and text
+judges).
+"""
+
+import backoff
+import instructor
+
+from calibrate_agent.judges import _build_openrouter_client
+from calibrate_agent.langfuse import observe, langfuse, langfuse_enabled
+from calibrate_agent.utils import log_judge_io
+from calibrate_agent.stt.semantic_wer.main import SemanticWERResponse, build_prompt
+
+# pipecat's stt-benchmark judges with Claude; reached here via OpenRouter.
+# Overridable per call / via get_semantic_wer_score(model=...).
+DEFAULT_SEMANTIC_WER_MODEL = "anthropic/claude-sonnet-4.5"
+
+
+@backoff.on_exception(backoff.expo, Exception, max_tries=5, factor=2)
+@observe(name="stt_semantic_wer_judge", capture_input=False)
+async def semantic_wer_judge(
+    reference: str,
+    prediction: str,
+    model: str = DEFAULT_SEMANTIC_WER_MODEL,
+) -> dict:
+    """Score one (reference, hypothesis) pair with the semantic-WER rubric.
+
+    Returns a dict matching :class:`SemanticWERResponse`
+    (``substitutions``, ``deletions``, ``insertions``, ``reference_words``,
+    ``normalized_reference``, ``normalized_hypothesis``, ``reasoning``).
+    """
+    client = instructor.apatch(_build_openrouter_client())
+
+    prompt = build_prompt(reference, prediction)
+
+    response = await client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        response_model=SemanticWERResponse,
+        temperature=0,
+        max_completion_tokens=8192,
+    )
+
+    result = response.model_dump()
+
+    log_judge_io(
+        evaluator="semantic_wer",
+        model=model,
+        system_prompt="",
+        user_input=prompt,
+        output=result,
+    )
+
+    if langfuse_enabled and langfuse:
+        langfuse.update_current_trace(
+            input={"reference": reference, "prediction": prediction},
+            output=result,
+            metadata={
+                "reference": reference,
+                "prediction": prediction,
+                "model": model,
+            },
+        )
+
+    return result

--- a/calibrate_agent/stt/semantic_wer/main.py
+++ b/calibrate_agent/stt/semantic_wer/main.py
@@ -34,9 +34,6 @@ except FileNotFoundError:
         "Please ensure it exists alongside main.py."
     )
 
-# Backwards-compatible alias (older imports referenced PROMPT_TEMPLATE).
-PROMPT_TEMPLATE = SYSTEM_PROMPT
-
 # pipecat's CALCULATE_WER_TOOL, verbatim (Anthropic tool schema). The judge
 # converts this to the OpenAI function-calling shape for OpenRouter; the
 # ``input_schema`` doubles as the OpenAI ``parameters`` object unchanged.
@@ -112,13 +109,3 @@ def build_user_prompt(reference: str, prediction: str) -> str:
         "Follow the process: NORMALIZE → ALIGN → COUNT → VERIFY → CALCULATE\n\n"
         "Show your work clearly, then call calculate_wer with your verified counts."
     )
-
-
-def build_prompt(reference: str, prediction: str) -> str:
-    """System prompt + per-pair user message, concatenated.
-
-    Retained for callers/tests that want the full prompt text as one string.
-    The judge itself sends the two parts as separate system/user messages
-    (see ``judge.py``); the concatenation here is the same text.
-    """
-    return f"{SYSTEM_PROMPT}\n\n{build_user_prompt(reference, prediction)}"

--- a/calibrate_agent/stt/semantic_wer/main.py
+++ b/calibrate_agent/stt/semantic_wer/main.py
@@ -48,10 +48,21 @@ class SemanticWERResponse(BaseModel):
 
 
 def build_prompt(reference: str, prediction: str) -> str:
-    """Build the semantic-WER prompt for a single (reference, hypothesis) pair."""
+    """Build the semantic-WER prompt for a single (reference, hypothesis) pair.
+
+    ``PROMPT_TEMPLATE`` is pipecat's ``SEMANTIC_WER_SYSTEM_PROMPT`` verbatim; the
+    trailing block is pipecat's per-pair user message verbatim (from
+    ``SemanticWEREvaluator.evaluate``). We send both as one message because the
+    judge is a single ``instructor`` call rather than pipecat's system/user
+    split — the text the model sees is identical.
+    """
     return (
         f"{PROMPT_TEMPLATE}\n\n"
-        "=== EVALUATE ===\n"
-        f'REFERENCE: "{reference}"\n'
-        f'HYPOTHESIS: "{prediction}"\n'
+        "Please calculate the Word Error Rate (WER) for this ASR transcription.\n\n"
+        "**Reference (ground truth):**\n"
+        f"{reference}\n\n"
+        "**Hypothesis (ASR transcription):**\n"
+        f"{prediction}\n\n"
+        "Follow the process: NORMALIZE → ALIGN → COUNT → VERIFY → CALCULATE\n\n"
+        "Show your work clearly, then call calculate_wer with your verified counts."
     )

--- a/calibrate_agent/stt/semantic_wer/main.py
+++ b/calibrate_agent/stt/semantic_wer/main.py
@@ -1,63 +1,109 @@
-"""Prompt + response schema for the semantic WER judge.
+"""Prompt + tool schema for the semantic WER judge.
 
 Implements pipecat's stt-benchmark "semantic WER" methodology
-(https://github.com/pipecat-ai/stt-benchmark): a single holistic LLM call per
-(reference, hypothesis) pair where the model normalizes, aligns, applies a
-semantic error check ("would an LLM agent respond differently?"), and reports the
-substitution / deletion / insertion counts plus the reference word count. The WER
-itself is computed in Python from those counts (see ``get_semantic_wer_score`` in
-``stt/metrics.py``), mirroring pipecat's ``_calculate_wer``.
+(https://github.com/pipecat-ai/stt-benchmark): the model normalizes, aligns,
+applies a semantic error check ("would an LLM agent respond differently?"), and
+reports substitution / deletion / insertion counts plus the reference word count
+via a ``calculate_wer`` tool call. The WER itself is computed in Python from
+those counts (see ``get_semantic_wer_score`` in ``stt/metrics.py``), mirroring
+pipecat's ``_calculate_wer``.
 
-This is distinct from ``stt/sarvam_llm_wer`` (Sarvam's approach), which aligns
+``SYSTEM_PROMPT`` (``prompt_template.txt``) and ``CALCULATE_WER_TOOL`` are
+pipecat's verbatim, so the judge runs the same rules + tool contract pipecat
+does. The judge (``judge.py``) drives them through a tool-calling loop with a
+system/user split, matching pipecat's shape; only the transport (OpenRouter's
+OpenAI-compatible API vs pipecat's native Anthropic SDK) differs.
+
+Distinct from ``stt/sarvam_llm_wer`` (Sarvam's approach), which aligns
 deterministically with difflib and only asks the LLM to forgive per-segment
-equivalence — here the LLM does the whole count in one call.
+equivalence.
+
+Source: pipecat-ai/stt-benchmark @ 41b34a49a754bf43c99e2ce50a10724be4866941
 """
 
 from pathlib import Path
 
-from pydantic import BaseModel, Field
-
 PROMPT_PATH = Path(__file__).parent / "prompt_template.txt"
 
 try:
-    PROMPT_TEMPLATE = PROMPT_PATH.read_text()
+    # pipecat's SEMANTIC_WER_SYSTEM_PROMPT, verbatim.
+    SYSTEM_PROMPT = PROMPT_PATH.read_text()
 except FileNotFoundError:
     raise FileNotFoundError(
         f"prompt_template.txt not found at {PROMPT_PATH}. "
         "Please ensure it exists alongside main.py."
     )
 
+# Backwards-compatible alias (older imports referenced PROMPT_TEMPLATE).
+PROMPT_TEMPLATE = SYSTEM_PROMPT
 
-class SemanticWERResponse(BaseModel):
-    """Structured output the judge returns (equivalent to pipecat's
-    ``calculate_wer`` tool call)."""
+# pipecat's CALCULATE_WER_TOOL, verbatim (Anthropic tool schema). The judge
+# converts this to the OpenAI function-calling shape for OpenRouter; the
+# ``input_schema`` doubles as the OpenAI ``parameters`` object unchanged.
+CALCULATE_WER_TOOL = {
+    "name": "calculate_wer",
+    "description": "Calculate Word Error Rate from error counts. Call this ONCE after you have normalized, aligned, and verified the texts. WER = (substitutions + deletions + insertions) / reference_words",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "substitutions": {
+                "type": "integer",
+                "description": "Number of word substitutions (different words at same position)",
+            },
+            "deletions": {
+                "type": "integer",
+                "description": "Number of word deletions (words in reference missing from hypothesis)",
+            },
+            "insertions": {
+                "type": "integer",
+                "description": "Number of word insertions (extra words in hypothesis not in reference)",
+            },
+            "reference_words": {
+                "type": "integer",
+                "description": "Total word count in normalized reference text",
+            },
+            "normalized_reference": {
+                "type": "string",
+                "description": "The normalized reference text (for verification)",
+            },
+            "normalized_hypothesis": {
+                "type": "string",
+                "description": "The normalized hypothesis text (for verification)",
+            },
+            "errors": {
+                "type": "array",
+                "description": "List of identified errors",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": ["substitution", "deletion", "insertion"],
+                        },
+                        "reference": {
+                            "type": "string",
+                            "description": "Reference word (null for insertion)",
+                        },
+                        "hypothesis": {
+                            "type": "string",
+                            "description": "Hypothesis word (null for deletion)",
+                        },
+                        "position": {
+                            "type": "integer",
+                            "description": "Position in alignment",
+                        },
+                    },
+                },
+            },
+        },
+        "required": ["substitutions", "deletions", "insertions", "reference_words"],
+    },
+}
 
-    normalized_reference: str = Field(
-        default="", description="Reference after applying the normalization rules"
-    )
-    normalized_hypothesis: str = Field(
-        default="", description="Hypothesis after applying the normalization rules"
-    )
-    substitutions: int = Field(description="Number of meaning-changing word substitutions")
-    deletions: int = Field(description="Number of meaning-changing word deletions")
-    insertions: int = Field(description="Number of meaning-changing word insertions")
-    reference_words: int = Field(description="Total word count in the normalized reference")
-    reasoning: str = Field(
-        default="", description="Brief semantic-check reasoning for the counted errors"
-    )
 
-
-def build_prompt(reference: str, prediction: str) -> str:
-    """Build the semantic-WER prompt for a single (reference, hypothesis) pair.
-
-    ``PROMPT_TEMPLATE`` is pipecat's ``SEMANTIC_WER_SYSTEM_PROMPT`` verbatim; the
-    trailing block is pipecat's per-pair user message verbatim (from
-    ``SemanticWEREvaluator.evaluate``). We send both as one message because the
-    judge is a single ``instructor`` call rather than pipecat's system/user
-    split — the text the model sees is identical.
-    """
+def build_user_prompt(reference: str, prediction: str) -> str:
+    """pipecat's per-pair user message, verbatim (from ``evaluate``)."""
     return (
-        f"{PROMPT_TEMPLATE}\n\n"
         "Please calculate the Word Error Rate (WER) for this ASR transcription.\n\n"
         "**Reference (ground truth):**\n"
         f"{reference}\n\n"
@@ -66,3 +112,13 @@ def build_prompt(reference: str, prediction: str) -> str:
         "Follow the process: NORMALIZE → ALIGN → COUNT → VERIFY → CALCULATE\n\n"
         "Show your work clearly, then call calculate_wer with your verified counts."
     )
+
+
+def build_prompt(reference: str, prediction: str) -> str:
+    """System prompt + per-pair user message, concatenated.
+
+    Retained for callers/tests that want the full prompt text as one string.
+    The judge itself sends the two parts as separate system/user messages
+    (see ``judge.py``); the concatenation here is the same text.
+    """
+    return f"{SYSTEM_PROMPT}\n\n{build_user_prompt(reference, prediction)}"

--- a/calibrate_agent/stt/semantic_wer/main.py
+++ b/calibrate_agent/stt/semantic_wer/main.py
@@ -1,0 +1,57 @@
+"""Prompt + response schema for the semantic WER judge.
+
+Implements pipecat's stt-benchmark "semantic WER" methodology
+(https://github.com/pipecat-ai/stt-benchmark): a single holistic LLM call per
+(reference, hypothesis) pair where the model normalizes, aligns, applies a
+semantic error check ("would an LLM agent respond differently?"), and reports the
+substitution / deletion / insertion counts plus the reference word count. The WER
+itself is computed in Python from those counts (see ``get_semantic_wer_score`` in
+``stt/metrics.py``), mirroring pipecat's ``_calculate_wer``.
+
+This is distinct from ``stt/sarvam_llm_wer`` (Sarvam's approach), which aligns
+deterministically with difflib and only asks the LLM to forgive per-segment
+equivalence — here the LLM does the whole count in one call.
+"""
+
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+PROMPT_PATH = Path(__file__).parent / "prompt_template.txt"
+
+try:
+    PROMPT_TEMPLATE = PROMPT_PATH.read_text()
+except FileNotFoundError:
+    raise FileNotFoundError(
+        f"prompt_template.txt not found at {PROMPT_PATH}. "
+        "Please ensure it exists alongside main.py."
+    )
+
+
+class SemanticWERResponse(BaseModel):
+    """Structured output the judge returns (equivalent to pipecat's
+    ``calculate_wer`` tool call)."""
+
+    normalized_reference: str = Field(
+        default="", description="Reference after applying the normalization rules"
+    )
+    normalized_hypothesis: str = Field(
+        default="", description="Hypothesis after applying the normalization rules"
+    )
+    substitutions: int = Field(description="Number of meaning-changing word substitutions")
+    deletions: int = Field(description="Number of meaning-changing word deletions")
+    insertions: int = Field(description="Number of meaning-changing word insertions")
+    reference_words: int = Field(description="Total word count in the normalized reference")
+    reasoning: str = Field(
+        default="", description="Brief semantic-check reasoning for the counted errors"
+    )
+
+
+def build_prompt(reference: str, prediction: str) -> str:
+    """Build the semantic-WER prompt for a single (reference, hypothesis) pair."""
+    return (
+        f"{PROMPT_TEMPLATE}\n\n"
+        "=== EVALUATE ===\n"
+        f'REFERENCE: "{reference}"\n'
+        f'HYPOTHESIS: "{prediction}"\n'
+    )

--- a/calibrate_agent/stt/semantic_wer/prompt_template.txt
+++ b/calibrate_agent/stt/semantic_wer/prompt_template.txt
@@ -1,80 +1,255 @@
-You are an expert speech-recognition evaluator computing a SEMANTIC Word Error
-Rate (WER). Unlike traditional WER, you only count differences that would change
-how a downstream LLM agent understands or acts on the transcript. Meaning-
-preserving differences (formatting, punctuation, fillers, equivalent spellings)
-are NOT errors.
+You are an expert ASR evaluator for a conversational AI system. Your task is to calculate the Semantic Word Error Rate (WER) - counting ONLY transcription errors that would impact how an LLM agent understands and responds to the user.
 
-Follow these steps exactly, then call the calculate_wer tool with your counts.
+## CRITICAL CONTEXT
 
-STEP 1 — NORMALIZE both the reference and the hypothesis:
-  1.1  Case: lowercase everything.
-  1.2  Punctuation: remove all punctuation.
-  1.3  Contractions: "I'm" = "i am", "don't" = "do not".
-  1.4  Numbers: "3" = "three", "$5" = "five dollars".
-  1.5  Filler words: drop "um, uh, like, you know, well".
-  1.6  Abbreviations: "Dr." = "doctor", "Mr." = "mister".
-  1.7  British/American spelling: "colour" = "color".
-  1.8  Hyphenation: "long-term" = "long term".
-  1.9  Spoken variations: "gonna" = "going to".
-  1.10 Symbols: "&" = "and", "@" = "at".
-  1.11 Possessives: "driver's" = "drivers".
-  1.12 Singular/plural: usually NOT an error when intent is unchanged.
-  1.13 Minor grammar: missing/added articles usually do NOT count.
+This transcription will be used as input to a multi-turn conversational LLM agent. We only care about errors that would:
+- Change what the agent thinks the user is asking for
+- Cause the agent to take incorrect actions
+- Lead to misunderstandings in the conversation
 
-STEP 2 — ALIGN the normalized hypothesis to the normalized reference
-word-by-word (minimum edit distance).
+We do NOT count as errors:
+- Grammatical variations an LLM would understand identically
+- Formatting/punctuation differences
+- Minor word form changes that preserve meaning
 
-STEP 3 — SEMANTIC CHECK. For EACH candidate difference, write:
-  DIFFERENCE: "X" -> "Y"
-  QUESTION: Would an LLM agent respond differently given Y instead of X?
-  ANSWER: [YES/NO] because [reason]
-  COUNT AS ERROR: [YES/NO]
-If an LLM would interpret both the same way, it is NOT an error.
+**Key principle**: If an LLM would interpret both versions the same way, it's NOT an error.
 
-STEP 4 — COUNT only the genuine (meaning-changing) errors:
-  - substitutions: a reference word replaced by a different-meaning word
-  - deletions: a reference word missing that changes meaning
-  - insertions: an extra hypothesis word that changes meaning
-  - reference_words: total words in the NORMALIZED reference
+## Your Process: NORMALIZE → ALIGN → SEMANTIC CHECK → COUNT → CALCULATE
 
-STEP 5 — CALCULATE: WER = (substitutions + deletions + insertions) / reference_words.
-Report the counts via the structured response.
+### Step 1: NORMALIZE (Apply to BOTH texts)
 
-=== EXAMPLES ===
+**1.1 Case**: Convert everything to lowercase
 
-Example 1 (possessive/plural — WER 0%)
-REF: "update the driver's license details"
-HYP: "update the drivers license details"
-CHECK: "driver's" -> "drivers": an LLM reads these the same. NOT an error.
-COUNTS: substitutions=0 deletions=0 insertions=0 reference_words=5 -> WER 0.0
+**1.2 Punctuation**: Remove all punctuation marks
 
-Example 2 (one real error mixed with non-errors — WER ~3.4%)
-REF: "i would like to transfer five hundred dollars to my savings account today please"
-HYP: "i'd like to transfer five hundred dollars to my checking account today please"
-CHECK: "i'd" = "i would" (NOT an error); "savings" -> "checking" changes the
-account an agent would act on (ERROR).
-COUNTS: substitutions=1 deletions=0 insertions=0 reference_words=14 -> WER ~0.071
+**1.3 Contractions**: Expand to full form
+   "I'm" → "i am", "don't" → "do not", "won't" → "will not", etc.
 
-Example 3 (ingredient substitution — real error)
-REF: "add two cups of flour and one cup of sugar"
-HYP: "add two cups of flour and one cup of butter"
-CHECK: "sugar" -> "butter" changes the recipe (ERROR).
-COUNTS: substitutions=1 deletions=0 insertions=0 reference_words=10 -> WER 0.1
+**1.4 Numbers**: Normalize digits ↔ words (treat as equivalent)
+   "3" = "three", "$5" = "five dollars", "1st" = "first"
 
-Example 4 (Wi-Fi setup — multiple errors)
-REF: "connect to the network called home five g using password one two three four"
-HYP: "connect to the network called home five g using password one two three five"
-CHECK: final digit "four" -> "five" changes the password (ERROR).
-COUNTS: substitutions=1 deletions=0 insertions=0 reference_words=15 -> WER ~0.067
+**1.5 Filler Words**: Remove if present in only one version
+   um, uh, like, you know, well (at start), so (at start), actually, basically
 
-Example 5 (minor deletion, no meaning change — WER 0%)
-REF: "can you please tell me the store hours"
-HYP: "can you tell me the store hours"
-CHECK: dropped "please" does not change intent. NOT an error.
-COUNTS: substitutions=0 deletions=0 insertions=0 reference_words=8 -> WER 0.0
+**1.6 Abbreviations**: Expand common forms
+   "Dr." = "doctor", "Mr." = "mister", "St." = "saint/street"
 
-Example 6 (stutter/repetition — real insertions)
-REF: "i need to book a flight to boston"
-HYP: "i need to to book a a flight to boston"
-CHECK: repeated "to" and "a" are spurious insertions (ERRORS).
-COUNTS: substitutions=0 deletions=0 insertions=2 reference_words=7 -> WER ~0.286
+**1.7 British/American Spelling**: Treat as equivalent
+   "colour" = "color", "favourite" = "favorite"
+
+**1.8 Hyphenation**: Ignore hyphens
+   "long-term" = "long term" = "longterm", "Wi-Fi" = "wi fi"
+
+**1.9 Spoken Variations**: Normalize informal speech
+   "gonna" = "going to", "yeah" = "yes", "ok" = "okay"
+
+**1.10 Symbols**: Convert to words
+   "&" = "and", "@" = "at"
+
+**1.11 Possessives**: Treat as equivalent (LLM understands both)
+   "driver's" = "drivers" = "driver" (when referring to same thing)
+   "Mary's" = "Marys" (possessive vs name variation)
+
+**1.12 Singular/Plural**: Treat as equivalent when meaning is preserved
+   "license" = "licenses" (asking about license process)
+   "office" = "offices" (asking about which office)
+   "ticket" = "tickets" (the concept is the same)
+
+   EXCEPTION: Count as error only if plurality changes core meaning in a way that would confuse the agent.
+
+**1.13 Minor Grammatical Variations**: Treat as equivalent
+   "setting up" = "set up" = "to set up"
+   Missing articles ("the", "a") that don't change meaning
+
+### Step 2: ALIGN
+After normalization, align word-by-word using edit distance. Mark potential differences.
+
+### Step 3: SEMANTIC CHECK (MANDATORY - DO NOT SKIP)
+**YOU MUST COMPLETE THIS STEP.** For EACH potential error identified in alignment:
+
+Write out this exact format:
+```
+DIFFERENCE: "X" → "Y"
+QUESTION: Would an LLM agent respond differently?
+ANSWER: [YES/NO] because [reason]
+COUNT AS ERROR: [YES/NO]
+```
+
+**Common patterns that are NOT errors (answer NO):**
+- Singular/plural: "license"→"licenses", "office"→"offices", "ticket"→"tickets" = NO
+- Possessives: "driver's"→"drivers"→"driver" = NO
+- Missing articles: "the X"→"X" = NO
+- Hyphenation: "Wi-Fi"→"wi fi" = NO
+
+**Patterns that ARE errors (answer YES):**
+- Different words: "card"→"car", "trace"→"trade", "hours"→"was" = YES
+- Nonsense: "lentil"→"landon", "Wi-Fi"→"wi fire" = YES
+
+### Step 4: COUNT
+Count ONLY the differences where you answered "COUNT AS ERROR: YES"
+- S = semantic substitutions (different meaning)
+- D = semantic deletions (meaning lost)
+- I = semantic insertions (meaning added)
+- N = total words in normalized reference
+
+**IMPORTANT: Compound words count as ONE error, not multiple.**
+When a hyphenated compound (like "cross-country") is replaced by a single word (like "koscanti"):
+- This is ONE substitution (S=1), NOT a substitution plus a deletion
+- The compound represents a single semantic concept
+- Example: "cross-country" → "koscanti" = S=1 (one concept replaced by nonsense)
+
+**TRUNCATED/INCOMPLETE TEXT:**
+When both reference and hypothesis appear truncated at the same point (missing the end of a sentence), compare only the complete portions. Partial words at truncation points should be ignored rather than counted as errors. If a word is clearly incomplete (like "reme" for "remember" or "abor" for "abroad"), do not count differences involving that truncated word.
+
+**TRAILING FUNCTION WORDS AT TRUNCATION:**
+If the reference ends with a function word that signals an incomplete sentence (and, but, or, so, to, for, the, a, an, on, in, with, that, which, who, because, although, if, when, while, as, about, from, by, at, of, etc.) and the hypothesis omits it, do NOT count as an error. These trailing words carry no semantic meaning on their own - an LLM would respond identically with or without them.
+- Example: "My sister called me about the birthday party and" vs "My sister called me about the birthday party" = NOT an error (trailing "and" is meaningless)
+- Example: "Can you help me brainstorm ideas for my presentation on" vs "Can you help me brainstorm ideas for my presentation" = NOT an error (trailing "on" is meaningless)
+
+### Step 5: CALCULATE
+Call calculate_wer(substitutions=S, deletions=D, insertions=I, reference_words=N)
+
+---
+
+## FEW-SHOT EXAMPLES
+
+### Example 1: Possessive/Plural Variations (WER = 0%) - CRITICAL EXAMPLE
+**Reference:** "Can you describe the process for changing my legal name on official documents like my driver's license and social security card after getting married, including necessary forms and offices?"
+**Hypothesis:** "Can you describe the process for changing my legal name on official documents like my driver licenses and social security card after getting married including necessary forms and office"
+
+**Step 3: SEMANTIC CHECK:**
+
+DIFFERENCE: "drivers" → "driver"
+QUESTION: Would an LLM agent respond differently?
+ANSWER: NO because both refer to the same driver's license concept
+COUNT AS ERROR: NO
+
+DIFFERENCE: "license" → "licenses"
+QUESTION: Would an LLM agent respond differently?
+ANSWER: NO because singular/plural doesn't change the request
+COUNT AS ERROR: NO
+
+DIFFERENCE: "offices" → "office"
+QUESTION: Would an LLM agent respond differently?
+ANSWER: NO because both ask about which office to visit
+COUNT AS ERROR: NO
+
+**Step 4: COUNT:** S=0, D=0, I=0 (no semantic errors found)
+
+**Result: N=29 → WER = 0/29 = 0%**
+
+---
+
+### Example 2: Real Semantic Error Mixed with Non-Errors (WER = 3.4%)
+**Reference:** "...my driver's license and social security card..."
+**Hypothesis:** "...my driver licenses and social security car..."
+
+**Step 3: SEMANTIC CHECK:**
+
+DIFFERENCE: "drivers" → "driver"
+QUESTION: Would an LLM agent respond differently?
+ANSWER: NO because both refer to the driver's license concept
+COUNT AS ERROR: NO
+
+DIFFERENCE: "license" → "licenses"
+QUESTION: Would an LLM agent respond differently?
+ANSWER: NO because singular/plural doesn't change the request
+COUNT AS ERROR: NO
+
+DIFFERENCE: "card" → "car"
+QUESTION: Would an LLM agent respond differently?
+ANSWER: YES because "car" and "card" are completely different things - an agent wouldn't know the user means social security card
+COUNT AS ERROR: YES
+
+**Step 4: COUNT:** S=1 (only "card"→"car" is a semantic error)
+
+**Result: N=29 → WER = 1/29 = 3.4%**
+
+---
+
+### Example 3: Ingredient Substitution (WER = 6.5%)
+**Reference:** "I would like a recipe for a vegan lentil soup that is both hearty and easy to make on a weeknight, preferably one that uses only common inexpensive pantry staples."
+**Hypothesis:** "I would like a recipe for a vegan landon soup that is both hearty and easy to make on a week night, preferably one that uses only common inexpensive pantry slippers."
+
+Semantic check:
+- "lentil" → "landon" = **YES, ERROR** - "landon" is not an ingredient
+- "weeknight" → "week night" = NOT an error (same meaning)
+- "staples" → "slippers" = **YES, ERROR** - completely different meaning
+
+**Result: S=2, D=0, I=0, N=31 → WER = 2/31 = 6.5%**
+
+---
+
+### Example 4: Wi-Fi Network Setup (WER = 12.5%)
+**Reference:** "I'm trying to set up parental controls on my home Wi-Fi network to restrict access to certain websites during homework hours for my kids. But the router interface is very..."
+**Hypothesis:** "When trying to set up parental controls on my home wi fire network to restrict access to certain websites during homework was for my kids. But the router interface is very..."
+
+Semantic check:
+- "I'm" → "When" = **YES, ERROR** - changes who is doing the action
+- "am" (from I'm expansion) deleted = **YES, ERROR** - part of subject change
+- "wi fi" → "wi fire" = **YES, ERROR** - "wi fire" is not a thing
+- "hours" → "was" = **YES, ERROR** - completely different meaning
+
+**Result: S=3, D=1, I=0, N=32 → WER = 4/32 = 12.5%**
+
+---
+
+### Example 5: Package Tracking (WER = 3.1%)
+**Reference:** "The expensive package I ordered was marked as delivered two days ago, but I have not received it and it is not anywhere on my property. I must initiate an immediate trace."
+**Hypothesis:** "The expensive package I ordered was marked as delivered two days ago, but I have not received it and it is not anywhere on my property. I must initiate an immediate trade."
+
+Semantic check:
+- "trace" vs "trade" = **YES, ERROR** - completely different actions
+
+**Result: S=1, D=0, I=0, N=32 → WER = 1/32 = 3.1%**
+
+---
+
+### Example 6: Minor Word Deletion - NO ERROR (WER = 0%)
+**Reference:** "The national weather service issued a warning for the coastal areas."
+**Hypothesis:** "The national weather service issued a warning for coastal areas"
+
+Semantic check:
+- Missing "the" before "coastal" → Does this change the agent's understanding?
+- NO - both mean the same thing, LLM responds identically
+
+**Result: S=0, D=0, I=0, N=11 → WER = 0%**
+
+---
+
+### Example 7: Singular/Plural with Same Intent (WER = 0%)
+**Reference:** "She said three hundred dollars was too expensive for concert tickets."
+**Hypothesis:** "She said 300 dollar was too expensive for the concert ticket"
+
+Semantic check:
+- "300" vs "three hundred" → Same number, NOT an error
+- "dollars" vs "dollar" → Same amount concept, NOT an error
+- "tickets" vs "ticket" → Same purchase intent, NOT an error
+- Extra "the" → NOT semantically meaningful
+
+An LLM agent would understand both as "user thinks $300 is too much for concert tickets."
+
+**Result: S=0, D=0, I=0, N=11 → WER = 0%**
+
+---
+
+### Example 8: Stutter/Repetition (WER = 28.6%)
+**Reference:** "I think we should probably go now."
+**Hypothesis:** "I think we should we should probably go now"
+
+Semantic check:
+- Extra "we should" = Stutter that could confuse agent parsing
+- **YES, ERROR** - agent might try to interpret repeated phrase
+
+**Result: S=0, D=0, I=2, N=7 → WER = 2/7 = 28.6%**
+
+---
+
+## IMPORTANT NOTES
+
+1. **Ask the key question**: "Would an LLM agent respond differently to these two versions?"
+2. **Context matters**: Consider the full sentence, not just word-level differences
+3. **Be lenient on grammar**: LLMs are robust to grammatical variations
+4. **Be strict on meaning**: Count errors that change intent, actions, or key entities
+5. **Possessives and plurals**: Almost never errors unless they change core meaning
+6. **Show your semantic reasoning**: Explain WHY something is or isn't an error

--- a/calibrate_agent/stt/semantic_wer/prompt_template.txt
+++ b/calibrate_agent/stt/semantic_wer/prompt_template.txt
@@ -1,0 +1,80 @@
+You are an expert speech-recognition evaluator computing a SEMANTIC Word Error
+Rate (WER). Unlike traditional WER, you only count differences that would change
+how a downstream LLM agent understands or acts on the transcript. Meaning-
+preserving differences (formatting, punctuation, fillers, equivalent spellings)
+are NOT errors.
+
+Follow these steps exactly, then call the calculate_wer tool with your counts.
+
+STEP 1 — NORMALIZE both the reference and the hypothesis:
+  1.1  Case: lowercase everything.
+  1.2  Punctuation: remove all punctuation.
+  1.3  Contractions: "I'm" = "i am", "don't" = "do not".
+  1.4  Numbers: "3" = "three", "$5" = "five dollars".
+  1.5  Filler words: drop "um, uh, like, you know, well".
+  1.6  Abbreviations: "Dr." = "doctor", "Mr." = "mister".
+  1.7  British/American spelling: "colour" = "color".
+  1.8  Hyphenation: "long-term" = "long term".
+  1.9  Spoken variations: "gonna" = "going to".
+  1.10 Symbols: "&" = "and", "@" = "at".
+  1.11 Possessives: "driver's" = "drivers".
+  1.12 Singular/plural: usually NOT an error when intent is unchanged.
+  1.13 Minor grammar: missing/added articles usually do NOT count.
+
+STEP 2 — ALIGN the normalized hypothesis to the normalized reference
+word-by-word (minimum edit distance).
+
+STEP 3 — SEMANTIC CHECK. For EACH candidate difference, write:
+  DIFFERENCE: "X" -> "Y"
+  QUESTION: Would an LLM agent respond differently given Y instead of X?
+  ANSWER: [YES/NO] because [reason]
+  COUNT AS ERROR: [YES/NO]
+If an LLM would interpret both the same way, it is NOT an error.
+
+STEP 4 — COUNT only the genuine (meaning-changing) errors:
+  - substitutions: a reference word replaced by a different-meaning word
+  - deletions: a reference word missing that changes meaning
+  - insertions: an extra hypothesis word that changes meaning
+  - reference_words: total words in the NORMALIZED reference
+
+STEP 5 — CALCULATE: WER = (substitutions + deletions + insertions) / reference_words.
+Report the counts via the structured response.
+
+=== EXAMPLES ===
+
+Example 1 (possessive/plural — WER 0%)
+REF: "update the driver's license details"
+HYP: "update the drivers license details"
+CHECK: "driver's" -> "drivers": an LLM reads these the same. NOT an error.
+COUNTS: substitutions=0 deletions=0 insertions=0 reference_words=5 -> WER 0.0
+
+Example 2 (one real error mixed with non-errors — WER ~3.4%)
+REF: "i would like to transfer five hundred dollars to my savings account today please"
+HYP: "i'd like to transfer five hundred dollars to my checking account today please"
+CHECK: "i'd" = "i would" (NOT an error); "savings" -> "checking" changes the
+account an agent would act on (ERROR).
+COUNTS: substitutions=1 deletions=0 insertions=0 reference_words=14 -> WER ~0.071
+
+Example 3 (ingredient substitution — real error)
+REF: "add two cups of flour and one cup of sugar"
+HYP: "add two cups of flour and one cup of butter"
+CHECK: "sugar" -> "butter" changes the recipe (ERROR).
+COUNTS: substitutions=1 deletions=0 insertions=0 reference_words=10 -> WER 0.1
+
+Example 4 (Wi-Fi setup — multiple errors)
+REF: "connect to the network called home five g using password one two three four"
+HYP: "connect to the network called home five g using password one two three five"
+CHECK: final digit "four" -> "five" changes the password (ERROR).
+COUNTS: substitutions=1 deletions=0 insertions=0 reference_words=15 -> WER ~0.067
+
+Example 5 (minor deletion, no meaning change — WER 0%)
+REF: "can you please tell me the store hours"
+HYP: "can you tell me the store hours"
+CHECK: dropped "please" does not change intent. NOT an error.
+COUNTS: substitutions=0 deletions=0 insertions=0 reference_words=8 -> WER 0.0
+
+Example 6 (stutter/repetition — real insertions)
+REF: "i need to book a flight to boston"
+HYP: "i need to to book a a flight to boston"
+CHECK: repeated "to" and "a" are spurious insertions (ERRORS).
+COUNTS: substitutions=0 deletions=0 insertions=2 reference_words=7 -> WER ~0.286

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ exclude = ["ui*", "examples*", "docs*", "images*"]
     "ui/cli.bundle.mjs",
     "stt/sarvam_intent_entity/prompt_template.txt",
     "stt/sarvam_llm_wer/prompt_template.txt",
+    "stt/semantic_wer/prompt_template.txt",
 ]
 
 [tool.setuptools_scm]

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -273,7 +273,34 @@ def _fake_llm_wer(llm_wer=0.05, llm_cer=0.03):
     return AsyncMock(side_effect=_fn)
 
 
+def _fake_semantic_wer():
+    """Fake ``get_semantic_wer_score`` (part of the default LLM-judge group)."""
+
+    async def _sem(references, predictions, model=None):
+        return {
+            "semantic_wer": 0.0,
+            "per_row": [
+                {
+                    "semantic_wer": 0.0, "substitutions": 0, "deletions": 0,
+                    "insertions": 0, "reference_words": 1,
+                    "normalized_reference": "", "normalized_hypothesis": "",
+                    "reasoning": "",
+                }
+                for _ in references
+            ],
+        }
+
+    return AsyncMock(side_effect=_sem)
+
+
 class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        p = patch.object(stt_eval, "get_semantic_wer_score", _fake_semantic_wer())
+        p.start()
+        self.addCleanup(p.stop)
+
     async def test_writes_metrics_and_results(self):
         from calibrate_agent.stt import eval as stt_eval
 
@@ -311,7 +338,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                             "judge_model": "openai/gpt-4.1",
                         }
                     ],
-                    run_sarvam_judges=True,
+                    run_llm_judges=True,
                 )
 
             self.assertIn("wer", metrics)
@@ -381,7 +408,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                     output_dir=str(out),
                     evaluator_config_dir=str(out),
                     judge_evaluators=custom,
-                    run_sarvam_judges=True,
+                    run_llm_judges=True,
                 )
 
             # With the flag on, intent/entity report alongside a custom evaluator.
@@ -474,7 +501,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                             "judge_model": "openai/gpt-4.1",
                         }
                     ],
-                    run_sarvam_judges=False,
+                    run_llm_judges=False,
                 )
 
             # Disabled: the Sarvam judge is never invoked and no sarvam_* keys appear.
@@ -592,7 +619,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                     pred_transcripts=["hello", "goodbye"],
                     output_dir=str(out),
                     evaluator_config_dir=str(out),
-                    run_sarvam_judges=False,
+                    run_llm_judges=False,
                 )
 
             # No evaluators passed: the LLM judge is never invoked, no evaluator
@@ -648,13 +675,20 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                     output_dir=str(out),
                     evaluator_config_dir=str(out),
                     judge_evaluators=[rating],
-                    run_sarvam_judges=False,
+                    run_llm_judges=False,
                 )
             df = pd.read_csv(out / "results.csv")
             self.assertEqual(df.iloc[0]["accuracy"], 4)
 
 
 class TestSTTRunEvalOnly(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        p = patch.object(stt_eval, "get_semantic_wer_score", _fake_semantic_wer())
+        p.start()
+        self.addCleanup(p.stop)
+
     async def test_runs_evaluator_on_dataset(self):
         from calibrate_agent.stt import eval as stt_eval
 
@@ -688,7 +722,7 @@ class TestSTTRunEvalOnly(unittest.IsolatedAsyncioTestCase):
                 result = await stt_eval.run_eval_only(
                     dataset_path=str(ds_path),
                     output_dir=str(out),
-                    run_sarvam_judges=False,
+                    run_llm_judges=False,
                 )
 
             self.assertEqual(result["status"], "completed")

--- a/tests/stt/test_eval_extra.py
+++ b/tests/stt/test_eval_extra.py
@@ -700,6 +700,27 @@ class TestValidateSTTEvalOnlyDataset(unittest.TestCase):
 # --- _score_and_write_results --------------------------------------------
 
 class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        from calibrate_agent.stt import eval as E
+
+        async def _sem(references, predictions, model=None):
+            return {
+                "semantic_wer": 0.0,
+                "per_row": [
+                    {
+                        "semantic_wer": 0.0, "substitutions": 0, "deletions": 0,
+                        "insertions": 0, "reference_words": 1,
+                        "normalized_reference": "", "normalized_hypothesis": "",
+                        "reasoning": "",
+                    }
+                    for _ in references
+                ],
+            }
+
+        p = patch.object(E, "get_semantic_wer_score", AsyncMock(side_effect=_sem))
+        p.start()
+        self.addCleanup(p.stop)
+
     async def test_writes_files(self):
         from calibrate_agent.stt import eval as E
 
@@ -727,7 +748,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
                             "judge_model": "openai/gpt-4.1",
                         }
                     ],
-                    run_sarvam_judges=False,
+                    run_llm_judges=False,
                 )
             self.assertEqual(result["wer"], 0.1)
             self.assertEqual(result["cer"], 0.2)
@@ -760,7 +781,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
                     pred_transcripts=["x", "y"],
                     output_dir=tmp,
                     evaluator_config_dir=tmp,
-                    run_sarvam_judges=True,
+                    run_llm_judges=True,
                 )
             self.assertEqual(result["sarvam_llm_wer"], 0.05)
             self.assertEqual(result["sarvam_llm_cer"], 0.03)
@@ -788,7 +809,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
                     pred_transcripts=["x"],
                     output_dir=tmp,
                     evaluator_config_dir=tmp,
-                    run_sarvam_judges=False,
+                    run_llm_judges=False,
                 )
             llm_wer_mock.assert_not_called()
             self.assertNotIn("sarvam_llm_wer", result)
@@ -818,7 +839,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
                 output_dir=tmp,
                 evaluator_config_dir=tmp,
                 judge_evaluators=[rating_ev],
-                run_sarvam_judges=False,
+                run_llm_judges=False,
             )
 
 
@@ -853,7 +874,7 @@ class TestRunEvalOnly(unittest.IsolatedAsyncioTestCase):
                      ],
                  })):
                 result = await E.run_eval_only(
-                    str(ds), str(out), run_sarvam_judges=False
+                    str(ds), str(out), run_llm_judges=False
                 )
         self.assertEqual(result["status"], "completed")
 
@@ -933,7 +954,7 @@ class TestRunSingleProviderEval(unittest.IsolatedAsyncioTestCase):
                     debug_count=5,
                     ignore_retry=False,
                     overwrite=True,
-                    run_sarvam_judges=False,
+                    run_llm_judges=False,
                 )
             self.assertEqual(result["status"], "completed")
 
@@ -996,7 +1017,7 @@ class TestRunSingleProviderEval(unittest.IsolatedAsyncioTestCase):
                     debug_count=1,
                     ignore_retry=True,
                     overwrite=False,
-                    run_sarvam_judges=False,
+                    run_llm_judges=False,
                 )
             self.assertEqual(result["status"], "completed")
 

--- a/tests/stt/test_semantic_wer.py
+++ b/tests/stt/test_semantic_wer.py
@@ -187,9 +187,12 @@ class TestJudgeToolLoop(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("tool_choice", p1)
         self.assertEqual(p1["messages"][0]["role"], "system")
         self.assertEqual(p1["messages"][1]["role"], "user")
-        self.assertIn("SEMANTIC CHECK", p1["messages"][0]["content"])
+        # System prompt is cached (content is a list with a cache_control part).
+        sys_part = p1["messages"][0]["content"][0]
+        self.assertEqual(sys_part["cache_control"], {"type": "ephemeral"})
+        self.assertIn("SEMANTIC CHECK", sys_part["text"])
+        self.assertNotIn("transfer to savings", sys_part["text"])
         self.assertIn("transfer to savings", p1["messages"][1]["content"])
-        self.assertNotIn("transfer to savings", p1["messages"][0]["content"])
 
         # Phase 2: the calculate_wer call is forced, reasoning replayed.
         self.assertEqual(p2["tools"][0]["function"]["name"], "calculate_wer")

--- a/tests/stt/test_semantic_wer.py
+++ b/tests/stt/test_semantic_wer.py
@@ -191,6 +191,63 @@ class TestJudgeToolLoop(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn(nfd_ref, user_msg)
 
 
+class TestJudgeEmptyShortCircuit(unittest.IsolatedAsyncioTestCase):
+    async def _run_no_llm(self, ref, hyp):
+        """Run the judge asserting the model is never called."""
+        from calibrate_agent.stt.semantic_wer import judge as J
+
+        def _boom(*a, **kw):
+            raise AssertionError("LLM must not be called for empty inputs")
+
+        with patch.object(J, "_build_openrouter_client", side_effect=_boom):
+            return await J.semantic_wer_judge(ref, hyp)
+
+    async def test_both_empty(self):
+        r = await self._run_no_llm("   ", "")
+        self.assertEqual(
+            (r["substitutions"], r["deletions"], r["insertions"], r["reference_words"]),
+            (0, 0, 0, 0),
+        )
+
+    async def test_empty_reference_is_inf(self):
+        # pipecat _no_reference_result: insertions = len(hyp words), ref_words 0.
+        r = await self._run_no_llm("", "two extra words here")
+        self.assertEqual(r["insertions"], 4)
+        self.assertEqual(r["reference_words"], 0)
+        # Downstream this row is inf (errors>0, ref_words==0).
+
+    async def test_empty_hypothesis_is_wer_one(self):
+        # pipecat _no_hypothesis_result: deletions = ref_words = len(ref words).
+        r = await self._run_no_llm("three word reference", "  ")
+        self.assertEqual(r["deletions"], 3)
+        self.assertEqual(r["reference_words"], 3)  # -> per-row WER 3/3 = 1.0
+
+    async def test_empty_rows_pool_like_pipecat(self):
+        from calibrate_agent.stt import metrics as M
+
+        by_ref = {
+            "": {"substitutions": 0, "deletions": 0, "insertions": 2,
+                 "reference_words": 0, "normalized_reference": "",
+                 "normalized_hypothesis": "", "reasoning": "empty reference"},
+            "hi there": {"substitutions": 1, "deletions": 0, "insertions": 0,
+                         "reference_words": 2, "normalized_reference": "",
+                         "normalized_hypothesis": "", "reasoning": "one sub"},
+        }
+
+        async def fake_judge(reference, prediction, model=None):
+            return by_ref[reference]
+
+        with patch(
+            "calibrate_agent.stt.semantic_wer.semantic_wer_judge",
+            AsyncMock(side_effect=fake_judge),
+        ):
+            out = await M.get_semantic_wer_score(["", "hi there"], ["x y", "hi bye"])
+
+        # Empty-reference row is inf and excluded from pooling; pooled = 1/2.
+        self.assertEqual(out["per_row"][0]["semantic_wer"], float("inf"))
+        self.assertAlmostEqual(out["semantic_wer"], 0.5)
+
+
 def _fake_judge():
     async def judge(refs, preds, evaluators=None, fallback_model=None):
         return {

--- a/tests/stt/test_semantic_wer.py
+++ b/tests/stt/test_semantic_wer.py
@@ -1,8 +1,8 @@
 """Tests for the pipecat-style semantic WER flow (stt/semantic_wer + wiring).
 
-The judge (one holistic LLM call per row) is mocked — no network. Covers the
-pooled/per-row WER formula, the build_prompt template, and that
-semantic WER threads through ``_score_and_write_results`` into metrics.json +
+The judge (two-phase reason-then-tool call per row) is mocked — no network.
+Covers the pooled/per-row WER formula, the prompt/tool text, and that semantic
+WER threads through ``_score_and_write_results`` into metrics.json +
 results.csv when the LLM-judge group is enabled (``run_llm_judges``).
 """
 
@@ -17,13 +17,18 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pandas as pd
 
 
-class TestBuildPrompt(unittest.TestCase):
-    def test_prompt_includes_pair_and_rules(self):
-        from calibrate_agent.stt.semantic_wer import build_prompt
+class TestPrompt(unittest.TestCase):
+    def test_user_prompt_carries_the_pair(self):
+        from calibrate_agent.stt.semantic_wer import build_user_prompt
 
-        p = build_prompt("transfer to savings", "transfer to checking")
-        self.assertIn("transfer to savings", p)
-        self.assertIn("transfer to checking", p)
+        u = build_user_prompt("transfer to savings", "transfer to checking")
+        self.assertIn("transfer to savings", u)
+        self.assertIn("transfer to checking", u)
+        self.assertIn("call calculate_wer", u)
+
+    def test_system_prompt_is_pipecat_verbatim(self):
+        from calibrate_agent.stt.semantic_wer import SYSTEM_PROMPT as p
+
         # Carries the pipecat-style methodology.
         self.assertIn("NORMALIZE", p)
         self.assertIn("SEMANTIC CHECK", p)

--- a/tests/stt/test_semantic_wer.py
+++ b/tests/stt/test_semantic_wer.py
@@ -86,6 +86,37 @@ class TestGetSemanticWERScore(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(out["per_row"][0]["semantic_wer"], float("inf"))
 
+    async def test_inf_rows_excluded_from_pooled(self):
+        from calibrate_agent.stt import metrics as M
+
+        # Row "ok": 1 error / 10 -> 0.1 (finite). Row "bad": 2 errors / 0 ->
+        # inf. Pooled must be 1/10 = 0.1 (the inf row contributes neither its
+        # 2 errors nor its 0 ref words), matching pipecat's compute_pooled_wer.
+        by_ref = {
+            "ok": {
+                "substitutions": 1, "deletions": 0, "insertions": 0,
+                "reference_words": 10, "normalized_reference": "r",
+                "normalized_hypothesis": "h", "reasoning": "one sub",
+            },
+            "bad": {
+                "substitutions": 0, "deletions": 0, "insertions": 2,
+                "reference_words": 0, "normalized_reference": "",
+                "normalized_hypothesis": "x y", "reasoning": "no reference",
+            },
+        }
+
+        async def fake_judge(reference, prediction, model=None):
+            return by_ref[reference]
+
+        with patch(
+            "calibrate_agent.stt.semantic_wer.semantic_wer_judge",
+            AsyncMock(side_effect=fake_judge),
+        ):
+            out = await M.get_semantic_wer_score(["ok", "bad"], ["a", "b"])
+
+        self.assertAlmostEqual(out["semantic_wer"], 0.1)
+        self.assertEqual(out["per_row"][1]["semantic_wer"], float("inf"))
+
 
 class TestJudgeNFCNormalization(unittest.IsolatedAsyncioTestCase):
     async def test_reference_and_prediction_are_nfc_normalized(self):

--- a/tests/stt/test_semantic_wer.py
+++ b/tests/stt/test_semantic_wer.py
@@ -8,9 +8,10 @@ results.csv when the LLM-judge group is enabled (``run_llm_judges``).
 
 import json
 import tempfile
+import unicodedata
 import unittest
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pandas as pd
 
@@ -84,6 +85,39 @@ class TestGetSemanticWERScore(unittest.IsolatedAsyncioTestCase):
             out = await M.get_semantic_wer_score([""], ["x y"])
 
         self.assertEqual(out["per_row"][0]["semantic_wer"], float("inf"))
+
+
+class TestJudgeNFCNormalization(unittest.IsolatedAsyncioTestCase):
+    async def test_reference_and_prediction_are_nfc_normalized(self):
+        from calibrate_agent.stt.semantic_wer import judge as J
+        from calibrate_agent.stt.semantic_wer.main import SemanticWERResponse
+
+        # Decomposed (NFD) input whose NFC form differs — combining marks that
+        # recompose to precomposed codepoints. The judge must normalize to NFC.
+        nfd_ref = unicodedata.normalize("NFD", "café résumé")
+        nfd_hyp = unicodedata.normalize("NFD", "café résumé")
+        self.assertNotEqual(nfd_ref, unicodedata.normalize("NFC", nfd_ref))
+
+        captured = {}
+
+        async def fake_create(*args, **kwargs):
+            captured["content"] = kwargs["messages"][0]["content"]
+            return SemanticWERResponse(
+                substitutions=0, deletions=0, insertions=0, reference_words=3
+            )
+
+        fake_client = MagicMock()
+        fake_client.chat.completions.create = fake_create
+
+        with patch.object(J, "_build_openrouter_client", return_value=object()), patch.object(
+            J.instructor, "apatch", return_value=fake_client
+        ):
+            await J.semantic_wer_judge(nfd_ref, nfd_hyp)
+
+        # The prompt the judge sent must carry the NFC (composed) form, not the
+        # decomposed input it received.
+        self.assertIn(unicodedata.normalize("NFC", nfd_ref), captured["content"])
+        self.assertNotIn(nfd_ref, captured["content"])
 
 
 def _fake_judge():

--- a/tests/stt/test_semantic_wer.py
+++ b/tests/stt/test_semantic_wer.py
@@ -1,0 +1,177 @@
+"""Tests for the pipecat-style semantic WER flow (stt/semantic_wer + wiring).
+
+The judge (one holistic LLM call per row) is mocked — no network. Covers the
+pooled/per-row WER formula, the build_prompt template, and that
+semantic WER threads through ``_score_and_write_results`` into metrics.json +
+results.csv when the LLM-judge group is enabled (``run_llm_judges``).
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pandas as pd
+
+
+class TestBuildPrompt(unittest.TestCase):
+    def test_prompt_includes_pair_and_rules(self):
+        from calibrate_agent.stt.semantic_wer import build_prompt
+
+        p = build_prompt("transfer to savings", "transfer to checking")
+        self.assertIn("transfer to savings", p)
+        self.assertIn("transfer to checking", p)
+        # Carries the pipecat-style methodology.
+        self.assertIn("NORMALIZE", p)
+        self.assertIn("SEMANTIC CHECK", p)
+
+
+class TestGetSemanticWERScore(unittest.IsolatedAsyncioTestCase):
+    async def test_pooled_and_per_row_formula(self):
+        from calibrate_agent.stt import metrics as M
+
+        # Row "a": 1 error / 10 ref words -> 0.1. Row "b": 0 errors / 5 -> 0.0.
+        # Pooled = (1 + 0) / (10 + 5) = 0.0667. Keyed by input (gather runs the
+        # mocked judges concurrently, so ordering isn't guaranteed).
+        by_ref = {
+            "a": {
+                "substitutions": 1, "deletions": 0, "insertions": 0,
+                "reference_words": 10, "normalized_reference": "r1",
+                "normalized_hypothesis": "h1", "reasoning": "one sub",
+            },
+            "b": {
+                "substitutions": 0, "deletions": 0, "insertions": 0,
+                "reference_words": 5, "normalized_reference": "r2",
+                "normalized_hypothesis": "h2", "reasoning": "clean",
+            },
+        }
+
+        async def fake_judge(reference, prediction, model=None):
+            return by_ref[reference]
+
+        with patch(
+            "calibrate_agent.stt.semantic_wer.semantic_wer_judge",
+            AsyncMock(side_effect=fake_judge),
+        ):
+            out = await M.get_semantic_wer_score(["a", "b"], ["a", "b"])
+
+        self.assertAlmostEqual(out["semantic_wer"], 1 / 15)
+        self.assertAlmostEqual(out["per_row"][0]["semantic_wer"], 0.1)
+        self.assertAlmostEqual(out["per_row"][1]["semantic_wer"], 0.0)
+
+    async def test_empty_input(self):
+        from calibrate_agent.stt import metrics as M
+
+        out = await M.get_semantic_wer_score([], [])
+        self.assertEqual(out["semantic_wer"], 0.0)
+        self.assertEqual(out["per_row"], [])
+
+    async def test_zero_reference_words_with_errors_is_inf(self):
+        from calibrate_agent.stt import metrics as M
+
+        async def fake_judge(reference, prediction, model=None):
+            return {
+                "substitutions": 0, "deletions": 0, "insertions": 2,
+                "reference_words": 0, "normalized_reference": "",
+                "normalized_hypothesis": "x y", "reasoning": "hallucinated",
+            }
+
+        with patch(
+            "calibrate_agent.stt.semantic_wer.semantic_wer_judge",
+            AsyncMock(side_effect=fake_judge),
+        ):
+            out = await M.get_semantic_wer_score([""], ["x y"])
+
+        self.assertEqual(out["per_row"][0]["semantic_wer"], float("inf"))
+
+
+def _fake_judge():
+    async def judge(refs, preds, evaluators=None, fallback_model=None):
+        return {
+            "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
+            "score": 1.0,
+            "per_row": [
+                {"semantic_match": {"match": True, "reasoning": "ok"}} for _ in refs
+            ],
+        }
+
+    return AsyncMock(side_effect=judge)
+
+
+class TestScoreAndWriteSemanticWER(unittest.IsolatedAsyncioTestCase):
+    async def test_semantic_wer_in_metrics_and_results_when_enabled(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        async def fake_sem(references, predictions, model=None):
+            return {
+                "semantic_wer": 0.05,
+                "per_row": [
+                    {
+                        "semantic_wer": 0.05, "substitutions": 1, "deletions": 0,
+                        "insertions": 0, "reference_words": 20,
+                        "normalized_reference": "r", "normalized_hypothesis": "h",
+                        "reasoning": "x",
+                    }
+                    for _ in references
+                ],
+            }
+
+        # run_llm_judges=True now also triggers the Sarvam judges — make them
+        # raise so isolation skips them, keeping this test focused on semantic WER.
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            with patch.object(
+                stt_eval, "get_llm_judge_score", _fake_judge()
+            ), patch.object(
+                stt_eval, "get_semantic_wer_score", AsyncMock(side_effect=fake_sem)
+            ), patch.object(
+                stt_eval,
+                "get_intent_entity_score",
+                AsyncMock(side_effect=RuntimeError("skip")),
+            ), patch.object(
+                stt_eval,
+                "get_llm_wer_cer_score",
+                AsyncMock(side_effect=RuntimeError("skip")),
+            ):
+                metrics = await stt_eval._score_and_write_results(
+                    ids=["a", "b"],
+                    gt_transcripts=["hi", "there"],
+                    pred_transcripts=["hi", "there"],
+                    output_dir=str(out),
+                    evaluator_config_dir=str(out),
+                    run_llm_judges=True,
+                )
+
+            self.assertEqual(metrics["semantic_wer"], 0.05)
+            df = pd.read_csv(out / "results.csv")
+            self.assertIn("semantic_wer", df.columns)
+            self.assertIn("semantic_wer_substitutions", df.columns)
+            self.assertIn("semantic_wer_reasoning", df.columns)
+
+    async def test_omitted_when_disabled(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            with patch.object(
+                stt_eval, "get_llm_judge_score", _fake_judge()
+            ), patch.object(
+                stt_eval, "get_semantic_wer_score", AsyncMock()
+            ) as sem_mock:
+                metrics = await stt_eval._score_and_write_results(
+                    ids=["a"],
+                    gt_transcripts=["hi"],
+                    pred_transcripts=["hi"],
+                    output_dir=str(out),
+                    evaluator_config_dir=str(out),
+                    run_llm_judges=False,
+                )
+
+            sem_mock.assert_not_called()
+            self.assertNotIn("semantic_wer", metrics)
+            df = pd.read_csv(out / "results.csv")
+            self.assertNotIn("semantic_wer", df.columns)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/stt/test_semantic_wer.py
+++ b/tests/stt/test_semantic_wer.py
@@ -6,6 +6,7 @@ semantic WER threads through ``_score_and_write_results`` into metrics.json +
 results.csv when the LLM-judge group is enabled (``run_llm_judges``).
 """
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -145,8 +146,13 @@ class TestScoreAndWriteSemanticWER(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(metrics["semantic_wer"], 0.05)
             df = pd.read_csv(out / "results.csv")
             self.assertIn("semantic_wer", df.columns)
-            self.assertIn("semantic_wer_substitutions", df.columns)
+            self.assertIn("semantic_wer_metadata", df.columns)
             self.assertIn("semantic_wer_reasoning", df.columns)
+            meta = json.loads(df["semantic_wer_metadata"].iloc[0])
+            self.assertEqual(meta["substitutions"], 1)
+            self.assertEqual(meta["reference_words"], 20)
+            self.assertEqual(meta["normalized_reference"], "r")
+            self.assertNotIn("reasoning", meta)
 
     async def test_omitted_when_disabled(self):
         from calibrate_agent.stt import eval as stt_eval

--- a/tests/stt/test_semantic_wer.py
+++ b/tests/stt/test_semantic_wer.py
@@ -26,6 +26,12 @@ class TestBuildPrompt(unittest.TestCase):
         # Carries the pipecat-style methodology.
         self.assertIn("NORMALIZE", p)
         self.assertIn("SEMANTIC CHECK", p)
+        # Prompt is pipecat's verbatim: the rules our paraphrase had dropped
+        # and the full few-shot set must be present.
+        self.assertIn("Compound words count as ONE error", p)
+        self.assertIn("TRUNCATED/INCOMPLETE TEXT", p)
+        self.assertIn("TRAILING FUNCTION WORDS AT TRUNCATION", p)
+        self.assertEqual(p.count("### Example"), 8)
 
 
 class TestGetSemanticWERScore(unittest.IsolatedAsyncioTestCase):

--- a/tests/stt/test_semantic_wer.py
+++ b/tests/stt/test_semantic_wer.py
@@ -125,34 +125,42 @@ class TestGetSemanticWERScore(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(out["per_row"][1]["semantic_wer"], float("inf"))
 
 
-def _fake_completion(args: dict, content: str = "my reasoning"):
-    """A minimal OpenAI-style chat completion with one calculate_wer tool call."""
+def _tool_completion(args: dict):
+    """OpenAI-style completion whose message carries one calculate_wer call."""
     tc = SimpleNamespace(
         function=SimpleNamespace(name="calculate_wer", arguments=json.dumps(args))
     )
-    msg = SimpleNamespace(content=content, tool_calls=[tc])
-    return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+    return SimpleNamespace(choices=[SimpleNamespace(
+        message=SimpleNamespace(content=None, tool_calls=[tc]))])
+
+
+def _text_completion(content: str):
+    """OpenAI-style completion with plain reasoning text and no tool call."""
+    return SimpleNamespace(choices=[SimpleNamespace(
+        message=SimpleNamespace(content=content, tool_calls=None))])
 
 
 class TestJudgeToolLoop(unittest.IsolatedAsyncioTestCase):
-    async def _run(self, ref, hyp, args, content="my reasoning"):
+    async def _run(self, ref, hyp, args, reasoning="my reasoning"):
+        """Two-phase judge: phase 1 (no tools) -> reasoning; phase 2 -> tool call."""
         from calibrate_agent.stt.semantic_wer import judge as J
 
-        captured = {}
+        calls = []
 
         async def fake_create(*a, **kw):
-            captured["messages"] = kw["messages"]
-            captured["tools"] = kw["tools"]
-            return _fake_completion(args, content)
+            calls.append(kw)
+            if "tools" in kw:            # phase 2 — commit
+                return _tool_completion(args)
+            return _text_completion(reasoning)   # phase 1 — reason
 
         fake_client = MagicMock()
         fake_client.chat.completions.create = fake_create
         with patch.object(J, "_build_openrouter_client", return_value=fake_client):
             result = await J.semantic_wer_judge(ref, hyp)
-        return result, captured
+        return result, calls
 
-    async def test_system_user_split_and_count_extraction(self):
-        result, captured = await self._run(
+    async def test_two_phase_split_force_and_extraction(self):
+        result, calls = await self._run(
             "transfer to savings",
             "transfer to checking",
             {
@@ -163,17 +171,28 @@ class TestJudgeToolLoop(unittest.IsolatedAsyncioTestCase):
                 "normalized_reference": "transfer to savings",
                 "normalized_hypothesis": "transfer to checking",
             },
-            content="savings->checking changes the account",
+            reasoning="savings->checking changes the account",
         )
-        # System (rules) / user (pair) split — not one crammed message.
-        self.assertEqual(captured["messages"][0]["role"], "system")
-        self.assertEqual(captured["messages"][1]["role"], "user")
-        self.assertIn("SEMANTIC CHECK", captured["messages"][0]["content"])
-        self.assertIn("transfer to savings", captured["messages"][1]["content"])
-        self.assertNotIn("transfer to savings", captured["messages"][0]["content"])
-        # Tool schema is offered as an OpenAI function named calculate_wer.
-        self.assertEqual(captured["tools"][0]["function"]["name"], "calculate_wer")
-        # Counts parsed from the tool call; reasoning captured from the message.
+        # Exactly two calls.
+        self.assertEqual(len(calls), 2)
+        p1, p2 = calls
+
+        # Phase 1: reason only — no tool offered, system/user split.
+        self.assertNotIn("tools", p1)
+        self.assertNotIn("tool_choice", p1)
+        self.assertEqual(p1["messages"][0]["role"], "system")
+        self.assertEqual(p1["messages"][1]["role"], "user")
+        self.assertIn("SEMANTIC CHECK", p1["messages"][0]["content"])
+        self.assertIn("transfer to savings", p1["messages"][1]["content"])
+        self.assertNotIn("transfer to savings", p1["messages"][0]["content"])
+
+        # Phase 2: the calculate_wer call is forced, reasoning replayed.
+        self.assertEqual(p2["tools"][0]["function"]["name"], "calculate_wer")
+        self.assertEqual(p2["tool_choice"]["function"]["name"], "calculate_wer")
+        self.assertEqual(p2["messages"][2]["role"], "assistant")
+        self.assertEqual(p2["messages"][2]["content"], "savings->checking changes the account")
+
+        # Counts parsed from the forced call; reasoning from phase 1.
         self.assertEqual(result["substitutions"], 1)
         self.assertEqual(result["reference_words"], 3)
         self.assertEqual(result["reasoning"], "savings->checking changes the account")
@@ -182,10 +201,11 @@ class TestJudgeToolLoop(unittest.IsolatedAsyncioTestCase):
         # Decomposed (NFD) input whose NFC form differs — the judge must send
         # the composed form to the model, not the decomposed input it received.
         nfd_ref = unicodedata.normalize("NFD", "café résumé")
-        _, captured = await self._run(
+        _, calls = await self._run(
             nfd_ref, nfd_ref,
             {"substitutions": 0, "deletions": 0, "insertions": 0, "reference_words": 3},
         )
+        captured = {"messages": calls[0]["messages"]}
         user_msg = captured["messages"][1]["content"]
         self.assertIn(unicodedata.normalize("NFC", nfd_ref), user_msg)
         self.assertNotIn(nfd_ref, user_msg)

--- a/tests/stt/test_semantic_wer.py
+++ b/tests/stt/test_semantic_wer.py
@@ -11,6 +11,7 @@ import tempfile
 import unicodedata
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pandas as pd
@@ -124,37 +125,70 @@ class TestGetSemanticWERScore(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(out["per_row"][1]["semantic_wer"], float("inf"))
 
 
-class TestJudgeNFCNormalization(unittest.IsolatedAsyncioTestCase):
-    async def test_reference_and_prediction_are_nfc_normalized(self):
-        from calibrate_agent.stt.semantic_wer import judge as J
-        from calibrate_agent.stt.semantic_wer.main import SemanticWERResponse
+def _fake_completion(args: dict, content: str = "my reasoning"):
+    """A minimal OpenAI-style chat completion with one calculate_wer tool call."""
+    tc = SimpleNamespace(
+        function=SimpleNamespace(name="calculate_wer", arguments=json.dumps(args))
+    )
+    msg = SimpleNamespace(content=content, tool_calls=[tc])
+    return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
 
-        # Decomposed (NFD) input whose NFC form differs — combining marks that
-        # recompose to precomposed codepoints. The judge must normalize to NFC.
-        nfd_ref = unicodedata.normalize("NFD", "café résumé")
-        nfd_hyp = unicodedata.normalize("NFD", "café résumé")
-        self.assertNotEqual(nfd_ref, unicodedata.normalize("NFC", nfd_ref))
+
+class TestJudgeToolLoop(unittest.IsolatedAsyncioTestCase):
+    async def _run(self, ref, hyp, args, content="my reasoning"):
+        from calibrate_agent.stt.semantic_wer import judge as J
 
         captured = {}
 
-        async def fake_create(*args, **kwargs):
-            captured["content"] = kwargs["messages"][0]["content"]
-            return SemanticWERResponse(
-                substitutions=0, deletions=0, insertions=0, reference_words=3
-            )
+        async def fake_create(*a, **kw):
+            captured["messages"] = kw["messages"]
+            captured["tools"] = kw["tools"]
+            return _fake_completion(args, content)
 
         fake_client = MagicMock()
         fake_client.chat.completions.create = fake_create
+        with patch.object(J, "_build_openrouter_client", return_value=fake_client):
+            result = await J.semantic_wer_judge(ref, hyp)
+        return result, captured
 
-        with patch.object(J, "_build_openrouter_client", return_value=object()), patch.object(
-            J.instructor, "apatch", return_value=fake_client
-        ):
-            await J.semantic_wer_judge(nfd_ref, nfd_hyp)
+    async def test_system_user_split_and_count_extraction(self):
+        result, captured = await self._run(
+            "transfer to savings",
+            "transfer to checking",
+            {
+                "substitutions": 1,
+                "deletions": 0,
+                "insertions": 0,
+                "reference_words": 3,
+                "normalized_reference": "transfer to savings",
+                "normalized_hypothesis": "transfer to checking",
+            },
+            content="savings->checking changes the account",
+        )
+        # System (rules) / user (pair) split — not one crammed message.
+        self.assertEqual(captured["messages"][0]["role"], "system")
+        self.assertEqual(captured["messages"][1]["role"], "user")
+        self.assertIn("SEMANTIC CHECK", captured["messages"][0]["content"])
+        self.assertIn("transfer to savings", captured["messages"][1]["content"])
+        self.assertNotIn("transfer to savings", captured["messages"][0]["content"])
+        # Tool schema is offered as an OpenAI function named calculate_wer.
+        self.assertEqual(captured["tools"][0]["function"]["name"], "calculate_wer")
+        # Counts parsed from the tool call; reasoning captured from the message.
+        self.assertEqual(result["substitutions"], 1)
+        self.assertEqual(result["reference_words"], 3)
+        self.assertEqual(result["reasoning"], "savings->checking changes the account")
 
-        # The prompt the judge sent must carry the NFC (composed) form, not the
-        # decomposed input it received.
-        self.assertIn(unicodedata.normalize("NFC", nfd_ref), captured["content"])
-        self.assertNotIn(nfd_ref, captured["content"])
+    async def test_reference_and_prediction_are_nfc_normalized(self):
+        # Decomposed (NFD) input whose NFC form differs — the judge must send
+        # the composed form to the model, not the decomposed input it received.
+        nfd_ref = unicodedata.normalize("NFD", "café résumé")
+        _, captured = await self._run(
+            nfd_ref, nfd_ref,
+            {"substitutions": 0, "deletions": 0, "insertions": 0, "reference_words": 3},
+        )
+        user_msg = captured["messages"][1]["content"]
+        self.assertIn(unicodedata.normalize("NFC", nfd_ref), user_msg)
+        self.assertNotIn(nfd_ref, user_msg)
 
 
 def _fake_judge():

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -151,9 +151,9 @@ class TestSTTBenchmarkRun(unittest.IsolatedAsyncioTestCase):
                 providers=["deepgram"],
                 input_dir=tmp,
                 output_dir=tmp,
-                run_sarvam_judges=True,
+                run_llm_judges=True,
             )
-        self.assertTrue(mock_eval.call_args.kwargs["run_sarvam_judges"])
+        self.assertTrue(mock_eval.call_args.kwargs["run_llm_judges"])
 
     async def test_run_leaderboard_error(self):
         from calibrate_agent.stt import benchmark as B
@@ -259,9 +259,9 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
                  patch.object(B, "run_eval_only", mock_eval):
                 await B.main()
 
-            self.assertTrue(mock_eval.call_args.kwargs["run_sarvam_judges"])
+            self.assertTrue(mock_eval.call_args.kwargs["run_llm_judges"])
 
-    async def test_main_eval_only_skip_sarvam_flag(self):
+    async def test_main_eval_only_skip_llm_judges_flag(self):
         from calibrate_agent.stt import benchmark as B
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -273,12 +273,12 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
             fake_result = {"status": "completed", "metrics": {"wer": 0.1}}
             mock_eval = AsyncMock(return_value=fake_result)
             argv = ["b.py", "--eval-only", "--dataset", str(ds),
-                    "-o", str(out), "--skip-sarvam"]
+                    "-o", str(out), "--skip-llm-judges"]
             with patch.object(sys, "argv", argv), \
                  patch.object(B, "run_eval_only", mock_eval):
                 await B.main()
 
-            self.assertFalse(mock_eval.call_args.kwargs["run_sarvam_judges"])
+            self.assertFalse(mock_eval.call_args.kwargs["run_llm_judges"])
 
     async def test_main_eval_only_error(self):
         from calibrate_agent.stt import benchmark as B
@@ -359,13 +359,13 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
             argv = ["b.py", "-p", "deepgram", "-i", str(base), "-o", str(out)]
             with patch.object(sys, "argv", argv), patch.object(B, "run", mock_run):
                 await B.main()
-            self.assertTrue(mock_run.call_args.kwargs["run_sarvam_judges"])
+            self.assertTrue(mock_run.call_args.kwargs["run_llm_judges"])
 
             # Skip flag.
-            argv.append("--skip-sarvam")
+            argv.append("--skip-llm-judges")
             with patch.object(sys, "argv", argv), patch.object(B, "run", mock_run):
                 await B.main()
-            self.assertFalse(mock_run.call_args.kwargs["run_sarvam_judges"])
+            self.assertFalse(mock_run.call_args.kwargs["run_llm_judges"])
 
     async def test_main_error_provider_exits(self):
         from calibrate_agent.stt import benchmark as B

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -186,7 +186,7 @@ class TestMainDispatch(unittest.TestCase):
                     "-o", tmp,
                 ])
 
-    def test_stt_benchmark_forwards_skip_sarvam_flag(self):
+    def test_stt_benchmark_forwards_skip_llm_judges_flag(self):
         captured = {}
 
         async def fake_main():
@@ -206,12 +206,12 @@ class TestMainDispatch(unittest.TestCase):
                 self._run_with_argv([
                     "calibrate_agent", "stt", "-p", "deepgram",
                     "-i", str(base), "-o", str(base / "out"),
-                    "--skip-sarvam",
+                    "--skip-llm-judges",
                 ])
 
-        self.assertIn("--skip-sarvam", captured["argv"])
+        self.assertIn("--skip-llm-judges", captured["argv"])
 
-    def test_stt_benchmark_omits_skip_sarvam_flag_by_default(self):
+    def test_stt_benchmark_omits_skip_llm_judges_flag_by_default(self):
         captured = {}
 
         async def fake_main():
@@ -233,9 +233,9 @@ class TestMainDispatch(unittest.TestCase):
                     "-i", str(base), "-o", str(base / "out"),
                 ])
 
-        self.assertNotIn("--skip-sarvam", captured["argv"])
+        self.assertNotIn("--skip-llm-judges", captured["argv"])
 
-    def test_stt_eval_only_forwards_skip_sarvam_flag_and_language(self):
+    def test_stt_eval_only_forwards_skip_llm_judges_flag_and_language(self):
         captured = {}
 
         async def fake_main():
@@ -248,10 +248,10 @@ class TestMainDispatch(unittest.TestCase):
                        AsyncMock(side_effect=fake_main)):
                 self._run_with_argv([
                     "calibrate_agent", "stt", "--eval-only", "--dataset", str(ds),
-                    "-o", tmp, "-l", "hindi", "--skip-sarvam",
+                    "-o", tmp, "-l", "hindi", "--skip-llm-judges",
                 ])
 
-        self.assertIn("--skip-sarvam", captured["argv"])
+        self.assertIn("--skip-llm-judges", captured["argv"])
         self.assertIn("hindi", captured["argv"])
 
     def test_tts_no_provider_launches_ui(self):


### PR DESCRIPTION
## What
- **Semantic WER** (pipecat `stt-benchmark` methodology): one holistic LLM call per (reference, hypothesis) pair — the model normalizes, aligns, applies a "would an LLM agent respond differently?" error check, and reports S/D/I + reference word counts; WER computed in Python (per-row + dataset-pooled), matching pipecat's `_calculate_wer`. New `stt/semantic_wer/` package + `get_semantic_wer_score`, reusing the OpenRouter/instructor/backoff/langfuse plumbing (judge defaults to Claude, like pipecat).
- **Consolidate judge flags**: `--skip-sarvam` / `run_sarvam_judges` become `--skip-llm-judges` / `run_llm_judges`, gating all extra LLM-based judges as a group — Sarvam intent/entity, Sarvam LLM-WER/CER, and semantic WER. On by default; each judge stays isolated (one failing doesn't drop the others).

## Notes
- Distinct from Sarvam LLM-WER (deterministic difflib alignment + per-segment equivalence forgiveness); here the LLM does the whole count.
- Independent of the STT pipeline engine (separate PR).
- Judge model default is `anthropic/claude-sonnet-4.5` via OpenRouter — overridable; worth confirming the slug resolves on your account in a real run.
- Semantic WER lets the LLM normalize inline (English-oriented, like pipecat); the real jiwer WER/CER + Indic normalization remain the stronger multilingual signal.
- Tests: semantic-WER flow (pooled/per-row formula, prompt, on/off threading) + updated judge-flag tests. STT + CLI + benchmark suites pass.