### PR TITLE
Show concise summary as semantic-WER reasoning, not raw CoT

### DIFF
--- a/calibrate_agent/stt/semantic_wer/judge.py
+++ b/calibrate_agent/stt/semantic_wer/judge.py
@@ -10,7 +10,9 @@ explicit calls per pair instead of pipecat's single auto tool-use loop:
             No tool is offered, so it can only produce text.
   Phase 2 — the phase-1 reasoning is replayed and the model is *required* to
             call ``calculate_wer`` (forced ``tool_choice``), committing the
-            counts.
+            counts plus a concise ``summary`` verdict. That summary — not the
+            verbose phase-1 CoT — becomes the row's public ``reasoning``; the raw
+            CoT is kept only in the per-provider debug log.
 
 This guarantees termination in exactly two calls (no nudge loop, no
 runaway-retry worst case) at the cost of one extra call per row versus
@@ -140,7 +142,16 @@ async def semantic_wer_judge(
             _CACHED_SYSTEM_MESSAGE,
             {"role": "user", "content": user_msg},
             {"role": "assistant", "content": reasoning},
-            {"role": "user", "content": "Now call calculate_wer with your final counts."},
+            {
+                "role": "user",
+                "content": (
+                    "Now call calculate_wer with your final counts and a concise "
+                    "`summary` (1-2 sentences, plain language) explaining the "
+                    "semantic errors you counted, or that there were none. The "
+                    "summary is shown publicly — do not restate your step-by-step "
+                    "working."
+                ),
+            },
         ],
         tools=[_OPENAI_TOOL],
         tool_choice=_FORCE_WER_TOOL,
