### PR TITLE
Coerce string rating scores in the audio/LLM judge

### DIFF
--- a/calibrate_agent/judges.py
+++ b/calibrate_agent/judges.py
@@ -42,7 +42,7 @@ import base64
 import json
 import os
 import re
-from typing import Literal, Optional
+from typing import Optional
 
 import instructor
 from pydantic import BaseModel, Field, create_model
@@ -330,13 +330,11 @@ class CriterionResult(BaseModel):
 
 
 def _build_rating_result_model(evaluator: dict) -> type[BaseModel]:
-    """Dynamically build a Pydantic model for a rating evaluator with a Literal-constrained score."""
+    """Dynamically build a Pydantic model for a rating evaluator with a range-bounded score."""
     values = _rating_range(evaluator)
-    # Literal[tuple(...)] expands to Literal[1, 2, 3, ...] — safe across Python 3.11+
-    ScoreType = Literal[tuple(values)]  # type: ignore[valid-type]
+    scale_min = values[0]
+    scale_max = values[-1]
 
-    scale_min = evaluator["scale_min"]
-    scale_max = evaluator["scale_max"]
     suffix = _sanitize_evaluator_for_tool_model(str(evaluator.get("name", "evaluator")))
     model_name = f"RatingResult_{suffix}"
 
@@ -353,9 +351,11 @@ def _build_rating_result_model(evaluator: dict) -> type[BaseModel]:
             ),
         ),
         score=(
-            ScoreType,
+            int,
             Field(
                 ...,
+                ge=scale_min,
+                le=scale_max,
                 description=(
                     f"Integer rating score from {scale_min} (lowest) to "
                     f"{scale_max} (highest) as defined in the system prompt."

--- a/examples/tts/config-rating.json
+++ b/examples/tts/config-rating.json
@@ -1,0 +1,13 @@
+{
+  "evaluators": [
+    {
+      "id": "pronunciation-id",
+      "name": "pronunciation",
+      "type": "rating",
+      "scale_min": 1,
+      "scale_max": 3,
+      "system_prompt": "You are a highly accurate evaluator that listens to an audio sample and compares its pronunciation against the reference text it is supposed to speak.\n\nYou will be given an audio sample (the synthesized speech) and the reference text. Rate the pronunciation from 1 (words are mispronounced or unclear) to 3 (every word is pronounced clearly and correctly).",
+      "judge_model": "openai/gpt-audio"
+    }
+  ]
+}

--- a/tests/test_judges.py
+++ b/tests/test_judges.py
@@ -255,6 +255,20 @@ class TestResultModelForEvaluator(unittest.TestCase):
         self.assertEqual(instance.score, 4)
         self.assertEqual(instance.reasoning, "good")
 
+    def test_rating_coerces_string_score(self):
+        Output = _result_model_for_evaluator(
+            {
+                "name": "pronunciation",
+                "type": "rating",
+                "scale_min": 1,
+                "scale_max": 3,
+                "system_prompt": "rate",
+            }
+        )
+        instance = Output(reasoning="ok", score="3")
+        self.assertEqual(instance.score, 3)
+        self.assertIsInstance(instance.score, int)
+
     def test_rating_rejects_score_out_of_range(self):
         from pydantic import ValidationError
 


### PR DESCRIPTION
## What
- Rating judges built the score field as a Literal, which pydantic will not coerce from a string. Some models (e.g. gpt-audio) return the score as `"3"`, so every instructor retry failed and crashed the whole TTS benchmark. Score is now a range-bounded int, so numeric strings coerce and the scale bounds still hold.
- Added a sample TTS config with a rating evaluator (`examples/tts/config-rating.json`) to exercise this path.

## Notes
- The allowed scores are always a contiguous range, so `ge`/`le` bounds are equivalent to the old Literal.