### PR TITLE
Single-source shared STT CLI flags into a helper module

### DIFF
--- a/calibrate_agent/_cli_args.py
+++ b/calibrate_agent/_cli_args.py
@@ -1,0 +1,82 @@
+"""Shared argparse builders for the STT eval/benchmark CLIs.
+
+The ``--skip-llm-judges``, ``--max-parallel``, ``--engine`` and
+``--max-concurrency`` flags are accepted by three entry points that must stay in
+lock-step: the top-level ``calibrate-agent stt`` parser (``calibrate_agent.cli``),
+the multi-provider benchmark (``calibrate_agent.stt.benchmark``) and the
+single-provider eval (``calibrate_agent.stt.eval``). Defining each flag once here
+keeps their help text, defaults and choices from drifting apart.
+
+Deliberately stdlib-only (imports nothing): ``calibrate_agent.cli`` builds its
+parser by calling these, and the CLI must build its parser *without* importing
+the heavy ``calibrate_agent.utils`` module — that shifts scipy/numpy init order
+and trips a scipy ``_CopyMode`` incompatibility in the voice path. Like
+``calibrate_agent._env``, this module must never grow a non-stdlib import.
+"""
+
+
+def add_stt_skip_llm_judges_arg(parser):
+    """Add ``--skip-llm-judges`` (report WER/CER only, no extra LLM judges)."""
+    parser.add_argument(
+        "--skip-llm-judges",
+        action="store_true",
+        help=(
+            "Skip the extra LLM-based judges (Sarvam intent & entity "
+            "preservation, Sarvam LLM-WER/CER, and pipecat-style semantic WER). "
+            "They all run by default; passing this reports WER/CER only."
+        ),
+    )
+
+
+def add_stt_max_parallel_arg(parser):
+    """Add ``--max-parallel`` (providers evaluated concurrently).
+
+    Only the multi-provider entry points expose this — the single-provider eval
+    has no across-provider parallelism to tune.
+    """
+    parser.add_argument(
+        "--max-parallel",
+        type=int,
+        default=None,
+        help=(
+            "Number of providers to evaluate in parallel (default: pipeline 1, "
+            "direct 2; or $CALIBRATE_STT_MAX_PARALLEL)."
+        ),
+    )
+
+
+def add_stt_engine_args(parser):
+    """Add ``--engine`` and ``--max-concurrency`` (per-clip transcription knobs)."""
+    parser.add_argument(
+        "--engine",
+        type=str,
+        default="pipeline",
+        choices=["direct", "pipeline"],
+        help=(
+            "Transcription engine: 'pipeline' (default; streams through a real "
+            "pipecat agent pipeline at real-time pace, also reporting TTFS "
+            "latency) or 'direct' (faster; per-provider SDK, no latency)."
+        ),
+    )
+    parser.add_argument(
+        "--max-concurrency",
+        type=int,
+        default=None,
+        help=(
+            "Concurrent clips per provider, both engines (default: pipeline 1, "
+            "direct 4; or $CALIBRATE_STT_MAX_CONCURRENCY). Pipeline defaults to "
+            "1 to keep TTFS latency uncontended."
+        ),
+    )
+
+
+def add_stt_eval_args(parser, *, include_max_parallel):
+    """Add every shared STT flag, in the canonical order the three sites use.
+
+    ``include_max_parallel`` is ``True`` for the multi-provider entry points
+    (``cli`` / ``benchmark``) and ``False`` for the single-provider eval.
+    """
+    add_stt_skip_llm_judges_arg(parser)
+    if include_max_parallel:
+        add_stt_max_parallel_arg(parser)
+    add_stt_engine_args(parser)

--- a/calibrate_agent/cli.py
+++ b/calibrate_agent/cli.py
@@ -25,11 +25,12 @@ import json
 from importlib.metadata import version as get_version
 from dotenv import find_dotenv, load_dotenv
 
-# ``calibrate_agent._env`` is stdlib-only (imports just ``os``), so this import is
-# safe at parser-build time — unlike ``calibrate_agent.utils``, which pulls in
-# scipy/numpy/pipecat and trips a scipy ``_CopyMode`` incompatibility in the
-# voice path if imported here.
+# ``calibrate_agent._env`` and ``calibrate_agent._cli_args`` are stdlib-only, so
+# these imports are safe at parser-build time — unlike ``calibrate_agent.utils``,
+# which pulls in scipy/numpy/pipecat and trips a scipy ``_CopyMode``
+# incompatibility in the voice path if imported here.
 from calibrate_agent._env import env_int
+from calibrate_agent._cli_args import add_stt_eval_args
 
 
 def _args_to_argv(args, exclude_keys=None, flag_mapping=None):