@@ -161,6 +172,11 @@ async def semantic_wer_judge(
         raise ValueError("semantic_wer_judge: forced calculate_wer call was not returned")
     tool_input = json.loads(wer_call.function.arguments)
 
+    # The publicly-shown reasoning is the model's concise phase-2 ``summary``, not
+    # the phase-1 chain-of-thought — the CoT is verbose working-out that leaks
+    # into the leaderboard UI. Fall back to the CoT only if the summary is missing
+    # (older models / truncated calls), so a row is never left without reasoning.
+    summary = (tool_input.get("summary") or "").strip()
     result = {
         "substitutions": int(tool_input.get("substitutions", 0)),
         "deletions": int(tool_input.get("deletions", 0)),
@@ -169,15 +185,17 @@ async def semantic_wer_judge(
         "reference_words": int(tool_input.get("reference_words", 1)),
         "normalized_reference": tool_input.get("normalized_reference") or "",
         "normalized_hypothesis": tool_input.get("normalized_hypothesis") or "",
-        "reasoning": reasoning,
+        "reasoning": summary or reasoning,
     }
 
+    # Persist the full CoT to the per-provider debug log (never the leaderboard):
+    # pipecat likewise keeps the raw reasoning trace only for offline debugging.
     log_judge_io(
         evaluator="semantic_wer",
         model=model,
         system_prompt=SYSTEM_PROMPT,
         user_input=user_msg,
-        output=result,
+        output={**result, "chain_of_thought": reasoning},
     )
 
     if langfuse_enabled and langfuse:

--- a/calibrate_agent/stt/semantic_wer/judge.py
+++ b/calibrate_agent/stt/semantic_wer/judge.py
@@ -97,7 +97,9 @@ async def semantic_wer_judge(
 
     Returns the ``calculate_wer`` counts plus reasoning:
     ``substitutions``, ``deletions``, ``insertions``, ``reference_words``,
-    ``normalized_reference``, ``normalized_hypothesis``, ``reasoning``.
+    ``normalized_reference``, ``normalized_hypothesis``, ``reasoning`` (the
+    concise public summary), and ``chain_of_thought`` (the full phase-1 CoT,
+    kept for debug surfaces only — never persisted to the leaderboard).
     """
     # Seam: NFC pre-normalization (see module docstring). Applied before the
     # judge sees the text so Indic codepoint variants aren't counted as errors.
@@ -186,16 +188,19 @@ async def semantic_wer_judge(
         "normalized_reference": tool_input.get("normalized_reference") or "",
         "normalized_hypothesis": tool_input.get("normalized_hypothesis") or "",
         "reasoning": summary or reasoning,
+        # Full CoT rides along for the debug surfaces below (log + Langfuse). It
+        # never reaches the leaderboard: get_semantic_wer_score and eval.py both
+        # cherry-pick named keys, so this one is dropped. pipecat likewise keeps
+        # the raw reasoning trace only for offline debugging.
+        "chain_of_thought": reasoning,
     }
 
-    # Persist the full CoT to the per-provider debug log (never the leaderboard):
-    # pipecat likewise keeps the raw reasoning trace only for offline debugging.
     log_judge_io(
         evaluator="semantic_wer",
         model=model,
         system_prompt=SYSTEM_PROMPT,
         user_input=user_msg,
-        output={**result, "chain_of_thought": reasoning},
+        output=result,
     )
 
     if langfuse_enabled and langfuse:

--- a/calibrate_agent/stt/semantic_wer/main.py
+++ b/calibrate_agent/stt/semantic_wer/main.py
@@ -8,11 +8,13 @@ via a ``calculate_wer`` tool call. The WER itself is computed in Python from
 those counts (see ``get_semantic_wer_score`` in ``stt/metrics.py``), mirroring
 pipecat's ``_calculate_wer``.
 
-``SYSTEM_PROMPT`` (``prompt_template.txt``) and ``CALCULATE_WER_TOOL`` are
-pipecat's verbatim, so the judge runs the same rules + tool contract pipecat
-does. The judge (``judge.py``) drives them through a tool-calling loop with a
-system/user split, matching pipecat's shape; only the transport (OpenRouter's
-OpenAI-compatible API vs pipecat's native Anthropic SDK) differs.
+``SYSTEM_PROMPT`` (``prompt_template.txt``) is pipecat's verbatim, and
+``CALCULATE_WER_TOOL`` is pipecat's plus one required ``summary`` field (a
+concise, publicly-showable verdict — see below), so the judge runs the same
+rules + tool contract pipecat does. The judge (``judge.py``) drives them through
+a tool-calling loop with a system/user split, matching pipecat's shape; only the
+transport (OpenRouter's OpenAI-compatible API vs pipecat's native Anthropic SDK)
+and the ``summary`` capture differ.
 
 Distinct from ``stt/sarvam_llm_wer`` (Sarvam's approach), which aligns
 deterministically with difflib and only asks the LLM to forgive per-segment
@@ -34,9 +36,15 @@ except FileNotFoundError:
         "Please ensure it exists alongside main.py."
     )
 
-# pipecat's CALCULATE_WER_TOOL, verbatim (Anthropic tool schema). The judge
-# converts this to the OpenAI function-calling shape for OpenRouter; the
-# ``input_schema`` doubles as the OpenAI ``parameters`` object unchanged.
+# pipecat's CALCULATE_WER_TOOL (Anthropic tool schema). The judge converts this
+# to the OpenAI function-calling shape for OpenRouter; the ``input_schema``
+# doubles as the OpenAI ``parameters`` object unchanged.
+#
+# Calibrate addition (not in pipecat): a required ``summary`` field. pipecat
+# keeps the model's full chain-of-thought only for offline debugging and never
+# surfaces it; calibrate shows per-row judge reasoning in the leaderboard UI, so
+# we ask the model to commit a short, publicly-showable verdict alongside the
+# counts instead of leaking the raw CoT. See ``semantic_wer_judge``.
 CALCULATE_WER_TOOL = {
     "name": "calculate_wer",
     "description": "Calculate Word Error Rate from error counts. Call this ONCE after you have normalized, aligned, and verified the texts. WER = (substitutions + deletions + insertions) / reference_words",
@@ -67,6 +75,17 @@ CALCULATE_WER_TOOL = {
                 "type": "string",
                 "description": "The normalized hypothesis text (for verification)",
             },
+            "summary": {
+                "type": "string",
+                "description": (
+                    "A concise, publicly-showable explanation (1-2 sentences, "
+                    "plain language) of the semantic errors you counted, or a "
+                    "brief statement that there were none. Summarize only the "
+                    "verdict and the errors that mattered — do NOT include "
+                    "step-by-step working, normalization steps, or alignment "
+                    "tables."
+                ),
+            },
             "errors": {
                 "type": "array",
                 "description": "List of identified errors",
@@ -93,7 +112,13 @@ CALCULATE_WER_TOOL = {
                 },
             },
         },
-        "required": ["substitutions", "deletions", "insertions", "reference_words"],
+        "required": [
+            "substitutions",
+            "deletions",
+            "insertions",
+            "reference_words",
+            "summary",
+        ],
     },
 }
 

--- a/tests/stt/test_semantic_wer.py
+++ b/tests/stt/test_semantic_wer.py
@@ -39,6 +39,17 @@ class TestPrompt(unittest.TestCase):
         self.assertIn("TRAILING FUNCTION WORDS AT TRUNCATION", p)
         self.assertEqual(p.count("### Example"), 8)
 
+    def test_tool_requires_concise_summary(self):
+        from calibrate_agent.stt.semantic_wer.main import CALCULATE_WER_TOOL
+
+        schema = CALCULATE_WER_TOOL["input_schema"]
+        # Calibrate adds a required ``summary`` field for the public reasoning.
+        self.assertIn("summary", schema["properties"])
+        self.assertIn("summary", schema["required"])
+        # pipecat's original counts are still required.
+        for field in ("substitutions", "deletions", "insertions", "reference_words"):
+            self.assertIn(field, schema["required"])
+
 
 class TestGetSemanticWERScore(unittest.IsolatedAsyncioTestCase):
     async def test_pooled_and_per_row_formula(self):
@@ -175,6 +186,7 @@ class TestJudgeToolLoop(unittest.IsolatedAsyncioTestCase):
                 "reference_words": 3,
                 "normalized_reference": "transfer to savings",
                 "normalized_hypothesis": "transfer to checking",
+                "summary": "'savings' misheard as 'checking' — the agent would act on the wrong account.",
             },
             reasoning="savings->checking changes the account",
         )
@@ -199,10 +211,32 @@ class TestJudgeToolLoop(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(p2["tool_choice"]["function"]["name"], "calculate_wer")
         self.assertEqual(p2["messages"][2]["role"], "assistant")
         self.assertEqual(p2["messages"][2]["content"], "savings->checking changes the account")
+        # Phase 2 nudges for the concise, public summary.
+        self.assertIn("summary", p2["messages"][3]["content"])
 
-        # Counts parsed from the forced call; reasoning from phase 1.
+        # Counts parsed from the forced call; the public reasoning is the concise
+        # phase-2 summary, NOT the verbose phase-1 chain-of-thought.
         self.assertEqual(result["substitutions"], 1)
         self.assertEqual(result["reference_words"], 3)
+        self.assertEqual(
+            result["reasoning"],
+            "'savings' misheard as 'checking' — the agent would act on the wrong account.",
+        )
+
+    async def test_reasoning_falls_back_to_cot_when_summary_missing(self):
+        # Older models / truncated calls may omit ``summary`` — the row must still
+        # carry reasoning rather than an empty string, so fall back to the CoT.
+        result, _ = await self._run(
+            "transfer to savings",
+            "transfer to checking",
+            {
+                "substitutions": 1,
+                "deletions": 0,
+                "insertions": 0,
+                "reference_words": 3,
+            },
+            reasoning="savings->checking changes the account",
+        )
         self.assertEqual(result["reasoning"], "savings->checking changes the account")
 
     async def test_reference_and_prediction_are_nfc_normalized(self):

--- a/tests/stt/test_semantic_wer.py
+++ b/tests/stt/test_semantic_wer.py
@@ -68,6 +68,9 @@ class TestGetSemanticWERScore(unittest.IsolatedAsyncioTestCase):
                 "substitutions": 0, "deletions": 0, "insertions": 0,
                 "reference_words": 5, "normalized_reference": "r2",
                 "normalized_hypothesis": "h2", "reasoning": "clean",
+                # A judge dict may also carry the full CoT — it must be dropped,
+                # not echoed into per_row (which feeds the persisted outputs).
+                "chain_of_thought": "long verbose working-out",
             },
         }
 
@@ -83,6 +86,7 @@ class TestGetSemanticWERScore(unittest.IsolatedAsyncioTestCase):
         self.assertAlmostEqual(out["semantic_wer"], 1 / 15)
         self.assertAlmostEqual(out["per_row"][0]["semantic_wer"], 0.1)
         self.assertAlmostEqual(out["per_row"][1]["semantic_wer"], 0.0)
+        self.assertNotIn("chain_of_thought", out["per_row"][1])
 
     async def test_empty_input(self):
         from calibrate_agent.stt import metrics as M
@@ -222,6 +226,9 @@ class TestJudgeToolLoop(unittest.IsolatedAsyncioTestCase):
             result["reasoning"],
             "'savings' misheard as 'checking' — the agent would act on the wrong account.",
         )
+        # The full CoT rides along for debug surfaces but is distinct from the
+        # public reasoning.
+        self.assertEqual(result["chain_of_thought"], "savings->checking changes the account")
 
     async def test_reasoning_falls_back_to_cot_when_summary_missing(self):
         # Older models / truncated calls may omit ``summary`` — the row must still


### PR DESCRIPTION
## What
- The semantic-WER judge stored the full phase-1 chain-of-thought in `reasoning`, which surfaced verbatim in the leaderboard tooltip. Replace it with a concise, publicly-showable verdict.
- Add a required `summary` field to the forced phase-2 `calculate_wer` tool call and use it as the row's `reasoning`.
- Keep the raw CoT only in the per-provider debug log (as `chain_of_thought`), mirroring how pipecat retains the reasoning trace for offline debugging.

## Notes
- `summary` is a model-written natural-language verdict, not pipecat's structured `errors` list — one field diverges from pipecat's otherwise-verbatim tool schema.
- Falls back to the CoT if `summary` is missing (older models / truncated calls).
- Existing `results.csv` from past runs still show old CoT; re-run to get concise summaries.