### PR TITLE
Judge cost, resume, and decoupling

### DIFF
--- a/COST_TRACKING.md
+++ b/COST_TRACKING.md
@@ -1,8 +1,16 @@
 # Cost tracking
 
-How Calibrate estimates per-provider cost for STT and TTS evaluation runs, the
-shape of the `cost` object written to each provider's `metrics.json`, and the
-caveats to surface anywhere costs are displayed.
+How Calibrate tracks cost for STT and TTS evaluation runs. There are two
+different kinds of number here:
+
+- **Provider cost** is *measured* after a run, from the audio duration or
+  character count actually processed. This is the bulk of the document below:
+  the shape of the `cost` object written to each provider's `metrics.json`,
+  and the caveats to surface anywhere it's displayed.
+- **Judge cost** is *estimated* before a run's LLM-as-judge calls are made,
+  from a token heuristic run over the dataset about to be graded — see
+  "Judge cost" below. It is a different kind of number from provider cost and
+  the two should not be added together casually.
 
 ## Where things live
 
@@ -134,16 +142,108 @@ Google-Sindhi (`gemini-2.5-flash-tts`)_
 No current provider is both audio-billed and INR-priced. The schema supports it:
 shape 5 plus `cost_in_currency` and `conversion_rate` (as in shape 2).
 
+## Judge cost
+
+An LLM-as-judge run issues one paid LLM call per dataset row per evaluator (STT
+also runs three built-in extra judges beyond the configured evaluator — see
+the STT/TTS CLI docs). Before any of those calls is made, Calibrate estimates
+what the whole judge phase will cost and asks for confirmation. Unlike
+provider cost above, this number is computed **before** the work happens, from
+an approximation of the input — it is a budgeting estimate, not a bill.
+
+**Where things live:**
+
+- **Rates:** the `llm` section of
+  [`calibrate_agent/pricing_data.json`](calibrate_agent/pricing_data.json) —
+  keyed by the full model id used by the judges (e.g.
+  `"anthropic/claude-sonnet-4.5"`), USD per million tokens. Each model's entry
+  has two columns, `openrouter` and `direct`:
+
+  ```jsonc
+  "anthropic/claude-sonnet-4.5": {
+    "openrouter": {
+      "input_price_per_million_tokens_usd": 3.0,
+      "output_price_per_million_tokens_usd": 15.0
+    },
+    "direct": {
+      "input_price_per_million_tokens_usd": 3.0,
+      "output_price_per_million_tokens_usd": 15.0
+    }
+  }
+  ```
+
+  An entry may also carry `audio_input_price_per_million_tokens_usd` /
+  `audio_output_price_per_million_tokens_usd` (models priced separately for
+  audio) and `reasoning_billed_as_output: true` (models that bill hidden
+  reasoning tokens at the output rate). Four models are priced today, the
+  judge defaults: `openai/gpt-5.4-mini` (the text evaluators, e.g.
+  `semantic_match`), `openai/gpt-audio` (the TTS `pronunciation` evaluator),
+  `google/gemini-2.5-flash` (the two Sarvam-derived STT judges), and
+  `anthropic/claude-sonnet-4.5` (semantic WER).
+- **Resolution:** `resolve_llm_pricing(model, source)` in
+  [`calibrate_agent/pricing.py`](calibrate_agent/pricing.py) — looks up one
+  model's rate entry for the `"openrouter"` or `"direct"` source, returning
+  `None` (not an error) when the model has no rates so an unpriced judge model
+  doesn't block the estimate.
+- **Estimate and confirmation:**
+  [`calibrate_agent/judge_cost.py`](calibrate_agent/judge_cost.py) —
+  `estimate_judge_cost_all_sources` prices the run's judge workload against
+  both `openrouter` and `direct`, `format_cost_estimate` renders the result as
+  text, and `confirm_judge_cost` prints that text and gates the run on a `y`
+  answer.
+- **Resumable grading:** [`calibrate_agent/judge_store.py`](calibrate_agent/judge_store.py)
+  — a separate mechanism from cost estimation. `JudgeStore` writes every
+  judge result to `judge_cache.jsonl` in the run's output directory the
+  moment it's computed, so an interrupted or partly failed judge run resumes
+  instead of re-grading (and re-paying for) rows already graded. The cache
+  key fingerprints the judge input together with the evaluator's system
+  prompt and judge model, so editing a prompt, changing the model, or
+  re-transcribing a row invalidates that row's cached grade rather than
+  returning it stale. `--overwrite` discards the cache along with
+  `results.csv`.
+
+**The token heuristic.** There is no tokenizer dependency, so token counts are
+approximated from character counts, weighted by writing system: Latin text at
+about 4 characters per token, Indic scripts (Devanagari through Malayalam) and
+Arabic at about 1.5 characters per token. A flat chars/4 rule holds for Latin
+text but undercounts Indic text by 2-3x, and Calibrate's datasets are largely
+Hindi, Kannada, and Telugu, so the split matters for the estimate to be
+usable. Mixed-script text is counted character by character, landing between
+the two pure rates. These are approximations of what a real tokenizer would
+count, not a measurement.
+
+**Audio is billed per token, not per minute.** The audio judge model
+(`openai/gpt-audio`) charges $32.00 per million audio input tokens. Audio
+duration is converted to tokens at roughly 10 audio tokens per second before
+it's priced — a different unit, and a different conversion, from the
+per-minute rates provider TTS/STT cost uses above.
+
+**The thinking-token allowance.** Gemini 2.5 Flash (`reasoning_billed_as_output:
+true`) bills hidden thinking tokens at its output rate; those tokens never
+appear in the visible response, so an estimate built from the visible answer
+alone would run low. The estimate compensates by multiplying that model's
+output-token figure by 3 before pricing it — a deliberately generous
+multiplier, since quoting too high is recoverable and quoting too low is not.
+
+**OpenRouter vs. direct.** Every model is priced under both `openrouter` and
+`direct` sources and both totals are shown. OpenRouter charges provider list
+price on all four models currently priced, so the two totals normally match;
+reporting both makes a divergence visible if one ever appears, and lets a
+direct-API user read the column that applies to them.
+
 ## Caveats (surface these wherever cost is displayed)
 
 - **Bundled, point-in-time rates.** Costs are estimated from a rate table
   captured ~July 2026, not live provider pricing — they drift as providers
-  change prices.
+  change prices. This applies to the `llm` rates behind the judge cost
+  estimate exactly as it does to the `stt`/`tts` rates above.
 - **Entry tier assumed.** We use the standard pay-as-you-go / entry tier;
-  volume or committed-use discounts and free tiers are not modeled.
+  volume or committed-use discounts and free tiers are not modeled — for the
+  judge models as much as for STT/TTS providers.
 - **Provider billing quirks not modeled.** Per-request minimums, billing
   increments/rounding, and taxes (GST) are ignored, so estimates run low for
-  many short requests.
+  many short requests. OpenRouter and provider billing minimums, rounding,
+  and negotiated discounts are equally unmodeled in the judge cost estimate.
 - **One variant per provider.** Each provider is priced at a single model/tier
   we selected — Cartesia entry (Pro) tier, ElevenLabs `eleven_multilingual_v2`,
   Deepgram nova-3 streaming, Smallest standard Lightning / standalone Pulse —
@@ -155,3 +255,12 @@ shape 5 plus `cost_in_currency` and `conversion_rate` (as in shape 2).
 - **INR converted via live mid-market FX.** For INR-billed providers, `cost_usd`
   uses a live mid-market USD→INR rate, which excludes the FX margin and GST a
   real payment would incur.
+- **Judge cost is an estimate computed before the work happens, not a
+  measurement of what was billed.** It is built from the character-based
+  token heuristic above, not a real tokenizer, so the token counts — and
+  therefore the total — are approximate; the provider's actual reported usage
+  for the same run will differ.
+- **The audio-tokens-per-second conversion is a fixed approximation.** The
+  ~10-tokens/second figure used to price the audio judge is not derived from
+  the specific audio being judged; actual billed audio tokens depend on the
+  audio's real encoding and length.

--- a/calibrate_agent/_cli_args.py
+++ b/calibrate_agent/_cli_args.py
@@ -1,11 +1,14 @@
-"""Shared argparse builders for the STT eval/benchmark CLIs.
+"""Shared argparse builders for the STT/TTS eval/benchmark CLIs.
 
 The ``--skip-llm-judges``, ``--max-parallel``, ``--engine`` and
 ``--max-concurrency`` flags are accepted by three entry points that must stay in
 lock-step: the top-level ``calibrate-agent stt`` parser (``calibrate_agent.cli``),
 the multi-provider benchmark (``calibrate_agent.stt.benchmark``) and the
-single-provider eval (``calibrate_agent.stt.eval``). Defining each flag once here
-keeps their help text, defaults and choices from drifting apart.
+single-provider eval (``calibrate_agent.stt.eval``). ``--yes`` is accepted by a
+wider set of entry points — the top-level ``stt``/``tts`` parsers plus both
+their benchmarks — since both eval kinds show a judge cost estimate before
+running. Defining each flag once here keeps their help text, defaults and
+choices from drifting apart.
 
 Deliberately stdlib-only (imports nothing): ``calibrate_agent.cli`` builds its
 parser by calling these, and the CLI must build its parser *without* importing
@@ -66,6 +69,19 @@ def add_stt_engine_args(parser):
             "Concurrent clips per provider, both engines (default: pipeline 1, "
             "direct 4; or $CALIBRATE_STT_MAX_CONCURRENCY). Pipeline defaults to "
             "1 to keep TTFS latency uncontended."
+        ),
+    )
+
+
+def add_assume_yes_arg(parser):
+    """Add ``--yes`` (skip the judge cost confirmation prompt)."""
+    parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help=(
+            "Proceed with the LLM-as-judge run without the interactive "
+            "cost-confirmation prompt."
         ),
     )
 

--- a/calibrate_agent/_cli_args.py
+++ b/calibrate_agent/_cli_args.py
@@ -1,6 +1,6 @@
 """Shared argparse builders for the STT/TTS eval/benchmark CLIs.
 
-The ``--skip-llm-judges``, ``--max-parallel``, ``--engine`` and
+The ``--skip-llm-judges``, ``--judges``, ``--max-parallel``, ``--engine`` and
 ``--max-concurrency`` flags are accepted by three entry points that must stay in
 lock-step: the top-level ``calibrate-agent stt`` parser (``calibrate_agent.cli``),
 the multi-provider benchmark (``calibrate_agent.stt.benchmark``) and the
@@ -17,16 +17,78 @@ and trips a scipy ``_CopyMode`` incompatibility in the voice path. Like
 ``calibrate_agent._env``, this module must never grow a non-stdlib import.
 """
 
+STT_LLM_JUDGES = ("intent", "llm_wer", "semantic_wer")
+DEFAULT_STT_LLM_JUDGES = frozenset(STT_LLM_JUDGES)
+
+
+def parse_stt_llm_judges(value: str) -> frozenset[str]:
+    """Parse a comma-separated ``--judges`` value into a frozenset of names.
+
+    Raises ``ValueError`` on an empty list or unknown name so argparse
+    surfaces a clear usage error (argparse converts ``ValueError`` from a
+    ``type=`` callable into an argument error).
+    """
+    names = {part.strip() for part in value.split(",") if part.strip()}
+    if not names:
+        raise ValueError(
+            "expected a comma-separated list of judge names; "
+            f"choose from: {', '.join(STT_LLM_JUDGES)}"
+        )
+    unknown = names - DEFAULT_STT_LLM_JUDGES
+    if unknown:
+        raise ValueError(
+            f"unknown judge name(s): {', '.join(sorted(unknown))}; "
+            f"choose from: {', '.join(STT_LLM_JUDGES)}"
+        )
+    return frozenset(names)
+
+
+def resolve_stt_llm_judges(
+    *, skip_llm_judges: bool, judges: frozenset[str] | None
+) -> frozenset[str]:
+    """Resolve which built-in STT LLM judges to run.
+
+    ``--skip-llm-judges`` and ``--judges`` are mutually exclusive. Omitting
+    both returns all three judges (today's default). Passing
+    ``--skip-llm-judges`` returns an empty set. Passing ``--judges`` returns
+    that subset.
+    """
+    if skip_llm_judges and judges is not None:
+        raise SystemExit(
+            "error: --judges and --skip-llm-judges are mutually exclusive"
+        )
+    if skip_llm_judges:
+        return frozenset()
+    if judges is None:
+        return DEFAULT_STT_LLM_JUDGES
+    return judges
+
 
 def add_stt_skip_llm_judges_arg(parser):
-    """Add ``--skip-llm-judges`` (report WER/CER only, no extra LLM judges)."""
+    """Add ``--skip-llm-judges`` (skip all three built-in LLM judges)."""
     parser.add_argument(
         "--skip-llm-judges",
         action="store_true",
         help=(
-            "Skip the extra LLM-based judges (Sarvam intent & entity "
+            "Skip all three built-in LLM judges (Sarvam intent & entity "
             "preservation, Sarvam LLM-WER/CER, and pipecat-style semantic WER). "
-            "They all run by default; passing this reports WER/CER only."
+            "Mutually exclusive with --judges. Config evaluators are unaffected."
+        ),
+    )
+
+
+def add_stt_judges_arg(parser):
+    """Add ``--judges`` (opt-in subset of the three built-in LLM judges)."""
+    parser.add_argument(
+        "--judges",
+        type=parse_stt_llm_judges,
+        default=None,
+        metavar="NAMES",
+        help=(
+            "Comma-separated subset of built-in LLM judges to run: "
+            "intent, llm_wer, semantic_wer. Omit to run all three. "
+            "Mutually exclusive with --skip-llm-judges. Config evaluators "
+            "are unaffected."
         ),
     )
 
@@ -93,6 +155,7 @@ def add_stt_eval_args(parser, *, include_max_parallel):
     (``cli`` / ``benchmark``) and ``False`` for the single-provider eval.
     """
     add_stt_skip_llm_judges_arg(parser)
+    add_stt_judges_arg(parser)
     if include_max_parallel:
         add_stt_max_parallel_arg(parser)
     add_stt_engine_args(parser)

--- a/calibrate_agent/cli.py
+++ b/calibrate_agent/cli.py
@@ -30,7 +30,7 @@ from dotenv import find_dotenv, load_dotenv
 # which pulls in scipy/numpy/pipecat and trips a scipy ``_CopyMode``
 # incompatibility in the voice path if imported here.
 from calibrate_agent._env import env_int
-from calibrate_agent._cli_args import add_stt_eval_args
+from calibrate_agent._cli_args import add_assume_yes_arg, add_stt_eval_args
 
 
 def _args_to_argv(args, exclude_keys=None, flag_mapping=None):
@@ -241,6 +241,7 @@ Examples:
         help="Path to dataset JSON (list of {id, gt, pred}). Required with --eval-only.",
     )
     add_stt_eval_args(stt_parser, include_max_parallel=True)
+    add_assume_yes_arg(stt_parser)
 
     # ── TTS ───────────────────────────────────────────────────────
     # `calibrate-agent tts` with no args → interactive UI
@@ -299,6 +300,7 @@ Examples:
             "is read directly. Required with --eval-only."
         ),
     )
+    add_assume_yes_arg(tts_parser)
 
     # ── LLM tests ───────────────────────────────────────────────
     # `calibrate-agent llm` with no args → interactive UI
@@ -559,6 +561,8 @@ Examples:
                 argv.extend(["--config", args.config])
             if args.skip_llm_judges:
                 argv.append("--skip-llm-judges")
+            if args.yes:
+                argv.append("--yes")
 
             sys.argv = argv
             asyncio.run(stt_benchmark_main())
@@ -592,6 +596,8 @@ Examples:
             if args.max_concurrency is not None:
                 argv.extend(["--max-concurrency", str(args.max_concurrency)])
             argv.extend(["--engine", args.engine])
+            if args.yes:
+                argv.append("--yes")
 
             sys.argv = argv
             asyncio.run(stt_benchmark_main())
@@ -613,6 +619,8 @@ Examples:
             argv.extend(["-o", args.output_dir])
             if args.config:
                 argv.extend(["--config", args.config])
+            if args.yes:
+                argv.append("--yes")
 
             sys.argv = argv
             asyncio.run(tts_benchmark_main())
@@ -632,6 +640,8 @@ Examples:
             if args.config:
                 argv.extend(["--config", args.config])
             argv.extend(["--max-parallel", str(args.max_parallel)])
+            if args.yes:
+                argv.append("--yes")
 
             sys.argv = argv
             asyncio.run(tts_benchmark_main())

--- a/calibrate_agent/cli.py
+++ b/calibrate_agent/cli.py
@@ -561,6 +561,8 @@ Examples:
                 argv.extend(["--config", args.config])
             if args.skip_llm_judges:
                 argv.append("--skip-llm-judges")
+            if args.judges is not None:
+                argv.extend(["--judges", ",".join(sorted(args.judges))])
             if args.yes:
                 argv.append("--yes")
 
@@ -588,6 +590,8 @@ Examples:
                 argv.extend(["--config", args.config])
             if args.skip_llm_judges:
                 argv.append("--skip-llm-judges")
+            if args.judges is not None:
+                argv.extend(["--judges", ",".join(sorted(args.judges))])
             # Only forward the parallelism knobs when the user set them
             # explicitly; otherwise let the benchmark resolve the per-engine
             # default (pipeline 1/1, direct 2/4).

--- a/calibrate_agent/judge_cost.py
+++ b/calibrate_agent/judge_cost.py
@@ -23,6 +23,7 @@ import sys
 from dataclasses import dataclass
 from typing import Callable, Optional, Sequence, TextIO
 
+from calibrate_agent._cli_args import DEFAULT_STT_LLM_JUDGES
 from calibrate_agent.judges import (
     DEFAULT_AUDIO_JUDGE_MODEL,
     DEFAULT_TEXT_JUDGE_MODEL,
@@ -163,19 +164,20 @@ def build_stt_judge_groups(
     references: Sequence[str],
     predictions: Optional[Sequence[str]] = None,
     evaluators: Optional[Sequence[dict]] = None,
-    run_llm_judges: bool = True,
+    llm_judges: frozenset[str] | None = None,
     providers: int = 1,
 ) -> list[JudgeCallGroup]:
     """Build the judge workload for an STT run, mirroring ``_score_and_write_results``.
 
     One group per judge that will actually run: the user ``evaluators`` (via
     ``get_llm_judge_score``), grouped by resolved model so a config mixing
-    models prices correctly; the Sarvam intent/entity judge; the Sarvam
-    LLM-WER/CER judge; and the semantic WER judge, split into its two calls
-    per row (a free-form reasoning call, then a forced tool-call commit). The
-    three built-in judges only appear when ``run_llm_judges`` is True; the
-    evaluators group only appears when ``evaluators`` is non-empty. Returns
-    ``[]`` when neither would run, or when ``references`` is empty.
+    models prices correctly; and each enabled built-in judge from
+    ``llm_judges`` (``intent``, ``llm_wer``, ``semantic_wer``). ``llm_judges``
+    of ``None`` means all three; an empty frozenset means none. Semantic WER
+    splits into two call groups per row (free-form reasoning, then a forced
+    tool-call commit). The evaluators group only appears when ``evaluators``
+    is non-empty. Returns ``[]`` when neither would run, or when
+    ``references`` is empty.
 
     The Sarvam LLM-WER/CER judge actually calls its equivalence judge once per
     *unique differing word segment* after alignment, not once per row — but
@@ -196,6 +198,7 @@ def build_stt_judge_groups(
     if n == 0:
         return []
     preds = list(predictions) if predictions is not None else list(references)
+    enabled = DEFAULT_STT_LLM_JUDGES if llm_judges is None else llm_judges
 
     groups: list[JudgeCallGroup] = []
 
@@ -227,22 +230,16 @@ def build_stt_judge_groups(
                 )
             )
 
-    if run_llm_judges:
-        # Deferred: importing sarvam_intent_entity eagerly pulls in
-        # transformers/indic-nlp/joblib (see stt/metrics.py), which should only
-        # happen when these judges are actually going to run.
+    if not enabled:
+        return groups
+
+    # Deferred: importing sarvam_intent_entity eagerly pulls in
+    # transformers/indic-nlp/joblib (see stt/metrics.py), which should only
+    # happen when these judges are actually going to run.
+    if "intent" in enabled:
         from calibrate_agent.stt.sarvam_intent_entity import (
             DEFAULT_INTENT_ENTITY_MODEL,
             build_prompt as build_intent_entity_prompt,
-        )
-        from calibrate_agent.stt.sarvam_llm_wer import (
-            DEFAULT_LLM_WER_MODEL,
-            build_prompt as build_llm_wer_prompt,
-        )
-        from calibrate_agent.stt.semantic_wer import (
-            DEFAULT_SEMANTIC_WER_MODEL,
-            SYSTEM_PROMPT as SEMANTIC_WER_SYSTEM_PROMPT,
-            build_user_prompt as build_semantic_wer_user_prompt,
         )
 
         intent_entity_tokens = _mean_tokens(
@@ -268,6 +265,12 @@ def build_stt_judge_groups(
             )
         )
 
+    if "llm_wer" in enabled:
+        from calibrate_agent.stt.sarvam_llm_wer import (
+            DEFAULT_LLM_WER_MODEL,
+            build_prompt as build_llm_wer_prompt,
+        )
+
         llm_wer_tokens = _mean_tokens(
             estimate_tokens(build_llm_wer_prompt({"reference": ref, "prediction": pred}))
             for ref, pred in zip(references, preds)
@@ -280,6 +283,13 @@ def build_stt_judge_groups(
                 input_tokens_per_call=llm_wer_tokens,
                 output_tokens_per_call=LLM_WER_OUTPUT_TOKENS,
             )
+        )
+
+    if "semantic_wer" in enabled:
+        from calibrate_agent.stt.semantic_wer import (
+            DEFAULT_SEMANTIC_WER_MODEL,
+            SYSTEM_PROMPT as SEMANTIC_WER_SYSTEM_PROMPT,
+            build_user_prompt as build_semantic_wer_user_prompt,
         )
 
         semantic_wer_system_tokens = estimate_tokens(SEMANTIC_WER_SYSTEM_PROMPT)

--- a/calibrate_agent/judge_cost.py
+++ b/calibrate_agent/judge_cost.py
@@ -1,0 +1,613 @@
+"""Up-front cost estimate for LLM-as-judge grading.
+
+A judge run issues one LLM call per dataset row per evaluator, so a large
+dataset turns into thousands of paid calls. This module estimates what that
+will cost before any call is made, and offers a confirmation gate so the run
+can be abandoned while it is still free.
+
+The workload is described as a list of :class:`JudgeCallGroup` — one per judge,
+each carrying its model, its call count, and the per-call token sizes.
+:func:`estimate_judge_cost_all_sources` prices those groups from the bundled
+rate table, :func:`format_cost_estimate` renders the result, and
+:func:`confirm_judge_cost` asks the user whether to continue.
+
+Token counts are estimated from character counts, weighted by writing system —
+there is no tokenizer dependency, so the figures are approximations.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+from dataclasses import dataclass
+from typing import Callable, Optional, Sequence, TextIO
+
+from calibrate_agent.judges import (
+    DEFAULT_AUDIO_JUDGE_MODEL,
+    DEFAULT_TEXT_JUDGE_MODEL,
+    DEFAULT_TTS_EVALUATOR,
+)
+from calibrate_agent.pricing import LLM_PRICING_SOURCES, resolve_llm_pricing
+
+# Unicode ranges whose characters cost far more tokens per character than
+# Latin text does: the Indic scripts (Devanagari through Malayalam) and Arabic
+# (the script Sindhi is written in).
+INDIC_ARABIC_RANGES = (
+    (0x0600, 0x06FF),  # Arabic
+    (0x0750, 0x077F),  # Arabic Supplement
+    (0x0900, 0x097F),  # Devanagari
+    (0x0980, 0x09FF),  # Bengali
+    (0x0A00, 0x0A7F),  # Gurmukhi
+    (0x0A80, 0x0AFF),  # Gujarati
+    (0x0B00, 0x0B7F),  # Odia
+    (0x0B80, 0x0BFF),  # Tamil
+    (0x0C00, 0x0C7F),  # Telugu
+    (0x0C80, 0x0CFF),  # Kannada
+    (0x0D00, 0x0D7F),  # Malayalam
+)
+
+# Characters per token. The flat chars/4 rule of thumb holds for Latin text but
+# undercounts Indic text by 2-3x, and the datasets are largely Hindi, Kannada
+# and Telugu, so the two writing systems are counted at separate rates.
+CHARS_PER_TOKEN_LATIN = 4.0
+CHARS_PER_TOKEN_INDIC = 1.5
+
+# Audio input tokens per second of audio, at OpenAI's tokenization rate. The
+# audio judge model bills audio per token, not per minute, so measured duration
+# has to be converted into tokens before it can be priced.
+AUDIO_TOKENS_PER_SECOND = 10.0
+
+# Tokens of text spoken per second of speech. Used to size audio that does not
+# exist yet (a TTS estimate is made before anything is synthesized).
+SPOKEN_TOKENS_PER_SECOND = 3.5
+
+# Multiplier applied to the output-token estimate for models that bill hidden
+# reasoning tokens at the output rate. Those tokens never appear in the
+# response, so an estimate built from the visible answer alone runs low. The
+# multiplier is deliberately generous: quoting too high is recoverable,
+# quoting too low is not.
+REASONING_TOKEN_MULTIPLIER = 3.0
+
+# Output-token allowances for each judge's reply shape, used by the group
+# builders below. Every judge caps its call far higher than these (noted per
+# constant); each value is a deliberately modest guess at what a real reply
+# actually contains, not the saturation point of the cap.
+
+# STT/TTS evaluator judges (``_judge_one_text`` / ``_judge_one_audio`` in
+# judges.py, capped at max_completion_tokens=8192): a short ``reasoning``
+# string plus a one-field verdict (``match`` or ``score``).
+EVALUATOR_OUTPUT_TOKENS = 300
+
+# Sarvam intent/entity judge (``IntentEntityResponse``, capped at
+# max_completion_tokens=8192): five text fields (two explanations plus three
+# entity lists) rather than one, so it runs larger than a single evaluator
+# verdict.
+INTENT_ENTITY_OUTPUT_TOKENS = 600
+
+# Sarvam LLM-WER/CER equivalence judge (``LLMEquivalenceResponse``, capped at
+# max_completion_tokens=8192): a bool plus one short ``reasoning`` string —
+# the smallest reply of the structured judges.
+LLM_WER_OUTPUT_TOKENS = 200
+
+# Semantic WER phase 1 — the free-form NORMALIZE/ALIGN/SEMANTIC-CHECK
+# reasoning (capped at max_tokens=4096). It has no fixed schema, so this is a
+# rough middle ground rather than a reply-shape derivation.
+SEMANTIC_WER_REASONING_OUTPUT_TOKENS = 500
+
+# Semantic WER phase 2 — the forced ``calculate_wer`` tool call (capped at
+# max_tokens=4096). Besides small counts/summary fields, its arguments echo
+# back the row's *entire* normalized reference and hypothesis, so its size
+# scales with the row's own text; callers add the row's own token count on top
+# of this fixed allowance for the rest of the call.
+SEMANTIC_WER_TOOL_CALL_OVERHEAD_TOKENS = 150
+
+_ENV_ASSUME_YES = "CALIBRATE_ASSUME_YES"
+
+
+def _is_indic_or_arabic(char: str) -> bool:
+    code_point = ord(char)
+    return any(start <= code_point <= end for start, end in INDIC_ARABIC_RANGES)
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate how many tokens ``text`` will be billed as.
+
+    Each character is classified by Unicode block and counted at its script's
+    characters-per-token rate, so mixed-script text lands between the pure
+    cases. Unclassified characters count at the Latin rate. Empty or
+    whitespace-only text is 0 tokens; anything else is at least 1.
+    """
+    if not text or not text.strip():
+        return 0
+
+    indic_chars = sum(1 for char in text if _is_indic_or_arabic(char))
+    latin_chars = len(text) - indic_chars
+    tokens = (
+        indic_chars / CHARS_PER_TOKEN_INDIC + latin_chars / CHARS_PER_TOKEN_LATIN
+    )
+    return max(1, math.ceil(tokens))
+
+
+def estimate_audio_seconds_from_text(text: str) -> float:
+    """Estimate how many seconds of speech ``text`` becomes when synthesized.
+
+    Derived from the token estimate rather than the character count, which
+    keeps the implied speaking rate roughly script-invariant: a Devanagari
+    character carries more speech than a Latin one.
+    """
+    return estimate_tokens(text) / SPOKEN_TOKENS_PER_SECOND
+
+
+@dataclass
+class JudgeCallGroup:
+    """One judge's workload: the same model and call shape repeated ``calls`` times."""
+
+    label: str
+    model: str
+    calls: int
+    input_tokens_per_call: int
+    output_tokens_per_call: int
+    audio_seconds_per_call: float = 0.0
+
+
+def _mean_tokens(values) -> int:
+    """Return the rounded mean of an iterable of token counts, or 0 if empty."""
+    values = list(values)
+    if not values:
+        return 0
+    return int(round(sum(values) / len(values)))
+
+
+def build_stt_judge_groups(
+    references: Sequence[str],
+    predictions: Optional[Sequence[str]] = None,
+    evaluators: Optional[Sequence[dict]] = None,
+    run_llm_judges: bool = True,
+    providers: int = 1,
+) -> list[JudgeCallGroup]:
+    """Build the judge workload for an STT run, mirroring ``_score_and_write_results``.
+
+    One group per judge that will actually run: the user ``evaluators`` (via
+    ``get_llm_judge_score``), grouped by resolved model so a config mixing
+    models prices correctly; the Sarvam intent/entity judge; the Sarvam
+    LLM-WER/CER judge; and the semantic WER judge, split into its two calls
+    per row (a free-form reasoning call, then a forced tool-call commit). The
+    three built-in judges only appear when ``run_llm_judges`` is True; the
+    evaluators group only appears when ``evaluators`` is non-empty. Returns
+    ``[]`` when neither would run, or when ``references`` is empty.
+
+    The Sarvam LLM-WER/CER judge actually calls its equivalence judge once per
+    *unique differing word segment* after alignment, not once per row — but
+    the segments don't exist until WER is computed, so this approximates one
+    call per row using each row's full (reference, prediction) text as a
+    stand-in segment (over-counting short/matching rows, under-counting rows
+    with several differing segments).
+
+    ``predictions`` is the STT hypothesis for each reference. When omitted (a
+    benchmark estimate runs before any transcription happens), each row's
+    prediction is assumed to be the same size as its reference, since the real
+    text doesn't exist yet.
+
+    ``providers`` multiplies every group's call count: a multi-provider
+    benchmark runs every judge once per provider's transcriptions.
+    """
+    n = len(references)
+    if n == 0:
+        return []
+    preds = list(predictions) if predictions is not None else list(references)
+
+    groups: list[JudgeCallGroup] = []
+
+    if evaluators:
+        by_model: dict[str, list[dict]] = {}
+        for ev in evaluators:
+            model = ev.get("judge_model") or DEFAULT_TEXT_JUDGE_MODEL
+            by_model.setdefault(model, []).append(ev)
+
+        # The STT evaluator user prompt (``stt_llm_judge`` in stt/metrics.py)
+        # doesn't depend on the evaluator, so its average is computed once and
+        # added to each model group's own average system-prompt size.
+        avg_user_tokens = _mean_tokens(
+            estimate_tokens(f"Source: {ref}\nTranscription: {pred}")
+            for ref, pred in zip(references, preds)
+        )
+
+        for model, evs in by_model.items():
+            avg_system_tokens = _mean_tokens(
+                estimate_tokens(ev.get("system_prompt", "")) for ev in evs
+            )
+            groups.append(
+                JudgeCallGroup(
+                    label=f"STT evaluators ({', '.join(ev['name'] for ev in evs)})",
+                    model=model,
+                    calls=n * len(evs) * providers,
+                    input_tokens_per_call=avg_system_tokens + avg_user_tokens,
+                    output_tokens_per_call=EVALUATOR_OUTPUT_TOKENS,
+                )
+            )
+
+    if run_llm_judges:
+        # Deferred: importing sarvam_intent_entity eagerly pulls in
+        # transformers/indic-nlp/joblib (see stt/metrics.py), which should only
+        # happen when these judges are actually going to run.
+        from calibrate_agent.stt.sarvam_intent_entity import (
+            DEFAULT_INTENT_ENTITY_MODEL,
+            build_prompt as build_intent_entity_prompt,
+        )
+        from calibrate_agent.stt.sarvam_llm_wer import (
+            DEFAULT_LLM_WER_MODEL,
+            build_prompt as build_llm_wer_prompt,
+        )
+        from calibrate_agent.stt.semantic_wer import (
+            DEFAULT_SEMANTIC_WER_MODEL,
+            SYSTEM_PROMPT as SEMANTIC_WER_SYSTEM_PROMPT,
+            build_user_prompt as build_semantic_wer_user_prompt,
+        )
+
+        intent_entity_tokens = _mean_tokens(
+            estimate_tokens(
+                build_intent_entity_prompt(
+                    {
+                        "index": i,
+                        "hypothesis": pred,
+                        "ground_truth": ref,
+                        "context": "",
+                    }
+                )
+            )
+            for i, (ref, pred) in enumerate(zip(references, preds))
+        )
+        groups.append(
+            JudgeCallGroup(
+                label="Sarvam intent/entity",
+                model=DEFAULT_INTENT_ENTITY_MODEL,
+                calls=n * providers,
+                input_tokens_per_call=intent_entity_tokens,
+                output_tokens_per_call=INTENT_ENTITY_OUTPUT_TOKENS,
+            )
+        )
+
+        llm_wer_tokens = _mean_tokens(
+            estimate_tokens(build_llm_wer_prompt({"reference": ref, "prediction": pred}))
+            for ref, pred in zip(references, preds)
+        )
+        groups.append(
+            JudgeCallGroup(
+                label="Sarvam LLM-WER/CER",
+                model=DEFAULT_LLM_WER_MODEL,
+                calls=n * providers,
+                input_tokens_per_call=llm_wer_tokens,
+                output_tokens_per_call=LLM_WER_OUTPUT_TOKENS,
+            )
+        )
+
+        semantic_wer_system_tokens = estimate_tokens(SEMANTIC_WER_SYSTEM_PROMPT)
+        semantic_wer_user_tokens = _mean_tokens(
+            estimate_tokens(build_semantic_wer_user_prompt(ref, pred))
+            for ref, pred in zip(references, preds)
+        )
+        semantic_wer_row_text_tokens = _mean_tokens(
+            estimate_tokens(ref) + estimate_tokens(pred)
+            for ref, pred in zip(references, preds)
+        )
+        groups.append(
+            JudgeCallGroup(
+                label="Semantic WER (reasoning)",
+                model=DEFAULT_SEMANTIC_WER_MODEL,
+                calls=n * providers,
+                input_tokens_per_call=semantic_wer_system_tokens
+                + semantic_wer_user_tokens,
+                output_tokens_per_call=SEMANTIC_WER_REASONING_OUTPUT_TOKENS,
+            )
+        )
+        groups.append(
+            JudgeCallGroup(
+                label="Semantic WER (commit)",
+                model=DEFAULT_SEMANTIC_WER_MODEL,
+                calls=n * providers,
+                # Phase 2 replays phase 1's prompt plus its reasoning plus a
+                # short nudge, so it costs strictly more input than phase 1;
+                # approximated by adding phase 1's own output-token estimate.
+                input_tokens_per_call=(
+                    semantic_wer_system_tokens
+                    + semantic_wer_user_tokens
+                    + SEMANTIC_WER_REASONING_OUTPUT_TOKENS
+                ),
+                output_tokens_per_call=semantic_wer_row_text_tokens
+                + SEMANTIC_WER_TOOL_CALL_OVERHEAD_TOKENS,
+            )
+        )
+
+    return groups
+
+
+def build_tts_judge_groups(
+    texts: Sequence[str],
+    audio_seconds: Optional[Sequence[float]] = None,
+    evaluators: Optional[Sequence[dict]] = None,
+    providers: int = 1,
+) -> list[JudgeCallGroup]:
+    """Build the judge workload for a TTS run, mirroring ``tts_llm_judge``.
+
+    One group per resolved evaluator model (evaluators are grouped by model,
+    like :func:`build_stt_judge_groups`); every call carries the row's audio.
+    ``audio_seconds[i]`` is used when known (a prior synthesis run's measured
+    duration); a row with no known duration (or when ``audio_seconds`` is
+    omitted entirely — a benchmark estimate runs before anything is
+    synthesized) falls back to :func:`estimate_audio_seconds_from_text`.
+    Returns ``[]`` when ``texts`` is empty.
+
+    ``providers`` multiplies every group's call count: a multi-provider
+    benchmark judges every provider's synthesized audio separately.
+    """
+    n = len(texts)
+    if n == 0:
+        return []
+    _evaluators = list(evaluators) if evaluators else [DEFAULT_TTS_EVALUATOR]
+
+    durations = list(audio_seconds) if audio_seconds is not None else [None] * n
+    if len(durations) < n:
+        durations = durations + [None] * (n - len(durations))
+    resolved_durations = [
+        d if d is not None else estimate_audio_seconds_from_text(str(t))
+        for d, t in zip(durations, texts)
+    ]
+    avg_duration = sum(resolved_durations) / n
+
+    # The audio judge's text preamble (``audio_judge`` in judges.py) doesn't
+    # depend on the evaluator, so its average is computed once and added to
+    # each model group's own average system-prompt size.
+    avg_preamble_tokens = _mean_tokens(
+        estimate_tokens(f"Reference text: {t}\n\nAudio:") for t in texts
+    )
+
+    by_model: dict[str, list[dict]] = {}
+    for ev in _evaluators:
+        model = ev.get("judge_model") or DEFAULT_AUDIO_JUDGE_MODEL
+        by_model.setdefault(model, []).append(ev)
+
+    groups: list[JudgeCallGroup] = []
+    for model, evs in by_model.items():
+        avg_system_tokens = _mean_tokens(
+            estimate_tokens(ev.get("system_prompt", "")) for ev in evs
+        )
+        groups.append(
+            JudgeCallGroup(
+                label=f"TTS evaluators ({', '.join(ev['name'] for ev in evs)})",
+                model=model,
+                calls=n * len(evs) * providers,
+                input_tokens_per_call=avg_system_tokens + avg_preamble_tokens,
+                output_tokens_per_call=EVALUATOR_OUTPUT_TOKENS,
+                audio_seconds_per_call=avg_duration,
+            )
+        )
+    return groups
+
+
+def estimate_judge_cost(
+    groups: Sequence[JudgeCallGroup],
+    source: str = "openrouter",
+) -> dict:
+    """Price ``groups`` against the ``source`` rate table.
+
+    Text input tokens bill at the input rate and output tokens at the output
+    rate, scaled by :data:`REASONING_TOKEN_MULTIPLIER` where the model bills
+    reasoning as output. Audio seconds convert to tokens at
+    :data:`AUDIO_TOKENS_PER_SECOND` and bill at the model's audio input rate,
+    falling back to its text input rate when it prices audio as text.
+
+    Returns the per-group breakdown, ``total_usd`` over the priced groups, and
+    the sorted list of models with no rates in ``unpriced``. A group whose
+    model is unpriced is reported with ``priced: False`` and contributes
+    nothing to the total, so an unknown model does not block the estimate.
+    """
+    group_rows: list[dict] = []
+    unpriced: set[str] = set()
+    total_usd = 0.0
+
+    for group in groups:
+        input_tokens = group.input_tokens_per_call * group.calls
+        output_tokens = group.output_tokens_per_call * group.calls
+        audio_tokens = int(
+            round(group.audio_seconds_per_call * AUDIO_TOKENS_PER_SECOND * group.calls)
+        )
+        row = {
+            "label": group.label,
+            "model": group.model,
+            "calls": group.calls,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "audio_tokens": audio_tokens,
+            "cost_usd": 0.0,
+            "priced": False,
+        }
+
+        pricing = resolve_llm_pricing(group.model, source=source)
+        if pricing is None:
+            unpriced.add(group.model)
+            group_rows.append(row)
+            continue
+
+        input_rate = pricing["input_price_per_million_tokens_usd"]
+        output_rate = pricing["output_price_per_million_tokens_usd"]
+        audio_rate = pricing.get(
+            "audio_input_price_per_million_tokens_usd", input_rate
+        )
+        billed_output_tokens = output_tokens * (
+            REASONING_TOKEN_MULTIPLIER
+            if pricing.get("reasoning_billed_as_output")
+            else 1.0
+        )
+        cost_usd = (
+            input_tokens * input_rate
+            + billed_output_tokens * output_rate
+            + audio_tokens * audio_rate
+        ) / 1_000_000
+
+        row["cost_usd"] = cost_usd
+        row["priced"] = True
+        total_usd += cost_usd
+        group_rows.append(row)
+
+    return {
+        "source": source,
+        "groups": group_rows,
+        "total_usd": total_usd,
+        "unpriced": sorted(unpriced),
+    }
+
+
+def estimate_judge_cost_all_sources(groups: Sequence[JudgeCallGroup]) -> dict:
+    """Price ``groups`` under every billing source, keyed by source name."""
+    return {
+        source: estimate_judge_cost(groups, source=source)
+        for source in LLM_PRICING_SOURCES
+    }
+
+
+def format_cost_estimate(both: dict) -> str:
+    """Render the output of :func:`estimate_judge_cost_all_sources` as a text block.
+
+    One line per judge group, then a total for each billing source, then the
+    caveats. OpenRouter charges provider list price on every model in the rate
+    table, so the two totals normally match; both are reported so a divergence
+    becomes visible if one appears.
+    """
+    openrouter = both.get("openrouter", {})
+    direct = both.get("direct", {})
+    groups = openrouter.get("groups", [])
+
+    lines = ["Estimated LLM-as-judge cost for this run:", ""]
+    for group in groups:
+        usage = (
+            f"{group['input_tokens']:,} input + {group['output_tokens']:,} output"
+        )
+        if group["audio_tokens"]:
+            usage += f" + {group['audio_tokens']:,} audio"
+        if group["priced"]:
+            amount = f"${group['cost_usd']:.4f}"
+        else:
+            amount = "cost unknown (unpriced)"
+        lines.append(
+            f"  {group['label']} ({group['model']}): {group['calls']:,} calls, "
+            f"{usage} tokens = {amount}"
+        )
+
+    openrouter_total = openrouter.get("total_usd", 0.0)
+    direct_total = direct.get("total_usd", 0.0)
+    lines.append("")
+    lines.append(f"  Total via OpenRouter: ${openrouter_total:.4f}")
+    lines.append(f"  Total via direct provider APIs: ${direct_total:.4f}")
+
+    unpriced = openrouter.get("unpriced") or direct.get("unpriced") or []
+    if unpriced:
+        lines.append("")
+        lines.append(
+            "  No rates for: "
+            + ", ".join(unpriced)
+            + " — those judges are excluded from the totals."
+        )
+
+    lines.append("")
+    lines.append(
+        "  Estimated from a bundled rate table and a character-based token "
+        "heuristic, so"
+    )
+    lines.append(
+        "  the actual cost will differ: token counts are approximate and "
+        "provider billing"
+    )
+    lines.append("  quirks (minimums, rounding, taxes, discounts) are not modeled.")
+    return "\n".join(lines)
+
+
+def _in_foreground() -> bool:
+    try:
+        return os.tcgetpgrp(sys.stdin.fileno()) == os.getpgrp()
+    except (AttributeError, OSError, ValueError):
+        return True
+
+
+def confirm_judge_cost(
+    both: dict,
+    assume_yes: bool = False,
+    stream: TextIO | None = None,
+) -> bool:
+    """Show the estimate and return whether the judge run should go ahead.
+
+    The estimate and the question are written to ``stream`` (``sys.stderr`` by
+    default, resolved per call). stderr is used because stdout is commonly
+    redirected — ``calibrate-agent stt ... > run.log`` should still put the
+    question on the screen the answer will be typed at, and stderr survives the
+    stream tee the benchmarks install.
+
+    Proceeds without asking when ``assume_yes`` is set, when the
+    ``CALIBRATE_ASSUME_YES`` environment variable is non-empty, when stdin is
+    not a terminal, or when the process is not in the terminal's foreground
+    process group. That last case covers ``calibrate-agent stt ... &``: stdin is
+    still the terminal, so it reads as one, but a background process group that
+    reads it is stopped by the kernel with SIGTTIN — asking there would suspend
+    the run instead of prompting.
+
+    An answer of ``y`` or ``yes`` (any case) proceeds; anything else, including
+    an empty line or an interrupted read, cancels.
+    """
+    out = sys.stderr if stream is None else stream
+    out.write(format_cost_estimate(both) + "\n")
+    out.flush()
+
+    if assume_yes or os.getenv(_ENV_ASSUME_YES):
+        return True
+    if not sys.stdin.isatty() or not _in_foreground():
+        return True
+
+    out.write("\nProceed with the judge run? [y/N]: ")
+    out.flush()
+    try:
+        answer = input()
+    except (EOFError, KeyboardInterrupt):
+        out.write("\n")
+        out.flush()
+        return False
+    return answer.strip().lower() in ("y", "yes")
+
+
+def confirm_estimated_judge_cost(
+    plan: Callable[[], tuple[Sequence[JudgeCallGroup], int]],
+    assume_yes: bool = False,
+    stream: TextIO | None = None,
+) -> bool:
+    """Estimate the cost of the workload ``plan`` describes and confirm it.
+
+    ``plan`` is called to produce ``(groups, cached_count)``, where
+    ``cached_count`` is how many judge results a prior run already checkpointed.
+    It is called inside a guard: an estimate is advisory, so a workload that
+    cannot be sized — an unreadable dataset, a missing audio file, a column that
+    is not there — proceeds unasked rather than stopping a run that would
+    otherwise succeed. The paths that genuinely require that data validate it
+    themselves and report it with their own message.
+
+    Returns whether the judge run should go ahead. A workload with no judge
+    calls in it needs no confirmation.
+    """
+    try:
+        groups, cached_count = plan()
+    except Exception:
+        return True
+
+    if not groups:
+        return True
+
+    if cached_count:
+        print(
+            f"Note: {cached_count} judge result(s) are already checkpointed from "
+            "a prior run and will be reused. The estimate below covers the whole "
+            "dataset, so it overstates what this run will spend."
+        )
+
+    return confirm_judge_cost(
+        estimate_judge_cost_all_sources(groups),
+        assume_yes=assume_yes,
+        stream=stream,
+    )

--- a/calibrate_agent/judge_store.py
+++ b/calibrate_agent/judge_store.py
@@ -1,0 +1,278 @@
+"""
+Resumable checkpoint for LLM-as-judge results.
+
+STT and TTS evaluation runs grade every dataset row with an LLM judge. A
+single run can issue hundreds of judge calls, each one a paid API call; if
+the process is interrupted or one row's judge call fails, the rows already
+graded should not have to be re-graded (and re-paid for) on the next run.
+
+``JudgeStore`` is an append-only JSONL checkpoint: every judge result is
+written to disk the moment it is computed, keyed by a :class:`JudgeKey` that
+fingerprints the exact input that produced it. Re-running with the same
+input, evaluator prompt, and judge model reuses the cached result; changing
+any of those changes the fingerprint, so the row is graded again instead of
+silently returning a stale grade.
+
+Two gather helpers, :func:`gather_with_store` and
+:func:`gather_evaluators_with_store`, are drop-in replacements for the
+``tqdm_asyncio.gather`` calls in the STT/TTS metrics modules: they skip
+already-cached rows (or, per evaluator, already-cached evaluator results)
+and persist each fresh result as it lands rather than waiting for the whole
+batch to finish.
+"""
+
+import asyncio
+import hashlib
+import json
+import os
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+
+from tqdm.asyncio import tqdm_asyncio
+
+
+@dataclass(frozen=True)
+class JudgeKey:
+    """Identity of one cached judge result.
+
+    ``row_id`` is coerced to ``str`` in ``__post_init__``: pandas reads a
+    numeric-looking ``id`` column back as an ``int`` on reload, so a key
+    built from the string ``"1"`` would otherwise fail to match one built
+    from the int ``1`` for the same row.
+
+    ``evaluator`` is set only for the per-evaluator kinds (``"evaluators"``,
+    ``"tts_evaluators"``) where one row produces one result per evaluator
+    name; the single-result-per-row kinds leave it ``None``.
+    """
+
+    kind: str
+    row_id: str
+    fingerprint: str
+    evaluator: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "row_id", str(self.row_id))
+
+
+def make_fingerprint(*parts: object) -> str:
+    """Return a stable hex sha256 digest over ``parts``.
+
+    Each part is encoded independently with
+    ``json.dumps(part, sort_keys=True, ensure_ascii=False, default=str)`` so
+    dict-valued parts fingerprint the same regardless of key order, then the
+    encoded parts are joined with ``"\\x00"`` — a separator that cannot
+    appear inside any of the JSON-encoded parts — before hashing.
+
+    Callers pass the judge input (reference/prediction text, audio path,
+    conversation, ...) together with the evaluator's system prompt and the
+    judge model id, so that editing the prompt, switching models, or
+    re-transcribing a row invalidates the cached result for that row.
+    """
+    encoded = [
+        json.dumps(part, sort_keys=True, ensure_ascii=False, default=str)
+        for part in parts
+    ]
+    joined = "\x00".join(encoded)
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+class JudgeStore:
+    """Append-only JSONL checkpoint of per-row judge results.
+
+    Use :meth:`load` to construct an instance — it creates ``output_dir`` if
+    needed and reads any results already on disk from a prior run.
+    """
+
+    FILENAME = "judge_cache.jsonl"
+
+    def __init__(self, output_dir: str) -> None:
+        self._output_dir = output_dir
+        self._path = os.path.join(output_dir, self.FILENAME)
+        self._records: dict[JudgeKey, dict] = {}
+        self._lock = asyncio.Lock()
+
+    @classmethod
+    def load(cls, output_dir: str) -> "JudgeStore":
+        """Create ``output_dir`` if needed and load any existing checkpoint file."""
+        os.makedirs(output_dir, exist_ok=True)
+        store = cls(output_dir)
+        store._load_existing()
+        return store
+
+    def _load_existing(self) -> None:
+        if not os.path.exists(self._path):
+            return
+        with open(self._path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                # A truncated final line is the expected shape of a killed
+                # run, not corruption — skip it rather than fail the load.
+                try:
+                    record = json.loads(line)
+                    key = JudgeKey(
+                        kind=record["kind"],
+                        row_id=record["row_id"],
+                        fingerprint=record["fingerprint"],
+                        evaluator=record.get("evaluator"),
+                    )
+                    result = record["result"]
+                except (json.JSONDecodeError, KeyError, TypeError):
+                    continue
+                self._records[key] = result
+
+    @property
+    def path(self) -> str:
+        """Absolute path to the JSONL checkpoint file."""
+        return self._path
+
+    def get(self, key: JudgeKey) -> dict | None:
+        """Return the cached result for ``key``, or ``None`` if not cached."""
+        return self._records.get(key)
+
+    async def put(self, key: JudgeKey, result: dict) -> None:
+        """Append one record for ``key``/``result`` and update the in-memory map.
+
+        The write is flushed and fsynced before the lock is released, so a
+        result is durable on disk before ``put`` returns — the property that
+        makes an interrupted run lose at most the row in flight.
+        """
+        record = {
+            "kind": key.kind,
+            "row_id": key.row_id,
+            "evaluator": key.evaluator,
+            "fingerprint": key.fingerprint,
+            "result": result,
+        }
+        line = json.dumps(record, ensure_ascii=False)
+        async with self._lock:
+            with open(self._path, "a", encoding="utf-8") as f:
+                f.write(line + "\n")
+                f.flush()
+                os.fsync(f.fileno())
+            self._records[key] = result
+
+    def pending(self, keys: Sequence[JudgeKey]) -> list[JudgeKey]:
+        """Return the subset of ``keys`` with no cached result, in input order."""
+        return [key for key in keys if key not in self._records]
+
+    def clear(self) -> None:
+        """Delete the checkpoint file and empty the in-memory map."""
+        if os.path.exists(self._path):
+            os.remove(self._path)
+        self._records.clear()
+
+    def __len__(self) -> int:
+        return len(self._records)
+
+
+async def gather_with_store(
+    keys: Sequence[JudgeKey | None],
+    run_one: Callable[[int], Awaitable[dict]],
+    store: JudgeStore | None,
+    desc: str,
+) -> list[dict]:
+    """Run one judge call per row, reusing cached results where possible.
+
+    For judges with exactly one result per row (intent/entity, LLM WER,
+    semantic WER). ``keys[i]`` identifies row ``i``'s judge input;
+    ``run_one(i)`` computes and returns its result. A row whose key is
+    cached in ``store`` skips ``run_one`` entirely; a row with no cache hit
+    runs immediately and its result is persisted to ``store`` before moving
+    on. When ``store`` is ``None``, or ``keys[i]`` is ``None``, row ``i``
+    always runs.
+
+    An exception raised by ``run_one`` propagates to the caller; any result
+    already computed and stored for other rows before the failure remains
+    on disk.
+
+    Returns:
+        Results in row order (index ``i`` is row ``i``'s result),
+        regardless of completion order.
+    """
+    results: list[dict | None] = [None] * len(keys)
+
+    async def resolve(index: int) -> None:
+        key = keys[index]
+        if store is not None and key is not None:
+            cached = store.get(key)
+            if cached is not None:
+                results[index] = cached
+                return
+        result = await run_one(index)
+        if store is not None and key is not None:
+            await store.put(key, result)
+        results[index] = result
+
+    await tqdm_asyncio.gather(
+        *[resolve(index) for index in range(len(keys))],
+        desc=desc,
+    )
+    return results
+
+
+async def gather_evaluators_with_store(
+    row_keys: Sequence[Mapping[str, JudgeKey]],
+    run_subset: Callable[[int, list[str]], Awaitable[Mapping[str, dict]]],
+    store: JudgeStore | None,
+    desc: str,
+) -> list[dict]:
+    """Run per-evaluator judge calls, reusing cached results per evaluator.
+
+    For evaluator-based judges where one row produces one result per
+    evaluator. ``row_keys[i]`` maps each evaluator name to its key for row
+    ``i``. ``run_subset(i, names)`` runs only the named evaluators for row
+    ``i`` and returns ``{evaluator_name: result}``.
+
+    A row whose evaluators are all cached in ``store`` skips ``run_subset``
+    entirely. A row with a partial cache hit calls ``run_subset`` with only
+    the missing evaluator names and merges the cached results back in, so
+    adding a new evaluator to a config only pays for that evaluator across
+    rows, not the ones already graded. Each freshly computed result is
+    persisted to ``store`` as it arrives. When ``store`` is ``None``, every
+    evaluator for every row is run.
+
+    Raises:
+        KeyError: if ``run_subset`` returns a mapping missing one of the
+            evaluator names it was asked to compute, naming the row and
+            evaluator.
+
+    Returns:
+        A list of ``{evaluator_name: result}`` dicts, one per row, in row
+        order — the same ``per_row`` shape the existing aggregation
+        functions produce.
+    """
+    results: list[dict | None] = [None] * len(row_keys)
+
+    async def resolve(index: int) -> None:
+        keys_for_row = row_keys[index]
+        cached: dict[str, dict] = {}
+        missing: list[str] = []
+        for name, key in keys_for_row.items():
+            hit = store.get(key) if store is not None else None
+            if hit is not None:
+                cached[name] = hit
+            else:
+                missing.append(name)
+
+        if missing:
+            fresh = await run_subset(index, missing)
+            for name in missing:
+                if name not in fresh:
+                    raise KeyError(
+                        f"run_subset for row {index!r} did not return a "
+                        f"result for evaluator {name!r}"
+                    )
+                result = fresh[name]
+                if store is not None:
+                    await store.put(keys_for_row[name], result)
+                cached[name] = result
+
+        results[index] = {name: cached[name] for name in keys_for_row}
+
+    await tqdm_asyncio.gather(
+        *[resolve(index) for index in range(len(row_keys))],
+        desc=desc,
+    )
+    return results

--- a/calibrate_agent/judge_store.py
+++ b/calibrate_agent/judge_store.py
@@ -172,6 +172,8 @@ async def gather_with_store(
     run_one: Callable[[int], Awaitable[dict]],
     store: JudgeStore | None,
     desc: str,
+    *,
+    error_result: Callable[[int, BaseException], dict] | None = None,
 ) -> list[dict]:
     """Run one judge call per row, reusing cached results where possible.
 
@@ -183,9 +185,11 @@ async def gather_with_store(
     on. When ``store`` is ``None``, or ``keys[i]`` is ``None``, row ``i``
     always runs.
 
-    An exception raised by ``run_one`` propagates to the caller; any result
-    already computed and stored for other rows before the failure remains
-    on disk.
+    When ``error_result`` is ``None``, an exception from ``run_one``
+    propagates to the caller (any results already stored for other rows
+    remain on disk). When ``error_result`` is set, a failed ``run_one`` is
+    replaced with ``error_result(index, exc)`` and is **not** written to
+    ``store``, so a transient failure is not cached as a permanent grade.
 
     Returns:
         Results in row order (index ``i`` is row ``i``'s result),
@@ -200,7 +204,13 @@ async def gather_with_store(
             if cached is not None:
                 results[index] = cached
                 return
-        result = await run_one(index)
+        try:
+            result = await run_one(index)
+        except Exception as exc:
+            if error_result is None:
+                raise
+            results[index] = error_result(index, exc)
+            return
         if store is not None and key is not None:
             await store.put(key, result)
         results[index] = result

--- a/calibrate_agent/pricing.py
+++ b/calibrate_agent/pricing.py
@@ -41,6 +41,16 @@ _COMPONENT_BILLING = {
 # that publish in USD; INR covers providers billed in rupees (e.g. Sarvam).
 _SUPPORTED_CURRENCIES = ("usd", "inr")
 
+# Where an LLM call is billed: through OpenRouter, or against the model
+# provider's own API. Both are priced per million tokens, in USD.
+LLM_PRICING_SOURCES = ("openrouter", "direct")
+
+# Present only on models that price audio separately from text.
+_LLM_OPTIONAL_RATE_KEYS = (
+    "audio_input_price_per_million_tokens_usd",
+    "audio_output_price_per_million_tokens_usd",
+)
+
 _COMPONENT_DEFAULT_MODELS = {
     "stt": STT_PROVIDER_MODELS,
     "tts": TTS_DEFAULT_MODELS,
@@ -88,6 +98,56 @@ def resolve_pricing(
                     "native_rate": float(price),
                 }
     return None
+
+
+def resolve_llm_pricing(model: str, source: str = "openrouter") -> dict | None:
+    """Return per-token pricing for an LLM ``model``.
+
+    ``model`` is the full model id used by the judges (e.g.
+    ``"anthropic/claude-sonnet-4.5"``), so the lookup is keyed by that single id
+    rather than by provider and model separately. ``source`` selects the
+    ``"openrouter"`` or ``"direct"`` rate block.
+
+    The returned dict carries ``model``, ``source``, the text
+    ``input_price_per_million_tokens_usd`` and
+    ``output_price_per_million_tokens_usd``, and
+    ``reasoning_billed_as_output`` (``False`` unless the model bills hidden
+    reasoning tokens at the output rate). Audio rates
+    (``audio_input_price_per_million_tokens_usd`` /
+    ``audio_output_price_per_million_tokens_usd``) appear only for models that
+    price audio separately. Returns ``None`` when the model or the requested
+    source has no rates, so callers can report the model as unpriced instead of
+    failing.
+    """
+    if source not in LLM_PRICING_SOURCES:
+        raise ValueError(f"Unsupported LLM pricing source: {source}")
+
+    model_pricing = _load_pricing_data().get("llm", {}).get(model)
+    if not isinstance(model_pricing, dict):
+        return None
+
+    source_pricing = model_pricing.get(source)
+    if not isinstance(source_pricing, dict):
+        return None
+
+    resolved = {
+        "model": model,
+        "source": source,
+        "input_price_per_million_tokens_usd": float(
+            source_pricing.get("input_price_per_million_tokens_usd", 0.0)
+        ),
+        "output_price_per_million_tokens_usd": float(
+            source_pricing.get("output_price_per_million_tokens_usd", 0.0)
+        ),
+        "reasoning_billed_as_output": bool(
+            source_pricing.get("reasoning_billed_as_output", False)
+        ),
+    }
+    for rate_key in _LLM_OPTIONAL_RATE_KEYS:
+        rate = source_pricing.get(rate_key)
+        if isinstance(rate, (int, float)):
+            resolved[rate_key] = float(rate)
+    return resolved
 
 
 def cost_breakdown(

--- a/calibrate_agent/pricing_data.json
+++ b/calibrate_agent/pricing_data.json
@@ -93,5 +93,55 @@
         "price_per_million_chars_usd": 17.5
       }
     }
+  },
+  "llm": {
+    "openai/gpt-5.4-mini": {
+      "openrouter": {
+        "input_price_per_million_tokens_usd": 0.75,
+        "output_price_per_million_tokens_usd": 4.5
+      },
+      "direct": {
+        "input_price_per_million_tokens_usd": 0.75,
+        "output_price_per_million_tokens_usd": 4.5
+      }
+    },
+    "openai/gpt-audio": {
+      "openrouter": {
+        "input_price_per_million_tokens_usd": 2.5,
+        "output_price_per_million_tokens_usd": 10.0,
+        "audio_input_price_per_million_tokens_usd": 32.0,
+        "audio_output_price_per_million_tokens_usd": 64.0
+      },
+      "direct": {
+        "input_price_per_million_tokens_usd": 2.5,
+        "output_price_per_million_tokens_usd": 10.0,
+        "audio_input_price_per_million_tokens_usd": 32.0,
+        "audio_output_price_per_million_tokens_usd": 64.0
+      }
+    },
+    "google/gemini-2.5-flash": {
+      "openrouter": {
+        "input_price_per_million_tokens_usd": 0.3,
+        "output_price_per_million_tokens_usd": 2.5,
+        "audio_input_price_per_million_tokens_usd": 1.0,
+        "reasoning_billed_as_output": true
+      },
+      "direct": {
+        "input_price_per_million_tokens_usd": 0.3,
+        "output_price_per_million_tokens_usd": 2.5,
+        "audio_input_price_per_million_tokens_usd": 1.0,
+        "reasoning_billed_as_output": true
+      }
+    },
+    "anthropic/claude-sonnet-4.5": {
+      "openrouter": {
+        "input_price_per_million_tokens_usd": 3.0,
+        "output_price_per_million_tokens_usd": 15.0
+      },
+      "direct": {
+        "input_price_per_million_tokens_usd": 3.0,
+        "output_price_per_million_tokens_usd": 15.0
+      }
+    }
   }
 }

--- a/calibrate_agent/stt/benchmark.py
+++ b/calibrate_agent/stt/benchmark.py
@@ -37,7 +37,11 @@ from calibrate_agent.stt.eval import (
 )
 from calibrate_agent.stt.leaderboard import generate_leaderboard
 from calibrate_agent._env import resolve_stt_parallelism
-from calibrate_agent._cli_args import add_assume_yes_arg, add_stt_eval_args
+from calibrate_agent._cli_args import (
+    add_assume_yes_arg,
+    add_stt_eval_args,
+    resolve_stt_llm_judges,
+)
 from calibrate_agent.judge_cost import (
     build_stt_judge_groups,
     confirm_estimated_judge_cost,
@@ -83,7 +87,7 @@ async def run(
     overwrite: bool = False,
     max_parallel: int = None,
     judge_evaluators: list[dict] = None,
-    run_llm_judges: bool = True,
+    llm_judges: frozenset[str] | None = None,
     engine: str = "pipeline",
     max_concurrency: int = None,
 ) -> dict:
@@ -108,9 +112,9 @@ async def run(
         judge_evaluators: Optional list of evaluator dicts (each with ``name``,
             ``system_prompt``, ``judge_model``, ``type``, ...). When omitted no
             LLM judge runs and only WER/CER are reported.
-        run_llm_judges: Run the Sarvam intent/entity judge (default True;
-            loads a normalizer model + makes per-row judge calls). Set to False
-            to skip it.
+        llm_judges: Built-in LLM judges to run (``intent``, ``llm_wer``,
+            ``semantic_wer``). ``None`` runs all three; an empty frozenset
+            skips them.
 
     Returns:
         dict: Results summary with status and output paths
@@ -145,7 +149,7 @@ async def run(
                 ignore_retry=ignore_retry,
                 overwrite=overwrite,
                 judge_evaluators=judge_evaluators,
-                run_llm_judges=run_llm_judges,
+                llm_judges=llm_judges,
                 engine=engine,
                 max_concurrency=max_concurrency,
             )
@@ -319,7 +323,9 @@ async def main():
         print(f"Output: {args.output_dir}")
         print("")
 
-        run_llm_judges = not args.skip_llm_judges
+        llm_judges = resolve_stt_llm_judges(
+            skip_llm_judges=args.skip_llm_judges, judges=args.judges
+        )
 
         def plan_eval_only_judges():
             is_valid, _error_msg, rows = validate_stt_eval_only_dataset(args.dataset)
@@ -333,7 +339,7 @@ async def main():
                     "" if r["pred"] is None else str(r["pred"]) for r in rows
                 ],
                 evaluators=judge_evaluators,
-                run_llm_judges=run_llm_judges,
+                llm_judges=llm_judges,
             )
             return groups, len(JudgeStore.load(args.output_dir))
 
@@ -348,7 +354,7 @@ async def main():
             output_dir=args.output_dir,
             judge_evaluators=judge_evaluators,
             language=args.language,
-            run_llm_judges=run_llm_judges,
+            llm_judges=llm_judges,
         )
 
         print(f"\n\033[92m{'='*60}\033[0m")
@@ -383,6 +389,10 @@ async def main():
         print(f"Output: {args.output_dir}")
         print("")
 
+        llm_judges = resolve_stt_llm_judges(
+            skip_llm_judges=args.skip_llm_judges, judges=args.judges
+        )
+
         def plan_benchmark_judges():
             gt_df = pd.read_csv(join(args.input_dir, args.input_file_name))
             if args.debug:
@@ -392,7 +402,7 @@ async def main():
             groups = build_stt_judge_groups(
                 references=gt_df["text"].astype(str).tolist(),
                 evaluators=judge_evaluators,
-                run_llm_judges=not args.skip_llm_judges,
+                llm_judges=llm_judges,
                 providers=len(providers),
             )
             cached_count = sum(
@@ -419,7 +429,7 @@ async def main():
             ignore_retry=args.ignore_retry,
             overwrite=args.overwrite,
             judge_evaluators=judge_evaluators,
-            run_llm_judges=not args.skip_llm_judges,
+            llm_judges=llm_judges,
             max_parallel=args.max_parallel,
             engine=args.engine,
             max_concurrency=args.max_concurrency,

--- a/calibrate_agent/stt/benchmark.py
+++ b/calibrate_agent/stt/benchmark.py
@@ -24,17 +24,25 @@ import os
 from os.path import exists, join
 from typing import Literal
 
+import pandas as pd
+
 from calibrate_agent.stt.eval import (
     run_single_provider_eval,
     run_eval_only,
     validate_stt_input_dir,
+    validate_stt_eval_only_dataset,
     format_metrics_summary,
     STT_PROVIDERS,
     STT_LANGUAGES,
 )
 from calibrate_agent.stt.leaderboard import generate_leaderboard
 from calibrate_agent._env import resolve_stt_parallelism
-from calibrate_agent._cli_args import add_stt_eval_args
+from calibrate_agent._cli_args import add_assume_yes_arg, add_stt_eval_args
+from calibrate_agent.judge_cost import (
+    build_stt_judge_groups,
+    confirm_estimated_judge_cost,
+)
+from calibrate_agent.judge_store import JudgeStore
 from calibrate_agent.utils import StreamTee
 
 
@@ -253,6 +261,7 @@ async def main():
         help="Path to optional JSON config file with an `evaluators` list",
     )
     add_stt_eval_args(parser, include_max_parallel=True)
+    add_assume_yes_arg(parser)
 
     args = parser.parse_args()
 
@@ -310,12 +319,36 @@ async def main():
         print(f"Output: {args.output_dir}")
         print("")
 
+        run_llm_judges = not args.skip_llm_judges
+
+        def plan_eval_only_judges():
+            is_valid, _error_msg, rows = validate_stt_eval_only_dataset(args.dataset)
+            if not is_valid:
+                return [], 0
+            # The dataset carries both gt and pred, so this estimate is exact
+            # rather than a prediction-length guess.
+            groups = build_stt_judge_groups(
+                references=[str(r["gt"]) for r in rows],
+                predictions=[
+                    "" if r["pred"] is None else str(r["pred"]) for r in rows
+                ],
+                evaluators=judge_evaluators,
+                run_llm_judges=run_llm_judges,
+            )
+            return groups, len(JudgeStore.load(args.output_dir))
+
+        if not confirm_estimated_judge_cost(
+            plan_eval_only_judges, assume_yes=args.yes
+        ):
+            print("Judge run cancelled.")
+            sys.exit(0)
+
         result = await run_eval_only(
             dataset_path=args.dataset,
             output_dir=args.output_dir,
             judge_evaluators=judge_evaluators,
             language=args.language,
-            run_llm_judges=not args.skip_llm_judges,
+            run_llm_judges=run_llm_judges,
         )
 
         print(f"\n\033[92m{'='*60}\033[0m")
@@ -349,6 +382,31 @@ async def main():
         print(f"Input: {args.input_dir}")
         print(f"Output: {args.output_dir}")
         print("")
+
+        def plan_benchmark_judges():
+            gt_df = pd.read_csv(join(args.input_dir, args.input_file_name))
+            if args.debug:
+                gt_df = gt_df.head(args.debug_count)
+            # Nothing has been transcribed yet, so the prediction half of each
+            # judge prompt is sized from its reference.
+            groups = build_stt_judge_groups(
+                references=gt_df["text"].astype(str).tolist(),
+                evaluators=judge_evaluators,
+                run_llm_judges=not args.skip_llm_judges,
+                providers=len(providers),
+            )
+            cached_count = sum(
+                len(JudgeStore.load(join(args.output_dir, provider)))
+                for provider in providers
+                if exists(join(args.output_dir, provider))
+            )
+            return groups, cached_count
+
+        if not confirm_estimated_judge_cost(
+            plan_benchmark_judges, assume_yes=args.yes
+        ):
+            print("Judge run cancelled.")
+            sys.exit(0)
 
         result = await run(
             providers=providers,

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -46,7 +46,11 @@ from calibrate_agent.stt.metrics import (
 from calibrate_agent.stt.pipeline_eval import transcribe_via_pipeline
 from calibrate_agent.judge_store import JudgeStore
 from calibrate_agent._env import resolve_stt_max_concurrency
-from calibrate_agent._cli_args import add_stt_eval_args
+from calibrate_agent._cli_args import (
+    DEFAULT_STT_LLM_JUDGES,
+    add_stt_eval_args,
+    resolve_stt_llm_judges,
+)
 from calibrate_agent.judges import (
     is_rating,
     require_unique_evaluator_names,
@@ -1266,7 +1270,7 @@ async def run_single_provider_eval(
     ignore_retry: bool,
     overwrite: bool,
     judge_evaluators: list[dict] = None,
-    run_llm_judges: bool = True,
+    llm_judges: frozenset[str] | None = None,
     engine: str = "pipeline",
     max_concurrency: int = None,
 ) -> dict:
@@ -1429,7 +1433,7 @@ async def run_single_provider_eval(
             evaluator_config_dir=output_dir,
             judge_evaluators=judge_evaluators,
             language=language,
-            run_llm_judges=run_llm_judges,
+            llm_judges=llm_judges,
             audio_durations=audio_durations,
             cost_metrics=cost_metrics,
             ttfs_values=all_ttfs,
@@ -1489,7 +1493,7 @@ async def _score_and_write_results(
     evaluator_config_dir: str,
     judge_evaluators: list[dict] = None,
     language: str = "english",
-    run_llm_judges: bool = True,
+    llm_judges: frozenset[str] | None = None,
     cost_metrics: dict | None = None,
     audio_durations: list[float | None] | None = None,
     ttfs_values: list = None,
@@ -1502,10 +1506,10 @@ async def _score_and_write_results(
     is empty/omitted, no judge runs, no evaluator config is written, and the
     evaluator columns/metrics are omitted. Returns the metrics_data dict.
 
-    The Sarvam intent/entity judge runs by default. When
-    ``run_llm_judges`` is False it is skipped entirely — no normalizer model
-    is loaded, no judge calls are made, and the ``sarvam_*`` columns/metrics are
-    omitted.
+    Built-in LLM judges are selected via ``llm_judges`` (``intent``,
+    ``llm_wer``, ``semantic_wer``). ``None`` runs all three; an empty
+    frozenset skips them entirely — no normalizer model is loaded, no judge
+    calls are made, and the corresponding columns/metrics are omitted.
 
     Each judge is isolated: if any judge raises, the failure is logged and that
     judge's columns/metrics are dropped, but WER/CER and any judges that
@@ -1536,16 +1540,13 @@ async def _score_and_write_results(
         )
 
     # Each judge below runs independently and is isolated: a failure in one
-    # (Sarvam intent/entity, Sarvam LLM-WER/CER, or the LLM judge) is logged and
-    # that judge's columns/metrics are omitted, but WER/CER and any judges that
-    # succeeded are still written.
+    # is logged and that judge's columns/metrics are omitted, but WER/CER and
+    # any judges that succeeded are still written.
+    enabled = DEFAULT_STT_LLM_JUDGES if llm_judges is None else llm_judges
 
-    # Intent + entity preservation and LLM-WER/CER run by default; setting
-    # ``run_llm_judges`` to False skips loading the normalizer model and the
-    # per-row judge calls.
     intent_entity_results = None
     llm_wer_results = None
-    if run_llm_judges:
+    if "intent" in enabled:
         try:
             intent_entity_results = await get_intent_entity_score(
                 gt_transcripts,
@@ -1561,6 +1562,7 @@ async def _score_and_write_results(
         except Exception as e:
             intent_entity_results = None
             _log(f"Sarvam intent/entity judge failed, skipping: {e}")
+    if "llm_wer" in enabled:
         try:
             llm_wer_results = await get_llm_wer_cer_score(
                 gt_transcripts,
@@ -1577,9 +1579,8 @@ async def _score_and_write_results(
             llm_wer_results = None
             _log(f"Sarvam LLM-WER/CER judge failed, skipping: {e}")
 
-    # Semantic WER (pipecat methodology) runs as part of the LLM judges group.
     semantic_wer_results = None
-    if run_llm_judges:
+    if "semantic_wer" in enabled:
         try:
             semantic_wer_results = await get_semantic_wer_score(
                 gt_transcripts, pred_transcripts, store=store, row_ids=ids
@@ -1759,7 +1760,7 @@ async def run_eval_only(
     output_dir: str,
     judge_evaluators: list[dict] = None,
     language: str = "english",
-    run_llm_judges: bool = True,
+    llm_judges: frozenset[str] | None = None,
     overwrite: bool = False,
 ) -> dict:
     """Run evaluators only on a pre-existing dataset of (gt, pred) pairs.
@@ -1774,9 +1775,9 @@ async def run_eval_only(
             LLM judge runs and only WER/CER are reported.
         language: Language of the dataset, used to normalize text before the
             intent/entity judge. Defaults to ``english``.
-        run_llm_judges: Run the Sarvam intent/entity judge (default True).
-            Setting it to False skips the normalizer model load and the judge
-            calls entirely.
+        llm_judges: Built-in LLM judges to run (``intent``, ``llm_wer``,
+            ``semantic_wer``). ``None`` runs all three; an empty frozenset
+            skips them.
         overwrite: Discard any judge results checkpointed under ``output_dir``
             from a prior run before scoring, so every row is graded fresh.
 
@@ -1812,7 +1813,7 @@ async def run_eval_only(
             evaluator_config_dir=output_dir,
             judge_evaluators=judge_evaluators,
             language=language,
-            run_llm_judges=run_llm_judges,
+            llm_judges=llm_judges,
             overwrite=overwrite,
         )
 
@@ -1830,7 +1831,7 @@ def format_metrics_summary(metrics: dict, prefix: str = "") -> str:
     shared by the single-provider, multi-provider, and eval-only paths.
 
     The Sarvam judge fields are only included when present in ``metrics``
-    (i.e. unless ``--skip-llm-judges`` was passed for the run).
+    (i.e. when those built-in judges ran for the run).
     """
     parts = [
         f"WER={metrics.get('wer', 0):.4f}",
@@ -1972,7 +1973,9 @@ async def main():
         debug_count=args.debug_count,
         ignore_retry=args.ignore_retry,
         overwrite=args.overwrite,
-        run_llm_judges=not args.skip_llm_judges,
+        llm_judges=resolve_stt_llm_judges(
+            skip_llm_judges=args.skip_llm_judges, judges=args.judges
+        ),
         engine=args.engine,
         max_concurrency=args.max_concurrency,
     )

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -44,6 +44,7 @@ from calibrate_agent.stt.metrics import (
     get_ttfs_stats,
 )
 from calibrate_agent.stt.pipeline_eval import transcribe_via_pipeline
+from calibrate_agent.judge_store import JudgeStore
 from calibrate_agent._env import resolve_stt_max_concurrency
 from calibrate_agent._cli_args import add_stt_eval_args
 from calibrate_agent.judges import (
@@ -1432,6 +1433,7 @@ async def run_single_provider_eval(
             audio_durations=audio_durations,
             cost_metrics=cost_metrics,
             ttfs_values=all_ttfs,
+            overwrite=overwrite,
         )
 
         return {
@@ -1491,6 +1493,7 @@ async def _score_and_write_results(
     cost_metrics: dict | None = None,
     audio_durations: list[float | None] | None = None,
     ttfs_values: list = None,
+    overwrite: bool = False,
 ) -> dict:
     """Run WER/CER (and optional LLM-judge evaluators) over (gt, pred) pairs.
 
@@ -1507,12 +1510,30 @@ async def _score_and_write_results(
     Each judge is isolated: if any judge raises, the failure is logged and that
     judge's columns/metrics are dropped, but WER/CER and any judges that
     succeeded are still written.
+
+    Every judge call is checkpointed through a :class:`JudgeStore` loaded
+    from ``output_dir``, keyed by ``ids``: a row already graded in a prior
+    (interrupted or completed) run for the same input, evaluator prompt, and
+    model is reused instead of re-judged. ``overwrite=True`` discards that
+    checkpoint (along with ``results.csv``) before scoring so every row is
+    graded fresh.
     """
     wer_results = get_wer_score(gt_transcripts, pred_transcripts, language=language)
     _log(f"WER: {wer_results['score']}", to_terminal=False)
 
     cer_results = get_cer_score(gt_transcripts, pred_transcripts, language=language)
     _log(f"CER: {cer_results['score']}", to_terminal=False)
+
+    store = JudgeStore.load(output_dir)
+    if overwrite:
+        store.clear()
+        _log("Overwrite enabled - cleared cached judge grades", to_terminal=False)
+    elif len(store) > 0:
+        _log(
+            f"Resuming judge grading: {len(store)} cached result(s) found in "
+            f"{store.path} and will be reused",
+            to_terminal=False,
+        )
 
     # Each judge below runs independently and is isolated: a failure in one
     # (Sarvam intent/entity, Sarvam LLM-WER/CER, or the LLM judge) is logged and
@@ -1527,7 +1548,11 @@ async def _score_and_write_results(
     if run_llm_judges:
         try:
             intent_entity_results = await get_intent_entity_score(
-                gt_transcripts, pred_transcripts, language=language
+                gt_transcripts,
+                pred_transcripts,
+                language=language,
+                store=store,
+                row_ids=ids,
             )
             _log(
                 f"Sarvam Intent Score: {intent_entity_results['intent']:.4f}  Sarvam Entity Score: {intent_entity_results['entity']:.4f}",
@@ -1538,7 +1563,11 @@ async def _score_and_write_results(
             _log(f"Sarvam intent/entity judge failed, skipping: {e}")
         try:
             llm_wer_results = await get_llm_wer_cer_score(
-                gt_transcripts, pred_transcripts, language=language
+                gt_transcripts,
+                pred_transcripts,
+                language=language,
+                store=store,
+                row_ids=ids,
             )
             _log(
                 f"Sarvam LLM WER: {llm_wer_results['llm_wer']:.4f}  Sarvam LLM CER: {llm_wer_results['llm_cer']:.4f}",
@@ -1553,7 +1582,7 @@ async def _score_and_write_results(
     if run_llm_judges:
         try:
             semantic_wer_results = await get_semantic_wer_score(
-                gt_transcripts, pred_transcripts
+                gt_transcripts, pred_transcripts, store=store, row_ids=ids
             )
             _log(
                 f"Semantic WER: {semantic_wer_results['semantic_wer']:.4f}",
@@ -1576,6 +1605,8 @@ async def _score_and_write_results(
                 gt_transcripts,
                 pred_transcripts,
                 evaluators=_evaluators,
+                store=store,
+                row_ids=ids,
             )
             for name, score_dict in llm_results["scores"].items():
                 _log(f"  {name}: {score_dict['mean']:.4f}")
@@ -1729,6 +1760,7 @@ async def run_eval_only(
     judge_evaluators: list[dict] = None,
     language: str = "english",
     run_llm_judges: bool = True,
+    overwrite: bool = False,
 ) -> dict:
     """Run evaluators only on a pre-existing dataset of (gt, pred) pairs.
 
@@ -1745,6 +1777,8 @@ async def run_eval_only(
         run_llm_judges: Run the Sarvam intent/entity judge (default True).
             Setting it to False skips the normalizer model load and the judge
             calls entirely.
+        overwrite: Discard any judge results checkpointed under ``output_dir``
+            from a prior run before scoring, so every row is graded fresh.
 
     Returns:
         dict with status, metrics, and output_dir.
@@ -1779,6 +1813,7 @@ async def run_eval_only(
             judge_evaluators=judge_evaluators,
             language=language,
             run_llm_judges=run_llm_judges,
+            overwrite=overwrite,
         )
 
         return {

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -5,7 +5,7 @@ import os
 import json
 import base64
 from os.path import join, exists
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List
 from urllib.parse import urlencode
@@ -48,6 +48,7 @@ from calibrate_agent.judge_store import JudgeStore
 from calibrate_agent._env import resolve_stt_max_concurrency
 from calibrate_agent._cli_args import (
     DEFAULT_STT_LLM_JUDGES,
+    STT_LLM_JUDGES,
     add_stt_eval_args,
     resolve_stt_llm_judges,
 )
@@ -1259,6 +1260,162 @@ STT_LANGUAGES = [
 ]
 
 
+# metrics.json keys written by each built-in LLM judge.
+_BUILT_IN_JUDGE_METRIC_KEYS: dict[str, tuple[str, ...]] = {
+    "intent": ("sarvam_intent_score", "sarvam_entity_score"),
+    "llm_wer": ("sarvam_llm_wer", "sarvam_llm_cer"),
+    "semantic_wer": ("semantic_wer",),
+}
+
+# results.csv columns written by each built-in LLM judge.
+_BUILT_IN_JUDGE_RESULT_COLUMNS: dict[str, tuple[str, ...]] = {
+    "intent": (
+        "sarvam_intent_score",
+        "sarvam_intent_reasoning",
+        "sarvam_entity_score",
+        "sarvam_entity_reasoning",
+    ),
+    "llm_wer": (
+        "sarvam_llm_wer",
+        "sarvam_llm_cer",
+        "sarvam_llm_wer_reasoning",
+    ),
+    "semantic_wer": (
+        "semantic_wer",
+        "semantic_wer_metadata",
+        "semantic_wer_reasoning",
+    ),
+}
+
+# Always refreshed on every scoring pass; never restored from a prior file.
+_ALWAYS_FRESH_METRIC_KEYS = frozenset({"wer", "cer", "cost", "ttfs"})
+_ALWAYS_FRESH_RESULT_COLUMNS = frozenset(
+    {"id", "gt", "pred", "wer", "cer", "audio_duration_seconds", "ttfs"}
+)
+
+
+def _load_prior_metrics(output_dir: str) -> dict | None:
+    path = join(output_dir, "metrics.json")
+    if not exists(path):
+        return None
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _load_prior_results(output_dir: str) -> pd.DataFrame | None:
+    path = join(output_dir, "results.csv")
+    if not exists(path):
+        return None
+    try:
+        return pd.read_csv(path)
+    except (OSError, pd.errors.EmptyDataError, pd.errors.ParserError):
+        return None
+
+
+def _archive_prior_metrics(output_dir: str, prior: dict) -> None:
+    """Write a timestamped copy of ``prior`` under ``judge_history/``."""
+    history_dir = Path(output_dir) / "judge_history"
+    history_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = history_dir / f"metrics_{stamp}.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(prior, f, indent=4)
+
+
+def _prior_evaluator_names(prior_metrics: dict) -> set[str]:
+    """Names of config-evaluator entries in a prior ``metrics.json``."""
+    names: set[str] = set()
+    for key, value in prior_metrics.items():
+        if key in _ALWAYS_FRESH_METRIC_KEYS:
+            continue
+        if any(key in keys for keys in _BUILT_IN_JUDGE_METRIC_KEYS.values()):
+            continue
+        if isinstance(value, dict) and "type" in value and "mean" in value:
+            names.add(key)
+    return names
+
+
+def _merge_prior_judge_outputs(
+    metrics_data: dict,
+    rows: list[dict],
+    output_dir: str,
+    *,
+    overwrite: bool,
+    enabled_judges: frozenset[str],
+    this_run_evaluator_names: set[str],
+) -> tuple[dict, list[dict]]:
+    """Keep prior built-in / config-evaluator outputs that this run did not refresh.
+
+    Always archives an existing ``metrics.json`` under ``judge_history/`` before
+    replacing it. When ``overwrite`` is True, returns the fresh artifacts
+    unchanged after that archive. Otherwise copies metrics keys and per-row
+    columns for judges (and config evaluators) that were not part of this
+    scoring pass, matched by ``id``.
+    """
+    prior_metrics = _load_prior_metrics(output_dir)
+    prior_df = _load_prior_results(output_dir)
+    if prior_metrics is None and prior_df is None:
+        return metrics_data, rows
+
+    if prior_metrics is not None:
+        _archive_prior_metrics(output_dir, prior_metrics)
+
+    if overwrite:
+        return metrics_data, rows
+
+    if prior_metrics is not None:
+        fresh_metric_keys = set(_ALWAYS_FRESH_METRIC_KEYS)
+        for name in enabled_judges:
+            fresh_metric_keys.update(_BUILT_IN_JUDGE_METRIC_KEYS.get(name, ()))
+        fresh_metric_keys.update(this_run_evaluator_names)
+
+        for key, value in prior_metrics.items():
+            if key in fresh_metric_keys:
+                continue
+            if key not in metrics_data:
+                metrics_data[key] = value
+
+    if prior_df is not None and not prior_df.empty and "id" in prior_df.columns:
+        prior_by_id = {
+            str(r["id"]): r for r in prior_df.to_dict("records")
+        }
+        preserve_columns: set[str] = set()
+        for name in STT_LLM_JUDGES:
+            if name in enabled_judges:
+                continue
+            preserve_columns.update(_BUILT_IN_JUDGE_RESULT_COLUMNS.get(name, ()))
+        if prior_metrics is not None:
+            for ev_name in _prior_evaluator_names(prior_metrics):
+                if ev_name in this_run_evaluator_names:
+                    continue
+                preserve_columns.add(ev_name)
+                preserve_columns.add(f"{ev_name}_reasoning")
+
+        preserve_columns = {
+            c
+            for c in preserve_columns
+            if c in prior_df.columns and c not in _ALWAYS_FRESH_RESULT_COLUMNS
+        }
+        if preserve_columns:
+            for row in rows:
+                prior_row = prior_by_id.get(str(row["id"]))
+                if prior_row is None:
+                    continue
+                for col in preserve_columns:
+                    if col in row:
+                        continue
+                    value = prior_row.get(col)
+                    if value is None or (isinstance(value, float) and pd.isna(value)):
+                        continue
+                    row[col] = value
+
+    return metrics_data, rows
+
+
 async def run_single_provider_eval(
     provider: str,
     language: str,
@@ -1746,6 +1903,15 @@ async def _score_and_write_results(
                 row[name] = bool(ev_result["match"])
             row[f"{name}_reasoning"] = ev_result["reasoning"]
         data.append(row)
+
+    metrics_data, data = _merge_prior_judge_outputs(
+        metrics_data,
+        data,
+        output_dir,
+        overwrite=overwrite,
+        enabled_judges=enabled,
+        this_run_evaluator_names=set(_evaluators_by_name),
+    )
 
     with open(join(output_dir, "metrics.json"), "w") as f:
         json.dump(metrics_data, f, indent=4)

--- a/calibrate_agent/stt/leaderboard.py
+++ b/calibrate_agent/stt/leaderboard.py
@@ -5,6 +5,7 @@ Generates comparison leaderboard from STT evaluation results.
 """
 
 import argparse
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pandas as pd
@@ -12,6 +13,7 @@ import pandas as pd
 from calibrate_agent.utils import read_leaderboard_metrics
 
 INVALID_SHEET_CHARS = set("[]:*?/\\")
+PAST_RUNS_SHEET = "past_runs"
 
 
 def generate_leaderboard(output_dir: str, save_dir: str | None = None) -> str:
@@ -59,7 +61,10 @@ def generate_leaderboard(output_dir: str, save_dir: str | None = None) -> str:
     summary_df = pd.DataFrame(summary_rows)
 
     workbook_path = save_path / "stt_leaderboard.xlsx"
-    _write_leaderboard_workbook(summary_df, run_results, workbook_path)
+    past_runs_df = _load_and_extend_past_runs(workbook_path, summary_df)
+    _write_leaderboard_workbook(
+        summary_df, run_results, workbook_path, past_runs_df=past_runs_df
+    )
     print(f"Saved leaderboard workbook to {workbook_path}")
 
     return str(save_path)
@@ -73,8 +78,53 @@ def _read_leaderboard_results(results_path: Path) -> pd.DataFrame:
     return pd.read_csv(results_path)
 
 
+def _load_and_extend_past_runs(
+    workbook_path: Path, new_summary: pd.DataFrame
+) -> pd.DataFrame:
+    """Archive the previous summary into ``past_runs`` and return the full history.
+
+    If ``workbook_path`` already exists, its current ``summary`` sheet is stamped
+    with ``archived_at`` and appended under any existing ``past_runs`` rows. The
+    newly computed ``new_summary`` is not archived yet — only the previous
+    workbook's snapshot is. Returns an empty frame when there is nothing to
+    archive.
+    """
+    if not workbook_path.exists():
+        return pd.DataFrame()
+
+    try:
+        existing_past = pd.read_excel(workbook_path, sheet_name=PAST_RUNS_SHEET)
+    except ValueError:
+        existing_past = pd.DataFrame()
+    except Exception:
+        existing_past = pd.DataFrame()
+
+    try:
+        previous_summary = pd.read_excel(workbook_path, sheet_name="summary")
+    except Exception:
+        return existing_past
+
+    if previous_summary.empty:
+        return existing_past
+
+    stamped = previous_summary.copy()
+    stamped.insert(
+        0,
+        "archived_at",
+        datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    )
+
+    frames = [df for df in (existing_past, stamped) if not df.empty]
+    if not frames:
+        return pd.DataFrame()
+    return pd.concat(frames, ignore_index=True, sort=False)
+
+
 def _write_leaderboard_workbook(
-    summary_df: pd.DataFrame, run_results: dict, workbook_path: Path
+    summary_df: pd.DataFrame,
+    run_results: dict,
+    workbook_path: Path,
+    past_runs_df: pd.DataFrame | None = None,
 ) -> None:
     """Write leaderboard Excel workbook."""
     workbook_path.parent.mkdir(parents=True, exist_ok=True)
@@ -84,6 +134,16 @@ def _write_leaderboard_workbook(
         summary_df.to_excel(
             writer, sheet_name="summary", index=False, float_format="%.5f"
         )
+        sheet_names.add("summary")
+
+        if past_runs_df is not None and not past_runs_df.empty:
+            past_runs_df.to_excel(
+                writer,
+                sheet_name=PAST_RUNS_SHEET,
+                index=False,
+                float_format="%.5f",
+            )
+            sheet_names.add(PAST_RUNS_SHEET)
 
         for run_name, df in run_results.items():
             sheet_name = _unique_sheet_name(run_name, sheet_names)

--- a/calibrate_agent/stt/metrics.py
+++ b/calibrate_agent/stt/metrics.py
@@ -30,7 +30,8 @@ from calibrate_agent.langfuse import observe, langfuse, langfuse_enabled
 # NOTE: ``calibrate_agent.stt.sarvam_intent_entity`` is imported lazily inside the
 # intent/entity functions below — importing it eagerly pulls in transformers,
 # indic-nlp, and joblib, which we want to avoid unless intent/entity scoring is
-# actually requested (it runs by default unless ``--skip-llm-judges`` is passed).
+# actually requested (it runs by default unless ``intent`` is omitted from
+# ``--judges`` / ``llm_judges``, or ``--skip-llm-judges`` is passed).
 
 # Re-export for existing imports
 DEFAULT_STT_JUDGE_MODEL = DEFAULT_TEXT_JUDGE_MODEL

--- a/calibrate_agent/stt/metrics.py
+++ b/calibrate_agent/stt/metrics.py
@@ -5,11 +5,10 @@ STT evaluation metrics.
 import asyncio
 import unicodedata
 from functools import lru_cache
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 import numpy as np
 import jiwer
-from tqdm.asyncio import tqdm_asyncio
 import backoff
 
 from calibrate_agent.judges import (
@@ -18,6 +17,13 @@ from calibrate_agent.judges import (
     evaluator_result_value,
     DEFAULT_TEXT_JUDGE_MODEL,
     DEFAULT_STT_EVALUATOR,
+)
+from calibrate_agent.judge_store import (
+    JudgeKey,
+    JudgeStore,
+    gather_evaluators_with_store,
+    gather_with_store,
+    make_fingerprint,
 )
 from calibrate_agent.langfuse import observe, langfuse, langfuse_enabled
 
@@ -258,6 +264,8 @@ async def get_semantic_wer_score(
     references: List[str],
     predictions: List[str],
     model: Optional[str] = None,
+    store: Optional[JudgeStore] = None,
+    row_ids: Optional[Sequence] = None,
 ) -> dict:
     """Compute pipecat-style semantic WER over (reference, prediction) pairs.
 
@@ -293,6 +301,11 @@ async def get_semantic_wer_score(
 
     ``model`` defaults to ``DEFAULT_SEMANTIC_WER_MODEL`` when omitted; ``per_row``
     order matches the input order.
+
+    ``store``, when given, checkpoints each row's judge result under kind
+    ``"stt_semantic_wer"`` — a row already graded for the same reference,
+    prediction, and model is skipped instead of re-judged. ``row_ids``
+    identifies each row for the checkpoint; row index is used when omitted.
     """
     if not references:
         return {"semantic_wer": 0.0, "per_row": []}
@@ -303,13 +316,23 @@ async def get_semantic_wer_score(
     if model is None:
         model = DEFAULT_SEMANTIC_WER_MODEL
 
-    coroutines = [
-        _semantic_wer.semantic_wer_judge(str(reference), str(prediction), model=model)
-        for reference, prediction in zip(references, predictions)
+    keys = [
+        JudgeKey(
+            kind="stt_semantic_wer",
+            row_id=row_ids[i] if row_ids is not None else i,
+            fingerprint=make_fingerprint(str(reference), str(prediction), model),
+        )
+        for i, (reference, prediction) in enumerate(zip(references, predictions))
     ]
-    results = await tqdm_asyncio.gather(
-        *coroutines,
-        desc="Running semantic WER judge",
+
+    async def run_one(index: int) -> dict:
+        reference, prediction = references[index], predictions[index]
+        return await _semantic_wer.semantic_wer_judge(
+            str(reference), str(prediction), model=model
+        )
+
+    results = await gather_with_store(
+        keys, run_one, store, desc="Running semantic WER judge"
     )
 
     total_errors = 0
@@ -441,6 +464,8 @@ async def get_llm_judge_score(
     predictions: List[str],
     evaluators: Optional[List[dict]] = None,
     fallback_model: str = DEFAULT_STT_JUDGE_MODEL,
+    store: Optional[JudgeStore] = None,
+    row_ids: Optional[Sequence] = None,
 ) -> dict:
     """Run STT judge across all rows and aggregate per-evaluator scores.
 
@@ -460,22 +485,57 @@ async def get_llm_judge_score(
     Iteration order of ``scores`` and each ``per_row`` entry matches the
     order of the ``evaluators`` argument (Python dicts preserve insertion
     order; ``asyncio.gather`` preserves coroutine order).
+
+    ``store``, when given, checkpoints each row/evaluator pair under kind
+    ``"stt_evaluators"``. A row that is already graded for an evaluator
+    skips that evaluator's call entirely; adding a new evaluator to
+    ``evaluators`` only pays for that evaluator on rows already graded for
+    the others. The checkpoint fingerprint covers the reference, the
+    prediction, the evaluator's ``system_prompt``, its resolved model, and
+    (for rating evaluators) its scale, so editing a prompt or re-scoring
+    with a different model invalidates the cached grade. ``row_ids``
+    identifies each row for the checkpoint; row index is used when omitted.
     """
     evaluators = _resolve_evaluators(evaluators)
 
-    coroutines = [
-        stt_llm_judge(
+    row_keys: List[dict] = []
+    for i, (reference, prediction) in enumerate(zip(references, predictions)):
+        ref = str(reference)
+        pred = str(prediction)
+        row_id = row_ids[i] if row_ids is not None else i
+        keys_for_row: dict = {}
+        for ev in evaluators:
+            model_id = ev.get("judge_model") or fallback_model
+            fp_parts = [
+                ref,
+                pred,
+                ev.get("system_prompt", ""),
+                model_id,
+                ev.get("type", "binary"),
+            ]
+            if is_rating(ev):
+                fp_parts.append(int(ev["scale_min"]))
+                fp_parts.append(int(ev["scale_max"]))
+            keys_for_row[ev["name"]] = JudgeKey(
+                kind="stt_evaluators",
+                row_id=row_id,
+                fingerprint=make_fingerprint(*fp_parts),
+                evaluator=ev["name"],
+            )
+        row_keys.append(keys_for_row)
+
+    async def run_subset(index: int, names: list[str]) -> dict:
+        reference, prediction = references[index], predictions[index]
+        subset = [ev for ev in evaluators if ev["name"] in names]
+        return await stt_llm_judge(
             str(reference),
             str(prediction),
-            evaluators=evaluators,
+            evaluators=subset,
             fallback_model=fallback_model,
         )
-        for reference, prediction in zip(references, predictions)
-    ]
 
-    results = await tqdm_asyncio.gather(
-        *coroutines,
-        desc="Running STT evaluators",
+    results = await gather_evaluators_with_store(
+        row_keys, run_subset, store, desc="Running STT evaluators"
     )
 
     # Aggregate per-evaluator scores — mean of 0/1 for binary, mean of scores for rating.
@@ -511,6 +571,8 @@ async def get_intent_entity_score(
     predictions: List[str],
     language: str = "english",
     model: Optional[str] = None,
+    store: Optional[JudgeStore] = None,
+    row_ids: Optional[Sequence] = None,
 ) -> dict:
     """Normalize, judge, and aggregate intent/entity preservation.
 
@@ -531,6 +593,12 @@ async def get_intent_entity_score(
     ``model`` defaults to ``DEFAULT_INTENT_ENTITY_MODEL`` when omitted.
     ``per_row`` order matches the input order (``asyncio.gather`` preserves
     coroutine order).
+
+    ``store``, when given, checkpoints each row's judge result under kind
+    ``"stt_intent_entity"``, fingerprinted on the *normalized* reference and
+    prediction actually sent to the judge (plus the language and model), so
+    a row already graded is skipped instead of re-judged. ``row_ids``
+    identifies each row for the checkpoint; row index is used when omitted.
     """
     if not references:
         return {"intent": 0.0, "entity": 0.0, "per_row": []}
@@ -550,18 +618,27 @@ async def get_intent_entity_score(
         _normalize_pairs, references, predictions, language
     )
 
-    coroutines = [
-        sarvam_intent_entity.intent_entity_judge(
-            str(reference), str(prediction), model=model, index=i
+    keys = [
+        JudgeKey(
+            kind="stt_intent_entity",
+            row_id=row_ids[i] if row_ids is not None else i,
+            fingerprint=make_fingerprint(
+                str(norm_reference), str(norm_prediction), model, language
+            ),
         )
-        for i, (reference, prediction) in enumerate(
+        for i, (norm_reference, norm_prediction) in enumerate(
             zip(norm_references, norm_predictions)
         )
     ]
 
-    results = await tqdm_asyncio.gather(
-        *coroutines,
-        desc="Running intent/entity judge",
+    async def run_one(index: int) -> dict:
+        reference, prediction = norm_references[index], norm_predictions[index]
+        return await sarvam_intent_entity.intent_entity_judge(
+            str(reference), str(prediction), model=model, index=index
+        )
+
+    results = await gather_with_store(
+        keys, run_one, store, desc="Running intent/entity judge"
     )
 
     intent_scores = [int(row["intent_score"]) for row in results]
@@ -579,6 +656,8 @@ async def get_llm_wer_cer_score(
     predictions: List[str],
     language: str = "english",
     model: Optional[str] = None,
+    store: Optional[JudgeStore] = None,
+    row_ids: Optional[Sequence] = None,
 ) -> dict:
     """Normalize, judge segment equivalence, forgive, and re-score WER/CER.
 
@@ -617,6 +696,17 @@ async def get_llm_wer_cer_score(
 
     ``model`` defaults to ``DEFAULT_LLM_WER_MODEL`` when omitted. ``per_row``
     order matches the input order.
+
+    ``store``, when given, checkpoints the equivalence judge under kind
+    ``"stt_llm_wer"``. The judged unit here is a deduplicated *segment pair*,
+    not a dataset row — the same pair can recur across many rows, or none,
+    depending on the dataset — so the checkpoint key identifies a pair by its
+    own (reference segment, prediction segment) content rather than by
+    ``row_ids``; ``row_ids`` is accepted for signature parity with the other
+    judge functions but is not used to build these keys. A segment pair
+    already judged for the same model is skipped instead of re-judged, and a
+    prediction change that alters which segments differ naturally produces a
+    different pair and a cache miss.
     """
     if not references:
         return {"llm_wer": 0.0, "llm_cer": 0.0, "per_row": []}
@@ -659,13 +749,21 @@ async def get_llm_wer_cer_score(
                 unique_pairs.setdefault((seg["reference"], seg["prediction"]), None)
 
     pair_list = list(unique_pairs.keys())
-    coroutines = [
-        sarvam_llm_wer.equivalence_judge(ref, pred, model=model)
+    keys = [
+        JudgeKey(
+            kind="stt_llm_wer",
+            row_id=make_fingerprint(ref, pred),
+            fingerprint=make_fingerprint(ref, pred, model),
+        )
         for ref, pred in pair_list
     ]
-    judge_results = await tqdm_asyncio.gather(
-        *coroutines,
-        desc="Running LLM-WER equivalence judge",
+
+    async def run_one(index: int) -> dict:
+        ref, pred = pair_list[index]
+        return await sarvam_llm_wer.equivalence_judge(ref, pred, model=model)
+
+    judge_results = await gather_with_store(
+        keys, run_one, store, desc="Running LLM-WER equivalence judge"
     )
 
     verdicts = {

--- a/calibrate_agent/stt/metrics.py
+++ b/calibrate_agent/stt/metrics.py
@@ -763,8 +763,21 @@ async def get_llm_wer_cer_score(
         ref, pred = pair_list[index]
         return await sarvam_llm_wer.equivalence_judge(ref, pred, model=model)
 
+    def _failed_segment(_index: int, exc: BaseException) -> dict:
+        # Treat the segment as not equivalent so WER still finishes; do not
+        # cache (gather_with_store skips store.put when error_result is used).
+        return {
+            "index": 0,
+            "equivalent": False,
+            "reasoning": f"equivalence judge failed: {exc}",
+        }
+
     judge_results = await gather_with_store(
-        keys, run_one, store, desc="Running LLM-WER equivalence judge"
+        keys,
+        run_one,
+        store,
+        desc="Running LLM-WER equivalence judge",
+        error_result=_failed_segment,
     )
 
     verdicts = {

--- a/calibrate_agent/stt/sarvam_llm_wer/judge.py
+++ b/calibrate_agent/stt/sarvam_llm_wer/judge.py
@@ -11,6 +11,10 @@ One judge call per *unique differing word segment* returns whether the segment
 is semantically/phonetically equivalent (forgiven) or a genuine error.
 """
 
+from __future__ import annotations
+
+from typing import List
+
 import backoff
 import instructor
 
@@ -22,6 +26,41 @@ from calibrate_agent.stt.sarvam_llm_wer.main import LLMEquivalenceResponse, buil
 # Model used to grade segment equivalence. Matches Sarvam's llm_wer flow, which
 # judges with google/gemini-2.5-flash (reached here via OpenRouter).
 DEFAULT_LLM_WER_MODEL = "google/gemini-2.5-flash"
+
+_MULTI_TOOL_CALL_MARKER = "multiple tool calls"
+
+
+def _is_multiple_tool_calls_error(exc: BaseException) -> bool:
+    """True when instructor rejected a response that contained >1 tool call."""
+    return _MULTI_TOOL_CALL_MARKER in str(exc).lower()
+
+
+async def _create_equivalence_response(client, *, model: str, prompt: str):
+    """Ask instructor for one ``LLMEquivalenceResponse``.
+
+    Some models (notably Gemini via OpenRouter) occasionally emit two tool
+    calls for the same single-segment prompt. Instructor rejects that with
+    ``multiple tool calls``. In that case we retry once asking for a list and
+    keep the first element — both calls are usually duplicates of one verdict.
+    """
+    create = client.chat.completions.create
+    shared = dict(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0,
+        max_completion_tokens=8192,
+    )
+    try:
+        return await create(response_model=LLMEquivalenceResponse, **shared)
+    except Exception as exc:
+        if not _is_multiple_tool_calls_error(exc):
+            raise
+        responses = await create(
+            response_model=List[LLMEquivalenceResponse], **shared
+        )
+        if not responses:
+            raise
+        return responses[0]
 
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=5, factor=2)
@@ -46,12 +85,8 @@ async def equivalence_judge(
 
     prompt = build_prompt({"reference": reference, "prediction": prediction})
 
-    response = await client.chat.completions.create(
-        model=model,
-        messages=[{"role": "user", "content": prompt}],
-        response_model=LLMEquivalenceResponse,
-        temperature=0,
-        max_completion_tokens=8192,
+    response = await _create_equivalence_response(
+        client, model=model, prompt=prompt
     )
 
     result = response.model_dump()

--- a/calibrate_agent/stt/semantic_wer/__init__.py
+++ b/calibrate_agent/stt/semantic_wer/__init__.py
@@ -11,7 +11,8 @@ OpenAI-compatible tool calling vs pipecat's native Anthropic SDK) differs.
 
 Distinct from ``stt/sarvam_llm_wer`` (deterministic difflib alignment + per-
 segment equivalence forgiveness). Runs by default as part of the LLM-judge
-group; disable the group with ``--skip-llm-judges``.
+group; select with ``--judges semantic_wer`` or skip all built-in judges with
+``--skip-llm-judges``.
 
 Reference: https://github.com/pipecat-ai/stt-benchmark
 """

--- a/calibrate_agent/tts/benchmark.py
+++ b/calibrate_agent/tts/benchmark.py
@@ -20,16 +20,25 @@ import sys
 from os.path import exists, join
 from typing import Literal
 
+import pandas as pd
+
 from calibrate_agent.tts.eval import (
     TTS_LANGUAGES,
     TTS_PROVIDERS,
     run_eval_only,
     run_single_provider_eval,
+    validate_tts_eval_only_dataset,
     validate_tts_input_file,
 )
 from calibrate_agent.tts.leaderboard import generate_leaderboard
 from calibrate_agent._env import env_int
-from calibrate_agent.utils import StreamTee
+from calibrate_agent._cli_args import add_assume_yes_arg
+from calibrate_agent.judge_cost import (
+    build_tts_judge_groups,
+    confirm_estimated_judge_cost,
+)
+from calibrate_agent.judge_store import JudgeStore
+from calibrate_agent.utils import StreamTee, get_audio_duration_seconds
 
 # Maximum number of providers to run in parallel
 MAX_PARALLEL_PROVIDERS = 2
@@ -215,6 +224,7 @@ async def main():
             "$CALIBRATE_TTS_MAX_PARALLEL)."
         ),
     )
+    add_assume_yes_arg(parser)
 
     args = parser.parse_args()
 
@@ -245,6 +255,28 @@ async def main():
         print(f"Dataset: {args.dataset}")
         print(f"Output: {args.output_dir}")
         print("")
+
+        def plan_eval_only_judges():
+            is_valid, _error_msg, rows = validate_tts_eval_only_dataset(args.dataset)
+            if not is_valid:
+                return [], 0
+            # The prior run's .wav files are on disk, so the audio is measured
+            # rather than estimated from the text.
+            audio_seconds = [
+                get_audio_duration_seconds(r["audio_path"]) or 0.0 for r in rows
+            ]
+            groups = build_tts_judge_groups(
+                texts=[str(r["text"]) for r in rows],
+                audio_seconds=audio_seconds,
+                evaluators=judge_evaluators,
+            )
+            return groups, len(JudgeStore.load(args.output_dir))
+
+        if not confirm_estimated_judge_cost(
+            plan_eval_only_judges, assume_yes=args.yes
+        ):
+            print("Judge run cancelled.")
+            sys.exit(0)
 
         result = await run_eval_only(
             dataset_path=args.dataset,
@@ -314,6 +346,30 @@ async def main():
         print(f"Input: {args.input}")
         print(f"Output: {args.output_dir}")
         print("")
+
+        def plan_benchmark_judges():
+            input_df = pd.read_csv(args.input)
+            if args.debug:
+                input_df = input_df.head(args.debug_count)
+            # Nothing has been synthesized yet, so audio duration is derived
+            # from the text that will be spoken.
+            groups = build_tts_judge_groups(
+                texts=input_df["text"].astype(str).tolist(),
+                evaluators=judge_evaluators,
+                providers=len(providers),
+            )
+            cached_count = sum(
+                len(JudgeStore.load(join(args.output_dir, provider)))
+                for provider in providers
+                if exists(join(args.output_dir, provider))
+            )
+            return groups, cached_count
+
+        if not confirm_estimated_judge_cost(
+            plan_benchmark_judges, assume_yes=args.yes
+        ):
+            print("Judge run cancelled.")
+            sys.exit(0)
 
         result = await run(
             input=args.input,

--- a/calibrate_agent/tts/eval.py
+++ b/calibrate_agent/tts/eval.py
@@ -36,6 +36,7 @@ from calibrate_agent.utils import (
     get_gemini_api_key,
 )
 from calibrate_agent.pricing import TTS_DEFAULT_MODELS, cost_breakdown, resolve_pricing
+from calibrate_agent.judge_store import JudgeStore
 from calibrate_agent.tts.metrics import get_tts_llm_judge_score
 from calibrate_agent.llm._metrics_utils import _latency_percentiles
 from calibrate_agent.judges import (
@@ -867,6 +868,7 @@ async def _score_and_write_results(
     judge_evaluators: list[dict] = None,
     ttfb_values: list = None,
     cost_metrics: dict = None,
+    overwrite: bool = False,
 ) -> dict:
     """Run the TTS audio judge over (audio_path, text) pairs and write outputs.
 
@@ -878,15 +880,34 @@ async def _score_and_write_results(
     and TTFB percentile metrics are included; when None (eval-only, where
     nothing is synthesized) both are omitted. When ``cost_metrics`` is provided
     it is attached under the ``cost`` key.
+
+    A ``JudgeStore`` checkpoint (``judge_cache.jsonl``) is loaded from
+    ``output_dir``, so a (row, evaluator) result already graded there is
+    reused instead of re-billing the audio judge for it. ``overwrite=True``
+    clears that checkpoint along with ``results.csv``, so a fresh run does
+    not resurrect stale grades.
     """
     _log("Running evaluators...")
     _evaluators = judge_evaluators if judge_evaluators else [DEFAULT_TTS_EVALUATOR]
     require_unique_evaluator_names(_evaluators)
     write_evaluator_config(evaluator_config_dir, _evaluators)
+
+    store = JudgeStore.load(output_dir)
+    if overwrite:
+        store.clear()
+    cached_before = len(store)
+    if cached_before:
+        _log(
+            f"Resuming from checkpoint: {cached_before} cached judge result(s) "
+            f"found in {store.path}, skipping their judge calls"
+        )
+
     llm_judge_results = await get_tts_llm_judge_score(
         audio_paths,
         texts,
         evaluators=_evaluators,
+        store=store,
+        row_ids=ids,
     )
     for name, score_dict in llm_judge_results["scores"].items():
         _log(f"  {name}: {score_dict['mean']:.4f}")
@@ -1050,6 +1071,7 @@ async def run_single_provider_eval(
             judge_evaluators=judge_evaluators,
             ttfb_values=all_ttfb,
             cost_metrics=cost_metrics,
+            overwrite=overwrite,
         )
 
         return {
@@ -1122,6 +1144,7 @@ async def run_eval_only(
     dataset_path: str,
     output_dir: str,
     judge_evaluators: list[dict] = None,
+    overwrite: bool = False,
 ) -> dict:
     """Run the TTS audio judge only, on a prior run's audio. Skips synthesis
     and reads the run directory's ``results.csv`` directly. Writes
@@ -1134,6 +1157,8 @@ async def run_eval_only(
         output_dir: Directory to write results and metrics.
         judge_evaluators: Optional list of evaluator dicts. Defaults to the
             built-in TTS evaluator (``DEFAULT_TTS_EVALUATOR``) when omitted.
+        overwrite: If True, clear ``output_dir``'s judge checkpoint
+            (``judge_cache.jsonl``) before scoring instead of resuming from it.
 
     Returns:
         dict with status, metrics, and output_dir.
@@ -1181,6 +1206,7 @@ async def run_eval_only(
             evaluator_config_dir=output_dir,
             judge_evaluators=judge_evaluators,
             ttfb_values=None,
+            overwrite=overwrite,
         )
 
         return {

--- a/calibrate_agent/tts/metrics.py
+++ b/calibrate_agent/tts/metrics.py
@@ -2,10 +2,10 @@
 TTS evaluation metrics.
 """
 
-from typing import List, Optional
+import hashlib
+from typing import List, Optional, Sequence
 
 import numpy as np
-from tqdm.asyncio import tqdm_asyncio
 import backoff
 
 from calibrate_agent.judges import (
@@ -14,6 +14,12 @@ from calibrate_agent.judges import (
     evaluator_result_value,
     DEFAULT_AUDIO_JUDGE_MODEL,
     DEFAULT_TTS_EVALUATOR,
+)
+from calibrate_agent.judge_store import (
+    JudgeKey,
+    JudgeStore,
+    gather_evaluators_with_store,
+    make_fingerprint,
 )
 from calibrate_agent.langfuse import observe
 
@@ -24,6 +30,26 @@ DEFAULT_TTS_JUDGE_MODEL = DEFAULT_AUDIO_JUDGE_MODEL
 def _resolve_evaluators(evaluators: Optional[List[dict]]) -> List[dict]:
     """Return ``evaluators`` if non-empty, else the implicit default."""
     return list(evaluators) if evaluators else [DEFAULT_TTS_EVALUATOR]
+
+
+def _audio_content_hash(audio_path: str) -> str:
+    """Hash the bytes of ``audio_path`` for the judge cache fingerprint.
+
+    A synthesized clip's audio file is overwritten in place when the row is
+    re-synthesized, so a fingerprint built from the path alone would return a
+    stale cached grade for audio that no longer exists at that path. Hashing
+    the file's content ties the cache entry to the actual audio.
+
+    A missing or unreadable file returns a sentinel string instead of raising:
+    it never matches a real sha256 digest, so the fingerprint always misses
+    and the read failure surfaces naturally from ``audio_judge`` opening the
+    same file, rather than aborting the whole batch here.
+    """
+    try:
+        with open(audio_path, "rb") as f:
+            return hashlib.sha256(f.read()).hexdigest()
+    except OSError as e:
+        return f"unreadable:{audio_path}:{e}"
 
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=5, factor=2)
@@ -68,8 +94,30 @@ async def get_tts_llm_judge_score(
     reference_texts: List[str],
     evaluators: Optional[List[dict]] = None,
     fallback_model: str = DEFAULT_TTS_JUDGE_MODEL,
+    store: Optional[JudgeStore] = None,
+    row_ids: Optional[Sequence] = None,
 ) -> dict:
     """Run TTS judge across all rows and aggregate per-evaluator scores.
+
+    Args:
+        audio_paths: Path to each row's synthesized WAV audio file.
+        reference_texts: The text that should have been spoken for each row.
+        evaluators: List of evaluator dicts. If omitted, the implicit
+            ``DEFAULT_TTS_EVALUATOR`` is used.
+        fallback_model: Audio-capable model id used when an evaluator lacks
+            ``judge_model``.
+        store: Optional ``JudgeStore`` checkpoint. When given, a
+            (row, evaluator) pair whose fingerprint is already cached skips
+            the judge call entirely; fresh results are persisted as they
+            complete. The fingerprint hashes the audio file's bytes (not just
+            its path), the reference text, the evaluator's ``system_prompt``,
+            its resolved model id, its type, and its rating scale — so
+            re-synthesizing a clip, editing a prompt, or switching models
+            invalidates the cached grade. When ``None``, every row/evaluator
+            runs unconditionally, matching the behavior with no checkpoint.
+        row_ids: Optional per-row id used to key the checkpoint, aligned with
+            ``audio_paths``/``reference_texts``. Defaults to the row index
+            when omitted.
 
     Returns:
         {
@@ -86,18 +134,50 @@ async def get_tts_llm_judge_score(
     """
     evaluators = _resolve_evaluators(evaluators)
 
-    coroutines = [
-        tts_llm_judge(
-            audio_path,
-            reference_text,
-            evaluators=evaluators,
-            fallback_model=fallback_model,
+    if row_ids is None:
+        row_ids = range(len(audio_paths))
+
+    audio_hashes = [_audio_content_hash(path) for path in audio_paths]
+
+    row_keys = [
+        {
+            ev["name"]: JudgeKey(
+                kind="tts_evaluators",
+                row_id=row_id,
+                fingerprint=make_fingerprint(
+                    audio_hash,
+                    reference_text,
+                    ev.get("system_prompt", ""),
+                    ev.get("judge_model") or fallback_model,
+                    ev.get("type", "binary"),
+                    *(
+                        (ev.get("scale_min"), ev.get("scale_max"))
+                        if is_rating(ev)
+                        else ()
+                    ),
+                ),
+                evaluator=ev["name"],
+            )
+            for ev in evaluators
+        }
+        for row_id, audio_hash, reference_text in zip(
+            row_ids, audio_hashes, reference_texts
         )
-        for audio_path, reference_text in zip(audio_paths, reference_texts)
     ]
 
-    results = await tqdm_asyncio.gather(
-        *coroutines,
+    async def run_subset(index: int, names: list[str]) -> dict:
+        subset = [ev for ev in evaluators if ev["name"] in names]
+        return await tts_llm_judge(
+            audio_paths[index],
+            reference_texts[index],
+            evaluators=subset,
+            fallback_model=fallback_model,
+        )
+
+    results = await gather_evaluators_with_store(
+        row_keys,
+        run_subset,
+        store,
         desc="Running TTS evaluators",
     )
 

--- a/docs/cli/speech-to-text.mdx
+++ b/docs/cli/speech-to-text.mdx
@@ -132,6 +132,65 @@ Refer to the [sample config](https://github.com/ARTPARK-SAHAI-ORG/calibrate/blob
   </Accordion>
 </AccordionGroup>
 
+Beyond the configured evaluator, an STT run also grades every row with three
+built-in judges — Sarvam intent/entity preservation, Sarvam LLM-WER/CER, and a
+semantic WER judge (two calls per row) — which is usually the largest share of
+judge cost on a large run. Pass `--skip-llm-judges` to skip all three and
+report WER/CER plus the configured evaluator(s) only.
+
+### Judge cost estimate
+
+Before any judge call is made, the CLI estimates the total cost of the judge
+phase — the configured evaluator(s) plus the three built-in judges above —
+and asks for confirmation:
+
+```text
+Estimated LLM-as-judge cost for this run:
+
+  semantic_match (openai/gpt-5.4-mini): 500 calls, 42,000 input + 15,000 output tokens = $0.0990
+  semantic WER (anthropic/claude-sonnet-4.5): 1,000 calls, 210,000 input + 50,000 output tokens = $1.3800
+  Sarvam intent/entity (google/gemini-2.5-flash): 500 calls, 63,000 input + 22,500 output tokens = $0.1877
+  Sarvam LLM WER (google/gemini-2.5-flash): 500 calls, 63,000 input + 22,500 output tokens = $0.1877
+
+  Total via OpenRouter: $1.8543
+  Total via direct provider APIs: $1.8543
+
+  Estimated from a bundled rate table and a character-based token heuristic, so
+  the actual cost will differ: token counts are approximate and provider billing
+  quirks (minimums, rounding, taxes, discounts) are not modeled.
+
+Proceed with the judge run? [y/N]:
+```
+
+The estimate is a token-count approximation, not a bill — actual cost depends
+on the real tokenizer output and each provider's exact billing. The estimate
+and the prompt are printed to stderr, so redirecting stdout to a file still
+shows the prompt on screen.
+
+| Flag                     | Description                                                                                       |
+| ------------------------ | --------------------------------------------------------------------------------------------------- |
+| `--yes`, `-y`             | Skip the confirmation prompt and proceed with the judge run.                                       |
+| `CALIBRATE_ASSUME_YES`    | Environment variable; set to any non-empty value to skip the confirmation prompt without passing `--yes`. |
+
+The prompt is also skipped automatically when stdin isn't a terminal (piped
+input, CI) or when the process is running in the background of one — the case
+that matters for `calibrate-agent stt ... &`, since a backgrounded process
+reading from the terminal would otherwise be suspended by the operating
+system rather than shown a prompt. For a backgrounded or scheduled run, pass
+`--yes` or set `CALIBRATE_ASSUME_YES=1` regardless, so the run proceeds
+unattended without depending on that detection.
+
+### Resuming an interrupted judge run
+
+Every judge result is written to `judge_cache.jsonl` in the run's output
+directory as soon as it's computed. If a judge run is interrupted or a row's
+judge call fails, restarting the same command reuses the cached results
+instead of re-grading — and re-paying for — rows already judged. Editing an
+evaluator's `system_prompt`, switching its `judge_model`, or re-transcribing a
+row invalidates that row's cached result, so it's judged again automatically.
+Pass `--overwrite` to discard `judge_cache.jsonl` along with `results.csv`
+and start clean.
+
 ## Output
 
 Once all the providers have completed, it displays a leaderboard measuring key metrics along with bar charts for better visualization.

--- a/docs/cli/speech-to-text.mdx
+++ b/docs/cli/speech-to-text.mdx
@@ -133,15 +133,18 @@ Refer to the [sample config](https://github.com/ARTPARK-SAHAI-ORG/calibrate/blob
 </AccordionGroup>
 
 Beyond the configured evaluator, an STT run also grades every row with three
-built-in judges — Sarvam intent/entity preservation, Sarvam LLM-WER/CER, and a
-semantic WER judge (two calls per row) — which is usually the largest share of
-judge cost on a large run. Pass `--skip-llm-judges` to skip all three and
-report WER/CER plus the configured evaluator(s) only.
+built-in judges — Sarvam intent/entity preservation (`intent`), Sarvam
+LLM-WER/CER (`llm_wer`), and a semantic WER judge (`semantic_wer`; two calls
+per row) — which is usually the largest share of judge cost on a large run.
+Pass `--judges intent,llm_wer` (comma-separated) to run only a subset, or
+`--skip-llm-judges` to skip all three and report WER/CER plus the configured
+evaluator(s) only. `--judges` and `--skip-llm-judges` are mutually exclusive.
+Config evaluators from `--config` are independent of this selection.
 
 ### Judge cost estimate
 
 Before any judge call is made, the CLI estimates the total cost of the judge
-phase — the configured evaluator(s) plus the three built-in judges above —
+phase — the configured evaluator(s) plus whichever built-in judges will run —
 and asks for confirmation:
 
 ```text
@@ -169,6 +172,8 @@ shows the prompt on screen.
 
 | Flag                     | Description                                                                                       |
 | ------------------------ | --------------------------------------------------------------------------------------------------- |
+| `--judges NAMES`          | Comma-separated subset of built-in judges to run: `intent`, `llm_wer`, `semantic_wer`. Omit to run all three. Mutually exclusive with `--skip-llm-judges`. |
+| `--skip-llm-judges`       | Skip all three built-in LLM judges. Mutually exclusive with `--judges`. Config evaluators are unaffected. |
 | `--yes`, `-y`             | Skip the confirmation prompt and proceed with the judge run.                                       |
 | `CALIBRATE_ASSUME_YES`    | Environment variable; set to any non-empty value to skip the confirmation prompt without passing `--yes`. |
 

--- a/docs/cli/text-to-speech.mdx
+++ b/docs/cli/text-to-speech.mdx
@@ -112,6 +112,57 @@ Refer to the [sample config](https://github.com/ARTPARK-SAHAI-ORG/calibrate/blob
   </Accordion>
 </AccordionGroup>
 
+### Judge cost estimate
+
+Before any audio judge call is made, the CLI estimates the total cost of the
+judge phase — one call per evaluator per row — and asks for confirmation:
+
+```text
+Estimated LLM-as-judge cost for this run:
+
+  pronunciation (openai/gpt-audio): 300 calls, 6,000 input + 15,000 output tokens + 12,000 audio tokens = $0.5490
+
+  Total via OpenRouter: $0.5490
+  Total via direct provider APIs: $0.5490
+
+  Estimated from a bundled rate table and a character-based token heuristic, so
+  the actual cost will differ: token counts are approximate and provider billing
+  quirks (minimums, rounding, taxes, discounts) are not modeled.
+
+Proceed with the judge run? [y/N]:
+```
+
+The audio judge model bills audio by token rather than by minute: audio
+duration is converted to tokens at roughly 10 audio tokens per second before
+being priced. The estimate as a whole is a token-count approximation, not a
+bill — actual cost depends on the real tokenizer output and each provider's
+exact billing. The estimate and the prompt are printed to stderr, so
+redirecting stdout to a file still shows the prompt on screen.
+
+| Flag                     | Description                                                                                       |
+| ------------------------ | --------------------------------------------------------------------------------------------------- |
+| `--yes`, `-y`             | Skip the confirmation prompt and proceed with the judge run.                                       |
+| `CALIBRATE_ASSUME_YES`    | Environment variable; set to any non-empty value to skip the confirmation prompt without passing `--yes`. |
+
+The prompt is also skipped automatically when stdin isn't a terminal (piped
+input, CI) or when the process is running in the background of one — the case
+that matters for `calibrate-agent tts ... &`, since a backgrounded process
+reading from the terminal would otherwise be suspended by the operating
+system rather than shown a prompt. For a backgrounded or scheduled run, pass
+`--yes` or set `CALIBRATE_ASSUME_YES=1` regardless, so the run proceeds
+unattended without depending on that detection.
+
+### Resuming an interrupted judge run
+
+Every judge result is written to `judge_cache.jsonl` in the run's output
+directory as soon as it's computed. If a judge run is interrupted or a row's
+judge call fails, restarting the same command reuses the cached results
+instead of re-grading — and re-paying for — rows already judged. Editing an
+evaluator's `system_prompt`, switching its `judge_model`, or re-synthesizing a
+row's audio invalidates that row's cached result, so it's judged again
+automatically. Pass `--overwrite` to discard `judge_cache.jsonl` along with
+`results.csv` and start clean.
+
 ## Output
 
 Once all the providers have completed, it displays a leaderboard measuring key metrics along with bar charts for better visualization.

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -626,6 +626,176 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             self.assertIn("sarvam_llm_wer", df.columns)
             self.assertEqual(int(df.loc[df["id"].astype(str) == "1", "sarvam_intent_score"].iloc[0]), 1)
 
+    async def test_merge_no_prior_returns_unchanged(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            metrics = {"wer": 0.1, "cer": 0.2}
+            rows = [{"id": "1", "gt": "a", "pred": "a", "wer": 0.0, "cer": 0.0}]
+            out_m, out_r = stt_eval._merge_prior_judge_outputs(
+                metrics,
+                rows,
+                tmp,
+                overwrite=False,
+                enabled_judges=frozenset({"llm_wer"}),
+                this_run_evaluator_names=set(),
+            )
+            self.assertEqual(out_m, metrics)
+            self.assertEqual(out_r, rows)
+            self.assertFalse((Path(tmp) / "judge_history").exists())
+
+    async def test_merge_overwrite_archives_but_does_not_restore(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            (out / "metrics.json").write_text(
+                json.dumps(
+                    {
+                        "wer": 0.5,
+                        "cer": 0.4,
+                        "sarvam_intent_score": 0.9,
+                        "sarvam_entity_score": 0.8,
+                    }
+                )
+            )
+            fresh = {"wer": 0.1, "cer": 0.05, "sarvam_llm_wer": 0.02}
+            rows = [{"id": "1", "gt": "a", "pred": "a", "wer": 0.0, "cer": 0.0}]
+            out_m, out_r = stt_eval._merge_prior_judge_outputs(
+                dict(fresh),
+                rows,
+                str(out),
+                overwrite=True,
+                enabled_judges=frozenset({"llm_wer"}),
+                this_run_evaluator_names=set(),
+            )
+            self.assertEqual(out_m, fresh)
+            self.assertNotIn("sarvam_intent_score", out_m)
+            self.assertEqual(len(list((out / "judge_history").glob("metrics_*.json"))), 1)
+
+    async def test_merge_skips_nan_prior_cells(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            (out / "metrics.json").write_text(
+                json.dumps({"wer": 0.5, "cer": 0.4, "sarvam_intent_score": 0.9})
+            )
+            pd.DataFrame(
+                [
+                    {
+                        "id": "1",
+                        "gt": "a",
+                        "pred": "a",
+                        "wer": 0.0,
+                        "cer": 0.0,
+                        "sarvam_intent_score": float("nan"),
+                        "sarvam_intent_reasoning": "ok",
+                    }
+                ]
+            ).to_csv(out / "results.csv", index=False)
+
+            rows = [{"id": "1", "gt": "a", "pred": "a", "wer": 0.0, "cer": 0.0}]
+            _, out_rows = stt_eval._merge_prior_judge_outputs(
+                {"wer": 0.1, "cer": 0.05},
+                rows,
+                str(out),
+                overwrite=False,
+                enabled_judges=frozenset({"llm_wer"}),
+                this_run_evaluator_names=set(),
+            )
+            self.assertNotIn("sarvam_intent_score", out_rows[0])
+            self.assertEqual(out_rows[0]["sarvam_intent_reasoning"], "ok")
+
+    async def test_merge_preserves_config_evaluator_columns(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            (out / "metrics.json").write_text(
+                json.dumps(
+                    {
+                        "wer": 0.5,
+                        "cer": 0.4,
+                        "semantic_match": {"type": "binary", "mean": 0.9},
+                    }
+                )
+            )
+            pd.DataFrame(
+                [
+                    {
+                        "id": "1",
+                        "gt": "a",
+                        "pred": "a",
+                        "wer": 0.0,
+                        "cer": 0.0,
+                        "semantic_match": True,
+                        "semantic_match_reasoning": "match",
+                    }
+                ]
+            ).to_csv(out / "results.csv", index=False)
+
+            metrics, rows = stt_eval._merge_prior_judge_outputs(
+                {"wer": 0.1, "cer": 0.05, "sarvam_llm_wer": 0.02},
+                [{"id": "1", "gt": "a", "pred": "a", "wer": 0.0, "cer": 0.0}],
+                str(out),
+                overwrite=False,
+                enabled_judges=frozenset({"llm_wer"}),
+                this_run_evaluator_names=set(),
+            )
+            self.assertEqual(metrics["semantic_match"]["mean"], 0.9)
+            self.assertTrue(rows[0]["semantic_match"])
+            self.assertEqual(rows[0]["semantic_match_reasoning"], "match")
+
+    async def test_load_prior_helpers_handle_corrupt_inputs(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            (out / "metrics.json").write_text("{not-json")
+            self.assertIsNone(stt_eval._load_prior_metrics(str(out)))
+
+            (out / "metrics.json").write_text("[1, 2]")
+            self.assertIsNone(stt_eval._load_prior_metrics(str(out)))
+
+            (out / "results.csv").write_text("")
+            self.assertIsNone(stt_eval._load_prior_results(str(out)))
+
+    async def test_merge_skips_rows_missing_from_prior(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            (out / "metrics.json").write_text(
+                json.dumps({"wer": 0.5, "sarvam_intent_score": 0.9})
+            )
+            pd.DataFrame(
+                [
+                    {
+                        "id": "1",
+                        "gt": "a",
+                        "pred": "a",
+                        "wer": 0.0,
+                        "cer": 0.0,
+                        "sarvam_intent_score": 1,
+                    }
+                ]
+            ).to_csv(out / "results.csv", index=False)
+
+            _, rows = stt_eval._merge_prior_judge_outputs(
+                {"wer": 0.1},
+                [
+                    {"id": "1", "gt": "a", "pred": "a", "wer": 0.0},
+                    {"id": "new", "gt": "b", "pred": "b", "wer": 0.0},
+                ],
+                str(out),
+                overwrite=False,
+                enabled_judges=frozenset({"llm_wer"}),
+                this_run_evaluator_names=set(),
+            )
+            self.assertEqual(rows[0]["sarvam_intent_score"], 1)
+            self.assertNotIn("sarvam_intent_score", rows[1])
+
     async def test_llm_judge_failure_still_writes_wer_cer_and_sarvam(self):
         from calibrate_agent.stt import eval as stt_eval
 

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -712,6 +712,35 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             df = pd.read_csv(out / "results.csv")
             self.assertEqual(df.iloc[0]["accuracy"], 4)
 
+    async def test_resume_logs_cached_judge_count(self):
+        from calibrate_agent.stt import eval as stt_eval
+        from calibrate_agent.judge_store import JudgeKey, JudgeStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            store = JudgeStore.load(str(out))
+            await store.put(
+                JudgeKey(kind="intent", row_id="1", fingerprint="fp"),
+                {"ok": True},
+            )
+
+            log_mock = MagicMock()
+            with patch.object(stt_eval, "_log", log_mock):
+                await stt_eval._score_and_write_results(
+                    ids=["1", "2"],
+                    gt_transcripts=["hello", "world"],
+                    pred_transcripts=["hello", "world"],
+                    output_dir=str(out),
+                    evaluator_config_dir=str(out),
+                    llm_judges=frozenset(),
+                )
+
+            resume_logged = any(
+                "Resuming judge grading" in str(call)
+                for call in log_mock.call_args_list
+            )
+            self.assertTrue(resume_logged)
+
 
 class TestSTTRunEvalOnly(unittest.IsolatedAsyncioTestCase):
     def setUp(self):

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -232,7 +232,7 @@ class TestTranscribeAudioRouter(unittest.IsolatedAsyncioTestCase):
 def _fake_intent_entity(intent=1, entity=1.0):
     """Build a fake ``get_intent_entity_score`` returning fixed scores per row."""
 
-    async def _fn(refs, preds, language="english", model=None):
+    async def _fn(refs, preds, language="english", model=None, **kwargs):
         return {
             "intent": float(intent),
             "entity": float(entity),
@@ -256,7 +256,7 @@ def _fake_intent_entity(intent=1, entity=1.0):
 def _fake_llm_wer(llm_wer=0.05, llm_cer=0.03):
     """Build a fake ``get_llm_wer_cer_score`` returning fixed scores per row."""
 
-    async def _fn(refs, preds, language="english", model=None):
+    async def _fn(refs, preds, language="english", model=None, **kwargs):
         return {
             "llm_wer": float(llm_wer),
             "llm_cer": float(llm_cer),
@@ -276,7 +276,7 @@ def _fake_llm_wer(llm_wer=0.05, llm_cer=0.03):
 def _fake_semantic_wer():
     """Fake ``get_semantic_wer_score`` (part of the default LLM-judge group)."""
 
-    async def _sem(references, predictions, model=None):
+    async def _sem(references, predictions, model=None, **kwargs):
         return {
             "semantic_wer": 0.0,
             "per_row": [
@@ -304,7 +304,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
     async def test_writes_metrics_and_results(self):
         from calibrate_agent.stt import eval as stt_eval
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, **kwargs):
             return {
                 "scores": {
                     "semantic_match": {"type": "binary", "mean": 1.0}
@@ -383,7 +383,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             }
         ]
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, **kwargs):
             return {
                 "scores": {"completeness": {"type": "binary", "mean": 0.5}},
                 "score": 0.5,
@@ -425,7 +425,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
     async def test_sarvam_judges_run_by_default(self):
         from calibrate_agent.stt import eval as stt_eval
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, **kwargs):
             return {
                 "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                 "score": 1.0,
@@ -472,7 +472,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
     async def test_sarvam_judges_skipped_when_disabled(self):
         from calibrate_agent.stt import eval as stt_eval
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, **kwargs):
             return {
                 "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                 "score": 1.0,
@@ -559,7 +559,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
     async def test_sarvam_failure_still_writes_wer_cer_and_evaluator(self):
         from calibrate_agent.stt import eval as stt_eval
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, **kwargs):
             return {
                 "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                 "score": 1.0,
@@ -645,7 +645,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             "scale_max": 5,
         }
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, **kwargs):
             return {
                 "scores": {
                     "accuracy": {
@@ -692,7 +692,7 @@ class TestSTTRunEvalOnly(unittest.IsolatedAsyncioTestCase):
     async def test_runs_evaluator_on_dataset(self):
         from calibrate_agent.stt import eval as stt_eval
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, **kwargs):
             return {
                 "scores": {"semantic_match": {"type": "binary", "mean": 0.5}},
                 "score": 0.5,

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -547,6 +547,85 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             self.assertNotIn("sarvam_llm_wer", df.columns)
             self.assertNotIn("semantic_wer", df.columns)
 
+    async def test_subset_run_preserves_prior_judge_outputs(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            # Prior full-judge artifacts on disk.
+            (out / "metrics.json").write_text(
+                json.dumps(
+                    {
+                        "wer": 0.5,
+                        "cer": 0.4,
+                        "sarvam_intent_score": 0.9,
+                        "sarvam_entity_score": 0.8,
+                        "sarvam_llm_wer": 0.2,
+                        "sarvam_llm_cer": 0.1,
+                    }
+                )
+            )
+            pd.DataFrame(
+                [
+                    {
+                        "id": "1",
+                        "gt": "hello",
+                        "pred": "hello",
+                        "wer": 0.0,
+                        "cer": 0.0,
+                        "sarvam_intent_score": 1,
+                        "sarvam_intent_reasoning": "ok",
+                        "sarvam_entity_score": 1.0,
+                        "sarvam_entity_reasoning": "ok",
+                        "sarvam_llm_wer": 0.0,
+                        "sarvam_llm_cer": 0.0,
+                        "sarvam_llm_wer_reasoning": "[]",
+                    },
+                    {
+                        "id": "2",
+                        "gt": "world",
+                        "pred": "word",
+                        "wer": 1.0,
+                        "cer": 0.2,
+                        "sarvam_intent_score": 0,
+                        "sarvam_intent_reasoning": "miss",
+                        "sarvam_entity_score": 0.5,
+                        "sarvam_entity_reasoning": "partial",
+                        "sarvam_llm_wer": 0.5,
+                        "sarvam_llm_cer": 0.2,
+                        "sarvam_llm_wer_reasoning": "[]",
+                    },
+                ]
+            ).to_csv(out / "results.csv", index=False)
+
+            llm_wer_mock = _fake_llm_wer(0.05, 0.03)
+            with patch.object(stt_eval, "get_llm_wer_cer_score", llm_wer_mock), patch.object(
+                stt_eval, "get_intent_entity_score", AsyncMock()
+            ) as ie_mock, patch.object(
+                stt_eval, "get_semantic_wer_score", AsyncMock()
+            ) as sem_mock:
+                metrics = await stt_eval._score_and_write_results(
+                    ids=["1", "2"],
+                    gt_transcripts=["hello", "world"],
+                    pred_transcripts=["hello", "word"],
+                    output_dir=str(out),
+                    evaluator_config_dir=str(out),
+                    llm_judges=frozenset({"llm_wer"}),
+                )
+
+            ie_mock.assert_not_awaited()
+            sem_mock.assert_not_awaited()
+            # Fresh llm_wer + preserved intent/entity from prior.
+            self.assertEqual(metrics["sarvam_llm_wer"], 0.05)
+            self.assertEqual(metrics["sarvam_intent_score"], 0.9)
+            self.assertEqual(metrics["sarvam_entity_score"], 0.8)
+            history = list((out / "judge_history").glob("metrics_*.json"))
+            self.assertEqual(len(history), 1)
+            df = pd.read_csv(out / "results.csv")
+            self.assertIn("sarvam_intent_score", df.columns)
+            self.assertIn("sarvam_llm_wer", df.columns)
+            self.assertEqual(int(df.loc[df["id"].astype(str) == "1", "sarvam_intent_score"].iloc[0]), 1)
+
     async def test_llm_judge_failure_still_writes_wer_cer_and_sarvam(self):
         from calibrate_agent.stt import eval as stt_eval
 

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -338,7 +338,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                             "judge_model": "openai/gpt-4.1",
                         }
                     ],
-                    run_llm_judges=True,
+                    llm_judges=None,
                 )
 
             self.assertIn("wer", metrics)
@@ -408,7 +408,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                     output_dir=str(out),
                     evaluator_config_dir=str(out),
                     judge_evaluators=custom,
-                    run_llm_judges=True,
+                    llm_judges=None,
                 )
 
             # With the flag on, intent/entity report alongside a custom evaluator.
@@ -501,7 +501,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                             "judge_model": "openai/gpt-4.1",
                         }
                     ],
-                    run_llm_judges=False,
+                    llm_judges=frozenset(),
                 )
 
             # Disabled: the Sarvam judge is never invoked and no sarvam_* keys appear.
@@ -514,6 +514,38 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             # WER/CER and the judge column are still written.
             self.assertIn("wer", metrics)
             self.assertIn("semantic_match", metrics)
+
+    async def test_llm_judges_subset_runs_only_selected(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        ie_mock = _fake_intent_entity(1, 1.0)
+        llm_wer_mock = AsyncMock()
+        semantic_wer_mock = AsyncMock()
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            with patch.object(stt_eval, "get_intent_entity_score", ie_mock), patch.object(
+                stt_eval, "get_llm_wer_cer_score", llm_wer_mock
+            ), patch.object(stt_eval, "get_semantic_wer_score", semantic_wer_mock):
+                metrics = await stt_eval._score_and_write_results(
+                    ids=["1", "2"],
+                    gt_transcripts=["hello", "world"],
+                    pred_transcripts=["hello", "world"],
+                    output_dir=str(out),
+                    evaluator_config_dir=str(out),
+                    llm_judges=frozenset({"intent"}),
+                )
+
+            ie_mock.assert_awaited_once()
+            llm_wer_mock.assert_not_awaited()
+            semantic_wer_mock.assert_not_awaited()
+            self.assertIn("sarvam_intent_score", metrics)
+            self.assertIn("sarvam_entity_score", metrics)
+            self.assertNotIn("sarvam_llm_wer", metrics)
+            self.assertNotIn("semantic_wer", metrics)
+            df = pd.read_csv(out / "results.csv")
+            self.assertIn("sarvam_intent_score", df.columns)
+            self.assertNotIn("sarvam_llm_wer", df.columns)
+            self.assertNotIn("semantic_wer", df.columns)
 
     async def test_llm_judge_failure_still_writes_wer_cer_and_sarvam(self):
         from calibrate_agent.stt import eval as stt_eval
@@ -619,7 +651,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                     pred_transcripts=["hello", "goodbye"],
                     output_dir=str(out),
                     evaluator_config_dir=str(out),
-                    run_llm_judges=False,
+                    llm_judges=frozenset(),
                 )
 
             # No evaluators passed: the LLM judge is never invoked, no evaluator
@@ -675,7 +707,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
                     output_dir=str(out),
                     evaluator_config_dir=str(out),
                     judge_evaluators=[rating],
-                    run_llm_judges=False,
+                    llm_judges=frozenset(),
                 )
             df = pd.read_csv(out / "results.csv")
             self.assertEqual(df.iloc[0]["accuracy"], 4)
@@ -722,7 +754,7 @@ class TestSTTRunEvalOnly(unittest.IsolatedAsyncioTestCase):
                 result = await stt_eval.run_eval_only(
                     dataset_path=str(ds_path),
                     output_dir=str(out),
-                    run_llm_judges=False,
+                    llm_judges=frozenset(),
                 )
 
             self.assertEqual(result["status"], "completed")

--- a/tests/stt/test_eval_extra.py
+++ b/tests/stt/test_eval_extra.py
@@ -748,7 +748,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
                             "judge_model": "openai/gpt-4.1",
                         }
                     ],
-                    run_llm_judges=False,
+                    llm_judges=frozenset(),
                 )
             self.assertEqual(result["wer"], 0.1)
             self.assertEqual(result["cer"], 0.2)
@@ -781,7 +781,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
                     pred_transcripts=["x", "y"],
                     output_dir=tmp,
                     evaluator_config_dir=tmp,
-                    run_llm_judges=True,
+                    llm_judges=None,
                 )
             self.assertEqual(result["sarvam_llm_wer"], 0.05)
             self.assertEqual(result["sarvam_llm_cer"], 0.03)
@@ -809,7 +809,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
                     pred_transcripts=["x"],
                     output_dir=tmp,
                     evaluator_config_dir=tmp,
-                    run_llm_judges=False,
+                    llm_judges=frozenset(),
                 )
             llm_wer_mock.assert_not_called()
             self.assertNotIn("sarvam_llm_wer", result)
@@ -839,7 +839,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
                 output_dir=tmp,
                 evaluator_config_dir=tmp,
                 judge_evaluators=[rating_ev],
-                run_llm_judges=False,
+                llm_judges=frozenset(),
             )
 
     async def test_short_row_extras_do_not_truncate_results(self):
@@ -1002,7 +1002,7 @@ class TestRunEvalOnly(unittest.IsolatedAsyncioTestCase):
                      ],
                  })):
                 result = await E.run_eval_only(
-                    str(ds), str(out), run_llm_judges=False
+                    str(ds), str(out), llm_judges=frozenset()
                 )
         self.assertEqual(result["status"], "completed")
 
@@ -1083,7 +1083,7 @@ class TestRunSingleProviderEval(unittest.IsolatedAsyncioTestCase):
                     debug_count=5,
                     ignore_retry=False,
                     overwrite=True,
-                    run_llm_judges=False,
+                    llm_judges=frozenset(),
                 )
             self.assertEqual(result["status"], "completed")
 
@@ -1146,7 +1146,7 @@ class TestRunSingleProviderEval(unittest.IsolatedAsyncioTestCase):
                     debug_count=1,
                     ignore_retry=True,
                     overwrite=False,
-                    run_llm_judges=False,
+                    llm_judges=frozenset(),
                     engine="direct",
                 )
             self.assertEqual(result["status"], "completed")

--- a/tests/stt/test_eval_extra.py
+++ b/tests/stt/test_eval_extra.py
@@ -16,7 +16,7 @@ import pandas as pd
 def _fake_intent_entity(intent=1, entity=1.0):
     """Adaptive ``get_intent_entity_score`` mock — one row per input pair."""
 
-    async def _fn(refs, preds, language="english", model=None):
+    async def _fn(refs, preds, language="english", model=None, **kwargs):
         return {
             "intent": float(intent),
             "entity": float(entity),
@@ -37,7 +37,7 @@ def _fake_intent_entity(intent=1, entity=1.0):
 def _fake_llm_wer(llm_wer=0.05, llm_cer=0.03):
     """Adaptive ``get_llm_wer_cer_score`` mock — one row per input pair."""
 
-    async def _fn(refs, preds, language="english", model=None):
+    async def _fn(refs, preds, language="english", model=None, **kwargs):
         return {
             "llm_wer": float(llm_wer),
             "llm_cer": float(llm_cer),
@@ -703,7 +703,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         from calibrate_agent.stt import eval as E
 
-        async def _sem(references, predictions, model=None):
+        async def _sem(references, predictions, model=None, **kwargs):
             return {
                 "semantic_wer": 0.0,
                 "per_row": [

--- a/tests/stt/test_leaderboard.py
+++ b/tests/stt/test_leaderboard.py
@@ -131,6 +131,35 @@ class TestSTTLeaderboard(unittest.TestCase):
             summary = pd.read_excel(xlsx, sheet_name="summary")
             self.assertEqual(list(summary["run"]), ["provider-x"])
 
+    def test_regenerate_archives_previous_summary_to_past_runs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            _write_provider(
+                base,
+                "deepgram",
+                {"wer": 0.1, "sarvam_intent_score": 0.9},
+                results_rows=[{"id": 1, "gt": "a", "pred": "a"}],
+            )
+            save_dir = base / "leaderboard"
+            generate_stt_leaderboard(str(base), str(save_dir))
+
+            # Update metrics and regenerate — prior summary should land on past_runs.
+            _write_provider(
+                base,
+                "deepgram",
+                {"wer": 0.2, "sarvam_llm_wer": 0.15},
+                results_rows=[{"id": 1, "gt": "a", "pred": "a"}],
+            )
+            generate_stt_leaderboard(str(base), str(save_dir))
+
+            xlsx = save_dir / "stt_leaderboard.xlsx"
+            summary = pd.read_excel(xlsx, sheet_name="summary")
+            past = pd.read_excel(xlsx, sheet_name="past_runs")
+            self.assertIn("sarvam_llm_wer", summary.columns)
+            self.assertIn("archived_at", past.columns)
+            self.assertIn("sarvam_intent_score", past.columns)
+            self.assertAlmostEqual(float(past["sarvam_intent_score"].iloc[0]), 0.9)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/stt/test_leaderboard.py
+++ b/tests/stt/test_leaderboard.py
@@ -160,6 +160,108 @@ class TestSTTLeaderboard(unittest.TestCase):
             self.assertIn("sarvam_intent_score", past.columns)
             self.assertAlmostEqual(float(past["sarvam_intent_score"].iloc[0]), 0.9)
 
+    def test_past_runs_missing_summary_keeps_existing_past(self):
+        from calibrate_agent.stt import leaderboard as LB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            xlsx = Path(tmp) / "stt_leaderboard.xlsx"
+            existing = pd.DataFrame(
+                [{"archived_at": "2020-01-01T00:00:00Z", "run": "old", "wer": 0.3}]
+            )
+            with pd.ExcelWriter(xlsx, engine="openpyxl") as writer:
+                existing.to_excel(writer, sheet_name="past_runs", index=False)
+                # Intentionally no summary sheet.
+
+            out = LB._load_and_extend_past_runs(xlsx, pd.DataFrame([{"run": "new"}]))
+            self.assertEqual(list(out["run"]), ["old"])
+            self.assertAlmostEqual(float(out["wer"].iloc[0]), 0.3)
+
+    def test_past_runs_empty_summary_keeps_existing_past(self):
+        from calibrate_agent.stt import leaderboard as LB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            xlsx = Path(tmp) / "stt_leaderboard.xlsx"
+            existing = pd.DataFrame(
+                [{"archived_at": "2020-01-01T00:00:00Z", "run": "old", "wer": 0.3}]
+            )
+            with pd.ExcelWriter(xlsx, engine="openpyxl") as writer:
+                existing.to_excel(writer, sheet_name="past_runs", index=False)
+                pd.DataFrame().to_excel(writer, sheet_name="summary", index=False)
+
+            out = LB._load_and_extend_past_runs(xlsx, pd.DataFrame([{"run": "new"}]))
+            self.assertEqual(list(out["run"]), ["old"])
+
+    def test_write_workbook_includes_stub_for_empty_provider_results(self):
+        from calibrate_agent.stt import leaderboard as LB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            xlsx = Path(tmp) / "stt_leaderboard.xlsx"
+            LB._write_leaderboard_workbook(
+                pd.DataFrame([{"run": "deepgram", "wer": 0.1}]),
+                {"deepgram": pd.DataFrame()},
+                xlsx,
+                past_runs_df=pd.DataFrame(
+                    [{"archived_at": "t", "run": "deepgram", "wer": 0.2}]
+                ),
+            )
+            stub = pd.read_excel(xlsx, sheet_name="deepgram")
+            self.assertIn("No results.csv found", stub["info"].iloc[0])
+            past = pd.read_excel(xlsx, sheet_name="past_runs")
+            self.assertEqual(list(past["run"]), ["deepgram"])
+
+    def test_unique_sheet_name_avoids_collisions(self):
+        from calibrate_agent.stt.leaderboard import _unique_sheet_name
+
+        existing = {"deepgram"}
+        self.assertEqual(_unique_sheet_name("deepgram", existing), "deepgram_1")
+        self.assertEqual(_unique_sheet_name("a[]:*?/\\b", set()), "a_______b")
+        self.assertEqual(_unique_sheet_name("   ", set()), "run")
+
+    def test_past_runs_generic_exception_on_past_sheet_yields_empty_past(self):
+        from unittest.mock import patch
+
+        from calibrate_agent.stt import leaderboard as LB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            xlsx = Path(tmp) / "stt_leaderboard.xlsx"
+            with pd.ExcelWriter(xlsx, engine="openpyxl") as writer:
+                pd.DataFrame([{"run": "deepgram", "wer": 0.1}]).to_excel(
+                    writer, sheet_name="summary", index=False
+                )
+
+            real_read = pd.read_excel
+
+            def fake_read_excel(*args, **kwargs):
+                sheet = kwargs.get("sheet_name")
+                if sheet == "past_runs":
+                    raise OSError("corrupt sheet")
+                return real_read(*args, **kwargs)
+
+            with patch.object(LB.pd, "read_excel", side_effect=fake_read_excel):
+                out = LB._load_and_extend_past_runs(
+                    xlsx, pd.DataFrame([{"run": "new"}])
+                )
+            self.assertIn("archived_at", out.columns)
+            self.assertEqual(list(out["run"]), ["deepgram"])
+
+    def test_leaderboard_main_cli(self):
+        import sys
+        from unittest.mock import patch
+
+        from calibrate_agent.stt import leaderboard as LB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            _write_provider(base, "deepgram", {"wer": 0.1})
+            save = base / "lb"
+            with patch.object(
+                sys,
+                "argv",
+                ["leaderboard.py", "-o", str(base), "-s", str(save)],
+            ):
+                LB.main()
+            self.assertTrue((save / "stt_leaderboard.xlsx").exists())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/stt/test_llm_wer.py
+++ b/tests/stt/test_llm_wer.py
@@ -77,6 +77,28 @@ class TestGetLlmWerCerScore(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result["per_row"][0]["segments"][0]["equivalent"])
         self.assertFalse(result["per_row"][1]["segments"][0]["equivalent"])
 
+    async def test_one_segment_failure_does_not_abort_metric(self):
+        from calibrate_agent.stt import sarvam_llm_wer as slw
+        from calibrate_agent.stt import metrics
+
+        async def fake_judge(reference, prediction, model=None):
+            if (reference, prediction) == ("doctor", "daktar"):
+                raise RuntimeError("boom")
+            return {"index": 0, "equivalent": False, "reasoning": "different"}
+
+        with patch.object(slw, "equivalence_judge", AsyncMock(side_effect=fake_judge)):
+            result = await metrics.get_llm_wer_cer_score(
+                references=["doctor ne bola", "hello world"],
+                predictions=["daktar ne bola", "hello word"],
+            )
+
+        # Failed segment is treated as not equivalent; metric still returns.
+        self.assertIn("llm_wer", result)
+        self.assertEqual(len(result["per_row"]), 2)
+        failed_seg = result["per_row"][0]["segments"][0]
+        self.assertFalse(failed_seg["equivalent"])
+        self.assertIn("failed", failed_seg["reasoning"].lower())
+
     async def test_unique_segments_judged_once(self):
         from calibrate_agent.stt import sarvam_llm_wer as slw
         from calibrate_agent.stt import metrics
@@ -246,6 +268,39 @@ class TestEquivalenceJudge(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(kwargs["temperature"], 0)
         self.assertEqual(kwargs["response_model"], jw.LLMEquivalenceResponse)
 
+    async def test_judge_recovers_from_multiple_tool_calls(self):
+        from calibrate_agent.stt.sarvam_llm_wer import judge as jw
+
+        fake_result = {"index": 0, "equivalent": True, "reasoning": "same"}
+        fake_response = MagicMock()
+        fake_response.model_dump.return_value = fake_result
+        list_item = MagicMock()
+        list_item.model_dump.return_value = fake_result
+
+        fake_client = MagicMock()
+        fake_client.chat.completions.create = AsyncMock(
+            side_effect=[
+                RuntimeError("Instructor does not support multiple tool calls"),
+                [list_item],
+            ]
+        )
+
+        inner = jw.equivalence_judge
+        while hasattr(inner, "__wrapped__"):
+            inner = inner.__wrapped__
+
+        with patch.object(jw, "_build_openrouter_client", return_value=MagicMock()), \
+             patch.object(jw.instructor, "apatch", return_value=fake_client):
+            result = await inner("a", "a", model="m")
+
+        self.assertEqual(result, fake_result)
+        self.assertEqual(fake_client.chat.completions.create.await_count, 2)
+        second_kwargs = fake_client.chat.completions.create.await_args_list[1].kwargs
+        from typing import List as TypingList
+
+        self.assertEqual(
+            second_kwargs["response_model"], TypingList[jw.LLMEquivalenceResponse]
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/stt/test_llm_wer.py
+++ b/tests/stt/test_llm_wer.py
@@ -302,5 +302,37 @@ class TestEquivalenceJudge(unittest.IsolatedAsyncioTestCase):
             second_kwargs["response_model"], TypingList[jw.LLMEquivalenceResponse]
         )
 
+    async def test_judge_non_multi_tool_error_reraises(self):
+        from calibrate_agent.stt.sarvam_llm_wer import judge as jw
+
+        fake_client = MagicMock()
+        fake_client.chat.completions.create = AsyncMock(
+            side_effect=RuntimeError("rate limited")
+        )
+
+        with self.assertRaises(RuntimeError) as ctx:
+            await jw._create_equivalence_response(
+                fake_client, model="m", prompt="hi"
+            )
+        self.assertIn("rate limited", str(ctx.exception))
+        self.assertEqual(fake_client.chat.completions.create.await_count, 1)
+
+    async def test_judge_empty_list_fallback_reraises(self):
+        from calibrate_agent.stt.sarvam_llm_wer import judge as jw
+
+        original = RuntimeError("Instructor does not support multiple tool calls")
+        fake_client = MagicMock()
+        fake_client.chat.completions.create = AsyncMock(
+            side_effect=[original, []]
+        )
+
+        with self.assertRaises(RuntimeError) as ctx:
+            await jw._create_equivalence_response(
+                fake_client, model="m", prompt="hi"
+            )
+        self.assertIs(ctx.exception, original)
+        self.assertEqual(fake_client.chat.completions.create.await_count, 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/stt/test_metrics.py
+++ b/tests/stt/test_metrics.py
@@ -5,8 +5,11 @@ Run with:
     python -m unittest tests.stt.test_metrics -v
 """
 
+import tempfile
 import unittest
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, MagicMock
+
+from calibrate_agent.judge_store import JudgeStore
 
 
 class TestEditMetrics(unittest.TestCase):
@@ -265,6 +268,455 @@ class TestSTTGetLLMJudgeScore(unittest.IsolatedAsyncioTestCase):
         call_kwargs = mock_stt_judge.call_args.kwargs
         self.assertEqual(call_kwargs["evaluators"], custom_evaluators)
         self.assertEqual(call_kwargs["fallback_model"], "custom-model")
+
+
+class TestSTTGetLLMJudgeScoreWithStore(unittest.IsolatedAsyncioTestCase):
+    async def _fake_judge(self, reference, prediction, evaluators=None, fallback_model=None):
+        return {
+            ev["name"]: {"match": reference == prediction, "reasoning": "ok"}
+            for ev in evaluators
+        }
+
+    async def test_store_none_matches_pre_store_behavior(self):
+        from calibrate_agent.stt import metrics as stt_metrics
+
+        mock = AsyncMock(side_effect=self._fake_judge)
+        evaluators = [
+            {"name": "semantic_match", "system_prompt": "match", "judge_model": "m"}
+        ]
+        with patch.object(stt_metrics, "stt_llm_judge", mock):
+            result = await stt_metrics.get_llm_judge_score(
+                references=["a", "b"],
+                predictions=["a", "x"],
+                evaluators=evaluators,
+                store=None,
+            )
+
+        self.assertEqual(mock.call_count, 2)
+        self.assertEqual(result["scores"]["semantic_match"]["mean"], 0.5)
+
+    async def test_prepopulated_store_skips_cached_rows(self):
+        from calibrate_agent.stt import metrics as stt_metrics
+
+        evaluators = [
+            {"name": "semantic_match", "system_prompt": "match", "judge_model": "m"}
+        ]
+        mock = AsyncMock(side_effect=self._fake_judge)
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            with patch.object(stt_metrics, "stt_llm_judge", mock):
+                # First pass grades only row "r1".
+                await stt_metrics.get_llm_judge_score(
+                    references=["a"],
+                    predictions=["a"],
+                    evaluators=evaluators,
+                    store=store,
+                    row_ids=["r1"],
+                )
+                self.assertEqual(mock.call_count, 1)
+
+                # Second pass includes "r1" (cached) and "r2" (new).
+                mock.reset_mock()
+                result = await stt_metrics.get_llm_judge_score(
+                    references=["a", "b"],
+                    predictions=["a", "y"],
+                    evaluators=evaluators,
+                    store=store,
+                    row_ids=["r1", "r2"],
+                )
+
+        self.assertEqual(mock.call_count, 1)
+        self.assertEqual(mock.call_args.args[0], "b")
+        self.assertEqual(mock.call_args.args[1], "y")
+        matches = [row["semantic_match"]["match"] for row in result["per_row"]]
+        self.assertEqual(matches, [True, False])
+
+    async def test_row_order_preserved_with_partial_cache(self):
+        from calibrate_agent.stt import metrics as stt_metrics
+
+        evaluators = [
+            {"name": "semantic_match", "system_prompt": "match", "judge_model": "m"}
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            with patch.object(
+                stt_metrics, "stt_llm_judge", AsyncMock(side_effect=self._fake_judge)
+            ):
+                # Cache the middle row only.
+                await stt_metrics.get_llm_judge_score(
+                    references=["b"],
+                    predictions=["b"],
+                    evaluators=evaluators,
+                    store=store,
+                    row_ids=["row1"],
+                )
+                result = await stt_metrics.get_llm_judge_score(
+                    references=["a", "b", "c"],
+                    predictions=["x", "b", "c"],
+                    evaluators=evaluators,
+                    store=store,
+                    row_ids=["row0", "row1", "row2"],
+                )
+
+        matches = [row["semantic_match"]["match"] for row in result["per_row"]]
+        self.assertEqual(matches, [False, True, True])
+
+    async def test_changed_system_prompt_invalidates_row(self):
+        from calibrate_agent.stt import metrics as stt_metrics
+
+        base_evaluator = {
+            "name": "semantic_match",
+            "system_prompt": "prompt v1",
+            "judge_model": "m",
+        }
+        mock = AsyncMock(side_effect=self._fake_judge)
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            with patch.object(stt_metrics, "stt_llm_judge", mock):
+                await stt_metrics.get_llm_judge_score(
+                    references=["a"],
+                    predictions=["a"],
+                    evaluators=[base_evaluator],
+                    store=store,
+                    row_ids=["r1"],
+                )
+                self.assertEqual(mock.call_count, 1)
+
+                # Same row, same prediction, but the prompt text changed.
+                changed_evaluator = dict(base_evaluator, system_prompt="prompt v2")
+                await stt_metrics.get_llm_judge_score(
+                    references=["a"],
+                    predictions=["a"],
+                    evaluators=[changed_evaluator],
+                    store=store,
+                    row_ids=["r1"],
+                )
+
+        self.assertEqual(mock.call_count, 2)
+
+    async def test_changed_prediction_invalidates_row(self):
+        from calibrate_agent.stt import metrics as stt_metrics
+
+        evaluator = {
+            "name": "semantic_match",
+            "system_prompt": "match",
+            "judge_model": "m",
+        }
+        mock = AsyncMock(side_effect=self._fake_judge)
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            with patch.object(stt_metrics, "stt_llm_judge", mock):
+                await stt_metrics.get_llm_judge_score(
+                    references=["a"],
+                    predictions=["a"],
+                    evaluators=[evaluator],
+                    store=store,
+                    row_ids=["r1"],
+                )
+                await stt_metrics.get_llm_judge_score(
+                    references=["a"],
+                    predictions=["different"],
+                    evaluators=[evaluator],
+                    store=store,
+                    row_ids=["r1"],
+                )
+
+        self.assertEqual(mock.call_count, 2)
+
+    async def test_adding_second_evaluator_runs_only_the_new_one(self):
+        from calibrate_agent.stt import metrics as stt_metrics
+
+        first_evaluator = {
+            "name": "semantic_match",
+            "system_prompt": "match",
+            "judge_model": "m",
+        }
+        second_evaluator = {
+            "name": "completeness",
+            "system_prompt": "complete",
+            "judge_model": "m",
+        }
+        mock = AsyncMock(side_effect=self._fake_judge)
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            with patch.object(stt_metrics, "stt_llm_judge", mock):
+                await stt_metrics.get_llm_judge_score(
+                    references=["a"],
+                    predictions=["a"],
+                    evaluators=[first_evaluator],
+                    store=store,
+                    row_ids=["r1"],
+                )
+                self.assertEqual(mock.call_count, 1)
+
+                mock.reset_mock()
+                result = await stt_metrics.get_llm_judge_score(
+                    references=["a"],
+                    predictions=["a"],
+                    evaluators=[first_evaluator, second_evaluator],
+                    store=store,
+                    row_ids=["r1"],
+                )
+
+        # Only the newly-added evaluator triggers a fresh judge call.
+        self.assertEqual(mock.call_count, 1)
+        called_names = {ev["name"] for ev in mock.call_args.kwargs["evaluators"]}
+        self.assertEqual(called_names, {"completeness"})
+        self.assertIn("semantic_match", result["per_row"][0])
+        self.assertIn("completeness", result["per_row"][0])
+
+
+def _identity_normalizer():
+    inst = MagicMock()
+    inst.normalize_texts.side_effect = lambda texts, langs, n_jobs=1: list(texts)
+    return inst
+
+
+def _intent_entity_row(intent=1, entity=1.0):
+    return {
+        "intent_score": intent,
+        "intent_explanation": "because",
+        "entity_score": entity,
+        "ground_truth_entities": "x",
+        "preserved_entities": "x" if entity else "",
+        "missing_entities": "" if entity else "x",
+        "entity_explanation": "because",
+    }
+
+
+class TestGetIntentEntityScoreWithStore(unittest.IsolatedAsyncioTestCase):
+    async def test_store_none_matches_pre_store_behavior(self):
+        from calibrate_agent.stt import metrics as stt_metrics
+        from calibrate_agent.stt import sarvam_intent_entity as sie
+
+        mock = AsyncMock(return_value=_intent_entity_row(1, 1.0))
+        with patch.object(
+            stt_metrics, "_get_indic_normalizer", return_value=_identity_normalizer()
+        ), patch.object(sie, "intent_entity_judge", mock):
+            result = await stt_metrics.get_intent_entity_score(
+                references=["a", "b"], predictions=["a", "b"], store=None
+            )
+
+        self.assertEqual(mock.call_count, 2)
+        self.assertEqual(result["intent"], 1.0)
+
+    async def test_prepopulated_store_skips_cached_rows(self):
+        from calibrate_agent.stt import metrics as stt_metrics
+        from calibrate_agent.stt import sarvam_intent_entity as sie
+
+        mock = AsyncMock(return_value=_intent_entity_row(1, 1.0))
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            with patch.object(
+                stt_metrics,
+                "_get_indic_normalizer",
+                return_value=_identity_normalizer(),
+            ), patch.object(sie, "intent_entity_judge", mock):
+                await stt_metrics.get_intent_entity_score(
+                    references=["a"],
+                    predictions=["a"],
+                    store=store,
+                    row_ids=["r1"],
+                )
+                self.assertEqual(mock.call_count, 1)
+
+                mock.reset_mock()
+                result = await stt_metrics.get_intent_entity_score(
+                    references=["a", "b"],
+                    predictions=["a", "b"],
+                    store=store,
+                    row_ids=["r1", "r2"],
+                )
+
+        self.assertEqual(mock.call_count, 1)
+        self.assertEqual(len(result["per_row"]), 2)
+
+    async def test_changed_prediction_invalidates_row(self):
+        from calibrate_agent.stt import metrics as stt_metrics
+        from calibrate_agent.stt import sarvam_intent_entity as sie
+
+        mock = AsyncMock(return_value=_intent_entity_row(1, 1.0))
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            with patch.object(
+                stt_metrics,
+                "_get_indic_normalizer",
+                return_value=_identity_normalizer(),
+            ), patch.object(sie, "intent_entity_judge", mock):
+                await stt_metrics.get_intent_entity_score(
+                    references=["a"],
+                    predictions=["a"],
+                    store=store,
+                    row_ids=["r1"],
+                )
+                await stt_metrics.get_intent_entity_score(
+                    references=["a"],
+                    predictions=["changed"],
+                    store=store,
+                    row_ids=["r1"],
+                )
+
+        self.assertEqual(mock.call_count, 2)
+
+
+class TestGetLLMWerCerScoreWithStore(unittest.IsolatedAsyncioTestCase):
+    async def _fake_judge(self, reference, prediction, model=None):
+        return {"equivalent": reference == prediction, "reasoning": "ok"}
+
+    async def test_store_none_matches_pre_store_behavior(self):
+        from calibrate_agent.stt import metrics as stt_metrics
+        from calibrate_agent.stt import sarvam_llm_wer as slw
+
+        mock = AsyncMock(side_effect=self._fake_judge)
+        with patch.object(slw, "equivalence_judge", mock):
+            result = await stt_metrics.get_llm_wer_cer_score(
+                references=["hello world"],
+                predictions=["hello word"],
+                store=None,
+            )
+
+        mock.assert_awaited()
+        self.assertIn("llm_wer", result)
+
+    async def test_prepopulated_store_skips_cached_segment_pairs(self):
+        from calibrate_agent.stt import metrics as stt_metrics
+        from calibrate_agent.stt import sarvam_llm_wer as slw
+
+        mock = AsyncMock(side_effect=self._fake_judge)
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            with patch.object(slw, "equivalence_judge", mock):
+                await stt_metrics.get_llm_wer_cer_score(
+                    references=["hello world"],
+                    predictions=["hello word"],
+                    store=store,
+                    row_ids=["r1"],
+                )
+                first_call_count = mock.call_count
+                self.assertGreater(first_call_count, 0)
+
+                mock.reset_mock()
+                # Same differing segment ("world" vs "word") reappears in a
+                # second row; it should not be re-judged.
+                result = await stt_metrics.get_llm_wer_cer_score(
+                    references=["hello world", "say world"],
+                    predictions=["hello word", "say word"],
+                    store=store,
+                    row_ids=["r1", "r2"],
+                )
+
+        self.assertEqual(mock.call_count, 0)
+        self.assertEqual(len(result["per_row"]), 2)
+
+    async def test_changed_prediction_reruns_segment_judge(self):
+        from calibrate_agent.stt import metrics as stt_metrics
+        from calibrate_agent.stt import sarvam_llm_wer as slw
+
+        mock = AsyncMock(side_effect=self._fake_judge)
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            with patch.object(slw, "equivalence_judge", mock):
+                await stt_metrics.get_llm_wer_cer_score(
+                    references=["hello world"],
+                    predictions=["hello word"],
+                    store=store,
+                    row_ids=["r1"],
+                )
+                mock.reset_mock()
+
+                # A different mismatched prediction produces a different
+                # segment pair, which must be judged (not silently reused).
+                await stt_metrics.get_llm_wer_cer_score(
+                    references=["hello world"],
+                    predictions=["hello wprld"],
+                    store=store,
+                    row_ids=["r1"],
+                )
+
+        self.assertEqual(mock.call_count, 1)
+
+
+class TestGetSemanticWerScoreWithStore(unittest.IsolatedAsyncioTestCase):
+    async def _fake_judge(self, reference, prediction, model=None):
+        if reference == prediction:
+            return {
+                "substitutions": 0, "deletions": 0, "insertions": 0,
+                "reference_words": len(reference.split()) or 1,
+                "normalized_reference": reference, "normalized_hypothesis": prediction,
+                "reasoning": "match",
+            }
+        return {
+            "substitutions": 1, "deletions": 0, "insertions": 0,
+            "reference_words": len(reference.split()) or 1,
+            "normalized_reference": reference, "normalized_hypothesis": prediction,
+            "reasoning": "mismatch",
+        }
+
+    async def test_store_none_matches_pre_store_behavior(self):
+        from calibrate_agent.stt import metrics as stt_metrics
+
+        mock = AsyncMock(side_effect=self._fake_judge)
+        with patch(
+            "calibrate_agent.stt.semantic_wer.semantic_wer_judge",
+            mock,
+        ):
+            result = await stt_metrics.get_semantic_wer_score(
+                references=["a", "b"], predictions=["a", "c"], store=None
+            )
+
+        self.assertEqual(mock.call_count, 2)
+        self.assertEqual(len(result["per_row"]), 2)
+
+    async def test_prepopulated_store_skips_cached_rows(self):
+        from calibrate_agent.stt import metrics as stt_metrics
+
+        mock = AsyncMock(side_effect=self._fake_judge)
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            with patch(
+                "calibrate_agent.stt.semantic_wer.semantic_wer_judge",
+                mock,
+            ):
+                await stt_metrics.get_semantic_wer_score(
+                    references=["a"], predictions=["a"], store=store, row_ids=["r1"]
+                )
+                self.assertEqual(mock.call_count, 1)
+
+                mock.reset_mock()
+                result = await stt_metrics.get_semantic_wer_score(
+                    references=["a", "b"],
+                    predictions=["a", "c"],
+                    store=store,
+                    row_ids=["r1", "r2"],
+                )
+
+        self.assertEqual(mock.call_count, 1)
+        self.assertEqual(mock.call_args.args[0], "b")
+        # Row order is preserved even though only row "r2" re-ran.
+        self.assertEqual(result["per_row"][0]["reasoning"], "match")
+        self.assertEqual(result["per_row"][1]["reasoning"], "mismatch")
+
+    async def test_changed_prediction_invalidates_row(self):
+        from calibrate_agent.stt import metrics as stt_metrics
+
+        mock = AsyncMock(side_effect=self._fake_judge)
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            with patch(
+                "calibrate_agent.stt.semantic_wer.semantic_wer_judge",
+                mock,
+            ):
+                await stt_metrics.get_semantic_wer_score(
+                    references=["a"], predictions=["a"], store=store, row_ids=["r1"]
+                )
+                await stt_metrics.get_semantic_wer_score(
+                    references=["a"],
+                    predictions=["changed"],
+                    store=store,
+                    row_ids=["r1"],
+                )
+
+        self.assertEqual(mock.call_count, 2)
 
 
 if __name__ == "__main__":

--- a/tests/stt/test_semantic_wer.py
+++ b/tests/stt/test_semantic_wer.py
@@ -318,7 +318,7 @@ class TestJudgeEmptyShortCircuit(unittest.IsolatedAsyncioTestCase):
 
 
 def _fake_judge():
-    async def judge(refs, preds, evaluators=None, fallback_model=None):
+    async def judge(refs, preds, evaluators=None, fallback_model=None, **kwargs):
         return {
             "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
             "score": 1.0,
@@ -334,7 +334,7 @@ class TestScoreAndWriteSemanticWER(unittest.IsolatedAsyncioTestCase):
     async def test_semantic_wer_in_metrics_and_results_when_enabled(self):
         from calibrate_agent.stt import eval as stt_eval
 
-        async def fake_sem(references, predictions, model=None):
+        async def fake_sem(references, predictions, model=None, **kwargs):
             return {
                 "semantic_wer": 0.05,
                 "per_row": [

--- a/tests/stt/test_semantic_wer.py
+++ b/tests/stt/test_semantic_wer.py
@@ -3,7 +3,7 @@
 The judge (two-phase reason-then-tool call per row) is mocked — no network.
 Covers the pooled/per-row WER formula, the prompt/tool text, and that semantic
 WER threads through ``_score_and_write_results`` into metrics.json +
-results.csv when the LLM-judge group is enabled (``run_llm_judges``).
+results.csv when the LLM-judge group is enabled (``llm_judges``).
 """
 
 import json
@@ -348,7 +348,7 @@ class TestScoreAndWriteSemanticWER(unittest.IsolatedAsyncioTestCase):
                 ],
             }
 
-        # run_llm_judges=True now also triggers the Sarvam judges — make them
+        # llm_judges=None now also triggers the Sarvam judges — make them
         # raise so isolation skips them, keeping this test focused on semantic WER.
         with tempfile.TemporaryDirectory() as tmp:
             out = Path(tmp)
@@ -371,7 +371,7 @@ class TestScoreAndWriteSemanticWER(unittest.IsolatedAsyncioTestCase):
                     pred_transcripts=["hi", "there"],
                     output_dir=str(out),
                     evaluator_config_dir=str(out),
-                    run_llm_judges=True,
+                    llm_judges=None,
                 )
 
             self.assertEqual(metrics["semantic_wer"], 0.05)
@@ -401,7 +401,7 @@ class TestScoreAndWriteSemanticWER(unittest.IsolatedAsyncioTestCase):
                     pred_transcripts=["hi"],
                     output_dir=str(out),
                     evaluator_config_dir=str(out),
-                    run_llm_judges=False,
+                    llm_judges=frozenset(),
                 )
 
             sem_mock.assert_not_called()

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -419,6 +419,41 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
                 await B.main()
             self.assertEqual(mock_run.call_args.kwargs["llm_judges"], frozenset())
 
+    async def test_main_provider_judges_subset_flag(self):
+        from calibrate_agent.stt import benchmark as B
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            self._make_input_dir(base)
+            out = base / "out"
+
+            fake_run_result = {
+                "status": "completed",
+                "output_dir": str(out),
+                "leaderboard_dir": str(out / "leaderboard"),
+                "providers": {
+                    "deepgram": {"status": "completed", "metrics": {"wer": 0.1}},
+                },
+            }
+            mock_run = AsyncMock(return_value=fake_run_result)
+            argv = [
+                "b.py",
+                "-p",
+                "deepgram",
+                "-i",
+                str(base),
+                "-o",
+                str(out),
+                "--judges",
+                "intent",
+                "-y",
+            ]
+            with patch.object(sys, "argv", argv), patch.object(B, "run", mock_run):
+                await B.main()
+            self.assertEqual(
+                mock_run.call_args.kwargs["llm_judges"], frozenset({"intent"})
+            )
+
     async def test_main_error_provider_exits(self):
         from calibrate_agent.stt import benchmark as B
 

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -151,9 +151,9 @@ class TestSTTBenchmarkRun(unittest.IsolatedAsyncioTestCase):
                 providers=["deepgram"],
                 input_dir=tmp,
                 output_dir=tmp,
-                run_llm_judges=True,
+                llm_judges=None,
             )
-        self.assertTrue(mock_eval.call_args.kwargs["run_llm_judges"])
+        self.assertIsNone(mock_eval.call_args.kwargs["llm_judges"])
 
     async def test_run_leaderboard_error(self):
         from calibrate_agent.stt import benchmark as B
@@ -244,6 +244,7 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(mock_eval.call_args.kwargs["language"], "hindi")
 
     async def test_main_eval_only_intent_entity_on_by_default(self):
+        from calibrate_agent._cli_args import DEFAULT_STT_LLM_JUDGES
         from calibrate_agent.stt import benchmark as B
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -254,12 +255,14 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
 
             fake_result = {"status": "completed", "metrics": {"wer": 0.1}}
             mock_eval = AsyncMock(return_value=fake_result)
-            argv = ["b.py", "--eval-only", "--dataset", str(ds), "-o", str(out)]
+            argv = ["b.py", "--eval-only", "--dataset", str(ds), "-o", str(out), "-y"]
             with patch.object(sys, "argv", argv), \
                  patch.object(B, "run_eval_only", mock_eval):
                 await B.main()
 
-            self.assertTrue(mock_eval.call_args.kwargs["run_llm_judges"])
+            self.assertEqual(
+                mock_eval.call_args.kwargs["llm_judges"], DEFAULT_STT_LLM_JUDGES
+            )
 
     async def test_main_eval_only_skip_llm_judges_flag(self):
         from calibrate_agent.stt import benchmark as B
@@ -273,12 +276,43 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
             fake_result = {"status": "completed", "metrics": {"wer": 0.1}}
             mock_eval = AsyncMock(return_value=fake_result)
             argv = ["b.py", "--eval-only", "--dataset", str(ds),
-                    "-o", str(out), "--skip-llm-judges"]
+                    "-o", str(out), "--skip-llm-judges", "-y"]
             with patch.object(sys, "argv", argv), \
                  patch.object(B, "run_eval_only", mock_eval):
                 await B.main()
 
-            self.assertFalse(mock_eval.call_args.kwargs["run_llm_judges"])
+            self.assertEqual(mock_eval.call_args.kwargs["llm_judges"], frozenset())
+
+    async def test_main_eval_only_judges_subset_flag(self):
+        from calibrate_agent.stt import benchmark as B
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            ds = base / "ds.json"
+            ds.write_text(json.dumps([{"id": "a", "gt": "hi", "pred": "hi"}]))
+            out = base / "out"
+
+            fake_result = {"status": "completed", "metrics": {"wer": 0.1}}
+            mock_eval = AsyncMock(return_value=fake_result)
+            argv = [
+                "b.py",
+                "--eval-only",
+                "--dataset",
+                str(ds),
+                "-o",
+                str(out),
+                "--judges",
+                "intent,llm_wer",
+                "-y",
+            ]
+            with patch.object(sys, "argv", argv), \
+                 patch.object(B, "run_eval_only", mock_eval):
+                await B.main()
+
+            self.assertEqual(
+                mock_eval.call_args.kwargs["llm_judges"],
+                frozenset({"intent", "llm_wer"}),
+            )
 
     async def test_main_eval_only_error(self):
         from calibrate_agent.stt import benchmark as B
@@ -338,6 +372,7 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
                 await B.main()
 
     async def test_main_forwards_intent_entity_flag_to_run(self):
+        from calibrate_agent._cli_args import DEFAULT_STT_LLM_JUDGES
         from calibrate_agent.stt import benchmark as B
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -356,16 +391,18 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
             mock_run = AsyncMock(return_value=fake_run_result)
 
             # Default on.
-            argv = ["b.py", "-p", "deepgram", "-i", str(base), "-o", str(out)]
+            argv = ["b.py", "-p", "deepgram", "-i", str(base), "-o", str(out), "-y"]
             with patch.object(sys, "argv", argv), patch.object(B, "run", mock_run):
                 await B.main()
-            self.assertTrue(mock_run.call_args.kwargs["run_llm_judges"])
+            self.assertEqual(
+                mock_run.call_args.kwargs["llm_judges"], DEFAULT_STT_LLM_JUDGES
+            )
 
             # Skip flag.
             argv.append("--skip-llm-judges")
             with patch.object(sys, "argv", argv), patch.object(B, "run", mock_run):
                 await B.main()
-            self.assertFalse(mock_run.call_args.kwargs["run_llm_judges"])
+            self.assertEqual(mock_run.call_args.kwargs["llm_judges"], frozenset())
 
     async def test_main_error_provider_exits(self):
         from calibrate_agent.stt import benchmark as B

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,15 +1,30 @@
 """Tests for benchmark modules — llm, stt, tts."""
 
 import asyncio
+import io
 import json
 import os
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
+from os.path import join
 from pathlib import Path
 from unittest.mock import patch, AsyncMock, MagicMock
 
 import pandas as pd
+
+
+def _write_judge_cache(provider_dir: Path, *, kind: str = "tts_evaluators") -> None:
+    provider_dir.mkdir(parents=True, exist_ok=True)
+    record = {
+        "kind": kind,
+        "row_id": "1",
+        "evaluator": None,
+        "fingerprint": "fp",
+        "result": {"ok": True},
+    }
+    (provider_dir / "judge_cache.jsonl").write_text(json.dumps(record) + "\n")
 
 
 # =============================================================================
@@ -450,6 +465,78 @@ class TestSTTBenchmarkMain(unittest.IsolatedAsyncioTestCase):
                  patch.object(B, "run", AsyncMock(return_value=fake_run_result)):
                 await B.main()
 
+    async def test_main_eval_only_cancel_on_decline(self):
+        from calibrate_agent.stt import benchmark as B
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            ds = base / "ds.json"
+            ds.write_text(json.dumps([{"id": "a", "gt": "hi", "pred": "hi"}]))
+            out = base / "out"
+
+            buf = io.StringIO()
+            argv = ["b.py", "--eval-only", "--dataset", str(ds), "-o", str(out)]
+            with patch.object(sys, "argv", argv), \
+                 patch.object(B, "run_eval_only", AsyncMock()) as mock_eval, \
+                 patch(
+                     "calibrate_agent.stt.benchmark.confirm_estimated_judge_cost",
+                     return_value=False,
+                 ), redirect_stdout(buf):
+                with self.assertRaises(SystemExit) as ctx:
+                    await B.main()
+
+            self.assertEqual(ctx.exception.code, 0)
+            mock_eval.assert_not_called()
+            self.assertIn("Judge run cancelled.", buf.getvalue())
+
+    async def test_main_multi_provider_cancel_on_decline(self):
+        from calibrate_agent.stt import benchmark as B
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            self._make_input_dir(base)
+            out = base / "out"
+
+            buf = io.StringIO()
+            argv = ["b.py", "-p", "deepgram", "-i", str(base), "-o", str(out)]
+            with patch.object(sys, "argv", argv), \
+                 patch.object(B, "run", AsyncMock()) as mock_run, \
+                 patch(
+                     "calibrate_agent.stt.benchmark.confirm_estimated_judge_cost",
+                     return_value=False,
+                 ), redirect_stdout(buf):
+                with self.assertRaises(SystemExit) as ctx:
+                    await B.main()
+
+            self.assertEqual(ctx.exception.code, 0)
+            mock_run.assert_not_called()
+            self.assertIn("Judge run cancelled.", buf.getvalue())
+
+    async def test_main_debug_yes_prints_cached_count_note(self):
+        from calibrate_agent.stt import benchmark as B
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            self._make_input_dir(base)
+            out = base / "out"
+            _write_judge_cache(out / "deepgram", kind="stt")
+
+            fake_run_result = {
+                "status": "completed",
+                "output_dir": str(out),
+                "leaderboard_dir": str(out / "leaderboard"),
+                "providers": {
+                    "deepgram": {"status": "completed", "metrics": {"wer": 0.1}},
+                },
+            }
+            argv = ["b.py", "-p", "deepgram", "-i", str(base), "-o", str(out), "-d", "-y"]
+            with patch.object(sys, "argv", argv), \
+                 patch.object(B, "run", AsyncMock(return_value=fake_run_result)):
+                await B.main()
+
+            log_content = Path(join(out, "logs")).read_text()
+            self.assertIn("checkpointed", log_content)
+
 
 # =============================================================================
 # TTS Benchmark
@@ -555,6 +642,77 @@ class TestTTSBenchmarkMain(unittest.IsolatedAsyncioTestCase):
                  patch.object(B, "run", AsyncMock(return_value=fake_run_result)):
                 with self.assertRaises(SystemExit):
                     await B.main()
+
+    async def test_main_cancel_on_decline(self):
+        from calibrate_agent.tts import benchmark as B
+
+        with tempfile.TemporaryDirectory() as tmp:
+            inp = Path(tmp) / "in.csv"
+            pd.DataFrame({"id": ["a"], "text": ["hi"]}).to_csv(str(inp), index=False)
+            out = Path(tmp) / "out"
+
+            buf = io.StringIO()
+            argv = ["b.py", "-p", "openai", "-i", str(inp), "-o", str(out)]
+            with patch.object(sys, "argv", argv), \
+                 patch.object(B, "run", AsyncMock()) as mock_run, \
+                 patch(
+                     "calibrate_agent.tts.benchmark.confirm_estimated_judge_cost",
+                     return_value=False,
+                 ), redirect_stdout(buf):
+                with self.assertRaises(SystemExit) as ctx:
+                    await B.main()
+
+            self.assertEqual(ctx.exception.code, 0)
+            mock_run.assert_not_called()
+            self.assertIn("Judge run cancelled.", buf.getvalue())
+
+    async def test_main_yes_proceeds_to_run(self):
+        from calibrate_agent.tts import benchmark as B
+
+        with tempfile.TemporaryDirectory() as tmp:
+            inp = Path(tmp) / "in.csv"
+            pd.DataFrame({"id": ["a"], "text": ["hi"]}).to_csv(str(inp), index=False)
+            out = Path(tmp) / "out"
+
+            fake_run_result = {
+                "status": "completed",
+                "output_dir": str(out),
+                "leaderboard_dir": str(out / "lb"),
+                "providers": {
+                    "openai": {"status": "completed", "metrics": {}},
+                },
+            }
+            mock_run = AsyncMock(return_value=fake_run_result)
+            argv = ["b.py", "-p", "openai", "-i", str(inp), "-o", str(out), "-y"]
+            with patch.object(sys, "argv", argv), patch.object(B, "run", mock_run):
+                await B.main()
+
+            mock_run.assert_called_once()
+
+    async def test_main_yes_prints_cached_count_note(self):
+        from calibrate_agent.tts import benchmark as B
+
+        with tempfile.TemporaryDirectory() as tmp:
+            inp = Path(tmp) / "in.csv"
+            pd.DataFrame({"id": ["a"], "text": ["hi"]}).to_csv(str(inp), index=False)
+            out = Path(tmp) / "out"
+            _write_judge_cache(out / "openai")
+
+            fake_run_result = {
+                "status": "completed",
+                "output_dir": str(out),
+                "leaderboard_dir": str(out / "lb"),
+                "providers": {
+                    "openai": {"status": "completed", "metrics": {}},
+                },
+            }
+            argv = ["b.py", "-p", "openai", "-i", str(inp), "-o", str(out), "-y"]
+            with patch.object(sys, "argv", argv), \
+                 patch.object(B, "run", AsyncMock(return_value=fake_run_result)):
+                await B.main()
+
+            log_content = Path(join(out, "logs")).read_text()
+            self.assertIn("checkpointed", log_content)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -4,11 +4,16 @@ import inspect
 
 import calibrate_agent._cli_args as cli_args
 from calibrate_agent._cli_args import (
+    DEFAULT_STT_LLM_JUDGES,
+    STT_LLM_JUDGES,
     add_assume_yes_arg,
     add_stt_engine_args,
     add_stt_eval_args,
+    add_stt_judges_arg,
     add_stt_max_parallel_arg,
     add_stt_skip_llm_judges_arg,
+    parse_stt_llm_judges,
+    resolve_stt_llm_judges,
 )
 
 
@@ -22,6 +27,7 @@ class TestAddSTTEvalArgs:
     def test_multi_provider_defaults(self):
         assert _defaults(include_max_parallel=True) == {
             "skip_llm_judges": False,
+            "judges": None,
             "max_parallel": None,
             "engine": "pipeline",
             "max_concurrency": None,
@@ -32,6 +38,7 @@ class TestAddSTTEvalArgs:
         assert "max_parallel" not in ns
         assert ns == {
             "skip_llm_judges": False,
+            "judges": None,
             "engine": "pipeline",
             "max_concurrency": None,
         }
@@ -57,6 +64,12 @@ class TestAddSTTEvalArgs:
             8,
         )
 
+    def test_judges_parses_subset(self):
+        parser = argparse.ArgumentParser()
+        add_stt_eval_args(parser, include_max_parallel=False)
+        ns = parser.parse_args(["--judges", "intent,llm_wer"])
+        assert ns.judges == frozenset({"intent", "llm_wer"})
+
     def test_engine_choices_enforced(self):
         parser = argparse.ArgumentParser()
         add_stt_engine_args(parser)
@@ -68,6 +81,67 @@ class TestAddSTTEvalArgs:
             raise AssertionError("invalid --engine choice should have been rejected")
 
 
+class TestParseSttLlmJudges:
+    def test_parses_comma_separated(self):
+        assert parse_stt_llm_judges("intent, semantic_wer") == frozenset(
+            {"intent", "semantic_wer"}
+        )
+
+    def test_rejects_unknown(self):
+        try:
+            parse_stt_llm_judges("intent,bogus")
+        except ValueError as e:
+            assert "bogus" in str(e)
+        else:  # pragma: no cover
+            raise AssertionError("expected ValueError for unknown judge")
+
+    def test_rejects_empty(self):
+        try:
+            parse_stt_llm_judges(" , ")
+        except ValueError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError("expected ValueError for empty list")
+
+    def test_cli_rejects_unknown_name(self):
+        parser = argparse.ArgumentParser()
+        add_stt_judges_arg(parser)
+        try:
+            parser.parse_args(["--judges", "nope"])
+        except SystemExit:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError("unknown --judges name should have been rejected")
+
+
+class TestResolveSttLlmJudges:
+    def test_default_is_all_three(self):
+        assert resolve_stt_llm_judges(skip_llm_judges=False, judges=None) == (
+            DEFAULT_STT_LLM_JUDGES
+        )
+        assert DEFAULT_STT_LLM_JUDGES == frozenset(STT_LLM_JUDGES)
+
+    def test_skip_returns_empty(self):
+        assert resolve_stt_llm_judges(skip_llm_judges=True, judges=None) == frozenset()
+
+    def test_subset_returned(self):
+        subset = frozenset({"intent"})
+        assert (
+            resolve_stt_llm_judges(skip_llm_judges=False, judges=subset) == subset
+        )
+
+    def test_mutual_exclusion(self):
+        try:
+            resolve_stt_llm_judges(
+                skip_llm_judges=True, judges=frozenset({"intent"})
+            )
+        except SystemExit as e:
+            assert "--judges" in str(e)
+            assert "--skip-llm-judges" in str(e)
+        else:  # pragma: no cover
+            raise AssertionError("expected SystemExit for mutual exclusion")
+
+
 class TestBuildersComposeConsistently:
     """The individual builders must produce the same actions add_stt_eval_args does."""
 
@@ -77,6 +151,7 @@ class TestBuildersComposeConsistently:
 
         pieces = argparse.ArgumentParser()
         add_stt_skip_llm_judges_arg(pieces)
+        add_stt_judges_arg(pieces)
         add_stt_max_parallel_arg(pieces)
         add_stt_engine_args(pieces)
 

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -4,6 +4,7 @@ import inspect
 
 import calibrate_agent._cli_args as cli_args
 from calibrate_agent._cli_args import (
+    add_assume_yes_arg,
     add_stt_engine_args,
     add_stt_eval_args,
     add_stt_max_parallel_arg,
@@ -87,6 +88,26 @@ class TestBuildersComposeConsistently:
             }
 
         assert signature(combined) == signature(pieces)
+
+
+class TestAddAssumeYesArg:
+    def test_default_false(self):
+        parser = argparse.ArgumentParser()
+        add_assume_yes_arg(parser)
+        ns = parser.parse_args([])
+        assert ns.yes is False
+
+    def test_long_flag_parses(self):
+        parser = argparse.ArgumentParser()
+        add_assume_yes_arg(parser)
+        ns = parser.parse_args(["--yes"])
+        assert ns.yes is True
+
+    def test_short_flag_parses(self):
+        parser = argparse.ArgumentParser()
+        add_assume_yes_arg(parser)
+        ns = parser.parse_args(["-y"])
+        assert ns.yes is True
 
 
 class TestStdlibOnly:

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -254,6 +254,73 @@ class TestMainDispatch(unittest.TestCase):
         self.assertIn("--skip-llm-judges", captured["argv"])
         self.assertIn("hindi", captured["argv"])
 
+    def test_stt_benchmark_forwards_yes_flag(self):
+        captured = {}
+
+        async def fake_main():
+            captured["argv"] = list(sys.argv)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            (base / "audios").mkdir()
+            import pandas as pd
+            pd.DataFrame({"id": ["a"], "text": ["hi"]}).to_csv(
+                base / "stt.csv", index=False
+            )
+            (base / "audios" / "a.wav").write_bytes(b"\x00")
+
+            with patch("calibrate_agent.stt.benchmark.main",
+                       AsyncMock(side_effect=fake_main)):
+                self._run_with_argv([
+                    "calibrate_agent", "stt", "-p", "deepgram",
+                    "-i", str(base), "-o", str(base / "out"),
+                    "--yes",
+                ])
+
+        self.assertIn("--yes", captured["argv"])
+
+    def test_stt_benchmark_omits_yes_flag_by_default(self):
+        captured = {}
+
+        async def fake_main():
+            captured["argv"] = list(sys.argv)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            (base / "audios").mkdir()
+            import pandas as pd
+            pd.DataFrame({"id": ["a"], "text": ["hi"]}).to_csv(
+                base / "stt.csv", index=False
+            )
+            (base / "audios" / "a.wav").write_bytes(b"\x00")
+
+            with patch("calibrate_agent.stt.benchmark.main",
+                       AsyncMock(side_effect=fake_main)):
+                self._run_with_argv([
+                    "calibrate_agent", "stt", "-p", "deepgram",
+                    "-i", str(base), "-o", str(base / "out"),
+                ])
+
+        self.assertNotIn("--yes", captured["argv"])
+
+    def test_stt_eval_only_forwards_yes_flag(self):
+        captured = {}
+
+        async def fake_main():
+            captured["argv"] = list(sys.argv)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            ds = Path(tmp) / "ds.json"
+            ds.write_text("[]")
+            with patch("calibrate_agent.stt.benchmark.main",
+                       AsyncMock(side_effect=fake_main)):
+                self._run_with_argv([
+                    "calibrate_agent", "stt", "--eval-only", "--dataset", str(ds),
+                    "-o", tmp, "--yes",
+                ])
+
+        self.assertIn("--yes", captured["argv"])
+
     def test_tts_no_provider_launches_ui(self):
         from calibrate_agent import cli
         with patch.object(cli, "_launch_ink_ui") as mock:
@@ -306,6 +373,41 @@ class TestMainDispatch(unittest.TestCase):
         self.assertIn("--config", captured["argv"])
         # Language is not forwarded to the eval-only path (judge ignores it).
         self.assertNotIn("-l", captured["argv"])
+
+    def test_tts_benchmark_forwards_yes_flag(self):
+        captured = {}
+
+        async def fake_main():
+            captured["argv"] = list(sys.argv)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            inp = Path(tmp) / "in.csv"
+            import pandas as pd
+            pd.DataFrame({"id": ["a"], "text": ["hi"]}).to_csv(str(inp), index=False)
+            with patch("calibrate_agent.tts.benchmark.main",
+                       AsyncMock(side_effect=fake_main)):
+                self._run_with_argv([
+                    "calibrate_agent", "tts", "-p", "openai",
+                    "-i", str(inp), "-o", tmp, "--yes",
+                ])
+
+        self.assertIn("--yes", captured["argv"])
+
+    def test_tts_eval_only_forwards_yes_flag(self):
+        captured = {}
+
+        async def fake_main():
+            captured["argv"] = list(sys.argv)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("calibrate_agent.tts.benchmark.main",
+                       AsyncMock(side_effect=fake_main)):
+                self._run_with_argv([
+                    "calibrate_agent", "tts", "--eval-only", "--dataset", tmp,
+                    "-o", str(Path(tmp) / "out"), "--yes",
+                ])
+
+        self.assertIn("--yes", captured["argv"])
 
     def test_llm_no_config_launches_ui(self):
         from calibrate_agent import cli

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -284,6 +284,29 @@ class TestMainDispatch(unittest.TestCase):
             frozenset({"intent", "llm_wer"}),
         )
 
+    def test_stt_eval_only_forwards_judges_flag(self):
+        captured = {}
+
+        async def fake_main():
+            captured["argv"] = list(sys.argv)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            ds = Path(tmp) / "ds.json"
+            ds.write_text("[]")
+            with patch("calibrate_agent.stt.benchmark.main",
+                       AsyncMock(side_effect=fake_main)):
+                self._run_with_argv([
+                    "calibrate_agent", "stt", "--eval-only", "--dataset", str(ds),
+                    "-o", tmp, "--judges", "intent,semantic_wer",
+                ])
+
+        self.assertIn("--judges", captured["argv"])
+        judges_idx = captured["argv"].index("--judges")
+        self.assertEqual(
+            frozenset(captured["argv"][judges_idx + 1].split(",")),
+            frozenset({"intent", "semantic_wer"}),
+        )
+
     def test_stt_benchmark_forwards_yes_flag(self):
         captured = {}
 

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -254,6 +254,36 @@ class TestMainDispatch(unittest.TestCase):
         self.assertIn("--skip-llm-judges", captured["argv"])
         self.assertIn("hindi", captured["argv"])
 
+    def test_stt_benchmark_forwards_judges_flag(self):
+        captured = {}
+
+        async def fake_main():
+            captured["argv"] = list(sys.argv)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            (base / "audios").mkdir()
+            import pandas as pd
+            pd.DataFrame({"id": ["a"], "text": ["hi"]}).to_csv(
+                base / "stt.csv", index=False
+            )
+            (base / "audios" / "a.wav").write_bytes(b"\x00")
+
+            with patch("calibrate_agent.stt.benchmark.main",
+                       AsyncMock(side_effect=fake_main)):
+                self._run_with_argv([
+                    "calibrate_agent", "stt", "-p", "deepgram",
+                    "-i", str(base), "-o", str(base / "out"),
+                    "--judges", "intent,llm_wer",
+                ])
+
+        self.assertIn("--judges", captured["argv"])
+        judges_idx = captured["argv"].index("--judges")
+        self.assertEqual(
+            frozenset(captured["argv"][judges_idx + 1].split(",")),
+            frozenset({"intent", "llm_wer"}),
+        )
+
     def test_stt_benchmark_forwards_yes_flag(self):
         captured = {}
 

--- a/tests/test_judge_cost.py
+++ b/tests/test_judge_cost.py
@@ -434,6 +434,14 @@ class TestConfirmJudgeCost(unittest.TestCase):
         self.assertFalse(decision)
         input_mock.assert_called_once()
 
+    def test_failing_tcgetpgrp_value_error_falls_back_to_isatty(self):
+        decision, _, _, input_mock = self._invoke(
+            tcgetpgrp=MagicMock(side_effect=ValueError), answer="n"
+        )
+
+        self.assertFalse(decision)
+        input_mock.assert_called_once()
+
     def test_yes_answers_proceed(self):
         for answer in ("y", "Y", "yes", "YES", " y "):
             with self.subTest(answer=answer):

--- a/tests/test_judge_cost.py
+++ b/tests/test_judge_cost.py
@@ -1,0 +1,779 @@
+"""Tests for calibrate_agent/judge_cost.py — token heuristic, cost math, confirmation gate."""
+
+import io
+import os
+import sys
+import unittest
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+
+class TestEstimateTokens(unittest.TestCase):
+    def test_ascii_text_uses_the_latin_rate(self):
+        from calibrate_agent.judge_cost import estimate_tokens
+
+        self.assertEqual(estimate_tokens("a" * 20), 5)
+
+    def test_devanagari_text_uses_the_indic_rate(self):
+        from calibrate_agent.judge_cost import estimate_tokens
+
+        self.assertEqual(estimate_tokens("क" * 20), 14)
+
+    def test_mixed_script_lands_between_the_pure_cases(self):
+        from calibrate_agent.judge_cost import estimate_tokens
+
+        ascii_rate = estimate_tokens("a" * 20) / 20
+        indic_rate = estimate_tokens("क" * 20) / 20
+        mixed_rate = estimate_tokens("a" * 10 + "क" * 10) / 20
+
+        self.assertLess(ascii_rate, mixed_rate)
+        self.assertLess(mixed_rate, indic_rate)
+
+    def test_empty_and_whitespace_text_is_zero_tokens(self):
+        from calibrate_agent.judge_cost import estimate_tokens
+
+        self.assertEqual(estimate_tokens(""), 0)
+        self.assertEqual(estimate_tokens("   \n\t "), 0)
+
+    def test_short_text_rounds_up_to_one_token(self):
+        from calibrate_agent.judge_cost import estimate_tokens
+
+        self.assertEqual(estimate_tokens("a"), 1)
+
+
+class TestEstimateAudioSecondsFromText(unittest.TestCase):
+    def test_derives_seconds_from_the_token_estimate(self):
+        from calibrate_agent.judge_cost import (
+            SPOKEN_TOKENS_PER_SECOND,
+            estimate_audio_seconds_from_text,
+            estimate_tokens,
+        )
+
+        text = "hello there, this is a spoken sentence"
+        self.assertAlmostEqual(
+            estimate_audio_seconds_from_text(text),
+            estimate_tokens(text) / SPOKEN_TOKENS_PER_SECOND,
+        )
+
+    def test_empty_text_is_zero_seconds(self):
+        from calibrate_agent.judge_cost import estimate_audio_seconds_from_text
+
+        self.assertEqual(estimate_audio_seconds_from_text(""), 0.0)
+
+
+class TestEstimateJudgeCost(unittest.TestCase):
+    def test_prices_a_text_only_group(self):
+        from calibrate_agent.judge_cost import JudgeCallGroup, estimate_judge_cost
+
+        group = JudgeCallGroup(
+            label="semantic WER",
+            model="anthropic/claude-sonnet-4.5",
+            calls=10,
+            input_tokens_per_call=1000,
+            output_tokens_per_call=200,
+        )
+
+        estimate = estimate_judge_cost([group])
+        row = estimate["groups"][0]
+
+        # (10_000 * $3.00 + 2_000 * $15.00) per million tokens.
+        self.assertEqual(row["input_tokens"], 10_000)
+        self.assertEqual(row["output_tokens"], 2_000)
+        self.assertEqual(row["audio_tokens"], 0)
+        self.assertTrue(row["priced"])
+        self.assertAlmostEqual(row["cost_usd"], 0.06)
+        self.assertAlmostEqual(estimate["total_usd"], 0.06)
+        self.assertEqual(estimate["source"], "openrouter")
+        self.assertEqual(estimate["unpriced"], [])
+
+    def test_both_sources_price_the_same_group(self):
+        from calibrate_agent.judge_cost import (
+            JudgeCallGroup,
+            estimate_judge_cost,
+            estimate_judge_cost_all_sources,
+        )
+
+        group = JudgeCallGroup(
+            label="correctness",
+            model="openai/gpt-5.4-mini",
+            calls=4,
+            input_tokens_per_call=500,
+            output_tokens_per_call=100,
+        )
+
+        direct = estimate_judge_cost([group], source="direct")
+        self.assertEqual(direct["source"], "direct")
+        # (2_000 * $0.75 + 400 * $4.50) per million tokens.
+        self.assertAlmostEqual(direct["total_usd"], 0.0033)
+
+        both = estimate_judge_cost_all_sources([group])
+        self.assertEqual(sorted(both), ["direct", "openrouter"])
+        self.assertAlmostEqual(
+            both["openrouter"]["total_usd"], both["direct"]["total_usd"]
+        )
+
+    def test_unpriced_model_is_reported_without_breaking_the_total(self):
+        from calibrate_agent.judge_cost import JudgeCallGroup, estimate_judge_cost
+
+        priced = JudgeCallGroup(
+            label="semantic WER",
+            model="anthropic/claude-sonnet-4.5",
+            calls=10,
+            input_tokens_per_call=1000,
+            output_tokens_per_call=200,
+        )
+        unpriced = JudgeCallGroup(
+            label="custom judge",
+            model="acme/does-not-exist",
+            calls=5,
+            input_tokens_per_call=1000,
+            output_tokens_per_call=200,
+        )
+
+        estimate = estimate_judge_cost([priced, unpriced])
+        unpriced_row = estimate["groups"][1]
+
+        self.assertFalse(unpriced_row["priced"])
+        self.assertEqual(unpriced_row["cost_usd"], 0.0)
+        self.assertEqual(unpriced_row["input_tokens"], 5_000)
+        self.assertEqual(estimate["unpriced"], ["acme/does-not-exist"])
+        self.assertAlmostEqual(estimate["total_usd"], 0.06)
+
+    def test_unpriced_models_are_deduped_and_sorted(self):
+        from calibrate_agent.judge_cost import JudgeCallGroup, estimate_judge_cost
+
+        groups = [
+            JudgeCallGroup("judge b", "zeta/unknown", 1, 10, 10),
+            JudgeCallGroup("judge a", "acme/unknown", 1, 10, 10),
+            JudgeCallGroup("judge c", "zeta/unknown", 1, 10, 10),
+        ]
+
+        estimate = estimate_judge_cost(groups)
+
+        self.assertEqual(estimate["unpriced"], ["acme/unknown", "zeta/unknown"])
+        self.assertEqual(estimate["total_usd"], 0.0)
+
+    def test_audio_seconds_bill_at_the_audio_rate(self):
+        from calibrate_agent.judge_cost import JudgeCallGroup, estimate_judge_cost
+
+        group = JudgeCallGroup(
+            label="pronunciation",
+            model="openai/gpt-audio",
+            calls=2,
+            input_tokens_per_call=100,
+            output_tokens_per_call=50,
+            audio_seconds_per_call=3.0,
+        )
+
+        row = estimate_judge_cost([group])["groups"][0]
+
+        # 2 calls * 3s * 10 tokens/s.
+        self.assertEqual(row["audio_tokens"], 60)
+        # (200 * $2.50 + 100 * $10.00 + 60 * $32.00) per million tokens.
+        self.assertAlmostEqual(row["cost_usd"], 0.00342)
+
+        text_rate_cost = (200 * 2.5 + 100 * 10.0 + 60 * 2.5) / 1_000_000
+        self.assertGreater(row["cost_usd"], text_rate_cost)
+
+    def test_audio_falls_back_to_the_text_input_rate(self):
+        from calibrate_agent.judge_cost import JudgeCallGroup, estimate_judge_cost
+
+        group = JudgeCallGroup(
+            label="text-only judge given audio",
+            model="anthropic/claude-sonnet-4.5",
+            calls=1,
+            input_tokens_per_call=0,
+            output_tokens_per_call=0,
+            audio_seconds_per_call=2.0,
+        )
+
+        row = estimate_judge_cost([group])["groups"][0]
+
+        self.assertEqual(row["audio_tokens"], 20)
+        # 20 tokens * $3.00 per million, the model's text input rate.
+        self.assertAlmostEqual(row["cost_usd"], 20 * 3.0 / 1_000_000)
+
+    def test_reasoning_multiplier_applies_only_to_reasoning_billed_models(self):
+        from calibrate_agent.judge_cost import (
+            REASONING_TOKEN_MULTIPLIER,
+            JudgeCallGroup,
+            estimate_judge_cost,
+        )
+
+        gemini = JudgeCallGroup(
+            label="LLM WER",
+            model="google/gemini-2.5-flash",
+            calls=1,
+            input_tokens_per_call=1000,
+            output_tokens_per_call=100,
+        )
+        mini = JudgeCallGroup(
+            label="correctness",
+            model="openai/gpt-5.4-mini",
+            calls=1,
+            input_tokens_per_call=1000,
+            output_tokens_per_call=100,
+        )
+
+        gemini_cost = estimate_judge_cost([gemini])["total_usd"]
+        mini_cost = estimate_judge_cost([mini])["total_usd"]
+
+        # (1_000 * $0.30 + 100 * 3.0 * $2.50) per million tokens.
+        self.assertAlmostEqual(gemini_cost, 0.00105)
+        self.assertAlmostEqual(
+            gemini_cost,
+            (1000 * 0.3 + 100 * REASONING_TOKEN_MULTIPLIER * 2.5) / 1_000_000,
+        )
+        # (1_000 * $0.75 + 100 * $4.50) per million tokens, unscaled.
+        self.assertAlmostEqual(mini_cost, 0.0012)
+
+    def test_reported_output_tokens_exclude_the_reasoning_allowance(self):
+        from calibrate_agent.judge_cost import JudgeCallGroup, estimate_judge_cost
+
+        group = JudgeCallGroup("LLM WER", "google/gemini-2.5-flash", 3, 100, 40)
+
+        row = estimate_judge_cost([group])["groups"][0]
+
+        self.assertEqual(row["output_tokens"], 120)
+
+    def test_empty_group_list(self):
+        from calibrate_agent.judge_cost import estimate_judge_cost
+
+        estimate = estimate_judge_cost([])
+
+        self.assertEqual(estimate["groups"], [])
+        self.assertEqual(estimate["total_usd"], 0.0)
+        self.assertEqual(estimate["unpriced"], [])
+
+
+class TestFormatCostEstimate(unittest.TestCase):
+    def test_names_every_group_and_both_totals(self):
+        from calibrate_agent.judge_cost import (
+            JudgeCallGroup,
+            estimate_judge_cost_all_sources,
+            format_cost_estimate,
+        )
+
+        groups = [
+            JudgeCallGroup(
+                "semantic WER", "anthropic/claude-sonnet-4.5", 10, 1000, 200
+            ),
+            JudgeCallGroup("pronunciation", "openai/gpt-audio", 2, 100, 50, 3.0),
+        ]
+
+        text = format_cost_estimate(estimate_judge_cost_all_sources(groups))
+
+        self.assertIn("semantic WER", text)
+        self.assertIn("anthropic/claude-sonnet-4.5", text)
+        self.assertIn("pronunciation", text)
+        self.assertIn("openai/gpt-audio", text)
+        self.assertIn("OpenRouter", text)
+        self.assertIn("direct", text)
+        self.assertIn("$0.0634", text)
+        self.assertIn("audio", text)
+        self.assertNotIn("unpriced", text)
+
+    def test_names_unpriced_models(self):
+        from calibrate_agent.judge_cost import (
+            JudgeCallGroup,
+            estimate_judge_cost_all_sources,
+            format_cost_estimate,
+        )
+
+        groups = [JudgeCallGroup("custom judge", "acme/does-not-exist", 5, 100, 20)]
+
+        text = format_cost_estimate(estimate_judge_cost_all_sources(groups))
+
+        self.assertIn("acme/does-not-exist", text)
+        self.assertIn("unpriced", text)
+
+    def test_mentions_the_estimate_caveats(self):
+        from calibrate_agent.judge_cost import (
+            JudgeCallGroup,
+            estimate_judge_cost_all_sources,
+            format_cost_estimate,
+        )
+
+        groups = [JudgeCallGroup("correctness", "openai/gpt-5.4-mini", 1, 100, 20)]
+
+        text = format_cost_estimate(estimate_judge_cost_all_sources(groups))
+
+        self.assertIn("Estimated from a bundled rate table", text)
+        self.assertIn("approximate", text)
+
+
+class _FakeStdin:
+    def __init__(self, tty: bool):
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+    def fileno(self) -> int:
+        return 0
+
+
+class TestConfirmJudgeCost(unittest.TestCase):
+    def setUp(self):
+        from calibrate_agent.judge_cost import (
+            JudgeCallGroup,
+            estimate_judge_cost_all_sources,
+        )
+
+        group = JudgeCallGroup(
+            "semantic WER", "anthropic/claude-sonnet-4.5", 10, 1000, 200
+        )
+        self.both = estimate_judge_cost_all_sources([group])
+
+    def _invoke(
+        self,
+        assume_yes=False,
+        tty=True,
+        env_assume_yes=None,
+        tcgetpgrp=None,
+        answer="",
+        answer_error=None,
+    ):
+        from calibrate_agent.judge_cost import confirm_judge_cost
+
+        env = {k: v for k, v in os.environ.items() if k != "CALIBRATE_ASSUME_YES"}
+        if env_assume_yes is not None:
+            env["CALIBRATE_ASSUME_YES"] = env_assume_yes
+
+        err_stream = io.StringIO()
+        out_stream = io.StringIO()
+        input_mock = MagicMock(return_value=answer, side_effect=answer_error)
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.dict(os.environ, env, clear=True))
+            stack.enter_context(patch.object(sys, "stdin", _FakeStdin(tty)))
+            stack.enter_context(patch.object(sys, "stdout", out_stream))
+            stack.enter_context(patch("builtins.input", input_mock))
+            if tcgetpgrp is not None:
+                stack.enter_context(patch.object(os, "tcgetpgrp", tcgetpgrp))
+                stack.enter_context(
+                    patch.object(os, "getpgrp", MagicMock(return_value=4242))
+                )
+            decision = confirm_judge_cost(
+                self.both, assume_yes=assume_yes, stream=err_stream
+            )
+
+        return decision, err_stream.getvalue(), out_stream.getvalue(), input_mock
+
+    def assertEstimateWentToStreamOnly(self, err_text: str, out_text: str):
+        self.assertIn("semantic WER", err_text)
+        self.assertIn("$0.0600", err_text)
+        self.assertEqual(out_text, "")
+
+    def test_assume_yes_proceeds_without_asking(self):
+        decision, err_text, out_text, input_mock = self._invoke(assume_yes=True)
+
+        self.assertTrue(decision)
+        input_mock.assert_not_called()
+        self.assertEstimateWentToStreamOnly(err_text, out_text)
+
+    def test_env_var_proceeds_without_asking(self):
+        decision, err_text, out_text, input_mock = self._invoke(env_assume_yes="1")
+
+        self.assertTrue(decision)
+        input_mock.assert_not_called()
+        self.assertEstimateWentToStreamOnly(err_text, out_text)
+
+    def test_empty_env_var_still_asks(self):
+        decision, _, _, input_mock = self._invoke(
+            env_assume_yes="", tcgetpgrp=MagicMock(return_value=4242), answer="y"
+        )
+
+        self.assertTrue(decision)
+        input_mock.assert_called_once()
+
+    def test_non_tty_stdin_proceeds_without_asking(self):
+        decision, err_text, out_text, input_mock = self._invoke(tty=False)
+
+        self.assertTrue(decision)
+        input_mock.assert_not_called()
+        self.assertEstimateWentToStreamOnly(err_text, out_text)
+
+    def test_background_process_group_proceeds_without_asking(self):
+        decision, err_text, out_text, input_mock = self._invoke(
+            tcgetpgrp=MagicMock(return_value=1)
+        )
+
+        self.assertTrue(decision)
+        input_mock.assert_not_called()
+        self.assertEstimateWentToStreamOnly(err_text, out_text)
+
+    def test_foreground_process_group_asks(self):
+        decision, err_text, out_text, input_mock = self._invoke(
+            tcgetpgrp=MagicMock(return_value=4242), answer="y"
+        )
+
+        self.assertTrue(decision)
+        input_mock.assert_called_once()
+        self.assertEstimateWentToStreamOnly(err_text, out_text)
+
+    def test_missing_tcgetpgrp_falls_back_to_isatty(self):
+        decision, _, _, input_mock = self._invoke(
+            tcgetpgrp=MagicMock(side_effect=AttributeError), answer="y"
+        )
+        self.assertTrue(decision)
+        input_mock.assert_called_once()
+
+        decision, err_text, out_text, input_mock = self._invoke(
+            tty=False, tcgetpgrp=MagicMock(side_effect=AttributeError)
+        )
+        self.assertTrue(decision)
+        input_mock.assert_not_called()
+        self.assertEstimateWentToStreamOnly(err_text, out_text)
+
+    def test_failing_tcgetpgrp_falls_back_to_isatty(self):
+        decision, _, _, input_mock = self._invoke(
+            tcgetpgrp=MagicMock(side_effect=OSError), answer="n"
+        )
+
+        self.assertFalse(decision)
+        input_mock.assert_called_once()
+
+    def test_yes_answers_proceed(self):
+        for answer in ("y", "Y", "yes", "YES", " y "):
+            with self.subTest(answer=answer):
+                decision, _, _, input_mock = self._invoke(
+                    tcgetpgrp=MagicMock(return_value=4242), answer=answer
+                )
+                self.assertTrue(decision)
+                input_mock.assert_called_once()
+
+    def test_no_answer_cancels(self):
+        decision, err_text, out_text, input_mock = self._invoke(
+            tcgetpgrp=MagicMock(return_value=4242), answer="n"
+        )
+
+        self.assertFalse(decision)
+        input_mock.assert_called_once()
+        self.assertEstimateWentToStreamOnly(err_text, out_text)
+        self.assertIn("Proceed with the judge run?", err_text)
+
+    def test_empty_answer_cancels(self):
+        decision, _, _, _ = self._invoke(
+            tcgetpgrp=MagicMock(return_value=4242), answer=""
+        )
+
+        self.assertFalse(decision)
+
+    def test_end_of_input_cancels(self):
+        decision, err_text, out_text, input_mock = self._invoke(
+            tcgetpgrp=MagicMock(return_value=4242), answer_error=EOFError
+        )
+
+        self.assertFalse(decision)
+        input_mock.assert_called_once()
+        self.assertEstimateWentToStreamOnly(err_text, out_text)
+
+    def test_interrupt_cancels(self):
+        decision, _, _, _ = self._invoke(
+            tcgetpgrp=MagicMock(return_value=4242), answer_error=KeyboardInterrupt
+        )
+
+        self.assertFalse(decision)
+
+    def test_defaults_to_stderr(self):
+        from calibrate_agent.judge_cost import confirm_judge_cost
+
+        err_stream = io.StringIO()
+        out_stream = io.StringIO()
+        with patch.object(sys, "stderr", err_stream), patch.object(
+            sys, "stdout", out_stream
+        ):
+            decision = confirm_judge_cost(self.both, assume_yes=True)
+
+        self.assertTrue(decision)
+        self.assertEstimateWentToStreamOnly(
+            err_stream.getvalue(), out_stream.getvalue()
+        )
+
+
+class TestBuildSttJudgeGroups(unittest.TestCase):
+    def setUp(self):
+        self.references = ["hello world", "how are you today"]
+        self.predictions = ["hello world", "how are you today"]
+
+    def test_no_evaluators_and_no_llm_judges_yields_nothing(self):
+        from calibrate_agent.judge_cost import build_stt_judge_groups
+
+        groups = build_stt_judge_groups(
+            self.references, self.predictions, evaluators=None, run_llm_judges=False
+        )
+
+        self.assertEqual(groups, [])
+
+    def test_run_llm_judges_produces_the_three_built_in_judges(self):
+        from calibrate_agent.judge_cost import build_stt_judge_groups
+
+        groups = build_stt_judge_groups(
+            self.references, self.predictions, evaluators=None, run_llm_judges=True
+        )
+        labels = [g.label for g in groups]
+
+        self.assertIn("Sarvam intent/entity", labels)
+        self.assertIn("Sarvam LLM-WER/CER", labels)
+        self.assertIn("Semantic WER (reasoning)", labels)
+        self.assertIn("Semantic WER (commit)", labels)
+        # No evaluator group since none were supplied.
+        self.assertFalse(any("evaluator" in label.lower() and "Sarvam" not in label and "Semantic" not in label for label in labels))
+
+    def test_run_llm_judges_false_drops_the_three_built_in_judges(self):
+        from calibrate_agent.judge_cost import build_stt_judge_groups
+
+        evaluators = [
+            {"name": "semantic_match", "system_prompt": "You are a judge."}
+        ]
+        groups = build_stt_judge_groups(
+            self.references,
+            self.predictions,
+            evaluators=evaluators,
+            run_llm_judges=False,
+        )
+        labels = [g.label for g in groups]
+
+        self.assertEqual(len(groups), 1)
+        self.assertIn("semantic_match", labels[0])
+
+    def test_semantic_wer_issues_two_calls_per_row(self):
+        from calibrate_agent.judge_cost import build_stt_judge_groups
+
+        groups = build_stt_judge_groups(
+            self.references, self.predictions, evaluators=None, run_llm_judges=True
+        )
+        by_label = {g.label: g for g in groups}
+
+        n = len(self.references)
+        self.assertEqual(by_label["Semantic WER (reasoning)"].calls, n)
+        self.assertEqual(by_label["Semantic WER (commit)"].calls, n)
+        self.assertEqual(by_label["Sarvam intent/entity"].calls, n)
+        self.assertEqual(by_label["Sarvam LLM-WER/CER"].calls, n)
+
+    def test_mixed_judge_models_produce_separate_evaluator_groups(self):
+        from calibrate_agent.judge_cost import build_stt_judge_groups
+
+        evaluators = [
+            {
+                "name": "correctness",
+                "system_prompt": "Judge A",
+                "judge_model": "openai/gpt-5.4-mini",
+            },
+            {
+                "name": "fluency",
+                "system_prompt": "Judge B",
+                "judge_model": "anthropic/claude-sonnet-4.5",
+            },
+        ]
+        groups = build_stt_judge_groups(
+            self.references,
+            self.predictions,
+            evaluators=evaluators,
+            run_llm_judges=False,
+        )
+        models = {g.model for g in groups}
+
+        self.assertEqual(len(groups), 2)
+        self.assertEqual(models, {"openai/gpt-5.4-mini", "anthropic/claude-sonnet-4.5"})
+
+    def test_providers_multiplies_call_counts(self):
+        from calibrate_agent.judge_cost import build_stt_judge_groups
+
+        evaluators = [{"name": "correctness", "system_prompt": "Judge A"}]
+        base = build_stt_judge_groups(
+            self.references,
+            self.predictions,
+            evaluators=evaluators,
+            run_llm_judges=True,
+            providers=1,
+        )
+        tripled = build_stt_judge_groups(
+            self.references,
+            self.predictions,
+            evaluators=evaluators,
+            run_llm_judges=True,
+            providers=3,
+        )
+        base_by_label = {g.label: g.calls for g in base}
+        tripled_by_label = {g.label: g.calls for g in tripled}
+
+        for label, calls in base_by_label.items():
+            self.assertEqual(tripled_by_label[label], calls * 3)
+
+    def test_predictions_none_still_produces_a_sane_estimate(self):
+        from calibrate_agent.judge_cost import build_stt_judge_groups
+
+        evaluators = [{"name": "correctness", "system_prompt": "Judge A"}]
+        groups = build_stt_judge_groups(
+            self.references,
+            predictions=None,
+            evaluators=evaluators,
+            run_llm_judges=True,
+        )
+
+        self.assertTrue(groups)
+        for g in groups:
+            self.assertGreater(g.calls, 0)
+            self.assertGreater(g.input_tokens_per_call, 0)
+
+    def test_empty_references_yields_no_calls(self):
+        from calibrate_agent.judge_cost import build_stt_judge_groups
+
+        groups = build_stt_judge_groups([], evaluators=None, run_llm_judges=True)
+
+        self.assertEqual(groups, [])
+
+
+class TestBuildTtsJudgeGroups(unittest.TestCase):
+    def test_default_evaluator_one_call_per_row(self):
+        from calibrate_agent.judge_cost import build_tts_judge_groups
+
+        texts = ["hello world", "this is a test", "another sentence here"]
+        groups = build_tts_judge_groups(texts)
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].calls, len(texts))
+
+    def test_multiple_evaluators_one_call_per_row_each(self):
+        from calibrate_agent.judge_cost import build_tts_judge_groups
+
+        texts = ["hello world", "this is a test"]
+        evaluators = [
+            {"name": "pronunciation", "system_prompt": "Judge A"},
+            {"name": "naturalness", "system_prompt": "Judge B"},
+        ]
+        groups = build_tts_judge_groups(texts, evaluators=evaluators)
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].calls, len(texts) * len(evaluators))
+
+    def test_mixed_judge_models_produce_separate_groups(self):
+        from calibrate_agent.judge_cost import build_tts_judge_groups
+
+        texts = ["hello world", "this is a test"]
+        evaluators = [
+            {
+                "name": "pronunciation",
+                "system_prompt": "Judge A",
+                "judge_model": "openai/gpt-audio",
+            },
+            {
+                "name": "naturalness",
+                "system_prompt": "Judge B",
+                "judge_model": "google/gemini-2.5-flash",
+            },
+        ]
+        groups = build_tts_judge_groups(texts, evaluators=evaluators)
+        models = {g.model for g in groups}
+
+        self.assertEqual(len(groups), 2)
+        self.assertEqual(models, {"openai/gpt-audio", "google/gemini-2.5-flash"})
+
+    def test_audio_seconds_passed_through_when_given(self):
+        from calibrate_agent.judge_cost import build_tts_judge_groups
+
+        texts = ["hello world", "this is a test"]
+        durations = [1.5, 4.5]
+        groups = build_tts_judge_groups(texts, audio_seconds=durations)
+
+        self.assertAlmostEqual(groups[0].audio_seconds_per_call, sum(durations) / len(durations))
+
+    def test_audio_seconds_derived_from_text_when_missing(self):
+        from calibrate_agent.judge_cost import (
+            build_tts_judge_groups,
+            estimate_audio_seconds_from_text,
+        )
+
+        texts = ["hello world", "this is a longer test sentence"]
+        groups = build_tts_judge_groups(texts, audio_seconds=None)
+
+        expected = sum(estimate_audio_seconds_from_text(t) for t in texts) / len(texts)
+        self.assertAlmostEqual(groups[0].audio_seconds_per_call, expected)
+
+    def test_providers_multiplies_call_counts(self):
+        from calibrate_agent.judge_cost import build_tts_judge_groups
+
+        texts = ["hello world", "this is a test"]
+        base = build_tts_judge_groups(texts, providers=1)
+        tripled = build_tts_judge_groups(texts, providers=3)
+
+        self.assertEqual(tripled[0].calls, base[0].calls * 3)
+
+    def test_empty_texts_yields_no_calls(self):
+        from calibrate_agent.judge_cost import build_tts_judge_groups
+
+        groups = build_tts_judge_groups([])
+
+        self.assertEqual(groups, [])
+
+
+class TestConfirmEstimatedJudgeCost(unittest.TestCase):
+    def _group(self):
+        from calibrate_agent.judge_cost import JudgeCallGroup
+
+        return JudgeCallGroup(
+            label="evaluators",
+            model="openai/gpt-5.4-mini",
+            calls=10,
+            input_tokens_per_call=100,
+            output_tokens_per_call=50,
+        )
+
+    def test_a_plan_that_raises_proceeds(self):
+        from calibrate_agent.judge_cost import confirm_estimated_judge_cost
+
+        def plan():
+            raise FileNotFoundError("dataset is not there")
+
+        stream = io.StringIO()
+        self.assertTrue(confirm_estimated_judge_cost(plan, stream=stream))
+        self.assertEqual(stream.getvalue(), "")
+
+    def test_no_groups_proceeds_without_an_estimate(self):
+        from calibrate_agent.judge_cost import confirm_estimated_judge_cost
+
+        stream = io.StringIO()
+        self.assertTrue(
+            confirm_estimated_judge_cost(lambda: ([], 0), stream=stream)
+        )
+        self.assertEqual(stream.getvalue(), "")
+
+    def test_estimate_is_shown_and_confirmed(self):
+        from calibrate_agent.judge_cost import confirm_estimated_judge_cost
+
+        stream = io.StringIO()
+        result = confirm_estimated_judge_cost(
+            lambda: ([self._group()], 0), assume_yes=True, stream=stream
+        )
+
+        self.assertTrue(result)
+        self.assertIn("evaluators", stream.getvalue())
+
+    def test_declining_is_reported(self):
+        from calibrate_agent.judge_cost import confirm_estimated_judge_cost
+
+        stream = io.StringIO()
+        with patch("calibrate_agent.judge_cost.confirm_judge_cost", return_value=False):
+            result = confirm_estimated_judge_cost(
+                lambda: ([self._group()], 0), stream=stream
+            )
+
+        self.assertFalse(result)
+
+    def test_cached_count_is_reported(self):
+        from calibrate_agent.judge_cost import confirm_estimated_judge_cost
+
+        stream = io.StringIO()
+        with patch("builtins.print") as fake_print:
+            confirm_estimated_judge_cost(
+                lambda: ([self._group()], 7), assume_yes=True, stream=stream
+            )
+
+        printed = " ".join(str(call) for call in fake_print.call_args_list)
+        self.assertIn("7", printed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judge_cost.py
+++ b/tests/test_judge_cost.py
@@ -501,7 +501,7 @@ class TestBuildSttJudgeGroups(unittest.TestCase):
         from calibrate_agent.judge_cost import build_stt_judge_groups
 
         groups = build_stt_judge_groups(
-            self.references, self.predictions, evaluators=None, run_llm_judges=False
+            self.references, self.predictions, evaluators=None, llm_judges=frozenset()
         )
 
         self.assertEqual(groups, [])
@@ -510,7 +510,7 @@ class TestBuildSttJudgeGroups(unittest.TestCase):
         from calibrate_agent.judge_cost import build_stt_judge_groups
 
         groups = build_stt_judge_groups(
-            self.references, self.predictions, evaluators=None, run_llm_judges=True
+            self.references, self.predictions, evaluators=None, llm_judges=None
         )
         labels = [g.label for g in groups]
 
@@ -531,18 +531,50 @@ class TestBuildSttJudgeGroups(unittest.TestCase):
             self.references,
             self.predictions,
             evaluators=evaluators,
-            run_llm_judges=False,
+            llm_judges=frozenset(),
         )
         labels = [g.label for g in groups]
 
         self.assertEqual(len(groups), 1)
         self.assertIn("semantic_match", labels[0])
 
+    def test_llm_judges_subset_emits_only_selected_groups(self):
+        from calibrate_agent.judge_cost import build_stt_judge_groups
+
+        groups = build_stt_judge_groups(
+            self.references,
+            self.predictions,
+            evaluators=None,
+            llm_judges=frozenset({"intent", "llm_wer"}),
+        )
+        labels = [g.label for g in groups]
+
+        self.assertEqual(
+            labels,
+            ["Sarvam intent/entity", "Sarvam LLM-WER/CER"],
+        )
+
+    def test_semantic_wer_only_emits_both_semantic_wer_call_groups(self):
+        from calibrate_agent.judge_cost import build_stt_judge_groups
+
+        groups = build_stt_judge_groups(
+            self.references,
+            self.predictions,
+            evaluators=None,
+            llm_judges=frozenset({"semantic_wer"}),
+        )
+        labels = [g.label for g in groups]
+
+        self.assertEqual(
+            labels,
+            ["Semantic WER (reasoning)", "Semantic WER (commit)"],
+        )
+
     def test_semantic_wer_issues_two_calls_per_row(self):
         from calibrate_agent.judge_cost import build_stt_judge_groups
 
         groups = build_stt_judge_groups(
-            self.references, self.predictions, evaluators=None, run_llm_judges=True
+            self.references, self.predictions, evaluators=None, llm_judges=None
         )
         by_label = {g.label: g for g in groups}
 
@@ -571,7 +603,7 @@ class TestBuildSttJudgeGroups(unittest.TestCase):
             self.references,
             self.predictions,
             evaluators=evaluators,
-            run_llm_judges=False,
+            llm_judges=frozenset(),
         )
         models = {g.model for g in groups}
 
@@ -586,14 +618,14 @@ class TestBuildSttJudgeGroups(unittest.TestCase):
             self.references,
             self.predictions,
             evaluators=evaluators,
-            run_llm_judges=True,
+            llm_judges=None,
             providers=1,
         )
         tripled = build_stt_judge_groups(
             self.references,
             self.predictions,
             evaluators=evaluators,
-            run_llm_judges=True,
+            llm_judges=None,
             providers=3,
         )
         base_by_label = {g.label: g.calls for g in base}
@@ -610,7 +642,7 @@ class TestBuildSttJudgeGroups(unittest.TestCase):
             self.references,
             predictions=None,
             evaluators=evaluators,
-            run_llm_judges=True,
+            llm_judges=None,
         )
 
         self.assertTrue(groups)
@@ -621,7 +653,7 @@ class TestBuildSttJudgeGroups(unittest.TestCase):
     def test_empty_references_yields_no_calls(self):
         from calibrate_agent.judge_cost import build_stt_judge_groups
 
-        groups = build_stt_judge_groups([], evaluators=None, run_llm_judges=True)
+        groups = build_stt_judge_groups([], evaluators=None, llm_judges=None)
 
         self.assertEqual(groups, [])
 

--- a/tests/test_judge_store.py
+++ b/tests/test_judge_store.py
@@ -283,6 +283,38 @@ class TestGatherWithStore(JudgeStoreTestBase):
         self.assertEqual(reloaded.get(keys[2]), {"score": 2})
         self.assertIsNone(reloaded.get(keys[1]))
 
+    async def test_error_result_isolates_failure_and_skips_cache(self):
+        store = JudgeStore.load(self.output_dir)
+        keys = [
+            JudgeKey(kind="llm_wer", row_id=str(i), fingerprint=f"fp{i}")
+            for i in range(3)
+        ]
+
+        async def run_one(index):
+            if index == 1:
+                raise ValueError("judge call failed")
+            return {"score": index}
+
+        results = await gather_with_store(
+            keys,
+            run_one,
+            store,
+            desc="test",
+            error_result=lambda i, exc: {
+                "score": "fallback",
+                "error": str(exc),
+                "index": i,
+            },
+        )
+
+        self.assertEqual(results[0]["score"], 0)
+        self.assertEqual(results[1]["score"], "fallback")
+        self.assertEqual(results[2]["score"], 2)
+        reloaded = JudgeStore.load(self.output_dir)
+        self.assertEqual(reloaded.get(keys[0]), {"score": 0})
+        self.assertIsNone(reloaded.get(keys[1]))
+        self.assertEqual(reloaded.get(keys[2]), {"score": 2})
+
 
 class TestGatherEvaluatorsWithStore(JudgeStoreTestBase):
     async def test_fully_cached_row_skips_run_subset(self):

--- a/tests/test_judge_store.py
+++ b/tests/test_judge_store.py
@@ -1,4 +1,10 @@
-"""Tests for calibrate_agent/judge_store.py — the resumable judge checkpoint."""
+"""
+Unit tests for calibrate_agent/judge_store.py — the append-only judge
+checkpoint and its gather helpers.
+
+Run with:
+    python -m pytest tests/test_judge_store.py -v
+"""
 
 import asyncio
 import json
@@ -16,448 +22,415 @@ from calibrate_agent.judge_store import (
 
 
 class TestMakeFingerprint(unittest.TestCase):
-    def test_deterministic_across_calls(self):
-        first = make_fingerprint("reference", "prediction", "openai/gpt-4.1")
-        second = make_fingerprint("reference", "prediction", "openai/gpt-4.1")
-        self.assertEqual(first, second)
-
-    def test_differs_when_any_part_differs(self):
-        base = make_fingerprint("reference", "prediction", "openai/gpt-4.1")
-        self.assertNotEqual(base, make_fingerprint("other", "prediction", "openai/gpt-4.1"))
-        self.assertNotEqual(base, make_fingerprint("reference", "other", "openai/gpt-4.1"))
-        self.assertNotEqual(base, make_fingerprint("reference", "prediction", "other-model"))
-
-    def test_dict_part_order_independent(self):
-        a = make_fingerprint("ref", {"scale_min": 1, "scale_max": 5, "name": "x"})
-        b = make_fingerprint("ref", {"name": "x", "scale_max": 5, "scale_min": 1})
+    def test_stable_for_equal_inputs(self):
+        a = make_fingerprint("reference text", "prediction text", "prompt", "model")
+        b = make_fingerprint("reference text", "prediction text", "prompt", "model")
         self.assertEqual(a, b)
 
-    def test_separator_prevents_split_collision(self):
-        # Without a separator between parts, ("ab", "c") and ("a", "bc") would
-        # encode to the same concatenated string.
-        self.assertNotEqual(make_fingerprint("ab", "c"), make_fingerprint("a", "bc"))
+    def test_differs_for_different_inputs(self):
+        a = make_fingerprint("reference text", "prediction text", "prompt", "model")
+        b = make_fingerprint("reference text", "different prediction", "prompt", "model")
+        self.assertNotEqual(a, b)
 
-    def test_non_json_serializable_uses_str_fallback(self):
-        class Unserializable:
-            def __str__(self):
-                return "unserializable-repr"
+    def test_differs_when_prompt_or_model_changes(self):
+        base = make_fingerprint("input", "prompt v1", "model-a")
+        different_prompt = make_fingerprint("input", "prompt v2", "model-a")
+        different_model = make_fingerprint("input", "prompt v1", "model-b")
+        self.assertNotEqual(base, different_prompt)
+        self.assertNotEqual(base, different_model)
 
-        fingerprint = make_fingerprint(Unserializable())
-        self.assertIsInstance(fingerprint, str)
-        # default=str means the object's str() is what actually gets hashed.
-        self.assertEqual(fingerprint, make_fingerprint("unserializable-repr"))
+    def test_insensitive_to_dict_key_order(self):
+        a = make_fingerprint({"reference": "r", "prediction": "p"})
+        b = make_fingerprint({"prediction": "p", "reference": "r"})
+        self.assertEqual(a, b)
 
-    def test_non_json_serializable_nested_in_dict(self):
-        class Unserializable:
-            def __str__(self):
-                return "nested-repr"
-
-        fingerprint = make_fingerprint({"value": Unserializable()})
-        self.assertEqual(fingerprint, make_fingerprint({"value": "nested-repr"}))
+    def test_returns_hex_sha256(self):
+        digest = make_fingerprint("x")
+        self.assertEqual(len(digest), 64)
+        int(digest, 16)  # raises ValueError if not valid hex
 
 
 class TestJudgeKey(unittest.TestCase):
-    def test_int_and_str_row_id_are_equal_and_hash_equal(self):
-        int_key = JudgeKey(kind="stt", row_id=1, fingerprint="fp")
-        str_key = JudgeKey(kind="stt", row_id="1", fingerprint="fp")
-        self.assertEqual(int_key, str_key)
-        self.assertEqual(hash(int_key), hash(str_key))
-
     def test_row_id_coerced_to_str(self):
-        key = JudgeKey(kind="stt", row_id=42, fingerprint="fp")
-        self.assertEqual(key.row_id, "42")
+        key = JudgeKey(kind="evaluators", row_id=1, fingerprint="abc")
+        self.assertEqual(key.row_id, "1")
         self.assertIsInstance(key.row_id, str)
 
-    def test_keys_differing_only_in_evaluator_are_distinct(self):
-        key_a = JudgeKey(kind="evaluators", row_id="1", fingerprint="fp", evaluator="a")
-        key_b = JudgeKey(kind="evaluators", row_id="1", fingerprint="fp", evaluator="b")
-        no_evaluator = JudgeKey(kind="evaluators", row_id="1", fingerprint="fp")
-        self.assertNotEqual(key_a, key_b)
-        self.assertNotEqual(key_a, no_evaluator)
+    def test_int_and_str_row_id_produce_equal_keys(self):
+        key_int = JudgeKey(kind="llm_wer", row_id=1, fingerprint="abc")
+        key_str = JudgeKey(kind="llm_wer", row_id="1", fingerprint="abc")
+        self.assertEqual(key_int, key_str)
+        self.assertEqual(hash(key_int), hash(key_str))
 
-    def test_usable_as_dict_key(self):
-        key = JudgeKey(kind="stt", row_id=1, fingerprint="fp")
-        mapping = {key: "value"}
-        self.assertEqual(mapping[JudgeKey(kind="stt", row_id="1", fingerprint="fp")], "value")
-
-    def test_usable_in_set(self):
-        keys = {
-            JudgeKey(kind="stt", row_id=1, fingerprint="fp"),
-            JudgeKey(kind="stt", row_id="1", fingerprint="fp"),
-        }
-        self.assertEqual(len(keys), 1)
+    def test_frozen_and_hashable(self):
+        key = JudgeKey(kind="llm_wer", row_id="1", fingerprint="abc")
+        with self.assertRaises(Exception):
+            key.row_id = "2"
+        {key: "usable as dict key"}  # does not raise
 
 
-class TestJudgeStoreLoad(unittest.TestCase):
-    def test_load_creates_missing_directory(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            target = os.path.join(tmp, "nested", "out")
-            self.assertFalse(os.path.exists(target))
-
-            store = JudgeStore.load(target)
-
-            self.assertTrue(os.path.isdir(target))
-            self.assertEqual(len(store), 0)
-
-    def test_path_points_at_checkpoint_file(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            store = JudgeStore.load(tmp)
-            self.assertEqual(store.path, os.path.join(tmp, JudgeStore.FILENAME))
-
-    def test_get_unknown_key_returns_none(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            store = JudgeStore.load(tmp)
-            self.assertIsNone(store.get(JudgeKey(kind="stt", row_id="1", fingerprint="fp")))
-
-    def test_load_skips_blank_missing_key_and_truncated_lines(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            path = os.path.join(tmp, JudgeStore.FILENAME)
-            valid_line = json.dumps({
-                "kind": "stt",
-                "row_id": "1",
-                "evaluator": None,
-                "fingerprint": "fp1",
-                "result": {"score": 1},
-            })
-            missing_result_key = json.dumps({
-                "kind": "stt",
-                "row_id": "2",
-                "evaluator": None,
-                "fingerprint": "fp2",
-            })
-            with open(path, "w", encoding="utf-8") as f:
-                f.write(valid_line + "\n")
-                f.write("\n")
-                f.write(missing_result_key + "\n")
-                f.write('{"kind": "stt", "row_id": "3", "fingerp')  # truncated, no newline
-
-            store = JudgeStore.load(tmp)
-
-            self.assertEqual(len(store), 1)
-            self.assertEqual(
-                store.get(JudgeKey(kind="stt", row_id="1", fingerprint="fp1")),
-                {"score": 1},
-            )
+class JudgeStoreTestBase(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.output_dir = self._tmpdir.name
 
 
-class TestJudgeStorePutAndGet(unittest.IsolatedAsyncioTestCase):
+class TestJudgeStorePersistence(JudgeStoreTestBase):
     async def test_put_then_get_round_trips(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            store = JudgeStore.load(tmp)
-            key = JudgeKey(kind="stt", row_id="1", fingerprint="fp")
+        store = JudgeStore.load(self.output_dir)
+        key = JudgeKey(kind="evaluators", row_id="row_a", fingerprint="fp1", evaluator="semantic_match")
+        result = {"reasoning": "matches", "match": True}
 
-            await store.put(key, {"match": True, "reasoning": "ok"})
+        await store.put(key, result)
 
-            self.assertEqual(store.get(key), {"match": True, "reasoning": "ok"})
-            self.assertEqual(len(store), 1)
+        self.assertEqual(store.get(key), result)
 
-    async def test_second_load_sees_results_from_first(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            first_run = JudgeStore.load(tmp)
-            key = JudgeKey(kind="stt", row_id="1", fingerprint="fp")
-            await first_run.put(key, {"score": 1})
+    async def test_load_from_fresh_instance_sees_prior_records(self):
+        store = JudgeStore.load(self.output_dir)
+        key = JudgeKey(kind="llm_wer", row_id="row_a", fingerprint="fp1")
+        result = {"score": 0.5}
+        await store.put(key, result)
 
-            resumed_run = JudgeStore.load(tmp)
+        reloaded = JudgeStore.load(self.output_dir)
 
-            self.assertEqual(resumed_run.get(key), {"score": 1})
-            self.assertEqual(len(resumed_run), 1)
+        self.assertEqual(reloaded.get(key), result)
+        self.assertEqual(len(reloaded), 1)
 
-    async def test_non_ascii_content_survives_reload(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            store = JudgeStore.load(tmp)
-            key = JudgeKey(kind="stt", row_id="1", fingerprint="fp")
-            result = {"reasoning": "पूरी तरह सही उत्तर है", "match": True}
+    async def test_creates_output_dir_if_missing(self):
+        nested = os.path.join(self.output_dir, "nested", "deeper")
+        self.assertFalse(os.path.exists(nested))
 
-            await store.put(key, result)
-            reloaded = JudgeStore.load(tmp)
+        store = JudgeStore.load(nested)
 
-            self.assertEqual(reloaded.get(key), result)
-            with open(store.path, encoding="utf-8") as f:
-                raw = f.read()
-            self.assertIn("पूरी तरह सही उत्तर है", raw)
+        self.assertTrue(os.path.isdir(nested))
+        self.assertEqual(store.path, os.path.join(nested, JudgeStore.FILENAME))
 
-    async def test_changed_fingerprint_is_a_cache_miss(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            store = JudgeStore.load(tmp)
-            old_key = JudgeKey(kind="stt", row_id="1", fingerprint="fp-before-edit")
-            await store.put(old_key, {"score": 1})
+    async def test_row_id_int_and_str_resolve_same_key(self):
+        store = JudgeStore.load(self.output_dir)
+        write_key = JudgeKey(kind="llm_wer", row_id=1, fingerprint="fp1")
+        await store.put(write_key, {"score": 1.0})
 
-            new_key = JudgeKey(kind="stt", row_id="1", fingerprint="fp-after-edit")
+        lookup_key = JudgeKey(kind="llm_wer", row_id="1", fingerprint="fp1")
 
-            self.assertIsNone(store.get(new_key))
-            self.assertEqual(store.pending([new_key]), [new_key])
+        self.assertEqual(store.get(lookup_key), {"score": 1.0})
 
-    async def test_pending_returns_uncached_keys_in_input_order(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            store = JudgeStore.load(tmp)
-            key1 = JudgeKey(kind="stt", row_id="1", fingerprint="fp1")
-            key2 = JudgeKey(kind="stt", row_id="2", fingerprint="fp2")
-            key3 = JudgeKey(kind="stt", row_id="3", fingerprint="fp3")
-            await store.put(key2, {"score": 2})
+    async def test_non_ascii_reasoning_survives_round_trip(self):
+        store = JudgeStore.load(self.output_dir)
+        key = JudgeKey(kind="evaluators", row_id="row_a", fingerprint="fp1", evaluator="semantic_match")
+        result = {"reasoning": "यह सही उत्तर है, ಸರಿಯಾಗಿದೆ", "match": True}
+        await store.put(key, result)
 
-            self.assertEqual(store.pending([key3, key1, key2]), [key3, key1])
+        with open(store.path, encoding="utf-8") as f:
+            raw = f.read()
+        self.assertIn("यह सही उत्तर है", raw)
+        self.assertIn("ಸರಿಯಾಗಿದೆ", raw)
+        self.assertNotIn("\\u", raw)
 
-    async def test_clear_removes_file_and_empties_map(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            store = JudgeStore.load(tmp)
-            key = JudgeKey(kind="stt", row_id="1", fingerprint="fp")
-            await store.put(key, {"score": 1})
-            self.assertTrue(os.path.exists(store.path))
+        reloaded = JudgeStore.load(self.output_dir)
+        self.assertEqual(reloaded.get(key), result)
 
-            store.clear()
+    async def test_truncated_final_line_is_skipped_not_fatal(self):
+        store = JudgeStore.load(self.output_dir)
+        good_key = JudgeKey(kind="llm_wer", row_id="row_a", fingerprint="fp1")
+        await store.put(good_key, {"score": 0.1})
 
-            self.assertFalse(os.path.exists(store.path))
-            self.assertEqual(len(store), 0)
-            self.assertIsNone(store.get(key))
+        with open(store.path, "a", encoding="utf-8") as f:
+            f.write('{"kind": "llm_wer", "row_id": "row_b", "fingerpr')  # truncated, no newline
 
-    async def test_clear_on_never_written_store_does_not_raise(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            store = JudgeStore.load(tmp)
-            store.clear()
-            self.assertEqual(len(store), 0)
+        reloaded = JudgeStore.load(self.output_dir)
 
-    async def test_concurrent_puts_all_survive_reload_without_corruption(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            store = JudgeStore.load(tmp)
-            keys = [
-                JudgeKey(kind="stt", row_id=str(i), fingerprint=f"fp{i}")
-                for i in range(50)
-            ]
+        self.assertEqual(len(reloaded), 1)
+        self.assertEqual(reloaded.get(good_key), {"score": 0.1})
 
-            await asyncio.gather(*[store.put(k, {"score": i}) for i, k in enumerate(keys)])
+    async def test_stale_fingerprint_never_returned_for_current_key(self):
+        store = JudgeStore.load(self.output_dir)
+        stale_key = JudgeKey(kind="llm_wer", row_id="row_a", fingerprint="old-fp")
+        await store.put(stale_key, {"score": 0.9})
 
-            with open(store.path, encoding="utf-8") as f:
-                lines = [line for line in f if line.strip()]
-            self.assertEqual(len(lines), 50)
-            for line in lines:
-                json.loads(line)  # each line is exactly one complete JSON object
+        current_key = JudgeKey(kind="llm_wer", row_id="row_a", fingerprint="new-fp")
 
-            reloaded = JudgeStore.load(tmp)
-            self.assertEqual(len(reloaded), 50)
-            for i, key in enumerate(keys):
-                self.assertEqual(reloaded.get(key), {"score": i})
+        self.assertIsNone(store.get(current_key))
+
+    async def test_pending_returns_only_uncached_keys_in_order(self):
+        store = JudgeStore.load(self.output_dir)
+        k1 = JudgeKey(kind="llm_wer", row_id="1", fingerprint="fp1")
+        k2 = JudgeKey(kind="llm_wer", row_id="2", fingerprint="fp2")
+        k3 = JudgeKey(kind="llm_wer", row_id="3", fingerprint="fp3")
+        await store.put(k2, {"score": 0.0})
+
+        result = store.pending([k1, k2, k3])
+
+        self.assertEqual(result, [k1, k3])
+
+    async def test_clear_removes_file_and_empties_store(self):
+        store = JudgeStore.load(self.output_dir)
+        key = JudgeKey(kind="llm_wer", row_id="1", fingerprint="fp1")
+        await store.put(key, {"score": 0.0})
+        self.assertTrue(os.path.exists(store.path))
+
+        store.clear()
+
+        self.assertFalse(os.path.exists(store.path))
+        self.assertEqual(len(store), 0)
+        self.assertIsNone(store.get(key))
+
+    async def test_concurrent_put_produces_that_many_valid_lines(self):
+        store = JudgeStore.load(self.output_dir)
+        n = 25
+        keys = [JudgeKey(kind="llm_wer", row_id=str(i), fingerprint=f"fp{i}") for i in range(n)]
+
+        await asyncio.gather(*[store.put(k, {"score": i}) for i, k in enumerate(keys)])
+
+        with open(store.path, encoding="utf-8") as f:
+            lines = [line for line in f.read().splitlines() if line]
+
+        self.assertEqual(len(lines), n)
+        for line in lines:
+            json.loads(line)  # each line parses independently
+        self.assertEqual(len(store), n)
 
 
-class TestGatherWithStore(unittest.IsolatedAsyncioTestCase):
-    async def test_results_returned_in_row_order_despite_scrambled_completion(self):
-        n = 5
-        keys = [None] * n
+class TestGatherWithStore(JudgeStoreTestBase):
+    async def test_results_returned_in_row_order(self):
+        store = JudgeStore.load(self.output_dir)
+        keys = [JudgeKey(kind="llm_wer", row_id=str(i), fingerprint=f"fp{i}") for i in range(3)]
 
         async def run_one(index):
-            # Later rows finish first; the helper must still return in row order.
-            await asyncio.sleep((n - index) * 0.01)
-            return {"index": index}
+            await asyncio.sleep(0.01 * (2 - index))  # complete out of order
+            return {"score": index}
+
+        results = await gather_with_store(keys, run_one, store, desc="test")
+
+        self.assertEqual(results, [{"score": 0}, {"score": 1}, {"score": 2}])
+
+    async def test_run_one_skipped_for_cached_rows(self):
+        store = JudgeStore.load(self.output_dir)
+        keys = [JudgeKey(kind="llm_wer", row_id=str(i), fingerprint=f"fp{i}") for i in range(3)]
+        await store.put(keys[1], {"score": "cached"})
+
+        calls = []
+
+        async def run_one(index):
+            calls.append(index)
+            return {"score": f"fresh-{index}"}
+
+        results = await gather_with_store(keys, run_one, store, desc="test")
+
+        self.assertEqual(sorted(calls), [0, 2])
+        self.assertEqual(results[1], {"score": "cached"})
+        self.assertEqual(results[0], {"score": "fresh-0"})
+        self.assertEqual(results[2], {"score": "fresh-2"})
+
+    async def test_fresh_results_are_persisted_immediately(self):
+        store = JudgeStore.load(self.output_dir)
+        keys = [JudgeKey(kind="llm_wer", row_id="a", fingerprint="fp1")]
+
+        async def run_one(index):
+            return {"score": 1.0}
+
+        await gather_with_store(keys, run_one, store, desc="test")
+
+        reloaded = JudgeStore.load(self.output_dir)
+        self.assertEqual(reloaded.get(keys[0]), {"score": 1.0})
+
+    async def test_store_none_runs_every_row(self):
+        keys = [JudgeKey(kind="llm_wer", row_id=str(i), fingerprint=f"fp{i}") for i in range(3)]
+        calls = []
+
+        async def run_one(index):
+            calls.append(index)
+            return {"score": index}
 
         results = await gather_with_store(keys, run_one, None, desc="test")
 
-        self.assertEqual([r["index"] for r in results], list(range(n)))
+        self.assertEqual(sorted(calls), [0, 1, 2])
+        self.assertEqual(results, [{"score": 0}, {"score": 1}, {"score": 2}])
 
-    async def test_fully_cached_run_never_calls_run_one(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            store = JudgeStore.load(tmp)
-            keys = [JudgeKey(kind="stt", row_id=str(i), fingerprint="fp") for i in range(3)]
-            for i, key in enumerate(keys):
-                await store.put(key, {"score": i})
+    async def test_none_key_forces_row_to_run(self):
+        store = JudgeStore.load(self.output_dir)
+        keys = [JudgeKey(kind="llm_wer", row_id="0", fingerprint="fp0"), None]
+        await store.put(keys[0], {"score": "cached"})
+        calls = []
 
-            calls = []
+        async def run_one(index):
+            calls.append(index)
+            return {"score": f"fresh-{index}"}
 
-            async def run_one(index):
-                calls.append(index)
-                return {"score": -1}
+        results = await gather_with_store(keys, run_one, store, desc="test")
 
-            results = await gather_with_store(keys, run_one, store, desc="test")
+        self.assertEqual(calls, [1])
+        self.assertEqual(results, [{"score": "cached"}, {"score": "fresh-1"}])
 
-            self.assertEqual(calls, [])
-            self.assertEqual([r["score"] for r in results], [0, 1, 2])
+    async def test_exception_propagates_but_stored_results_persist(self):
+        store = JudgeStore.load(self.output_dir)
+        keys = [JudgeKey(kind="llm_wer", row_id=str(i), fingerprint=f"fp{i}") for i in range(3)]
 
-    async def test_partial_cache_runs_only_uncached_indices(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            store = JudgeStore.load(tmp)
-            keys = [JudgeKey(kind="stt", row_id=str(i), fingerprint="fp") for i in range(3)]
-            await store.put(keys[1], {"score": "cached"})
+        async def run_one(index):
+            if index == 1:
+                await asyncio.sleep(0.05)
+                raise ValueError("judge call failed")
+            return {"score": index}
 
-            calls = []
+        with self.assertRaises(ValueError):
+            await gather_with_store(keys, run_one, store, desc="test")
 
-            async def run_one(index):
-                calls.append(index)
-                return {"score": "fresh"}
+        # Give the still-running background tasks (if any) a chance to finish.
+        await asyncio.sleep(0.1)
 
-            results = await gather_with_store(keys, run_one, store, desc="test")
-
-            self.assertEqual(sorted(calls), [0, 2])
-            self.assertEqual(results[0]["score"], "fresh")
-            self.assertEqual(results[1]["score"], "cached")
-            self.assertEqual(results[2]["score"], "fresh")
-
-    async def test_store_none_runs_every_row_and_writes_nothing(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            keys = [JudgeKey(kind="stt", row_id=str(i), fingerprint="fp") for i in range(3)]
-            calls = []
-
-            async def run_one(index):
-                calls.append(index)
-                return {"score": index}
-
-            results = await gather_with_store(keys, run_one, None, desc="test")
-
-            self.assertEqual(sorted(calls), [0, 1, 2])
-            self.assertEqual([r["score"] for r in results], [0, 1, 2])
-            self.assertFalse(os.path.exists(os.path.join(tmp, JudgeStore.FILENAME)))
-
-    async def test_none_key_at_index_always_runs(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            store = JudgeStore.load(tmp)
-            cached_key = JudgeKey(kind="stt", row_id="0", fingerprint="fp")
-            await store.put(cached_key, {"score": "cached"})
-            keys = [cached_key, None]
-
-            calls = []
-
-            async def run_one(index):
-                calls.append(index)
-                return {"score": "fresh"}
-
-            results = await gather_with_store(keys, run_one, store, desc="test")
-
-            self.assertEqual(calls, [1])
-            self.assertEqual(results[0]["score"], "cached")
-            self.assertEqual(results[1]["score"], "fresh")
-
-    async def test_exception_propagates_and_completed_rows_persist(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            store = JudgeStore.load(tmp)
-            keys = [JudgeKey(kind="stt", row_id=str(i), fingerprint="fp") for i in range(3)]
-
-            async def run_one(index):
-                if index == 1:
-                    # Delay the failure so rows 0 and 2 (no delay) finish and
-                    # persist first. asyncio.gather(return_exceptions=False,
-                    # the default) propagates the first exception without
-                    # cancelling sibling tasks, so their work is not lost.
-                    await asyncio.sleep(0.05)
-                    raise ValueError("judge call failed")
-                return {"score": index}
-
-            with self.assertRaises(ValueError):
-                await gather_with_store(keys, run_one, store, desc="test")
-
-            reloaded = JudgeStore.load(tmp)
-            self.assertEqual(reloaded.get(keys[0]), {"score": 0})
-            self.assertEqual(reloaded.get(keys[2]), {"score": 2})
-            self.assertIsNone(reloaded.get(keys[1]))
+        reloaded = JudgeStore.load(self.output_dir)
+        self.assertEqual(reloaded.get(keys[0]), {"score": 0})
+        self.assertEqual(reloaded.get(keys[2]), {"score": 2})
+        self.assertIsNone(reloaded.get(keys[1]))
 
 
-class TestGatherEvaluatorsWithStore(unittest.IsolatedAsyncioTestCase):
-    async def test_returns_one_dict_per_row_in_row_and_key_order(self):
+class TestGatherEvaluatorsWithStore(JudgeStoreTestBase):
+    async def test_fully_cached_row_skips_run_subset(self):
+        store = JudgeStore.load(self.output_dir)
         row_keys = [
             {
-                "b": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="b"),
-                "a": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="a"),
-            },
+                "semantic_match": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp-sm", evaluator="semantic_match"),
+                "fluency": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp-fl", evaluator="fluency"),
+            }
+        ]
+        await store.put(row_keys[0]["semantic_match"], {"match": True, "reasoning": "ok"})
+        await store.put(row_keys[0]["fluency"], {"match": False, "reasoning": "meh"})
+
+        async def run_subset(index, names):
+            raise AssertionError("run_subset should not be called for a fully cached row")
+
+        results = await gather_evaluators_with_store(row_keys, run_subset, store, desc="test")
+
+        self.assertEqual(
+            results,
+            [{"semantic_match": {"match": True, "reasoning": "ok"}, "fluency": {"match": False, "reasoning": "meh"}}],
+        )
+
+    async def test_partially_cached_row_runs_only_missing_names(self):
+        store = JudgeStore.load(self.output_dir)
+        row_keys = [
             {
-                "a": JudgeKey(kind="evaluators", row_id="1", fingerprint="fp", evaluator="a"),
-            },
+                "semantic_match": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp-sm", evaluator="semantic_match"),
+                "fluency": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp-fl", evaluator="fluency"),
+            }
+        ]
+        await store.put(row_keys[0]["semantic_match"], {"match": True, "reasoning": "cached"})
+        calls = []
+
+        async def run_subset(index, names):
+            calls.append((index, list(names)))
+            return {name: {"match": True, "reasoning": f"fresh-{name}"} for name in names}
+
+        results = await gather_evaluators_with_store(row_keys, run_subset, store, desc="test")
+
+        self.assertEqual(calls, [(0, ["fluency"])])
+        self.assertEqual(
+            results,
+            [
+                {
+                    "semantic_match": {"match": True, "reasoning": "cached"},
+                    "fluency": {"match": True, "reasoning": "fresh-fluency"},
+                }
+            ],
+        )
+
+    async def test_fresh_evaluator_results_are_persisted(self):
+        store = JudgeStore.load(self.output_dir)
+        row_keys = [
+            {"semantic_match": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp-sm", evaluator="semantic_match")}
         ]
 
         async def run_subset(index, names):
-            return {name: {"score": f"{index}-{name}"} for name in names}
+            return {name: {"match": True, "reasoning": "fresh"} for name in names}
 
-        results = await gather_evaluators_with_store(row_keys, run_subset, None, desc="test")
+        await gather_evaluators_with_store(row_keys, run_subset, store, desc="test")
 
-        self.assertEqual(len(results), 2)
-        # Key order follows the input mapping's order ("b" before "a" for row 0).
-        self.assertEqual(list(results[0].keys()), ["b", "a"])
-        self.assertEqual(results[0]["a"], {"score": "0-a"})
-        self.assertEqual(results[1], {"a": {"score": "1-a"}})
+        reloaded = JudgeStore.load(self.output_dir)
+        self.assertEqual(
+            reloaded.get(row_keys[0]["semantic_match"]),
+            {"match": True, "reasoning": "fresh"},
+        )
 
-    async def test_fully_cached_row_never_calls_run_subset(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            store = JudgeStore.load(tmp)
-            key_a = JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="a")
-            key_b = JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="b")
-            await store.put(key_a, {"score": "cached-a"})
-            await store.put(key_b, {"score": "cached-b"})
-            row_keys = [{"a": key_a, "b": key_b}]
-
-            calls = []
-
-            async def run_subset(index, names):
-                calls.append(names)
-                return {}
-
-            results = await gather_evaluators_with_store(row_keys, run_subset, store, desc="test")
-
-            self.assertEqual(calls, [])
-            self.assertEqual(
-                results[0], {"a": {"score": "cached-a"}, "b": {"score": "cached-b"}}
-            )
-
-    async def test_partial_hit_runs_only_missing_evaluators_and_merges(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            store = JudgeStore.load(tmp)
-            key_a = JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="a")
-            key_b = JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="b")
-            await store.put(key_a, {"score": "cached-a"})
-            row_keys = [{"a": key_a, "b": key_b}]
-
-            calls = []
-
-            async def run_subset(index, names):
-                calls.append(list(names))
-                return {name: {"score": f"fresh-{name}"} for name in names}
-
-            results = await gather_evaluators_with_store(row_keys, run_subset, store, desc="test")
-
-            # Only the missing evaluator is asked for, not the already-cached one.
-            self.assertEqual(calls, [["b"]])
-            self.assertEqual(results[0]["a"], {"score": "cached-a"})
-            self.assertEqual(results[0]["b"], {"score": "fresh-b"})
-
-    async def test_fresh_results_are_persisted_for_reload(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            store = JudgeStore.load(tmp)
-            key_a = JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="a")
-            row_keys = [{"a": key_a}]
-
-            async def run_subset(index, names):
-                return {name: {"score": "fresh"} for name in names}
-
-            await gather_evaluators_with_store(row_keys, run_subset, store, desc="test")
-
-            reloaded = JudgeStore.load(tmp)
-            self.assertEqual(reloaded.get(key_a), {"score": "fresh"})
-
-    async def test_run_subset_omitting_requested_evaluator_raises_key_error(self):
-        row_keys = [{
-            "a": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="a"),
-            "b": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="b"),
-        }]
+    async def test_results_in_row_order(self):
+        store = JudgeStore.load(self.output_dir)
+        row_keys = [
+            {"a": JudgeKey(kind="evaluators", row_id=str(i), fingerprint=f"fp{i}", evaluator="a")}
+            for i in range(3)
+        ]
 
         async def run_subset(index, names):
-            return {"a": {"score": "only-a"}}  # "b" was requested but omitted
+            await asyncio.sleep(0.01 * (2 - index))  # complete out of order
+            return {name: {"match": True, "reasoning": f"row-{index}"} for name in names}
 
-        with self.assertRaises(KeyError) as ctx:
-            await gather_evaluators_with_store(row_keys, run_subset, None, desc="test")
+        results = await gather_evaluators_with_store(row_keys, run_subset, store, desc="test")
 
-        message = str(ctx.exception)
-        self.assertIn("0", message)
-        self.assertIn("b", message)
+        self.assertEqual(
+            [r["a"]["reasoning"] for r in results],
+            ["row-0", "row-1", "row-2"],
+        )
+
+    async def test_new_evaluator_reruns_only_that_evaluator_across_rows(self):
+        store = JudgeStore.load(self.output_dir)
+        row_keys = [
+            {"semantic_match": JudgeKey(kind="evaluators", row_id=str(i), fingerprint=f"fp{i}", evaluator="semantic_match")}
+            for i in range(2)
+        ]
+
+        async def run_subset_first_pass(index, names):
+            return {name: {"match": True, "reasoning": "pass1"} for name in names}
+
+        await gather_evaluators_with_store(row_keys, run_subset_first_pass, store, desc="test")
+
+        # Second pass adds a "fluency" evaluator to every row.
+        row_keys_v2 = [
+            {
+                **row_keys[i],
+                "fluency": JudgeKey(kind="evaluators", row_id=str(i), fingerprint=f"fp-fl-{i}", evaluator="fluency"),
+            }
+            for i in range(2)
+        ]
+        calls = []
+
+        async def run_subset_second_pass(index, names):
+            calls.append((index, list(names)))
+            return {name: {"match": True, "reasoning": "pass2"} for name in names}
+
+        results = await gather_evaluators_with_store(row_keys_v2, run_subset_second_pass, store, desc="test")
+
+        self.assertEqual(sorted(calls), [(0, ["fluency"]), (1, ["fluency"])])
+        for r in results:
+            self.assertEqual(r["semantic_match"]["reasoning"], "pass1")
+            self.assertEqual(r["fluency"]["reasoning"], "pass2")
 
     async def test_store_none_runs_every_evaluator_for_every_row(self):
         row_keys = [
-            {"a": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="a")},
-            {"a": JudgeKey(kind="evaluators", row_id="1", fingerprint="fp", evaluator="a")},
+            {"a": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp0", evaluator="a")}
         ]
         calls = []
 
         async def run_subset(index, names):
-            calls.append((index, tuple(names)))
-            return {name: {"score": "x"} for name in names}
+            calls.append((index, list(names)))
+            return {name: {"match": True, "reasoning": "fresh"} for name in names}
 
         results = await gather_evaluators_with_store(row_keys, run_subset, None, desc="test")
 
-        self.assertEqual(sorted(calls), [(0, ("a",)), (1, ("a",))])
-        self.assertEqual(len(results), 2)
+        self.assertEqual(calls, [(0, ["a"])])
+        self.assertEqual(results, [{"a": {"match": True, "reasoning": "fresh"}}])
+
+    async def test_missing_name_in_run_subset_result_raises(self):
+        store = JudgeStore.load(self.output_dir)
+        row_keys = [
+            {
+                "semantic_match": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp-sm", evaluator="semantic_match"),
+                "fluency": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp-fl", evaluator="fluency"),
+            }
+        ]
+
+        async def run_subset(index, names):
+            return {"semantic_match": {"match": True, "reasoning": "ok"}}  # missing "fluency"
+
+        with self.assertRaises(KeyError):
+            await gather_evaluators_with_store(row_keys, run_subset, store, desc="test")
 
 
 if __name__ == "__main__":

--- a/tests/test_judge_store.py
+++ b/tests/test_judge_store.py
@@ -1,0 +1,464 @@
+"""Tests for calibrate_agent/judge_store.py — the resumable judge checkpoint."""
+
+import asyncio
+import json
+import os
+import tempfile
+import unittest
+
+from calibrate_agent.judge_store import (
+    JudgeKey,
+    JudgeStore,
+    gather_evaluators_with_store,
+    gather_with_store,
+    make_fingerprint,
+)
+
+
+class TestMakeFingerprint(unittest.TestCase):
+    def test_deterministic_across_calls(self):
+        first = make_fingerprint("reference", "prediction", "openai/gpt-4.1")
+        second = make_fingerprint("reference", "prediction", "openai/gpt-4.1")
+        self.assertEqual(first, second)
+
+    def test_differs_when_any_part_differs(self):
+        base = make_fingerprint("reference", "prediction", "openai/gpt-4.1")
+        self.assertNotEqual(base, make_fingerprint("other", "prediction", "openai/gpt-4.1"))
+        self.assertNotEqual(base, make_fingerprint("reference", "other", "openai/gpt-4.1"))
+        self.assertNotEqual(base, make_fingerprint("reference", "prediction", "other-model"))
+
+    def test_dict_part_order_independent(self):
+        a = make_fingerprint("ref", {"scale_min": 1, "scale_max": 5, "name": "x"})
+        b = make_fingerprint("ref", {"name": "x", "scale_max": 5, "scale_min": 1})
+        self.assertEqual(a, b)
+
+    def test_separator_prevents_split_collision(self):
+        # Without a separator between parts, ("ab", "c") and ("a", "bc") would
+        # encode to the same concatenated string.
+        self.assertNotEqual(make_fingerprint("ab", "c"), make_fingerprint("a", "bc"))
+
+    def test_non_json_serializable_uses_str_fallback(self):
+        class Unserializable:
+            def __str__(self):
+                return "unserializable-repr"
+
+        fingerprint = make_fingerprint(Unserializable())
+        self.assertIsInstance(fingerprint, str)
+        # default=str means the object's str() is what actually gets hashed.
+        self.assertEqual(fingerprint, make_fingerprint("unserializable-repr"))
+
+    def test_non_json_serializable_nested_in_dict(self):
+        class Unserializable:
+            def __str__(self):
+                return "nested-repr"
+
+        fingerprint = make_fingerprint({"value": Unserializable()})
+        self.assertEqual(fingerprint, make_fingerprint({"value": "nested-repr"}))
+
+
+class TestJudgeKey(unittest.TestCase):
+    def test_int_and_str_row_id_are_equal_and_hash_equal(self):
+        int_key = JudgeKey(kind="stt", row_id=1, fingerprint="fp")
+        str_key = JudgeKey(kind="stt", row_id="1", fingerprint="fp")
+        self.assertEqual(int_key, str_key)
+        self.assertEqual(hash(int_key), hash(str_key))
+
+    def test_row_id_coerced_to_str(self):
+        key = JudgeKey(kind="stt", row_id=42, fingerprint="fp")
+        self.assertEqual(key.row_id, "42")
+        self.assertIsInstance(key.row_id, str)
+
+    def test_keys_differing_only_in_evaluator_are_distinct(self):
+        key_a = JudgeKey(kind="evaluators", row_id="1", fingerprint="fp", evaluator="a")
+        key_b = JudgeKey(kind="evaluators", row_id="1", fingerprint="fp", evaluator="b")
+        no_evaluator = JudgeKey(kind="evaluators", row_id="1", fingerprint="fp")
+        self.assertNotEqual(key_a, key_b)
+        self.assertNotEqual(key_a, no_evaluator)
+
+    def test_usable_as_dict_key(self):
+        key = JudgeKey(kind="stt", row_id=1, fingerprint="fp")
+        mapping = {key: "value"}
+        self.assertEqual(mapping[JudgeKey(kind="stt", row_id="1", fingerprint="fp")], "value")
+
+    def test_usable_in_set(self):
+        keys = {
+            JudgeKey(kind="stt", row_id=1, fingerprint="fp"),
+            JudgeKey(kind="stt", row_id="1", fingerprint="fp"),
+        }
+        self.assertEqual(len(keys), 1)
+
+
+class TestJudgeStoreLoad(unittest.TestCase):
+    def test_load_creates_missing_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "nested", "out")
+            self.assertFalse(os.path.exists(target))
+
+            store = JudgeStore.load(target)
+
+            self.assertTrue(os.path.isdir(target))
+            self.assertEqual(len(store), 0)
+
+    def test_path_points_at_checkpoint_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            self.assertEqual(store.path, os.path.join(tmp, JudgeStore.FILENAME))
+
+    def test_get_unknown_key_returns_none(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            self.assertIsNone(store.get(JudgeKey(kind="stt", row_id="1", fingerprint="fp")))
+
+    def test_load_skips_blank_missing_key_and_truncated_lines(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, JudgeStore.FILENAME)
+            valid_line = json.dumps({
+                "kind": "stt",
+                "row_id": "1",
+                "evaluator": None,
+                "fingerprint": "fp1",
+                "result": {"score": 1},
+            })
+            missing_result_key = json.dumps({
+                "kind": "stt",
+                "row_id": "2",
+                "evaluator": None,
+                "fingerprint": "fp2",
+            })
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(valid_line + "\n")
+                f.write("\n")
+                f.write(missing_result_key + "\n")
+                f.write('{"kind": "stt", "row_id": "3", "fingerp')  # truncated, no newline
+
+            store = JudgeStore.load(tmp)
+
+            self.assertEqual(len(store), 1)
+            self.assertEqual(
+                store.get(JudgeKey(kind="stt", row_id="1", fingerprint="fp1")),
+                {"score": 1},
+            )
+
+
+class TestJudgeStorePutAndGet(unittest.IsolatedAsyncioTestCase):
+    async def test_put_then_get_round_trips(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            key = JudgeKey(kind="stt", row_id="1", fingerprint="fp")
+
+            await store.put(key, {"match": True, "reasoning": "ok"})
+
+            self.assertEqual(store.get(key), {"match": True, "reasoning": "ok"})
+            self.assertEqual(len(store), 1)
+
+    async def test_second_load_sees_results_from_first(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            first_run = JudgeStore.load(tmp)
+            key = JudgeKey(kind="stt", row_id="1", fingerprint="fp")
+            await first_run.put(key, {"score": 1})
+
+            resumed_run = JudgeStore.load(tmp)
+
+            self.assertEqual(resumed_run.get(key), {"score": 1})
+            self.assertEqual(len(resumed_run), 1)
+
+    async def test_non_ascii_content_survives_reload(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            key = JudgeKey(kind="stt", row_id="1", fingerprint="fp")
+            result = {"reasoning": "पूरी तरह सही उत्तर है", "match": True}
+
+            await store.put(key, result)
+            reloaded = JudgeStore.load(tmp)
+
+            self.assertEqual(reloaded.get(key), result)
+            with open(store.path, encoding="utf-8") as f:
+                raw = f.read()
+            self.assertIn("पूरी तरह सही उत्तर है", raw)
+
+    async def test_changed_fingerprint_is_a_cache_miss(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            old_key = JudgeKey(kind="stt", row_id="1", fingerprint="fp-before-edit")
+            await store.put(old_key, {"score": 1})
+
+            new_key = JudgeKey(kind="stt", row_id="1", fingerprint="fp-after-edit")
+
+            self.assertIsNone(store.get(new_key))
+            self.assertEqual(store.pending([new_key]), [new_key])
+
+    async def test_pending_returns_uncached_keys_in_input_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            key1 = JudgeKey(kind="stt", row_id="1", fingerprint="fp1")
+            key2 = JudgeKey(kind="stt", row_id="2", fingerprint="fp2")
+            key3 = JudgeKey(kind="stt", row_id="3", fingerprint="fp3")
+            await store.put(key2, {"score": 2})
+
+            self.assertEqual(store.pending([key3, key1, key2]), [key3, key1])
+
+    async def test_clear_removes_file_and_empties_map(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            key = JudgeKey(kind="stt", row_id="1", fingerprint="fp")
+            await store.put(key, {"score": 1})
+            self.assertTrue(os.path.exists(store.path))
+
+            store.clear()
+
+            self.assertFalse(os.path.exists(store.path))
+            self.assertEqual(len(store), 0)
+            self.assertIsNone(store.get(key))
+
+    async def test_clear_on_never_written_store_does_not_raise(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            store.clear()
+            self.assertEqual(len(store), 0)
+
+    async def test_concurrent_puts_all_survive_reload_without_corruption(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            keys = [
+                JudgeKey(kind="stt", row_id=str(i), fingerprint=f"fp{i}")
+                for i in range(50)
+            ]
+
+            await asyncio.gather(*[store.put(k, {"score": i}) for i, k in enumerate(keys)])
+
+            with open(store.path, encoding="utf-8") as f:
+                lines = [line for line in f if line.strip()]
+            self.assertEqual(len(lines), 50)
+            for line in lines:
+                json.loads(line)  # each line is exactly one complete JSON object
+
+            reloaded = JudgeStore.load(tmp)
+            self.assertEqual(len(reloaded), 50)
+            for i, key in enumerate(keys):
+                self.assertEqual(reloaded.get(key), {"score": i})
+
+
+class TestGatherWithStore(unittest.IsolatedAsyncioTestCase):
+    async def test_results_returned_in_row_order_despite_scrambled_completion(self):
+        n = 5
+        keys = [None] * n
+
+        async def run_one(index):
+            # Later rows finish first; the helper must still return in row order.
+            await asyncio.sleep((n - index) * 0.01)
+            return {"index": index}
+
+        results = await gather_with_store(keys, run_one, None, desc="test")
+
+        self.assertEqual([r["index"] for r in results], list(range(n)))
+
+    async def test_fully_cached_run_never_calls_run_one(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            keys = [JudgeKey(kind="stt", row_id=str(i), fingerprint="fp") for i in range(3)]
+            for i, key in enumerate(keys):
+                await store.put(key, {"score": i})
+
+            calls = []
+
+            async def run_one(index):
+                calls.append(index)
+                return {"score": -1}
+
+            results = await gather_with_store(keys, run_one, store, desc="test")
+
+            self.assertEqual(calls, [])
+            self.assertEqual([r["score"] for r in results], [0, 1, 2])
+
+    async def test_partial_cache_runs_only_uncached_indices(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            keys = [JudgeKey(kind="stt", row_id=str(i), fingerprint="fp") for i in range(3)]
+            await store.put(keys[1], {"score": "cached"})
+
+            calls = []
+
+            async def run_one(index):
+                calls.append(index)
+                return {"score": "fresh"}
+
+            results = await gather_with_store(keys, run_one, store, desc="test")
+
+            self.assertEqual(sorted(calls), [0, 2])
+            self.assertEqual(results[0]["score"], "fresh")
+            self.assertEqual(results[1]["score"], "cached")
+            self.assertEqual(results[2]["score"], "fresh")
+
+    async def test_store_none_runs_every_row_and_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            keys = [JudgeKey(kind="stt", row_id=str(i), fingerprint="fp") for i in range(3)]
+            calls = []
+
+            async def run_one(index):
+                calls.append(index)
+                return {"score": index}
+
+            results = await gather_with_store(keys, run_one, None, desc="test")
+
+            self.assertEqual(sorted(calls), [0, 1, 2])
+            self.assertEqual([r["score"] for r in results], [0, 1, 2])
+            self.assertFalse(os.path.exists(os.path.join(tmp, JudgeStore.FILENAME)))
+
+    async def test_none_key_at_index_always_runs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            cached_key = JudgeKey(kind="stt", row_id="0", fingerprint="fp")
+            await store.put(cached_key, {"score": "cached"})
+            keys = [cached_key, None]
+
+            calls = []
+
+            async def run_one(index):
+                calls.append(index)
+                return {"score": "fresh"}
+
+            results = await gather_with_store(keys, run_one, store, desc="test")
+
+            self.assertEqual(calls, [1])
+            self.assertEqual(results[0]["score"], "cached")
+            self.assertEqual(results[1]["score"], "fresh")
+
+    async def test_exception_propagates_and_completed_rows_persist(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            keys = [JudgeKey(kind="stt", row_id=str(i), fingerprint="fp") for i in range(3)]
+
+            async def run_one(index):
+                if index == 1:
+                    # Delay the failure so rows 0 and 2 (no delay) finish and
+                    # persist first. asyncio.gather(return_exceptions=False,
+                    # the default) propagates the first exception without
+                    # cancelling sibling tasks, so their work is not lost.
+                    await asyncio.sleep(0.05)
+                    raise ValueError("judge call failed")
+                return {"score": index}
+
+            with self.assertRaises(ValueError):
+                await gather_with_store(keys, run_one, store, desc="test")
+
+            reloaded = JudgeStore.load(tmp)
+            self.assertEqual(reloaded.get(keys[0]), {"score": 0})
+            self.assertEqual(reloaded.get(keys[2]), {"score": 2})
+            self.assertIsNone(reloaded.get(keys[1]))
+
+
+class TestGatherEvaluatorsWithStore(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_one_dict_per_row_in_row_and_key_order(self):
+        row_keys = [
+            {
+                "b": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="b"),
+                "a": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="a"),
+            },
+            {
+                "a": JudgeKey(kind="evaluators", row_id="1", fingerprint="fp", evaluator="a"),
+            },
+        ]
+
+        async def run_subset(index, names):
+            return {name: {"score": f"{index}-{name}"} for name in names}
+
+        results = await gather_evaluators_with_store(row_keys, run_subset, None, desc="test")
+
+        self.assertEqual(len(results), 2)
+        # Key order follows the input mapping's order ("b" before "a" for row 0).
+        self.assertEqual(list(results[0].keys()), ["b", "a"])
+        self.assertEqual(results[0]["a"], {"score": "0-a"})
+        self.assertEqual(results[1], {"a": {"score": "1-a"}})
+
+    async def test_fully_cached_row_never_calls_run_subset(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            key_a = JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="a")
+            key_b = JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="b")
+            await store.put(key_a, {"score": "cached-a"})
+            await store.put(key_b, {"score": "cached-b"})
+            row_keys = [{"a": key_a, "b": key_b}]
+
+            calls = []
+
+            async def run_subset(index, names):
+                calls.append(names)
+                return {}
+
+            results = await gather_evaluators_with_store(row_keys, run_subset, store, desc="test")
+
+            self.assertEqual(calls, [])
+            self.assertEqual(
+                results[0], {"a": {"score": "cached-a"}, "b": {"score": "cached-b"}}
+            )
+
+    async def test_partial_hit_runs_only_missing_evaluators_and_merges(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            key_a = JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="a")
+            key_b = JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="b")
+            await store.put(key_a, {"score": "cached-a"})
+            row_keys = [{"a": key_a, "b": key_b}]
+
+            calls = []
+
+            async def run_subset(index, names):
+                calls.append(list(names))
+                return {name: {"score": f"fresh-{name}"} for name in names}
+
+            results = await gather_evaluators_with_store(row_keys, run_subset, store, desc="test")
+
+            # Only the missing evaluator is asked for, not the already-cached one.
+            self.assertEqual(calls, [["b"]])
+            self.assertEqual(results[0]["a"], {"score": "cached-a"})
+            self.assertEqual(results[0]["b"], {"score": "fresh-b"})
+
+    async def test_fresh_results_are_persisted_for_reload(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            key_a = JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="a")
+            row_keys = [{"a": key_a}]
+
+            async def run_subset(index, names):
+                return {name: {"score": "fresh"} for name in names}
+
+            await gather_evaluators_with_store(row_keys, run_subset, store, desc="test")
+
+            reloaded = JudgeStore.load(tmp)
+            self.assertEqual(reloaded.get(key_a), {"score": "fresh"})
+
+    async def test_run_subset_omitting_requested_evaluator_raises_key_error(self):
+        row_keys = [{
+            "a": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="a"),
+            "b": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="b"),
+        }]
+
+        async def run_subset(index, names):
+            return {"a": {"score": "only-a"}}  # "b" was requested but omitted
+
+        with self.assertRaises(KeyError) as ctx:
+            await gather_evaluators_with_store(row_keys, run_subset, None, desc="test")
+
+        message = str(ctx.exception)
+        self.assertIn("0", message)
+        self.assertIn("b", message)
+
+    async def test_store_none_runs_every_evaluator_for_every_row(self):
+        row_keys = [
+            {"a": JudgeKey(kind="evaluators", row_id="0", fingerprint="fp", evaluator="a")},
+            {"a": JudgeKey(kind="evaluators", row_id="1", fingerprint="fp", evaluator="a")},
+        ]
+        calls = []
+
+        async def run_subset(index, names):
+            calls.append((index, tuple(names)))
+            return {name: {"score": "x"} for name in names}
+
+        results = await gather_evaluators_with_store(row_keys, run_subset, None, desc="test")
+
+        self.assertEqual(sorted(calls), [(0, ("a",)), (1, ("a",))])
+        self.assertEqual(len(results), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -144,7 +144,9 @@ class TestCostBreakdown(unittest.TestCase):
         from calibrate_agent import pricing as P
 
         entry = {"currency": "INR", "native_rate": 3000.0, "provider": "sarvam"}
-        with patch.object(P, "get_usd_to_inr_rate", side_effect=RuntimeError("no FX")):
+        with patch.object(
+            P, "get_usd_to_inr_rate", side_effect=RuntimeError("no FX")
+        ), patch.object(P, "provider_log") as log_mock:
             fields = P.cost_breakdown(entry, 2.0, "cost_per_million_chars")
 
         # Native-currency cost is still reported; USD is skipped, not raised.
@@ -153,6 +155,10 @@ class TestCostBreakdown(unittest.TestCase):
         self.assertEqual(fields["cost_in_currency"], 6000.0)
         self.assertNotIn("cost_usd", fields)
         self.assertNotIn("conversion_rate", fields)
+        log_mock.assert_called_once()
+        message = log_mock.call_args[0][0]
+        self.assertIn("FX", message)
+        self.assertIn("skipping cost_usd", message)
 
 
 class TestLLMPricingResolver(unittest.TestCase):

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -155,6 +155,110 @@ class TestCostBreakdown(unittest.TestCase):
         self.assertNotIn("conversion_rate", fields)
 
 
+class TestLLMPricingResolver(unittest.TestCase):
+    EXPECTED_RATES = {
+        "openai/gpt-5.4-mini": (0.75, 4.5),
+        "openai/gpt-audio": (2.5, 10.0),
+        "google/gemini-2.5-flash": (0.3, 2.5),
+        "anthropic/claude-sonnet-4.5": (3.0, 15.0),
+    }
+
+    def test_resolves_text_rates_for_every_source(self):
+        from calibrate_agent.pricing import resolve_llm_pricing
+
+        for model, (input_rate, output_rate) in self.EXPECTED_RATES.items():
+            for source in ("openrouter", "direct"):
+                with self.subTest(model=model, source=source):
+                    pricing = resolve_llm_pricing(model, source=source)
+
+                    self.assertEqual(pricing["model"], model)
+                    self.assertEqual(pricing["source"], source)
+                    self.assertEqual(
+                        pricing["input_price_per_million_tokens_usd"], input_rate
+                    )
+                    self.assertEqual(
+                        pricing["output_price_per_million_tokens_usd"], output_rate
+                    )
+
+    def test_openrouter_is_the_default_source(self):
+        from calibrate_agent.pricing import resolve_llm_pricing
+
+        self.assertEqual(
+            resolve_llm_pricing("openai/gpt-5.4-mini")["source"], "openrouter"
+        )
+
+    def test_audio_rates_present_only_for_audio_priced_models(self):
+        from calibrate_agent.pricing import resolve_llm_pricing
+
+        audio_pricing = resolve_llm_pricing("openai/gpt-audio")
+        self.assertEqual(
+            audio_pricing["audio_input_price_per_million_tokens_usd"], 32.0
+        )
+        self.assertEqual(
+            audio_pricing["audio_output_price_per_million_tokens_usd"], 64.0
+        )
+
+        gemini_pricing = resolve_llm_pricing("google/gemini-2.5-flash")
+        self.assertEqual(
+            gemini_pricing["audio_input_price_per_million_tokens_usd"], 1.0
+        )
+
+        for model in ("openai/gpt-5.4-mini", "anthropic/claude-sonnet-4.5"):
+            with self.subTest(model=model):
+                pricing = resolve_llm_pricing(model)
+                self.assertNotIn("audio_input_price_per_million_tokens_usd", pricing)
+                self.assertNotIn("audio_output_price_per_million_tokens_usd", pricing)
+
+    def test_reasoning_billed_as_output_only_for_gemini(self):
+        from calibrate_agent.pricing import resolve_llm_pricing
+
+        self.assertTrue(
+            resolve_llm_pricing("google/gemini-2.5-flash")[
+                "reasoning_billed_as_output"
+            ]
+        )
+        for model in (
+            "openai/gpt-5.4-mini",
+            "openai/gpt-audio",
+            "anthropic/claude-sonnet-4.5",
+        ):
+            with self.subTest(model=model):
+                self.assertFalse(
+                    resolve_llm_pricing(model)["reasoning_billed_as_output"]
+                )
+
+    def test_unknown_model_returns_none(self):
+        from calibrate_agent.pricing import resolve_llm_pricing
+
+        self.assertIsNone(resolve_llm_pricing("acme/does-not-exist"))
+
+    def test_unknown_source_raises(self):
+        from calibrate_agent.pricing import resolve_llm_pricing
+
+        with self.assertRaises(ValueError):
+            resolve_llm_pricing("openai/gpt-5.4-mini", source="bedrock")
+
+    def test_every_judge_default_model_is_priced(self):
+        from calibrate_agent.judges import (
+            DEFAULT_AUDIO_JUDGE_MODEL,
+            DEFAULT_TEXT_JUDGE_MODEL,
+        )
+        from calibrate_agent.pricing import resolve_llm_pricing
+        from calibrate_agent.stt.sarvam_intent_entity import DEFAULT_INTENT_ENTITY_MODEL
+        from calibrate_agent.stt.sarvam_llm_wer import DEFAULT_LLM_WER_MODEL
+        from calibrate_agent.stt.semantic_wer import DEFAULT_SEMANTIC_WER_MODEL
+
+        for model in (
+            DEFAULT_TEXT_JUDGE_MODEL,
+            DEFAULT_AUDIO_JUDGE_MODEL,
+            DEFAULT_INTENT_ENTITY_MODEL,
+            DEFAULT_LLM_WER_MODEL,
+            DEFAULT_SEMANTIC_WER_MODEL,
+        ):
+            with self.subTest(model=model):
+                self.assertIsNotNone(resolve_llm_pricing(model))
+
+
 class TestPricingResolverGuards(unittest.TestCase):
     def test_unknown_provider_returns_none(self):
         from calibrate_agent.pricing import resolve_pricing

--- a/tests/tts/test_benchmark.py
+++ b/tests/tts/test_benchmark.py
@@ -6,12 +6,38 @@ Run with:
     python -m pytest tests/tts/test_benchmark.py -v
 """
 
+import io
 import os
 import sys
 import tempfile
 import unittest
+import wave
+from contextlib import redirect_stdout
 from pathlib import Path
 from unittest.mock import patch, AsyncMock
+
+import pandas as pd
+
+
+def _write_wav(path: str) -> None:
+    """Write a tiny valid WAV file so eval-only validation's existence check passes."""
+    with wave.open(path, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(16000)
+        wf.writeframes(b"\x00\x00" * 100)
+
+
+def _make_run_dir(tmp: str, audio_path: str = "audios/row_1.wav", extra_cols: dict = None) -> str:
+    """Create a minimal TTS run dir (results.csv + audios/row_1.wav) under ``tmp``."""
+    run_dir = os.path.join(tmp, "openai")
+    os.makedirs(os.path.join(run_dir, "audios"))
+    _write_wav(os.path.join(run_dir, "audios", "row_1.wav"))
+    row = {"id": "row_1", "text": "hello world", "audio_path": audio_path}
+    if extra_cols:
+        row.update(extra_cols)
+    pd.DataFrame([row]).to_csv(os.path.join(run_dir, "results.csv"), index=False)
+    return run_dir
 
 
 class TestTTSBenchmarkEvalOnly(unittest.IsolatedAsyncioTestCase):
@@ -83,6 +109,49 @@ class TestTTSBenchmarkEvalOnly(unittest.IsolatedAsyncioTestCase):
             ):
                 with self.assertRaises(SystemExit):
                     await self._run_main(["--dataset", tmp, "-o", os.path.join(tmp, "out")])
+
+    async def test_eval_only_with_yes_runs_cost_gate(self):
+        mock_eval = AsyncMock(
+            return_value={
+                "status": "completed",
+                "metrics": {"quality": {"type": "binary", "mean": 0.9}},
+                "output_dir": "",
+            }
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_run_dir(tmp)
+            out = os.path.join(tmp, "out")
+            with patch(
+                "calibrate_agent.tts.benchmark.run_eval_only",
+                mock_eval,
+            ):
+                await self._run_main(["--dataset", run_dir, "-o", out, "-y"])
+
+        mock_eval.assert_called_once()
+        self.assertEqual(mock_eval.call_args.kwargs["dataset_path"], run_dir)
+        self.assertEqual(mock_eval.call_args.kwargs["output_dir"], out)
+
+    async def test_eval_only_cancel_on_decline(self):
+        mock_eval = AsyncMock()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_run_dir(tmp)
+            out = os.path.join(tmp, "out")
+            buf = io.StringIO()
+            with patch(
+                "calibrate_agent.tts.benchmark.confirm_estimated_judge_cost",
+                return_value=False,
+            ), patch(
+                "calibrate_agent.tts.benchmark.run_eval_only",
+                mock_eval,
+            ), redirect_stdout(buf):
+                with self.assertRaises(SystemExit) as ctx:
+                    await self._run_main(["--dataset", run_dir, "-o", out])
+
+        self.assertEqual(ctx.exception.code, 0)
+        mock_eval.assert_not_called()
+        self.assertIn("Judge run cancelled.", buf.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/tts/test_eval.py
+++ b/tests/tts/test_eval.py
@@ -289,6 +289,148 @@ class TestRunTTSEval(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(df.iloc[0]["ttfb"], 0.5)
 
 
+class TestScoreAndWriteResultsStore(unittest.IsolatedAsyncioTestCase):
+    """JudgeStore checkpointing in _score_and_write_results."""
+
+    def _wav(self, tmp: str, name: str, content: bytes = b"audio-bytes") -> str:
+        path = os.path.join(tmp, name)
+        with open(path, "wb") as f:
+            f.write(content)
+        return path
+
+    async def test_writes_judge_cache_file(self):
+        from calibrate_agent.tts import eval as tts_eval
+        from calibrate_agent.tts import metrics as tts_metrics
+        from calibrate_agent.judge_store import JudgeStore
+
+        async def fake_tts_llm_judge(audio_path, reference_text, evaluators=None,
+                                      fallback_model=None):
+            return {"pronunciation": {"match": True, "reasoning": "ok"}}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audio_path = self._wav(tmp, "a.wav")
+            with patch.object(
+                tts_metrics, "tts_llm_judge", AsyncMock(side_effect=fake_tts_llm_judge)
+            ):
+                await tts_eval._score_and_write_results(
+                    ids=["row_a"],
+                    texts=["hello"],
+                    audio_paths=[audio_path],
+                    output_dir=tmp,
+                    evaluator_config_dir=tmp,
+                )
+
+            self.assertTrue(os.path.exists(os.path.join(tmp, JudgeStore.FILENAME)))
+
+    async def test_second_call_reuses_cache_and_judges_fewer_times(self):
+        """End-to-end (real get_tts_llm_judge_score) resume: a second call
+        over the same audio reuses the cached grade instead of re-judging."""
+        from calibrate_agent.tts import eval as tts_eval
+        from calibrate_agent.tts import metrics as tts_metrics
+
+        call_count = {"n": 0}
+
+        async def fake_tts_llm_judge(audio_path, reference_text, evaluators=None,
+                                      fallback_model=None):
+            call_count["n"] += 1
+            return {"pronunciation": {"match": True, "reasoning": "ok"}}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audio_path = self._wav(tmp, "a.wav")
+
+            with patch.object(
+                tts_metrics, "tts_llm_judge", AsyncMock(side_effect=fake_tts_llm_judge)
+            ):
+                await tts_eval._score_and_write_results(
+                    ids=["row_a"],
+                    texts=["hello"],
+                    audio_paths=[audio_path],
+                    output_dir=tmp,
+                    evaluator_config_dir=tmp,
+                )
+                self.assertEqual(call_count["n"], 1)
+
+                await tts_eval._score_and_write_results(
+                    ids=["row_a"],
+                    texts=["hello"],
+                    audio_paths=[audio_path],
+                    output_dir=tmp,
+                    evaluator_config_dir=tmp,
+                )
+
+            # No new judge call — the second run reused the checkpoint.
+            self.assertEqual(call_count["n"], 1)
+
+    async def test_overwrite_clears_judge_cache(self):
+        from calibrate_agent.tts import eval as tts_eval
+        from calibrate_agent.tts import metrics as tts_metrics
+
+        call_count = {"n": 0}
+
+        async def fake_tts_llm_judge(audio_path, reference_text, evaluators=None,
+                                      fallback_model=None):
+            call_count["n"] += 1
+            return {"pronunciation": {"match": True, "reasoning": "ok"}}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audio_path = self._wav(tmp, "a.wav")
+
+            with patch.object(
+                tts_metrics, "tts_llm_judge", AsyncMock(side_effect=fake_tts_llm_judge)
+            ):
+                await tts_eval._score_and_write_results(
+                    ids=["row_a"],
+                    texts=["hello"],
+                    audio_paths=[audio_path],
+                    output_dir=tmp,
+                    evaluator_config_dir=tmp,
+                )
+                self.assertEqual(call_count["n"], 1)
+
+                await tts_eval._score_and_write_results(
+                    ids=["row_a"],
+                    texts=["hello"],
+                    audio_paths=[audio_path],
+                    output_dir=tmp,
+                    evaluator_config_dir=tmp,
+                    overwrite=True,
+                )
+
+            # overwrite=True discarded the checkpoint, so the row is re-judged.
+            self.assertEqual(call_count["n"], 2)
+
+    async def test_run_eval_only_threads_overwrite_to_store(self):
+        from calibrate_agent.tts import eval as tts_eval
+        from calibrate_agent.tts import metrics as tts_metrics
+
+        call_count = {"n": 0}
+
+        async def fake_tts_llm_judge(audio_path, reference_text, evaluators=None,
+                                      fallback_model=None):
+            call_count["n"] += 1
+            return {"pronunciation": {"match": True, "reasoning": "ok"}}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_run_dir(tmp)
+            out = os.path.join(tmp, "eval")
+
+            with patch.object(
+                tts_metrics, "tts_llm_judge", AsyncMock(side_effect=fake_tts_llm_judge)
+            ):
+                await tts_eval.run_eval_only(dataset_path=run_dir, output_dir=out)
+                self.assertEqual(call_count["n"], 1)
+
+                # Resumed run: cache hit, no new judge call.
+                await tts_eval.run_eval_only(dataset_path=run_dir, output_dir=out)
+                self.assertEqual(call_count["n"], 1)
+
+                # overwrite=True clears the checkpoint and re-judges.
+                await tts_eval.run_eval_only(
+                    dataset_path=run_dir, output_dir=out, overwrite=True
+                )
+                self.assertEqual(call_count["n"], 2)
+
+
 class TestSynthesizeGemini(unittest.IsolatedAsyncioTestCase):
     def _chunk(self, pcm: bytes):
         from types import SimpleNamespace
@@ -502,7 +644,8 @@ class TestTTSRunEvalOnly(unittest.IsolatedAsyncioTestCase):
         """End-to-end: point run_eval_only at a run dir, no dataset transform."""
         from calibrate_agent.tts import eval as tts_eval
 
-        async def fake_judge(audio_paths, texts, evaluators=None, fallback_model=None):
+        async def fake_judge(audio_paths, texts, evaluators=None, fallback_model=None,
+                              store=None, row_ids=None):
             return {
                 "scores": {"quality": {"type": "binary", "mean": 1.0}},
                 "score": 1.0,

--- a/tests/tts/test_metrics.py
+++ b/tests/tts/test_metrics.py
@@ -5,6 +5,8 @@ Run with:
     python -m unittest tests.tts.test_metrics -v
 """
 
+import os
+import tempfile
 import unittest
 from unittest.mock import patch, AsyncMock
 
@@ -123,6 +125,348 @@ class TestTTSGetLLMJudgeScore(unittest.IsolatedAsyncioTestCase):
         call_kwargs = mock_tts_judge.call_args.kwargs
         self.assertEqual(call_kwargs["evaluators"], custom_evaluators)
         self.assertEqual(call_kwargs["fallback_model"], "custom-audio-model")
+
+
+def _write_audio(path: str, content: bytes = b"RIFF-fake-audio-bytes") -> None:
+    with open(path, "wb") as f:
+        f.write(content)
+
+
+class TestTTSGetLLMJudgeScoreWithStore(unittest.IsolatedAsyncioTestCase):
+    """Resumable-checkpoint behavior of get_tts_llm_judge_score."""
+
+    async def test_store_none_behaves_exactly_as_before(self):
+        from calibrate_agent.tts import metrics as tts_metrics
+
+        mock_tts_judge = AsyncMock(
+            side_effect=[
+                {"pronunciation": {"match": True, "reasoning": "clear"}},
+                {"pronunciation": {"match": False, "reasoning": "garbled"}},
+            ]
+        )
+        with patch.object(tts_metrics, "tts_llm_judge", mock_tts_judge):
+            result = await tts_metrics.get_tts_llm_judge_score(
+                audio_paths=["/tmp/does-not-exist-a.wav", "/tmp/does-not-exist-b.wav"],
+                reference_texts=["hi", "bye"],
+            )
+
+        self.assertEqual(mock_tts_judge.await_count, 2)
+        self.assertEqual(result["scores"]["pronunciation"]["mean"], 0.5)
+
+    async def test_prepopulated_store_only_judges_uncached_rows(self):
+        from calibrate_agent.tts import metrics as tts_metrics
+        from calibrate_agent.judge_store import JudgeStore, JudgeKey, make_fingerprint
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audio_a = os.path.join(tmp, "a.wav")
+            audio_b = os.path.join(tmp, "b.wav")
+            _write_audio(audio_a, b"content-a")
+            _write_audio(audio_b, b"content-b")
+
+            store = JudgeStore.load(tmp)
+            fp_a = make_fingerprint(
+                tts_metrics._audio_content_hash(audio_a),
+                "hello",
+                tts_metrics.DEFAULT_TTS_EVALUATOR["system_prompt"],
+                tts_metrics.DEFAULT_TTS_EVALUATOR["judge_model"],
+                "binary",
+            )
+            key_a = JudgeKey(
+                kind="tts_evaluators",
+                row_id="row_a",
+                fingerprint=fp_a,
+                evaluator="pronunciation",
+            )
+            await store.put(key_a, {"match": True, "reasoning": "cached"})
+
+            mock_tts_judge = AsyncMock(
+                return_value={"pronunciation": {"match": False, "reasoning": "fresh"}}
+            )
+            with patch.object(tts_metrics, "tts_llm_judge", mock_tts_judge):
+                result = await tts_metrics.get_tts_llm_judge_score(
+                    audio_paths=[audio_a, audio_b],
+                    reference_texts=["hello", "world"],
+                    store=store,
+                    row_ids=["row_a", "row_b"],
+                )
+
+            # Only row_b (uncached) triggers a judge call.
+            mock_tts_judge.assert_awaited_once_with(
+                audio_b,
+                "world",
+                evaluators=[tts_metrics.DEFAULT_TTS_EVALUATOR],
+                fallback_model=tts_metrics.DEFAULT_TTS_JUDGE_MODEL,
+            )
+            self.assertEqual(
+                result["per_row"][0]["pronunciation"],
+                {"match": True, "reasoning": "cached"},
+            )
+            self.assertEqual(
+                result["per_row"][1]["pronunciation"],
+                {"match": False, "reasoning": "fresh"},
+            )
+
+    async def test_results_returned_in_row_order_with_partial_cache(self):
+        from calibrate_agent.tts import metrics as tts_metrics
+        from calibrate_agent.judge_store import JudgeStore, JudgeKey, make_fingerprint
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = [os.path.join(tmp, f"{i}.wav") for i in range(3)]
+            for i, p in enumerate(paths):
+                _write_audio(p, f"content-{i}".encode())
+
+            store = JudgeStore.load(tmp)
+            # Cache only the middle row.
+            fp = make_fingerprint(
+                tts_metrics._audio_content_hash(paths[1]),
+                "text-1",
+                tts_metrics.DEFAULT_TTS_EVALUATOR["system_prompt"],
+                tts_metrics.DEFAULT_TTS_EVALUATOR["judge_model"],
+                "binary",
+            )
+            key = JudgeKey(
+                kind="tts_evaluators", row_id="1", fingerprint=fp, evaluator="pronunciation"
+            )
+            await store.put(key, {"match": True, "reasoning": "cached-middle"})
+
+            mock_tts_judge = AsyncMock(
+                return_value={"pronunciation": {"match": False, "reasoning": "fresh"}}
+            )
+            with patch.object(tts_metrics, "tts_llm_judge", mock_tts_judge):
+                result = await tts_metrics.get_tts_llm_judge_score(
+                    audio_paths=paths,
+                    reference_texts=["text-0", "text-1", "text-2"],
+                    store=store,
+                    row_ids=["0", "1", "2"],
+                )
+
+            self.assertEqual(mock_tts_judge.await_count, 2)
+            self.assertEqual(
+                result["per_row"][1]["pronunciation"]["reasoning"], "cached-middle"
+            )
+            self.assertEqual(
+                result["per_row"][0]["pronunciation"]["reasoning"], "fresh"
+            )
+            self.assertEqual(
+                result["per_row"][2]["pronunciation"]["reasoning"], "fresh"
+            )
+
+    async def test_rewriting_audio_bytes_invalidates_cached_row(self):
+        """A re-synthesized clip at the same path is re-judged, not reused."""
+        from calibrate_agent.tts import metrics as tts_metrics
+        from calibrate_agent.judge_store import JudgeStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audio_dir = tempfile.mkdtemp()
+            audio_path = os.path.join(audio_dir, "a.wav")
+            _write_audio(audio_path, b"first-take")
+
+            store = JudgeStore.load(tmp)
+            mock_tts_judge = AsyncMock(
+                return_value={"pronunciation": {"match": True, "reasoning": "r1"}}
+            )
+            with patch.object(tts_metrics, "tts_llm_judge", mock_tts_judge):
+                await tts_metrics.get_tts_llm_judge_score(
+                    audio_paths=[audio_path],
+                    reference_texts=["hello"],
+                    store=store,
+                    row_ids=["row_a"],
+                )
+            self.assertEqual(mock_tts_judge.await_count, 1)
+
+            # Re-synthesize: same path, different bytes.
+            _write_audio(audio_path, b"second-take-different-bytes")
+            mock_tts_judge.reset_mock()
+            mock_tts_judge.return_value = {
+                "pronunciation": {"match": False, "reasoning": "r2"}
+            }
+            with patch.object(tts_metrics, "tts_llm_judge", mock_tts_judge):
+                result = await tts_metrics.get_tts_llm_judge_score(
+                    audio_paths=[audio_path],
+                    reference_texts=["hello"],
+                    store=store,
+                    row_ids=["row_a"],
+                )
+
+            self.assertEqual(mock_tts_judge.await_count, 1)
+            self.assertEqual(
+                result["per_row"][0]["pronunciation"]["reasoning"], "r2"
+            )
+
+    async def test_changed_reference_text_invalidates_row(self):
+        from calibrate_agent.tts import metrics as tts_metrics
+        from calibrate_agent.judge_store import JudgeStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audio_path = os.path.join(tmp, "a.wav")
+            _write_audio(audio_path, b"same-audio")
+            store = JudgeStore.load(tmp)
+
+            mock_tts_judge = AsyncMock(
+                return_value={"pronunciation": {"match": True, "reasoning": "r1"}}
+            )
+            with patch.object(tts_metrics, "tts_llm_judge", mock_tts_judge):
+                await tts_metrics.get_tts_llm_judge_score(
+                    audio_paths=[audio_path],
+                    reference_texts=["hello"],
+                    store=store,
+                    row_ids=["row_a"],
+                )
+
+            mock_tts_judge.reset_mock()
+            with patch.object(tts_metrics, "tts_llm_judge", mock_tts_judge):
+                await tts_metrics.get_tts_llm_judge_score(
+                    audio_paths=[audio_path],
+                    reference_texts=["a different sentence"],
+                    store=store,
+                    row_ids=["row_a"],
+                )
+
+            mock_tts_judge.assert_awaited_once()
+
+    async def test_changed_system_prompt_invalidates_row(self):
+        from calibrate_agent.tts import metrics as tts_metrics
+        from calibrate_agent.judge_store import JudgeStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audio_path = os.path.join(tmp, "a.wav")
+            _write_audio(audio_path, b"same-audio")
+            store = JudgeStore.load(tmp)
+
+            evaluator = {
+                "name": "pronunciation",
+                "system_prompt": "original prompt",
+                "judge_model": "openai/gpt-audio",
+            }
+            mock_tts_judge = AsyncMock(
+                return_value={"pronunciation": {"match": True, "reasoning": "r1"}}
+            )
+            with patch.object(tts_metrics, "tts_llm_judge", mock_tts_judge):
+                await tts_metrics.get_tts_llm_judge_score(
+                    audio_paths=[audio_path],
+                    reference_texts=["hello"],
+                    evaluators=[evaluator],
+                    store=store,
+                    row_ids=["row_a"],
+                )
+
+            mock_tts_judge.reset_mock()
+            evaluator_edited = dict(evaluator, system_prompt="edited prompt")
+            with patch.object(tts_metrics, "tts_llm_judge", mock_tts_judge):
+                await tts_metrics.get_tts_llm_judge_score(
+                    audio_paths=[audio_path],
+                    reference_texts=["hello"],
+                    evaluators=[evaluator_edited],
+                    store=store,
+                    row_ids=["row_a"],
+                )
+
+            mock_tts_judge.assert_awaited_once()
+
+    async def test_adding_second_evaluator_only_runs_the_new_one(self):
+        from calibrate_agent.tts import metrics as tts_metrics
+        from calibrate_agent.judge_store import JudgeStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            audio_path = os.path.join(tmp, "a.wav")
+            _write_audio(audio_path, b"same-audio")
+            store = JudgeStore.load(tmp)
+
+            ev_first = {
+                "name": "pronunciation",
+                "system_prompt": "p1",
+                "judge_model": "openai/gpt-audio",
+            }
+            mock_tts_judge = AsyncMock(
+                return_value={"pronunciation": {"match": True, "reasoning": "r1"}}
+            )
+            with patch.object(tts_metrics, "tts_llm_judge", mock_tts_judge):
+                await tts_metrics.get_tts_llm_judge_score(
+                    audio_paths=[audio_path],
+                    reference_texts=["hello"],
+                    evaluators=[ev_first],
+                    store=store,
+                    row_ids=["row_a"],
+                )
+
+            ev_second = {
+                "name": "clarity",
+                "system_prompt": "p2",
+                "judge_model": "openai/gpt-audio",
+            }
+            mock_tts_judge.reset_mock()
+            mock_tts_judge.return_value = {"clarity": {"match": False, "reasoning": "r2"}}
+            with patch.object(tts_metrics, "tts_llm_judge", mock_tts_judge):
+                result = await tts_metrics.get_tts_llm_judge_score(
+                    audio_paths=[audio_path],
+                    reference_texts=["hello"],
+                    evaluators=[ev_first, ev_second],
+                    store=store,
+                    row_ids=["row_a"],
+                )
+
+            # Only the new evaluator ("clarity") triggers a judge call.
+            mock_tts_judge.assert_awaited_once_with(
+                audio_path,
+                "hello",
+                evaluators=[ev_second],
+                fallback_model=tts_metrics.DEFAULT_TTS_JUDGE_MODEL,
+            )
+            self.assertEqual(
+                result["per_row"][0]["pronunciation"]["reasoning"], "r1"
+            )
+            self.assertEqual(result["per_row"][0]["clarity"]["reasoning"], "r2")
+
+    async def test_missing_audio_file_does_not_crash_fingerprinting(self):
+        from calibrate_agent.tts import metrics as tts_metrics
+        from calibrate_agent.judge_store import JudgeStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgeStore.load(tmp)
+            mock_tts_judge = AsyncMock(
+                side_effect=FileNotFoundError("no such file")
+            )
+            with patch.object(tts_metrics, "tts_llm_judge", mock_tts_judge):
+                with self.assertRaises(FileNotFoundError):
+                    await tts_metrics.get_tts_llm_judge_score(
+                        audio_paths=["/nonexistent/missing.wav"],
+                        reference_texts=["hello"],
+                        store=store,
+                        row_ids=["row_a"],
+                    )
+            # Fingerprinting itself didn't raise — the failure is the judge
+            # call's own file-not-found error, propagated as-is.
+            mock_tts_judge.assert_awaited_once()
+
+
+class TestAudioContentHash(unittest.TestCase):
+    def test_hash_changes_with_content(self):
+        from calibrate_agent.tts.metrics import _audio_content_hash
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "a.wav")
+            _write_audio(path, b"one")
+            h1 = _audio_content_hash(path)
+            _write_audio(path, b"two")
+            h2 = _audio_content_hash(path)
+            self.assertNotEqual(h1, h2)
+
+    def test_same_content_same_hash(self):
+        from calibrate_agent.tts.metrics import _audio_content_hash
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path_a = os.path.join(tmp, "a.wav")
+            path_b = os.path.join(tmp, "b.wav")
+            _write_audio(path_a, b"identical")
+            _write_audio(path_b, b"identical")
+            self.assertEqual(_audio_content_hash(path_a), _audio_content_hash(path_b))
+
+    def test_missing_file_returns_sentinel_without_raising(self):
+        from calibrate_agent.tts.metrics import _audio_content_hash
+
+        result = _audio_content_hash("/definitely/not/a/real/path.wav")
+        self.assertIsInstance(result, str)
+        self.assertIn("unreadable", result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. The STT and TTS benchmarks now size the judge workload before starting and ask for confirmation
2. Every per-row judge result is appended to a checkpoint file as soon as it is computed. An interrupted run resumes instead of re-grading
3. Decoupled the LLM judges so that we can choose which ones we want to run