### PR TITLE
Write eval results row by row as each judge result arrives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,14 @@ pandas coerces numeric `id` values to int on read — if your dataset uses
 string-looking ids like `"1"`, they round-trip as `1` and string comparisons
 break. Tests use non-numeric ids (`"row_a"`) for this reason.
 
+`results.csv` belongs to that resume logic: the full run owns the file and
+reads it back on retry. Only the `--eval-only` paths pass `stream_rows=True` to
+`_score_and_write_results`, which appends each row as its judge result arrives
+(`PartialResultsWriter` in `judges.py`). Turning that on for a full run would
+replace the transcriptions/synthesis rows mid-judge and cost a re-run of the
+provider on every ungraded row. `general` has no resume file, so it always
+streams.
+
 ### Logging
 `provider_log` (alias `_log` in eval modules) writes to both stdout and a
 per-provider `logs` file under the output dir. Set `to_terminal=False` to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,8 +306,9 @@ break. Tests use non-numeric ids (`"row_a"`) for this reason.
 reads it back on retry. Only the `--eval-only` paths pass `stream_rows=True` to
 `_score_and_write_results`, which appends each row as its judge result arrives
 (`PartialResultsWriter` in `judges.py`). Turning that on for a full run would
-replace the transcription/synthesis rows mid-judge, and a judged row carries
-neither `ttfb` nor a transcription of its own: STT resumes off the surviving
+replace the transcription/synthesis rows mid-judge with only the rows judged so
+far, minus the columns the run itself produced (`ttfs` /
+`audio_duration_seconds` for STT, `ttfb` for TTS): STT resumes off the surviving
 `id`s and re-transcribes everything else, while TTS fails
 `validate_existing_results_csv` (no `ttfb` column) and stops the next run until
 `--overwrite`, which re-synthesizes every row. `general` has no resume file, so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,6 +413,11 @@ pre-commit hook on `main`.
 
 ### When the user asks "how do I test this?"
 