@@ -239,45 +240,7 @@ Examples:
         default=None,
         help="Path to dataset JSON (list of {id, gt, pred}). Required with --eval-only.",
     )
-    stt_parser.add_argument(
-        "--skip-llm-judges",
-        action="store_true",
-        help=(
-            "Skip the extra LLM-based judges (Sarvam intent & entity "
-            "preservation, Sarvam LLM-WER/CER, and pipecat-style semantic WER). "
-            "They all run by default; passing this reports WER/CER only."
-        ),
-    )
-    stt_parser.add_argument(
-        "--max-parallel",
-        type=int,
-        default=None,
-        help=(
-            "Number of providers to evaluate in parallel (default: pipeline 1, "
-            "direct 2; or $CALIBRATE_STT_MAX_PARALLEL)."
-        ),
-    )
-    stt_parser.add_argument(
-        "--engine",
-        type=str,
-        default="pipeline",
-        choices=["direct", "pipeline"],
-        help=(
-            "Transcription engine: 'pipeline' (default; streams through a real "
-            "pipecat agent pipeline at real-time pace, also reporting TTFS "
-            "latency) or 'direct' (faster; per-provider SDK, no latency)."
-        ),
-    )
-    stt_parser.add_argument(
-        "--max-concurrency",
-        type=int,
-        default=None,
-        help=(
-            "Concurrent clips per provider, both engines (default: pipeline 1, "
-            "direct 4; or $CALIBRATE_STT_MAX_CONCURRENCY). Pipeline defaults to "
-            "1 to keep TTFS latency uncontended."
-        ),
-    )
+    add_stt_eval_args(stt_parser, include_max_parallel=True)
 
     # ── TTS ───────────────────────────────────────────────────────
     # `calibrate-agent tts` with no args → interactive UI

--- a/calibrate_agent/stt/benchmark.py
+++ b/calibrate_agent/stt/benchmark.py
@@ -34,6 +34,7 @@ from calibrate_agent.stt.eval import (
 )
 from calibrate_agent.stt.leaderboard import generate_leaderboard
 from calibrate_agent._env import resolve_stt_parallelism
+from calibrate_agent._cli_args import add_stt_eval_args
 from calibrate_agent.utils import StreamTee
 
 
@@ -251,45 +252,7 @@ async def main():
         default=None,
         help="Path to optional JSON config file with an `evaluators` list",
     )
-    parser.add_argument(
-        "--skip-llm-judges",
-        action="store_true",
-        help=(
-            "Skip the extra LLM-based judges (Sarvam intent & entity "
-            "preservation, Sarvam LLM-WER/CER, and pipecat-style semantic WER). "
-            "They all run by default; passing this reports WER/CER only."
-        ),
-    )
-    parser.add_argument(
-        "--max-parallel",
-        type=int,
-        default=None,
-        help=(
-            "Number of providers to evaluate in parallel (default: pipeline 1, "
-            "direct 2; or $CALIBRATE_STT_MAX_PARALLEL)."
-        ),
-    )
-    parser.add_argument(
-        "--engine",
-        type=str,
-        default="pipeline",
-        choices=["direct", "pipeline"],
-        help=(
-            "Transcription engine: 'pipeline' (default; streams through a real "
-            "pipecat agent pipeline at real-time pace, also reporting TTFS "
-            "latency) or 'direct' (faster; per-provider SDK, no latency)."
-        ),
-    )
-    parser.add_argument(
-        "--max-concurrency",
-        type=int,
-        default=None,
-        help=(
-            "Concurrent clips per provider, both engines (default: pipeline 1, "
-            "direct 4; or $CALIBRATE_STT_MAX_CONCURRENCY). Pipeline defaults to "
-            "1 to keep TTFS latency uncontended."
-        ),
-    )
+    add_stt_eval_args(parser, include_max_parallel=True)
 
     args = parser.parse_args()
 

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -45,6 +45,7 @@ from calibrate_agent.stt.metrics import (
 )
 from calibrate_agent.stt.pipeline_eval import transcribe_via_pipeline
 from calibrate_agent._env import resolve_stt_max_concurrency
+from calibrate_agent._cli_args import add_stt_eval_args
 from calibrate_agent.judges import (
     is_rating,
     require_unique_evaluator_names,
@@ -1897,36 +1898,7 @@ async def main():
         action="store_true",
         help="Overwrite existing results instead of resuming from last checkpoint",
     )