+This is always about running the real thing by hand — a `calibrate-agent …`
+invocation against a real dataset and real API keys. It is never `uv run
+pytest`, never a test file, never "the suite passes". Say what the output should
+look like when it worked.
+
 Answer with the **single specific command they should run locally** for the
 change at hand — the exact `uv run …` / `calibrate-agent …` invocation, with the
 real flags, dataset path, and provider filled in (use `examples/` datasets when

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,9 +306,12 @@ break. Tests use non-numeric ids (`"row_a"`) for this reason.
 reads it back on retry. Only the `--eval-only` paths pass `stream_rows=True` to
 `_score_and_write_results`, which appends each row as its judge result arrives
 (`PartialResultsWriter` in `judges.py`). Turning that on for a full run would
-replace the transcriptions/synthesis rows mid-judge and cost a re-run of the
-provider on every ungraded row. `general` has no resume file, so it always
-streams.
+replace the transcription/synthesis rows mid-judge, and a judged row carries
+neither `ttfb` nor a transcription of its own: STT resumes off the surviving
+`id`s and re-transcribes everything else, while TTS fails
+`validate_existing_results_csv` (no `ttfb` column) and stops the next run until
+`--overwrite`, which re-synthesizes every row. `general` has no resume file, so
+it always streams.
 
 ### Logging
 `provider_log` (alias `_log` in eval modules) writes to both stdout and a

--- a/calibrate_agent/general/eval.py
+++ b/calibrate_agent/general/eval.py
@@ -140,9 +140,10 @@ async def _score_and_write_results(
     """
     write_evaluator_config(output_dir, evaluators)
 
+    evaluators_by_name = {ev["name"]: ev for ev in evaluators}
     partial_writer = PartialResultsWriter(
         join(output_dir, "results.csv"),
-        evaluators,
+        evaluators_by_name,
         [
             {"id": _id, "input": input_text, "output": output_text}
             for _id, input_text, output_text in zip(ids, inputs, outputs)
@@ -160,8 +161,6 @@ async def _score_and_write_results(
         partial_writer.close()
     for name, score_dict in llm_results["scores"].items():
         _log(f"  {name}: {score_dict['mean']:.4f}")
-
-    evaluators_by_name = {ev["name"]: ev for ev in evaluators}
 
     metrics_data: dict = {}
     for name, score_dict in llm_results["scores"].items():

--- a/calibrate_agent/general/eval.py
+++ b/calibrate_agent/general/eval.py
@@ -133,6 +133,11 @@ async def _score_and_write_results(
     Writes ``results.csv`` and ``metrics.json`` plus the resolved evaluator
     ``config.json`` under ``output_dir``. Returns the metrics_data dict.
 
+    Each row is appended to ``results.csv`` as its judge result arrives, so a
+    run killed part-way still leaves the graded rows on disk. Nothing else owns
+    that file here — the general task has no inference step and no resume, so
+    the judge is free to write it from the first row onwards.
+
     Args:
         arguments_list: Optional per-row ``arguments`` dicts (one entry per
             row, ``None`` for rows with no injection) forwarded to the judge to

--- a/calibrate_agent/general/eval.py
+++ b/calibrate_agent/general/eval.py
@@ -19,7 +19,8 @@ import pandas as pd
 
 from calibrate_agent.general.metrics import get_general_judge_score
 from calibrate_agent.judges import (
-    is_rating,
+    PartialResultsWriter,
+    evaluator_row_columns,
     require_unique_evaluator_names,
     write_evaluator_config,
 )
@@ -139,12 +140,24 @@ async def _score_and_write_results(
     """
     write_evaluator_config(output_dir, evaluators)
 
-    llm_results = await get_general_judge_score(
-        inputs,
-        outputs,
-        evaluators=evaluators,
-        arguments_list=arguments_list,
+    partial_writer = PartialResultsWriter(
+        join(output_dir, "results.csv"),
+        evaluators,
+        [
+            {"id": _id, "input": input_text, "output": output_text}
+            for _id, input_text, output_text in zip(ids, inputs, outputs)
+        ],
     )
+    try:
+        llm_results = await get_general_judge_score(
+            inputs,
+            outputs,
+            evaluators=evaluators,
+            arguments_list=arguments_list,
+            on_row=partial_writer.write,
+        )
+    finally:
+        partial_writer.close()
     for name, score_dict in llm_results["scores"].items():
         _log(f"  {name}: {score_dict['mean']:.4f}")
 
@@ -163,13 +176,7 @@ async def _score_and_write_results(
             "input": input_text,
             "output": output_text,
         }
-        for name, ev in evaluators_by_name.items():
-            ev_result = llm_row[name]
-            if is_rating(ev):
-                row[name] = ev_result["score"]
-            else:
-                row[name] = bool(ev_result["match"])
-            row[f"{name}_reasoning"] = ev_result["reasoning"]
+        row.update(evaluator_row_columns(evaluators_by_name, llm_row))
         data.append(row)
 
     with open(join(output_dir, "metrics.json"), "w") as f:

--- a/calibrate_agent/general/metrics.py
+++ b/calibrate_agent/general/metrics.py
@@ -5,7 +5,7 @@ Thin, non-conversational counterpart to ``calibrate_agent.stt.metrics`` /
 against a list of evaluators and aggregate per-evaluator scores.
 """
 
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 import numpy as np
 import backoff
@@ -18,6 +18,7 @@ from calibrate_agent.judges import (
     ensure_known_evaluator_names,
     render_evaluator,
     require_unique_evaluator_names,
+    with_row_callback,
     DEFAULT_TEXT_JUDGE_MODEL,
 )
 from calibrate_agent.langfuse import observe, langfuse, langfuse_enabled
@@ -93,8 +94,12 @@ async def get_general_judge_score(
     evaluators: List[dict],
     fallback_model: str = DEFAULT_GENERAL_JUDGE_MODEL,
     arguments_list: Optional[List[Optional[dict]]] = None,
+    on_row: Optional[Callable] = None,
 ) -> dict:
     """Run the general judge across all rows and aggregate per-evaluator scores.
+
+    ``on_row`` is called with ``(row_index, row_result)`` as each row's judge
+    finishes, so a caller can persist results as they arrive.
 
     ``inputs`` and ``outputs`` are positionally paired; ``inputs[i]`` may be
     ``None`` to judge ``outputs[i]`` on its own.
@@ -170,7 +175,7 @@ async def get_general_judge_score(
         )
 
     results = await tqdm_asyncio.gather(
-        *coroutines,
+        *with_row_callback(coroutines, on_row),
         desc="Running general evaluators",
     )
 

--- a/calibrate_agent/judges.py
+++ b/calibrate_agent/judges.py
@@ -41,7 +41,6 @@ import asyncio
 import base64
 import csv
 import json
-import logging
 import os
 import re
 from typing import Callable, Optional
@@ -50,7 +49,7 @@ import instructor
 from pydantic import BaseModel, Field, create_model
 
 from calibrate_agent.langfuse import AsyncOpenAI, observe, langfuse, langfuse_enabled
-from calibrate_agent.utils import log_judge_io
+from calibrate_agent.utils import log_judge_io, provider_log
 
 
 # ── OpenRouter configuration ────────────────────────────────────────────────
@@ -243,9 +242,11 @@ class PartialResultsWriter:
     order; the ``id`` column identifies each one.
     """
 
-    def __init__(self, path: str, evaluators: list[dict], base_rows: list[dict]):
+    def __init__(
+        self, path: str, evaluators_by_name: dict, base_rows: list[dict]
+    ):
         self._path = path
-        self._evaluators_by_name = {ev["name"]: ev for ev in evaluators}
+        self._evaluators_by_name = evaluators_by_name
         self._base_rows = base_rows
         self._file = None
         self._writer = None
@@ -254,8 +255,6 @@ class PartialResultsWriter:
         """Append one judged row. Never raises: a failure here must not take
         down the run whose results it is only mirroring."""
         try:
-            if index >= len(self._base_rows):
-                return
             row = {
                 **self._base_rows[index],
                 **evaluator_row_columns(self._evaluators_by_name, judge_row),
@@ -267,9 +266,7 @@ class PartialResultsWriter:
             self._writer.writerow(row)
             self._file.flush()
         except Exception as e:
-            logging.getLogger(__name__).warning(
-                f"Failed to append partial result row {index}: {e}"
-            )
+            provider_log(f"Failed to append partial result row {index}: {e}")
 
     def close(self) -> None:
         if self._file is not None:

--- a/calibrate_agent/judges.py
+++ b/calibrate_agent/judges.py
@@ -39,10 +39,12 @@ Simulation has no implicit default — callers must supply evaluators.
 
 import asyncio
 import base64
+import csv
 import json
+import logging
 import os
 import re
-from typing import Optional
+from typing import Callable, Optional
 
 import instructor
 from pydantic import BaseModel, Field, create_model
@@ -191,6 +193,91 @@ def evaluator_result_value(evaluator: dict, result: dict) -> float:
     if is_rating(evaluator):
         return float(result["score"])
     return float(int(bool(result["match"])))
+
+
+def evaluator_row_columns(evaluators_by_name: dict, judge_row: dict) -> dict:
+    """Flatten one row's judge result into its ``results.csv`` columns.
+
+    Produces ``{name: value, f"{name}_reasoning": str}`` per evaluator — the
+    score for rating evaluators, a bool for binary ones.
+    """
+    columns: dict = {}
+    for name, evaluator in evaluators_by_name.items():
+        result = judge_row[name]
+        if is_rating(evaluator):
+            columns[name] = result["score"]
+        else:
+            columns[name] = bool(result["match"])
+        columns[f"{name}_reasoning"] = result["reasoning"]
+    return columns
+
+
+def with_row_callback(coroutines: list, on_row: Optional[Callable]) -> list:
+    """Wrap judge coroutines so ``on_row(index, result)`` fires as each finishes.
+
+    Returns the coroutines unchanged when ``on_row`` is None, so callers can
+    pass it through without branching.
+    """
+    if on_row is None:
+        return coroutines
+
+    async def _run(index: int, coroutine):
+        result = await coroutine
+        on_row(index, result)
+        return result
+
+    return [_run(index, coroutine) for index, coroutine in enumerate(coroutines)]
+
+
+class PartialResultsWriter:
+    """Append each row to ``results.csv`` as its judge result arrives.
+
+    A run that is killed part-way then leaves the rows already graded on disk
+    instead of an empty directory, and a reader watching the file sees results
+    accumulate. The full-table write at the end of a run replaces the file, so
+    this only ever holds a prefix of the final columns (no WER, latency, or
+    other post-judge columns).
+
+    ``base_rows`` supplies the non-evaluator columns per row index, in dataset
+    order. Rows are appended in completion order, which need not match dataset
+    order; the ``id`` column identifies each one.
+    """
+
+    def __init__(self, path: str, evaluators: list[dict], base_rows: list[dict]):
+        self._path = path
+        self._evaluators_by_name = {ev["name"]: ev for ev in evaluators}
+        self._base_rows = base_rows
+        self._file = None
+        self._writer = None
+
+    def write(self, index: int, judge_row: dict) -> None:
+        """Append one judged row. Never raises: a failure here must not take
+        down the run whose results it is only mirroring."""
+        try:
+            if index >= len(self._base_rows):
+                return
+            row = {
+                **self._base_rows[index],
+                **evaluator_row_columns(self._evaluators_by_name, judge_row),
+            }
+            if self._writer is None:
+                self._file = open(self._path, "w", newline="", encoding="utf-8")
+                self._writer = csv.DictWriter(self._file, fieldnames=list(row))
+                self._writer.writeheader()
+            self._writer.writerow(row)
+            self._file.flush()
+        except Exception as e:
+            logging.getLogger(__name__).warning(
+                f"Failed to append partial result row {index}: {e}"
+            )
+
+    def close(self) -> None:
+        if self._file is not None:
+            try:
+                self._file.close()
+            finally:
+                self._file = None
+                self._writer = None
 
 
 def attach_evaluator_id(evaluator: dict, result: dict) -> dict:

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -1576,6 +1576,7 @@ async def _score_and_write_results(
     # calls, no evaluator columns/metrics).
     _evaluators = judge_evaluators or []
     llm_results = None
+    evaluators_by_name: dict = {}
     if _evaluators:
         require_unique_evaluator_names(_evaluators)
         write_evaluator_config(evaluator_config_dir, _evaluators)
@@ -1731,8 +1732,7 @@ async def _score_and_write_results(
                 ensure_ascii=False,
             )
             row["semantic_wer_reasoning"] = semantic_wer_row["reasoning"]
-        if _evaluators_by_name:
-            row.update(evaluator_row_columns(_evaluators_by_name, llm_row))
+        row.update(evaluator_row_columns(_evaluators_by_name, llm_row))
         data.append(row)
 
     with open(join(output_dir, "metrics.json"), "w") as f:

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -1579,10 +1579,11 @@ async def _score_and_write_results(
     if _evaluators:
         require_unique_evaluator_names(_evaluators)
         write_evaluator_config(evaluator_config_dir, _evaluators)
+        evaluators_by_name = {ev["name"]: ev for ev in _evaluators}
         partial_writer = (
             PartialResultsWriter(
                 join(output_dir, "results.csv"),
-                _evaluators,
+                evaluators_by_name,
                 [
                     {"id": _id, "gt": gt_text, "pred": pred_text}
                     for _id, gt_text, pred_text in zip(
@@ -1610,9 +1611,7 @@ async def _score_and_write_results(
                 partial_writer.close()
 
     # Only surface evaluator columns for judges that actually produced results.
-    _evaluators_by_name = (
-        {ev["name"]: ev for ev in _evaluators} if llm_results is not None else {}
-    )
+    _evaluators_by_name = evaluators_by_name if llm_results is not None else {}
 
     metrics_data = {
         "wer": wer_results["score"],

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -47,7 +47,8 @@ from calibrate_agent.stt.pipeline_eval import transcribe_via_pipeline
 from calibrate_agent._env import resolve_stt_max_concurrency
 from calibrate_agent._cli_args import add_stt_eval_args
 from calibrate_agent.judges import (
-    is_rating,
+    PartialResultsWriter,
+    evaluator_row_columns,
     require_unique_evaluator_names,
     write_evaluator_config,
 )
@@ -1491,6 +1492,7 @@ async def _score_and_write_results(
     cost_metrics: dict | None = None,
     audio_durations: list[float | None] | None = None,
     ttfs_values: list = None,
+    stream_rows: bool = False,
 ) -> dict:
     """Run WER/CER (and optional LLM-judge evaluators) over (gt, pred) pairs.
 
@@ -1507,6 +1509,12 @@ async def _score_and_write_results(
     Each judge is isolated: if any judge raises, the failure is logged and that
     judge's columns/metrics are dropped, but WER/CER and any judges that
     succeeded are still written.
+
+    ``stream_rows`` appends each row to ``results.csv`` as its judge result
+    arrives, so a run killed part-way still leaves the graded rows on disk.
+    Only safe when nothing else owns that file: the full evaluation writes its
+    transcriptions there as it goes and resumes from them, and overwriting it
+    mid-judge would cost a re-transcription of every row not yet graded.
     """
     wer_results = get_wer_score(gt_transcripts, pred_transcripts, language=language)
     _log(f"WER: {wer_results['score']}", to_terminal=False)
@@ -1571,17 +1579,35 @@ async def _score_and_write_results(
     if _evaluators:
         require_unique_evaluator_names(_evaluators)
         write_evaluator_config(evaluator_config_dir, _evaluators)
+        partial_writer = (
+            PartialResultsWriter(
+                join(output_dir, "results.csv"),
+                _evaluators,
+                [
+                    {"id": _id, "gt": gt_text, "pred": pred_text}
+                    for _id, gt_text, pred_text in zip(
+                        ids, gt_transcripts, pred_transcripts
+                    )
+                ],
+            )
+            if stream_rows
+            else None
+        )
         try:
             llm_results = await get_llm_judge_score(
                 gt_transcripts,
                 pred_transcripts,
                 evaluators=_evaluators,
+                on_row=partial_writer.write if partial_writer else None,
             )
             for name, score_dict in llm_results["scores"].items():
                 _log(f"  {name}: {score_dict['mean']:.4f}")
         except Exception as e:
             llm_results = None
             _log(f"LLM judge failed, skipping evaluator columns: {e}")
+        finally:
+            if partial_writer:
+                partial_writer.close()
 
     # Only surface evaluator columns for judges that actually produced results.
     _evaluators_by_name = (
@@ -1706,13 +1732,8 @@ async def _score_and_write_results(
                 ensure_ascii=False,
             )
             row["semantic_wer_reasoning"] = semantic_wer_row["reasoning"]
-        for name, ev in _evaluators_by_name.items():
-            ev_result = llm_row[name]
-            if is_rating(ev):
-                row[name] = ev_result["score"]
-            else:
-                row[name] = bool(ev_result["match"])
-            row[f"{name}_reasoning"] = ev_result["reasoning"]
+        if _evaluators_by_name:
+            row.update(evaluator_row_columns(_evaluators_by_name, llm_row))
         data.append(row)
 
     with open(join(output_dir, "metrics.json"), "w") as f:
@@ -1779,6 +1800,7 @@ async def run_eval_only(
             judge_evaluators=judge_evaluators,
             language=language,
             run_llm_judges=run_llm_judges,
+            stream_rows=True,
         )
 
         return {

--- a/calibrate_agent/stt/metrics.py
+++ b/calibrate_agent/stt/metrics.py
@@ -5,7 +5,7 @@ STT evaluation metrics.
 import asyncio
 import unicodedata
 from functools import lru_cache
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 import numpy as np
 import jiwer
@@ -14,6 +14,7 @@ import backoff
 
 from calibrate_agent.judges import (
     text_judge,
+    with_row_callback,
     is_rating,
     evaluator_result_value,
     DEFAULT_TEXT_JUDGE_MODEL,
@@ -441,8 +442,12 @@ async def get_llm_judge_score(
     predictions: List[str],
     evaluators: Optional[List[dict]] = None,
     fallback_model: str = DEFAULT_STT_JUDGE_MODEL,
+    on_row: Optional[Callable] = None,
 ) -> dict:
     """Run STT judge across all rows and aggregate per-evaluator scores.
+
+    ``on_row`` is called with ``(row_index, row_result)`` as each row's judge
+    finishes, so callers can persist results while the run is still going.
 
     Returns:
         {
@@ -474,7 +479,7 @@ async def get_llm_judge_score(
     ]
 
     results = await tqdm_asyncio.gather(
-        *coroutines,
+        *with_row_callback(coroutines, on_row),
         desc="Running STT evaluators",
     )
 

--- a/calibrate_agent/tts/eval.py
+++ b/calibrate_agent/tts/eval.py
@@ -891,10 +891,12 @@ async def _score_and_write_results(
     _evaluators = judge_evaluators if judge_evaluators else [DEFAULT_TTS_EVALUATOR]
     require_unique_evaluator_names(_evaluators)
     write_evaluator_config(evaluator_config_dir, _evaluators)
+    # Map evaluator name → evaluator dict (for per-row value extraction).
+    _evaluators_by_name = {ev["name"]: ev for ev in _evaluators}
     partial_writer = (
         PartialResultsWriter(
             join(output_dir, "results.csv"),
-            _evaluators,
+            _evaluators_by_name,
             [
                 {"id": _id, "text": text, "audio_path": audio_path}
                 for _id, text, audio_path in zip(ids, texts, audio_paths)
@@ -915,9 +917,6 @@ async def _score_and_write_results(
             partial_writer.close()
     for name, score_dict in llm_judge_results["scores"].items():
         _log(f"  {name}: {score_dict['mean']:.4f}")
-
-    # Map evaluator name → evaluator dict (for per-row value extraction).
-    _evaluators_by_name = {ev["name"]: ev for ev in _evaluators}
 
     # Each evaluator gets one entry keyed by its name. The value is the full
     # per-criterion dict (``type``, ``mean``, plus ``scale_min``/``scale_max``

--- a/calibrate_agent/tts/eval.py
+++ b/calibrate_agent/tts/eval.py
@@ -884,8 +884,10 @@ async def _score_and_write_results(
     ``stream_rows`` appends each row to ``results.csv`` as its judge result
     arrives, so a run killed part-way still leaves the graded rows on disk.
     Only safe when nothing else owns that file: the full evaluation writes its
-    synthesis results there as it goes and resumes from them, and overwriting
-    it mid-judge would cost a re-synthesis of every row not yet graded.
+    synthesis results there as it goes and resumes from them. A judged row
+    carries no ``ttfb``, so replacing that file mid-judge leaves it missing a
+    column ``validate_existing_results_csv`` requires — the next run stops with
+    an error until ``--overwrite``, which re-synthesizes every row.
     """
     _log("Running evaluators...")
     _evaluators = judge_evaluators if judge_evaluators else [DEFAULT_TTS_EVALUATOR]

--- a/calibrate_agent/tts/eval.py
+++ b/calibrate_agent/tts/eval.py
@@ -39,8 +39,9 @@ from calibrate_agent.pricing import TTS_DEFAULT_MODELS, cost_breakdown, resolve_
 from calibrate_agent.tts.metrics import get_tts_llm_judge_score
 from calibrate_agent.llm._metrics_utils import _latency_percentiles
 from calibrate_agent.judges import (
-    is_rating,
     DEFAULT_TTS_EVALUATOR,
+    PartialResultsWriter,
+    evaluator_row_columns,
     require_unique_evaluator_names,
     write_evaluator_config,
 )
@@ -867,6 +868,7 @@ async def _score_and_write_results(
     judge_evaluators: list[dict] = None,
     ttfb_values: list = None,
     cost_metrics: dict = None,
+    stream_rows: bool = False,
 ) -> dict:
     """Run the TTS audio judge over (audio_path, text) pairs and write outputs.
 
@@ -878,16 +880,39 @@ async def _score_and_write_results(
     and TTFB percentile metrics are included; when None (eval-only, where
     nothing is synthesized) both are omitted. When ``cost_metrics`` is provided
     it is attached under the ``cost`` key.
+
+    ``stream_rows`` appends each row to ``results.csv`` as its judge result
+    arrives, so a run killed part-way still leaves the graded rows on disk.
+    Only safe when nothing else owns that file: the full evaluation writes its
+    synthesis results there as it goes and resumes from them, and overwriting
+    it mid-judge would cost a re-synthesis of every row not yet graded.
     """
     _log("Running evaluators...")
     _evaluators = judge_evaluators if judge_evaluators else [DEFAULT_TTS_EVALUATOR]
     require_unique_evaluator_names(_evaluators)
     write_evaluator_config(evaluator_config_dir, _evaluators)
-    llm_judge_results = await get_tts_llm_judge_score(
-        audio_paths,
-        texts,
-        evaluators=_evaluators,
+    partial_writer = (
+        PartialResultsWriter(
+            join(output_dir, "results.csv"),
+            _evaluators,
+            [
+                {"id": _id, "text": text, "audio_path": audio_path}
+                for _id, text, audio_path in zip(ids, texts, audio_paths)
+            ],
+        )
+        if stream_rows
+        else None
     )
+    try:
+        llm_judge_results = await get_tts_llm_judge_score(
+            audio_paths,
+            texts,
+            evaluators=_evaluators,
+            on_row=partial_writer.write if partial_writer else None,
+        )
+    finally:
+        if partial_writer:
+            partial_writer.close()
     for name, score_dict in llm_judge_results["scores"].items():
         _log(f"  {name}: {score_dict['mean']:.4f}")
 
@@ -935,13 +960,7 @@ async def _score_and_write_results(
         row = {"id": _id, "text": text, "audio_path": audio_path}
         if ttfb_values is not None:
             row["ttfb"] = ttfb
-        for name, ev in _evaluators_by_name.items():
-            ev_result = llm_row[name]
-            if is_rating(ev):
-                row[name] = ev_result["score"]
-            else:
-                row[name] = bool(ev_result["match"])
-            row[f"{name}_reasoning"] = ev_result["reasoning"]
+        row.update(evaluator_row_columns(_evaluators_by_name, llm_row))
         data.append(row)
 
     results_csv_path = join(output_dir, "results.csv")
@@ -1181,6 +1200,7 @@ async def run_eval_only(
             evaluator_config_dir=output_dir,
             judge_evaluators=judge_evaluators,
             ttfb_values=None,
+            stream_rows=True,
         )
 
         return {

--- a/calibrate_agent/tts/metrics.py
+++ b/calibrate_agent/tts/metrics.py
@@ -2,7 +2,7 @@
 TTS evaluation metrics.
 """
 
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 import numpy as np
 from tqdm.asyncio import tqdm_asyncio
@@ -12,6 +12,7 @@ from calibrate_agent.judges import (
     audio_judge,
     is_rating,
     evaluator_result_value,
+    with_row_callback,
     DEFAULT_AUDIO_JUDGE_MODEL,
     DEFAULT_TTS_EVALUATOR,
 )
@@ -68,8 +69,12 @@ async def get_tts_llm_judge_score(
     reference_texts: List[str],
     evaluators: Optional[List[dict]] = None,
     fallback_model: str = DEFAULT_TTS_JUDGE_MODEL,
+    on_row: Optional[Callable] = None,
 ) -> dict:
     """Run TTS judge across all rows and aggregate per-evaluator scores.
+
+    ``on_row`` is called with ``(row_index, row_result)`` as each row's judge
+    finishes, so a caller can persist results as they arrive.
 
     Returns:
         {
@@ -97,7 +102,7 @@ async def get_tts_llm_judge_score(
     ]
 
     results = await tqdm_asyncio.gather(
-        *coroutines,
+        *with_row_callback(coroutines, on_row),
         desc="Running TTS evaluators",
     )
 

--- a/tests/general/test_eval.py
+++ b/tests/general/test_eval.py
@@ -5,6 +5,7 @@ end-to-end run_general_eval path (with the judge mocked) producing
 metrics.json + results.csv.
 """
 
+import asyncio
 import json
 import os
 import sys
@@ -306,6 +307,50 @@ class TestRunGeneralEval(unittest.IsolatedAsyncioTestCase):
             judge_mock.call_args.kwargs["arguments_list"],
             [{"faithful": {"name": "Ann"}}, None],
         )
+
+
+class TestGeneralPartialResults(unittest.IsolatedAsyncioTestCase):
+    """results.csv holds the rows graded so far while the judge is still running."""
+
+    async def test_partial_results_written_during_run(self):
+        from calibrate_agent.general.eval import _score_and_write_results
+
+        with tempfile.TemporaryDirectory() as out_dir:
+            results_path = os.path.join(out_dir, "results.csv")
+            seen = {}
+
+            async def fake_judge(_input, output, **kwargs):
+                if output == "sum B":
+                    # Row A finishes first; capture what is on disk by then.
+                    await asyncio.sleep(0.05)
+                    seen["partial"] = pd.read_csv(results_path)
+                return {"faithful": {"reasoning": output, "match": output == "sum A"}}
+
+            with patch(
+                "calibrate_agent.general.metrics.general_judge",
+                AsyncMock(side_effect=fake_judge),
+            ):
+                metrics = await _score_and_write_results(
+                    ids=["row_a", "row_b"],
+                    inputs=["doc A", "doc B"],
+                    outputs=["sum A", "sum B"],
+                    evaluators=[BINARY_EV],
+                    output_dir=out_dir,
+                )
+
+            partial = seen["partial"]
+            self.assertEqual(list(partial["id"]), ["row_a"])
+            self.assertEqual(bool(partial.iloc[0]["faithful"]), True)
+            self.assertEqual(partial.iloc[0]["faithful_reasoning"], "sum A")
+
+            self.assertAlmostEqual(metrics["faithful"]["mean"], 0.5)
+            df = pd.read_csv(results_path)
+            self.assertEqual(list(df["id"]), ["row_a", "row_b"])
+            self.assertEqual(
+                list(df.columns),
+                ["id", "input", "output", "faithful", "faithful_reasoning"],
+            )
+            self.assertEqual([bool(v) for v in df["faithful"]], [True, False])
 
 
 class TestMain(unittest.IsolatedAsyncioTestCase):

--- a/tests/general/test_metrics.py
+++ b/tests/general/test_metrics.py
@@ -299,22 +299,6 @@ class TestGeneralJudgeOnRow(unittest.IsolatedAsyncioTestCase):
             [row["faithful"]["reasoning"] for row in result["per_row"]], ["o1", "o2"]
         )
 
-    async def test_without_on_row_results_unchanged(self):
-        with patch(
-            "calibrate_agent.general.metrics.general_judge",
-            AsyncMock(side_effect=self._slow_first),
-        ):
-            result = await get_general_judge_score(
-                inputs=["i1", "i2"],
-                outputs=["o1", "o2"],
-                evaluators=[BINARY_EV],
-            )
-
-        self.assertEqual(
-            [row["faithful"]["reasoning"] for row in result["per_row"]], ["o1", "o2"]
-        )
-        self.assertAlmostEqual(result["scores"]["faithful"]["mean"], 1.0)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/general/test_metrics.py
+++ b/tests/general/test_metrics.py
@@ -7,6 +7,7 @@ Covers the general (non-conversational) task scoring path:
   scores into the {scores, score, per_row} shape
 """
 
+import asyncio
 import unittest
 from unittest.mock import patch, AsyncMock, MagicMock
 
@@ -266,6 +267,53 @@ class TestGetGeneralJudgeScoreArguments(unittest.IsolatedAsyncioTestCase):
             )
         self.assertEqual(seen_by_output["o1"], "judge against {{reference}}")
         self.assertEqual(seen_by_output["o2"], "judge against gold-B")
+
+
+class TestGeneralJudgeOnRow(unittest.IsolatedAsyncioTestCase):
+    """``on_row`` fires per row as its judge finishes, without reordering results."""
+
+    @staticmethod
+    async def _slow_first(_input, output, **kwargs):
+        # Row 0 finishes last, so completion order differs from dataset order.
+        if output == "o1":
+            await asyncio.sleep(0.05)
+        return {"faithful": {"reasoning": output, "match": True}}
+
+    async def test_on_row_called_per_row_and_order_preserved(self):
+        seen = []
+        with patch(
+            "calibrate_agent.general.metrics.general_judge",
+            AsyncMock(side_effect=self._slow_first),
+        ):
+            result = await get_general_judge_score(
+                inputs=["i1", "i2"],
+                outputs=["o1", "o2"],
+                evaluators=[BINARY_EV],
+                on_row=lambda index, row: seen.append((index, row)),
+            )
+
+        self.assertEqual([index for index, _ in seen], [1, 0])
+        self.assertEqual(seen[0][1]["faithful"]["reasoning"], "o2")
+        self.assertEqual(seen[1][1]["faithful"]["reasoning"], "o1")
+        self.assertEqual(
+            [row["faithful"]["reasoning"] for row in result["per_row"]], ["o1", "o2"]
+        )
+
+    async def test_without_on_row_results_unchanged(self):
+        with patch(
+            "calibrate_agent.general.metrics.general_judge",
+            AsyncMock(side_effect=self._slow_first),
+        ):
+            result = await get_general_judge_score(
+                inputs=["i1", "i2"],
+                outputs=["o1", "o2"],
+                evaluators=[BINARY_EV],
+            )
+
+        self.assertEqual(
+            [row["faithful"]["reasoning"] for row in result["per_row"]], ["o1", "o2"]
+        )
+        self.assertAlmostEqual(result["scores"]["faithful"]["mean"], 1.0)
 
 
 if __name__ == "__main__":

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -304,7 +304,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
     async def test_writes_metrics_and_results(self):
         from calibrate_agent.stt import eval as stt_eval
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None):
             return {
                 "scores": {
                     "semantic_match": {"type": "binary", "mean": 1.0}
@@ -383,7 +383,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             }
         ]
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None):
             return {
                 "scores": {"completeness": {"type": "binary", "mean": 0.5}},
                 "score": 0.5,
@@ -425,7 +425,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
     async def test_sarvam_judges_run_by_default(self):
         from calibrate_agent.stt import eval as stt_eval
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None):
             return {
                 "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                 "score": 1.0,
@@ -472,7 +472,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
     async def test_sarvam_judges_skipped_when_disabled(self):
         from calibrate_agent.stt import eval as stt_eval
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None):
             return {
                 "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                 "score": 1.0,
@@ -514,6 +514,130 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             # WER/CER and the judge column are still written.
             self.assertIn("wer", metrics)
             self.assertIn("semantic_match", metrics)
+
+    async def test_partial_results_written_while_judge_still_running(self):
+        import asyncio
+
+        from calibrate_agent.stt import eval as stt_eval
+        from calibrate_agent.stt import metrics as stt_metrics
+
+        seen_by_second_row = {}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_path = out / "results.csv"
+
+            async def fake_row_judge(
+                reference, prediction, evaluators=None, fallback_model=None
+            ):
+                if reference == "second":
+                    # Wait for the first row's result to land on disk, then
+                    # record what the file held mid-run.
+                    for _ in range(200):
+                        if results_path.exists():
+                            seen_by_second_row["csv"] = results_path.read_text()
+                            break
+                        await asyncio.sleep(0.01)
+                return {"semantic_match": {"match": True, "reasoning": reference}}
+
+            with patch.object(
+                stt_metrics, "stt_llm_judge", AsyncMock(side_effect=fake_row_judge)
+            ), patch.object(
+                stt_eval, "get_intent_entity_score", _fake_intent_entity(1, 1.0)
+            ), patch.object(
+                stt_eval, "get_llm_wer_cer_score", _fake_llm_wer(0.05, 0.03)
+            ):
+                await stt_eval._score_and_write_results(
+                    ids=["row_a", "row_b"],
+                    gt_transcripts=["first", "second"],
+                    pred_transcripts=["first", "second"],
+                    output_dir=str(out),
+                    evaluator_config_dir=str(out),
+                    judge_evaluators=[
+                        {
+                            "name": "semantic_match",
+                            "system_prompt": "match",
+                            "judge_model": "openai/gpt-4.1",
+                        }
+                    ],
+                    run_llm_judges=True,
+                    stream_rows=True,
+                )
+
+            partial = seen_by_second_row.get("csv")
+            self.assertIsNotNone(
+                partial, "results.csv was not written before the judge finished"
+            )
+            self.assertIn("row_a", partial)
+            self.assertIn("first", partial)
+
+            # The final file replaces the partial one and keeps its full shape.
+            df = pd.read_csv(results_path)
+            self.assertEqual(len(df), 2)
+            self.assertTrue(
+                set(df.columns)
+                >= {
+                    "id",
+                    "gt",
+                    "pred",
+                    "wer",
+                    "cer",
+                    "semantic_match",
+                    "semantic_match_reasoning",
+                }
+            )
+            self.assertEqual(sorted(df["id"]), ["row_a", "row_b"])
+
+    async def test_no_partial_results_without_stream_rows(self):
+        """The full evaluation keeps its own transcriptions in results.csv and
+        resumes from them, so the judge must not overwrite that file mid-run."""
+        import asyncio
+
+        from calibrate_agent.stt import eval as stt_eval
+        from calibrate_agent.stt import metrics as stt_metrics
+
+        seen_by_second_row = {}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            results_path = out / "results.csv"
+            results_path.write_text("id,gt,pred\nrow_a,first,first\n")
+
+            async def fake_row_judge(
+                reference, prediction, evaluators=None, fallback_model=None
+            ):
+                if reference == "second":
+                    await asyncio.sleep(0.05)
+                    seen_by_second_row["csv"] = results_path.read_text()
+                return {"semantic_match": {"match": True, "reasoning": reference}}
+
+            with patch.object(
+                stt_metrics, "stt_llm_judge", AsyncMock(side_effect=fake_row_judge)
+            ), patch.object(
+                stt_eval, "get_intent_entity_score", _fake_intent_entity(1, 1.0)
+            ), patch.object(
+                stt_eval, "get_llm_wer_cer_score", _fake_llm_wer(0.05, 0.03)
+            ):
+                await stt_eval._score_and_write_results(
+                    ids=["row_a", "row_b"],
+                    gt_transcripts=["first", "second"],
+                    pred_transcripts=["first", "second"],
+                    output_dir=str(out),
+                    evaluator_config_dir=str(out),
+                    judge_evaluators=[
+                        {
+                            "name": "semantic_match",
+                            "system_prompt": "match",
+                            "judge_model": "openai/gpt-4.1",
+                        }
+                    ],
+                    run_llm_judges=True,
+                )
+
+            self.assertEqual(
+                seen_by_second_row.get("csv"),
+                "id,gt,pred\nrow_a,first,first\n",
+            )
 
     async def test_llm_judge_failure_still_writes_wer_cer_and_sarvam(self):
         from calibrate_agent.stt import eval as stt_eval
@@ -559,7 +683,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
     async def test_sarvam_failure_still_writes_wer_cer_and_evaluator(self):
         from calibrate_agent.stt import eval as stt_eval
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None):
             return {
                 "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                 "score": 1.0,
@@ -645,7 +769,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             "scale_max": 5,
         }
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None):
             return {
                 "scores": {
                     "accuracy": {
@@ -692,7 +816,7 @@ class TestSTTRunEvalOnly(unittest.IsolatedAsyncioTestCase):
     async def test_runs_evaluator_on_dataset(self):
         from calibrate_agent.stt import eval as stt_eval
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None):
             return {
                 "scores": {"semantic_match": {"type": "binary", "mean": 0.5}},
                 "score": 0.5,

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -853,6 +853,60 @@ class TestSTTRunEvalOnly(unittest.IsolatedAsyncioTestCase):
             self.assertTrue((out / "metrics.json").exists())
             self.assertTrue((out / "results.csv").exists())
 
+    async def test_rows_land_in_results_csv_while_the_run_is_going(self):
+        """Guards the whole eval-only run, not just the scoring step it calls:
+        this fails if ``run_eval_only`` stops asking for row-by-row writing."""
+        import asyncio
+
+        from calibrate_agent.stt import eval as stt_eval
+        from calibrate_agent.stt import metrics as stt_metrics
+
+        seen = {}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            ds_path = Path(tmp) / "ds.json"
+            ds_path.write_text(
+                json.dumps(
+                    [
+                        {"id": "row_a", "gt": "first", "pred": "first"},
+                        {"id": "row_b", "gt": "second", "pred": "second"},
+                    ]
+                )
+            )
+            out = Path(tmp) / "out"
+            results_path = out / "results.csv"
+
+            async def fake_row_judge(
+                reference, prediction, evaluators=None, fallback_model=None
+            ):
+                if reference == "second":
+                    for _ in range(200):
+                        if results_path.exists():
+                            seen["csv"] = results_path.read_text()
+                            break
+                        await asyncio.sleep(0.01)
+                return {"semantic_match": {"match": True, "reasoning": reference}}
+
+            with patch.object(
+                stt_metrics, "stt_llm_judge", AsyncMock(side_effect=fake_row_judge)
+            ):
+                result = await stt_eval.run_eval_only(
+                    dataset_path=str(ds_path),
+                    output_dir=str(out),
+                    judge_evaluators=[
+                        {
+                            "name": "semantic_match",
+                            "system_prompt": "match",
+                            "judge_model": "openai/gpt-4.1",
+                        }
+                    ],
+                    run_llm_judges=False,
+                )
+
+            self.assertEqual(result["status"], "completed")
+            self.assertIn("row_a", seen.get("csv", ""))
+            self.assertEqual(sorted(pd.read_csv(results_path)["id"]), ["row_a", "row_b"])
+
     async def test_invalid_dataset_returns_error(self):
         from calibrate_agent.stt import eval as stt_eval
 

--- a/tests/stt/test_metrics.py
+++ b/tests/stt/test_metrics.py
@@ -243,6 +243,55 @@ class TestSTTGetLLMJudgeScore(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["scores"]["semantic_accuracy"]["scale_min"], 1)
         self.assertEqual(result["scores"]["semantic_accuracy"]["scale_max"], 5)
 
+    async def test_on_row_fires_per_row_and_results_stay_in_order(self):
+        from calibrate_agent.stt import metrics as stt_metrics
+
+        async def fake_judge(reference, prediction, evaluators=None, fallback_model=None):
+            return {"semantic_match": {"match": True, "reasoning": reference}}
+
+        seen = []
+
+        with patch.object(
+            stt_metrics, "stt_llm_judge", AsyncMock(side_effect=fake_judge)
+        ):
+            result = await stt_metrics.get_llm_judge_score(
+                references=["a", "b", "c"],
+                predictions=["a", "b", "c"],
+                on_row=lambda index, row: seen.append((index, row)),
+            )
+
+        # One callback per row, each carrying that row's own index and result.
+        # Rows finish in whatever order the judge completes them.
+        self.assertEqual(sorted(index for index, _ in seen), [0, 1, 2])
+        self.assertEqual(
+            {index: row["semantic_match"]["reasoning"] for index, row in seen},
+            {0: "a", 1: "b", 2: "c"},
+        )
+        self.assertEqual(
+            [row["semantic_match"]["reasoning"] for row in result["per_row"]],
+            ["a", "b", "c"],
+        )
+
+    async def test_without_on_row_results_unchanged(self):
+        from calibrate_agent.stt import metrics as stt_metrics
+
+        async def fake_judge(reference, prediction, evaluators=None, fallback_model=None):
+            return {"semantic_match": {"match": True, "reasoning": reference}}
+
+        with patch.object(
+            stt_metrics, "stt_llm_judge", AsyncMock(side_effect=fake_judge)
+        ):
+            result = await stt_metrics.get_llm_judge_score(
+                references=["a", "b"],
+                predictions=["a", "b"],
+            )
+
+        self.assertEqual(
+            [row["semantic_match"]["reasoning"] for row in result["per_row"]],
+            ["a", "b"],
+        )
+        self.assertEqual(result["scores"]["semantic_match"]["mean"], 1.0)
+
     async def test_custom_evaluators_passed_through(self):
         from calibrate_agent.stt import metrics as stt_metrics
 

--- a/tests/tts/test_eval.py
+++ b/tests/tts/test_eval.py
@@ -623,6 +623,49 @@ class TestTTSPartialResults(unittest.IsolatedAsyncioTestCase):
             )
             self.assertEqual([bool(v) for v in df["quality"]], [True, False])
 
+    async def test_no_partial_results_without_stream_rows(self):
+        """The full run keeps its synthesis results in results.csv and resumes
+        from them, so the judge must not overwrite that file mid-run."""
+        from calibrate_agent.tts import metrics as tts_metrics
+        from calibrate_agent.tts.eval import _score_and_write_results
+
+        evaluator = {
+            "name": "quality",
+            "system_prompt": "judge quality",
+            "judge_model": "openai/gpt-audio",
+            "type": "binary",
+        }
+
+        with tempfile.TemporaryDirectory() as out_dir:
+            results_path = os.path.join(out_dir, "results.csv")
+            synthesis_csv = "id,text,audio_path,ttfb\nrow_a,first,/tmp/a.wav,0.2\n"
+            with open(results_path, "w") as f:
+                f.write(synthesis_csv)
+            seen = {}
+
+            async def fake_judge(audio_path, reference_text, **kwargs):
+                if reference_text == "second":
+                    await asyncio.sleep(0.05)
+                    with open(results_path) as f:
+                        seen["mid_run"] = f.read()
+                return {
+                    "quality": {"match": True, "reasoning": reference_text}
+                }
+
+            with patch.object(
+                tts_metrics, "tts_llm_judge", AsyncMock(side_effect=fake_judge)
+            ):
+                await _score_and_write_results(
+                    ids=["row_a", "row_b"],
+                    texts=["first", "second"],
+                    audio_paths=["/tmp/a.wav", "/tmp/b.wav"],
+                    output_dir=out_dir,
+                    evaluator_config_dir=out_dir,
+                    judge_evaluators=[evaluator],
+                )
+
+            self.assertEqual(seen["mid_run"], synthesis_csv)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tts/test_eval.py
+++ b/tests/tts/test_eval.py
@@ -539,6 +539,60 @@ class TestTTSRunEvalOnly(unittest.IsolatedAsyncioTestCase):
             self.assertIn("quality", df.columns)
             self.assertIn("quality_reasoning", df.columns)
 
+    async def test_rows_land_in_results_csv_while_the_run_is_going(self):
+        """Guards the whole eval-only run, not just the scoring step it calls:
+        this fails if ``run_eval_only`` stops asking for row-by-row writing."""
+        from calibrate_agent.tts import eval as tts_eval
+        from calibrate_agent.tts import metrics as tts_metrics
+
+        seen = {}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = os.path.join(tmp, "openai")
+            os.makedirs(os.path.join(run_dir, "audios"))
+            for name in ("row_a", "row_b"):
+                _write_wav(os.path.join(run_dir, "audios", f"{name}.wav"))
+            pd.DataFrame(
+                [
+                    {"id": "row_a", "text": "first", "audio_path": "audios/row_a.wav"},
+                    {"id": "row_b", "text": "second", "audio_path": "audios/row_b.wav"},
+                ]
+            ).to_csv(os.path.join(run_dir, "results.csv"), index=False)
+            out = os.path.join(tmp, "eval")
+            results_path = os.path.join(out, "results.csv")
+
+            async def fake_row_judge(audio_path, reference_text, **kwargs):
+                if reference_text == "second":
+                    for _ in range(200):
+                        if os.path.exists(results_path):
+                            with open(results_path) as f:
+                                seen["csv"] = f.read()
+                            break
+                        await asyncio.sleep(0.01)
+                return {"quality": {"match": True, "reasoning": reference_text}}
+
+            with patch.object(
+                tts_metrics, "tts_llm_judge", AsyncMock(side_effect=fake_row_judge)
+            ):
+                result = await tts_eval.run_eval_only(
+                    dataset_path=run_dir,
+                    output_dir=out,
+                    judge_evaluators=[
+                        {
+                            "name": "quality",
+                            "system_prompt": "judge quality",
+                            "judge_model": "openai/gpt-4.1",
+                            "type": "binary",
+                        }
+                    ],
+                )
+
+            self.assertEqual(result["status"], "completed")
+            self.assertIn("row_a", seen.get("csv", ""))
+            self.assertEqual(
+                sorted(pd.read_csv(results_path)["id"]), ["row_a", "row_b"]
+            )
+
     async def test_invalid_dataset_returns_error(self):
         from calibrate_agent.tts import eval as tts_eval
 

--- a/tests/tts/test_eval.py
+++ b/tests/tts/test_eval.py
@@ -5,6 +5,7 @@ Run with:
     python -m unittest tests.tts.test_eval -v
 """
 
+import asyncio
 import os
 import tempfile
 import unittest
@@ -502,7 +503,7 @@ class TestTTSRunEvalOnly(unittest.IsolatedAsyncioTestCase):
         """End-to-end: point run_eval_only at a run dir, no dataset transform."""
         from calibrate_agent.tts import eval as tts_eval
 
-        async def fake_judge(audio_paths, texts, evaluators=None, fallback_model=None):
+        async def fake_judge(audio_paths, texts, **kwargs):
             return {
                 "scores": {"quality": {"type": "binary", "mean": 1.0}},
                 "score": 1.0,
@@ -563,6 +564,64 @@ class TestTTSRunEvalOnly(unittest.IsolatedAsyncioTestCase):
             # The original run's results.csv is untouched (ttfb column intact).
             df = pd.read_csv(os.path.join(run_dir, "results.csv"))
             self.assertIn("ttfb", df.columns)
+
+
+class TestTTSPartialResults(unittest.IsolatedAsyncioTestCase):
+    """results.csv holds the rows graded so far while the judge is still running."""
+
+    async def test_partial_results_written_during_run(self):
+        from calibrate_agent.tts import metrics as tts_metrics
+        from calibrate_agent.tts.eval import _score_and_write_results
+
+        evaluator = {
+            "name": "quality",
+            "system_prompt": "judge quality",
+            "judge_model": "openai/gpt-audio",
+            "type": "binary",
+        }
+
+        with tempfile.TemporaryDirectory() as out_dir:
+            results_path = os.path.join(out_dir, "results.csv")
+            seen = {}
+
+            async def fake_judge(audio_path, reference_text, **kwargs):
+                if reference_text == "second":
+                    # The first row finishes first; capture what is on disk by then.
+                    await asyncio.sleep(0.05)
+                    seen["partial"] = pd.read_csv(results_path)
+                return {
+                    "quality": {
+                        "match": reference_text == "first",
+                        "reasoning": reference_text,
+                    }
+                }
+
+            with patch.object(
+                tts_metrics, "tts_llm_judge", AsyncMock(side_effect=fake_judge)
+            ):
+                metrics = await _score_and_write_results(
+                    ids=["row_a", "row_b"],
+                    texts=["first", "second"],
+                    audio_paths=["/tmp/a.wav", "/tmp/b.wav"],
+                    output_dir=out_dir,
+                    evaluator_config_dir=out_dir,
+                    judge_evaluators=[evaluator],
+                    stream_rows=True,
+                )
+
+            partial = seen["partial"]
+            self.assertEqual(list(partial["id"]), ["row_a"])
+            self.assertEqual(bool(partial.iloc[0]["quality"]), True)
+            self.assertEqual(partial.iloc[0]["quality_reasoning"], "first")
+
+            self.assertAlmostEqual(metrics["quality"]["mean"], 0.5)
+            df = pd.read_csv(results_path)
+            self.assertEqual(list(df["id"]), ["row_a", "row_b"])
+            self.assertEqual(
+                list(df.columns),
+                ["id", "text", "audio_path", "quality", "quality_reasoning"],
+            )
+            self.assertEqual([bool(v) for v in df["quality"]], [True, False])
 
 
 if __name__ == "__main__":

--- a/tests/tts/test_metrics.py
+++ b/tests/tts/test_metrics.py
@@ -5,6 +5,7 @@ Run with:
     python -m unittest tests.tts.test_metrics -v
 """
 
+import asyncio
 import unittest
 from unittest.mock import patch, AsyncMock
 
@@ -123,6 +124,60 @@ class TestTTSGetLLMJudgeScore(unittest.IsolatedAsyncioTestCase):
         call_kwargs = mock_tts_judge.call_args.kwargs
         self.assertEqual(call_kwargs["evaluators"], custom_evaluators)
         self.assertEqual(call_kwargs["fallback_model"], "custom-audio-model")
+
+
+class TestTTSJudgeOnRow(unittest.IsolatedAsyncioTestCase):
+    """``on_row`` fires per row as its judge finishes, without reordering results."""
+
+    EVALUATORS = [
+        {"name": "quality", "system_prompt": "q", "judge_model": "openai/gpt-audio"}
+    ]
+
+    @staticmethod
+    async def _slow_first(audio_path, reference_text, **kwargs):
+        # Row 0 finishes last, so completion order differs from dataset order.
+        if audio_path.endswith("a.wav"):
+            await asyncio.sleep(0.05)
+        return {"quality": {"match": True, "reasoning": reference_text}}
+
+    async def test_on_row_called_per_row_and_order_preserved(self):
+        from calibrate_agent.tts import metrics as tts_metrics
+
+        seen = []
+        with patch.object(
+            tts_metrics, "tts_llm_judge", AsyncMock(side_effect=self._slow_first)
+        ):
+            result = await tts_metrics.get_tts_llm_judge_score(
+                audio_paths=["/tmp/a.wav", "/tmp/b.wav"],
+                reference_texts=["hi", "bye"],
+                evaluators=self.EVALUATORS,
+                on_row=lambda index, row: seen.append((index, row)),
+            )
+
+        # Row 1 completes first; each callback carries its own dataset index.
+        self.assertEqual([index for index, _ in seen], [1, 0])
+        self.assertEqual(seen[0][1]["quality"]["reasoning"], "bye")
+        self.assertEqual(seen[1][1]["quality"]["reasoning"], "hi")
+        self.assertEqual(
+            [row["quality"]["reasoning"] for row in result["per_row"]], ["hi", "bye"]
+        )
+
+    async def test_without_on_row_results_unchanged(self):
+        from calibrate_agent.tts import metrics as tts_metrics
+
+        with patch.object(
+            tts_metrics, "tts_llm_judge", AsyncMock(side_effect=self._slow_first)
+        ):
+            result = await tts_metrics.get_tts_llm_judge_score(
+                audio_paths=["/tmp/a.wav", "/tmp/b.wav"],
+                reference_texts=["hi", "bye"],
+                evaluators=self.EVALUATORS,
+            )
+
+        self.assertEqual(
+            [row["quality"]["reasoning"] for row in result["per_row"]], ["hi", "bye"]
+        )
+        self.assertEqual(result["scores"]["quality"]["mean"], 1.0)
 
 
 if __name__ == "__main__":

--- a/tests/tts/test_metrics.py
+++ b/tests/tts/test_metrics.py
@@ -162,23 +162,6 @@ class TestTTSJudgeOnRow(unittest.IsolatedAsyncioTestCase):
             [row["quality"]["reasoning"] for row in result["per_row"]], ["hi", "bye"]
         )
 
-    async def test_without_on_row_results_unchanged(self):
-        from calibrate_agent.tts import metrics as tts_metrics
-
-        with patch.object(
-            tts_metrics, "tts_llm_judge", AsyncMock(side_effect=self._slow_first)
-        ):
-            result = await tts_metrics.get_tts_llm_judge_score(
-                audio_paths=["/tmp/a.wav", "/tmp/b.wav"],
-                reference_texts=["hi", "bye"],
-                evaluators=self.EVALUATORS,
-            )
-
-        self.assertEqual(
-            [row["quality"]["reasoning"] for row in result["per_row"]], ["hi", "bye"]
-        )
-        self.assertEqual(result["scores"]["quality"]["mean"], 1.0)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What
- The speech-to-text, text-to-speech and general evaluations built the whole results table in memory and wrote it once at the end, so a run killed part-way left an empty output directory. Each judge aggregator now reports rows as they finish and the eval-only runs append them to `results.csv` as they arrive.
- Shared helpers in `judges.py`: `PartialResultsWriter`, `with_row_callback`, and `evaluator_row_columns` (the flatten-one-row-into-columns block that was copied in three places).

## Notes
- Row-by-row writing is on only for the eval-only runs. A full run keeps its transcriptions in the same `results.csv` and resumes from them, so overwriting that file mid-judge would cost a re-run of the speech provider on every ungraded row. `tests/stt/test_eval.py::test_no_partial_results_without_stream_rows` fails if that gate is removed.
- Rows are appended in completion order, not dataset order, so a killed run leaves an unordered subset identified by the `id` column.
- Speech-to-text runs its built-in Sarvam and semantic scoring over all rows first, so rows only start appearing once those finish.