-    parser.add_argument(
-        "--skip-llm-judges",
-        action="store_true",
-        help=(
-            "Skip the extra LLM-based judges (Sarvam intent & entity "
-            "preservation, Sarvam LLM-WER/CER, and pipecat-style semantic WER). "
-            "They all run by default; passing this reports WER/CER only."
-        ),
-    )
-    parser.add_argument(
-        "--engine",
-        type=str,
-        default="pipeline",
-        choices=["direct", "pipeline"],
-        help=(
-            "Transcription engine: 'pipeline' (default; streams through a real "
-            "pipecat agent pipeline at real-time pace, also reporting TTFS "
-            "latency) or 'direct' (faster; per-provider SDK, no latency)."
-        ),
-    )
-    parser.add_argument(
-        "--max-concurrency",
-        type=int,
-        default=None,
-        help=(
-            "Concurrent clips per provider, both engines (default: pipeline 1, "
-            "direct 4; or $CALIBRATE_STT_MAX_CONCURRENCY). Pipeline defaults to "
-            "1 to keep TTFS latency uncontended."
-        ),
-    )
+    add_stt_eval_args(parser, include_max_parallel=False)
 
     args = parser.parse_args()
 

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,0 +1,103 @@
+import argparse
+import ast
+import inspect
+
+import calibrate_agent._cli_args as cli_args
+from calibrate_agent._cli_args import (
+    add_stt_engine_args,
+    add_stt_eval_args,
+    add_stt_max_parallel_arg,
+    add_stt_skip_llm_judges_arg,
+)
+
+
+def _defaults(include_max_parallel):
+    parser = argparse.ArgumentParser()
+    add_stt_eval_args(parser, include_max_parallel=include_max_parallel)
+    return vars(parser.parse_args([]))
+
+
+class TestAddSTTEvalArgs:
+    def test_multi_provider_defaults(self):
+        assert _defaults(include_max_parallel=True) == {
+            "skip_llm_judges": False,
+            "max_parallel": None,
+            "engine": "pipeline",
+            "max_concurrency": None,
+        }
+
+    def test_single_provider_omits_max_parallel(self):
+        ns = _defaults(include_max_parallel=False)
+        assert "max_parallel" not in ns
+        assert ns == {
+            "skip_llm_judges": False,
+            "engine": "pipeline",
+            "max_concurrency": None,
+        }
+
+    def test_values_parse(self):
+        parser = argparse.ArgumentParser()
+        add_stt_eval_args(parser, include_max_parallel=True)
+        ns = parser.parse_args(
+            [
+                "--skip-llm-judges",
+                "--max-parallel",
+                "3",
+                "--engine",
+                "direct",
+                "--max-concurrency",
+                "8",
+            ]
+        )
+        assert (ns.skip_llm_judges, ns.max_parallel, ns.engine, ns.max_concurrency) == (
+            True,
+            3,
+            "direct",
+            8,
+        )
+
+    def test_engine_choices_enforced(self):
+        parser = argparse.ArgumentParser()
+        add_stt_engine_args(parser)
+        try:
+            parser.parse_args(["--engine", "bogus"])
+        except SystemExit:
+            pass
+        else:  # pragma: no cover - fails the assert below
+            raise AssertionError("invalid --engine choice should have been rejected")
+
+
+class TestBuildersComposeConsistently:
+    """The individual builders must produce the same actions add_stt_eval_args does."""
+
+    def test_pieces_match_combined(self):
+        combined = argparse.ArgumentParser()
+        add_stt_eval_args(combined, include_max_parallel=True)
+
+        pieces = argparse.ArgumentParser()
+        add_stt_skip_llm_judges_arg(pieces)
+        add_stt_max_parallel_arg(pieces)
+        add_stt_engine_args(pieces)
+
+        def signature(parser):
+            return {
+                a.dest: (a.option_strings, a.default, a.choices, a.help)
+                for a in parser._actions
+                if a.dest != "help"
+            }
+
+        assert signature(combined) == signature(pieces)
+
+
+class TestStdlibOnly:
+    """cli.py builds its parser via this module before any heavy import, so it
+    must not pull in scipy/numpy/pipecat. Guard that it imports nothing at all."""
+
+    def test_module_has_no_imports(self):
+        tree = ast.parse(inspect.getsource(cli_args))
+        imports = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+        ]
+        assert imports == []


### PR DESCRIPTION
## What
- `--engine`, `--max-concurrency`, `--skip-llm-judges` and `--max-parallel` were copied verbatim across the stt CLI parser, the multi-provider benchmark, and the single-provider eval; each site now calls `add_stt_eval_args()` from a new `calibrate_agent._cli_args`, so help text/defaults/choices can't drift.
- The helper is a top-level sibling of `_env.py` and imports nothing — `cli.py` must build its parser without the heavy `utils`/scipy path, and putting it under `stt/` would have re-triggered that via `stt/__init__.py`.
- `eval.py` is single-provider, so it omits `--max-parallel` via `include_max_parallel=False`.

## Notes
- Behavior-preserving refactor; no flag semantics change. New `tests/test_cli_args.py` guards default/value parity, the single-vs-multi shape, and that the module stays import-free.