### PR TITLE
Add a general test type to LLM tests

### DIFF
--- a/calibrate_agent/llm/__init__.py
+++ b/calibrate_agent/llm/__init__.py
@@ -101,6 +101,8 @@ class _Tests:
             _get_name_to_evaluator_dict,
             _evaluators_for_config_output,
             _resolve_evaluators_for_test_case,
+            test_case_history,
+            EVALUATOR_TEST_TYPES,
             _run_items_parallel,
             _load_resumable_results,
         )
@@ -159,12 +161,12 @@ class _Tests:
                         include_default=(evaluation.get("type") == "response"),
                     ),
                 )
-                if evaluation.get("type") in ("response", "conversation", "general")
+                if evaluation.get("type") in EVALUATOR_TEST_TYPES
                 else None
             )
             if agent is not None:
                 result = await _run_test_external(
-                    chat_history=test_case["history"],
+                    chat_history=test_case_history(test_case),
                     evaluation=evaluation,
                     agent=agent,
                     model=agent_model_hint,
@@ -173,7 +175,7 @@ class _Tests:
                 )
             else:
                 result = await _run_test(
-                    chat_history=test_case["history"],
+                    chat_history=test_case_history(test_case),
                     evaluation=evaluation,
                     system_prompt=system_prompt,
                     model=model,
@@ -536,6 +538,7 @@ class _Tests:
             run_test as _run_test,
             _get_name_to_evaluator_dict,
             _resolve_evaluators_for_test_case,
+            EVALUATOR_TEST_TYPES,
         )
 
         evaluator_config = {"evaluators": evaluators or []}
@@ -547,7 +550,7 @@ class _Tests:
                     include_default=(evaluation.get("type") == "response"),
                 ),
             )
-            if evaluation.get("type") in ("response", "conversation", "general")
+            if evaluation.get("type") in EVALUATOR_TEST_TYPES
             else None
         )
 

--- a/calibrate_agent/llm/__init__.py
+++ b/calibrate_agent/llm/__init__.py
@@ -159,7 +159,7 @@ class _Tests:
                         include_default=(evaluation.get("type") == "response"),
                     ),
                 )
-                if evaluation.get("type") in ("response", "conversation")
+                if evaluation.get("type") in ("response", "conversation", "general")
                 else None
             )
             if agent is not None:
@@ -547,7 +547,7 @@ class _Tests:
                     include_default=(evaluation.get("type") == "response"),
                 ),
             )
-            if evaluation.get("type") in ("response", "conversation")
+            if evaluation.get("type") in ("response", "conversation", "general")
             else None
         )
 

--- a/calibrate_agent/llm/run_tests.py
+++ b/calibrate_agent/llm/run_tests.py
@@ -50,6 +50,7 @@ from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.services.openrouter.llm import OpenRouterLLMService
 from pipecat.observers.loggers.llm_log_observer import LLMLogObserver
 from calibrate_agent.llm.metrics import test_response_llm_judge, evaluate_simuation
+from calibrate_agent.general.metrics import general_judge
 from calibrate_agent.llm._metrics_utils import _numeric_or_none, _latency_percentiles
 from calibrate_agent.judges import (
     DEFAULT_LLM_TEST_EVALUATOR,
@@ -1376,6 +1377,38 @@ async def _evaluate_conversation(
     return _metrics_from_judge_results(evaluators, result)
 
 
+async def _evaluate_general(
+    chat_history: List[dict],
+    evaluators: List[dict],
+    output: dict,
+    no_response_reasoning: str,
+) -> dict:
+    """Judge the agent's reply as a plain input/output pair, not a transcript.
+
+    The input is the last user message in ``chat_history``; tool calls play no
+    part, since a general test case grades only the text the agent produced.
+    """
+    response = output.get("response")
+    if not response:
+        return {
+            "passed": False,
+            "reasoning": no_response_reasoning,
+            "judge_results": _no_response_judge_results(
+                evaluators, no_response_reasoning
+            ),
+        }
+    input_text = next(
+        (
+            message.get("content")
+            for message in reversed(chat_history or [])
+            if message.get("role") == "user"
+        ),
+        None,
+    )
+    result = await general_judge(input_text, response, evaluators=evaluators)
+    return _metrics_from_judge_results(evaluators, result)
+
+
 async def evaluate_test_case_output(
     chat_history: List[dict],
     evaluation: dict,
@@ -1397,6 +1430,15 @@ async def evaluate_test_case_output(
             evaluators=evaluators or [],
             output=output,
             no_response_reasoning_no_tool_calls=(
+                no_response_reasoning_no_tool_calls or "No reply was returned"
+            ),
+        )
+    if evaluation["type"] == "general":
+        return await _evaluate_general(
+            chat_history=chat_history,
+            evaluators=evaluators or [],
+            output=output,
+            no_response_reasoning=(
                 no_response_reasoning_no_tool_calls or "No reply was returned"
             ),
         )
@@ -1598,7 +1640,7 @@ def _aggregate_criteria(results: List[dict], name_to_evaluator: dict) -> dict:
         metrics = result.get("metrics", {})
         evaluation = result.get("test_case", {}).get("evaluation", {})
 
-        if evaluation.get("type") not in ("response", "conversation"):
+        if evaluation.get("type") not in ("response", "conversation", "general"):
             continue
 
         judge_results = metrics.get("judge_results")
@@ -1915,7 +1957,7 @@ async def run_model_tests(
                     include_default=(evaluation.get("type") == "response"),
                 ),
             )
-            if evaluation.get("type") in ("response", "conversation")
+            if evaluation.get("type") in ("response", "conversation", "general")
             else None
         )
 
@@ -2105,11 +2147,11 @@ def validate_llm_eval_only_dataset(
         if not isinstance(tc["evaluation"], dict):
             return False, f"Item {i}: 'test_case.evaluation' must be an object"
         ev_type = tc["evaluation"].get("type")
-        if ev_type not in ("response", "tool_call", "conversation"):
+        if ev_type not in ("response", "tool_call", "conversation", "general"):
             return (
                 False,
                 f"Item {i}: 'test_case.evaluation.type' must be 'response', "
-                f"'tool_call', or 'conversation' (got {ev_type!r})",
+                f"'tool_call', 'conversation', or 'general' (got {ev_type!r})",
             )
         if "response" not in out or "tool_calls" not in out:
             return (
@@ -2168,7 +2210,7 @@ async def run_eval_only_tests(
                     include_default=(evaluation.get("type") == "response"),
                 ),
             )
-            if evaluation.get("type") in ("response", "conversation")
+            if evaluation.get("type") in ("response", "conversation", "general")
             else None
         )
 

--- a/calibrate_agent/llm/run_tests.py
+++ b/calibrate_agent/llm/run_tests.py
@@ -67,6 +67,38 @@ from calibrate_agent.judges import (
 from calibrate_agent.langfuse import observe, langfuse, langfuse_enabled
 
 
+# The four kinds of LLM test case. ``EVALUATOR_TEST_TYPES`` are the ones graded
+# by evaluators the test case names in ``evaluation.criteria``; ``tool_call``
+# cases are graded against an expected tool-call list instead.
+EVALUATOR_TEST_TYPES = ("response", "conversation", "general")
+TEST_TYPES = ("tool_call",) + EVALUATOR_TEST_TYPES
+
+
+def test_case_history(test_case: dict) -> List[dict]:
+    """Return the messages to send to the agent for ``test_case``.
+
+    A ``general`` test case is single-shot: it carries a plain ``input`` string
+    and no conversation, so its one user message is built here. Every other kind
+    carries its own ``history``.
+    """
+    evaluation = test_case.get("evaluation") or {}
+    if evaluation.get("type") != "general":
+        return test_case["history"]
+
+    if "history" in test_case:
+        raise ValueError(
+            "A 'general' test case is single-shot: it takes a plain 'input' "
+            "string and must not carry a 'history'."
+        )
+    input_text = test_case.get("input")
+    if not isinstance(input_text, str) or not input_text.strip():
+        raise ValueError(
+            "A 'general' test case requires a non-empty 'input' string "
+            f"(got: {input_text!r})."
+        )
+    return [{"role": "user", "content": input_text}]
+
+
 # ── Evaluator resolution helpers (LLM-test-specific) ────────────────────────
 
 
@@ -157,7 +189,15 @@ def _resolve_evaluators_for_test_case(
     evaluation: dict, name_to_evaluator: dict
 ) -> list[dict]:
     """Resolve a test case's ``evaluation.criteria`` to rendered evaluator dicts."""
-    refs = _normalize_criteria_refs(evaluation.get("criteria"))
+    criteria = evaluation.get("criteria")
+    if evaluation.get("type") == "general" and isinstance(criteria, str):
+        raise ValueError(
+            "A 'general' test case must list its evaluators by name, e.g. "
+            '"criteria": [{"name": "helpful"}]. A plain criteria string selects '
+            f"the built-in '{DEFAULT_LLM_TEST_EVALUATOR['name']}' evaluator, "
+            "which general test cases do not use."
+        )
+    refs = _normalize_criteria_refs(criteria)
     ensure_known_evaluator_names(
         [ref["name"] for ref in refs], name_to_evaluator, context="test case criteria"
     )
@@ -1292,6 +1332,13 @@ def _evaluator_passed(evaluator: dict, ev_result: dict) -> bool:
 
 
 def _metrics_from_judge_results(evaluators: List[dict], result: dict) -> dict:
+    # Nothing to object to means nothing was graded — report that instead of a
+    # pass, which is what an empty `evaluation.criteria` would otherwise produce.
+    if not evaluators:
+        raise ValueError(
+            "This test case names no evaluators, so nothing would be graded. "
+            "List at least one evaluator under 'evaluation.criteria'."
+        )
     failing = [ev for ev in evaluators if not _evaluator_passed(ev, result[ev["name"]])]
     return {
         "passed": not failing,
@@ -1326,25 +1373,29 @@ async def _evaluate_response(
 
     Returns a dict with ``passed``, ``reasoning``, and ``judge_results``.
     """
-    metrics: dict = {"passed": False}
-    if response:
-        evaluators = evaluators or []
-        result = await test_response_llm_judge(
-            conversation=chat_history,
-            response=response,
-            evaluators=evaluators,
+    evaluators = evaluators or []
+    if not response:
+        return _no_response_metrics(
+            evaluators,
+            no_response_reasoning_with_tool_calls
+            if tool_calls
+            else no_response_reasoning_no_tool_calls,
         )
-        metrics.update(_metrics_from_judge_results(evaluators, result))
-    else:
-        if tool_calls:
-            metrics["reasoning"] = no_response_reasoning_with_tool_calls
-        else:
-            metrics["reasoning"] = no_response_reasoning_no_tool_calls
+    result = await test_response_llm_judge(
+        conversation=chat_history,
+        response=response,
+        evaluators=evaluators,
+    )
+    return _metrics_from_judge_results(evaluators, result)
 
-        metrics["judge_results"] = _no_response_judge_results(
-            evaluators or [], metrics["reasoning"]
-        )
-    return metrics
+
+def _no_response_metrics(evaluators: List[dict], reasoning: str) -> dict:
+    """Build the failed-with-no-reply metrics dict for a judged test case."""
+    return {
+        "passed": False,
+        "reasoning": reasoning,
+        "judge_results": _no_response_judge_results(evaluators or [], reasoning),
+    }
 
 
 async def _evaluate_conversation(
@@ -1357,13 +1408,7 @@ async def _evaluate_conversation(
     response = output.get("response")
     tool_calls = output.get("tool_calls") or []
     if not response and not tool_calls:
-        return {
-            "passed": False,
-            "reasoning": no_response_reasoning_no_tool_calls,
-            "judge_results": _no_response_judge_results(
-                evaluators or [], no_response_reasoning_no_tool_calls
-            ),
-        }
+        return _no_response_metrics(evaluators, no_response_reasoning_no_tool_calls)
     turn: dict = {"role": "assistant", "content": response or ""}
     if tool_calls:
         turn["tool_calls"] = [
@@ -1385,26 +1430,26 @@ async def _evaluate_general(
 ) -> dict:
     """Judge the agent's reply as a plain input/output pair, not a transcript.
 
-    The input is the last user message in ``chat_history``; tool calls play no
-    part, since a general test case grades only the text the agent produced.
+    ``chat_history`` holds the single user message built from the test case's
+    ``input``. Tool calls play no part: a general test case grades only the text
+    the agent produced.
     """
     response = output.get("response")
     if not response:
-        return {
-            "passed": False,
-            "reasoning": no_response_reasoning,
-            "judge_results": _no_response_judge_results(
-                evaluators, no_response_reasoning
-            ),
-        }
+        return _no_response_metrics(evaluators, no_response_reasoning)
     input_text = next(
         (
             message.get("content")
-            for message in reversed(chat_history or [])
+            for message in reversed(chat_history)
             if message.get("role") == "user"
         ),
         None,
     )
+    if input_text is None:
+        raise ValueError(
+            "A 'general' test case needs a user message to judge the reply "
+            "against; none was found."
+        )
     result = await general_judge(input_text, response, evaluators=evaluators)
     return _metrics_from_judge_results(evaluators, result)
 
@@ -1640,7 +1685,7 @@ def _aggregate_criteria(results: List[dict], name_to_evaluator: dict) -> dict:
         metrics = result.get("metrics", {})
         evaluation = result.get("test_case", {}).get("evaluation", {})
 
-        if evaluation.get("type") not in ("response", "conversation", "general"):
+        if evaluation.get("type") not in EVALUATOR_TEST_TYPES:
             continue
 
         judge_results = metrics.get("judge_results")
@@ -1947,7 +1992,7 @@ async def run_model_tests(
     async def process(test_case_index: int, test_case: dict) -> dict:
         evaluation = test_case["evaluation"]
         preprocessed_history = preprocess_conversation_history(
-            test_case["history"], tools
+            test_case_history(test_case), tools
         )
         resolved_evaluators = (
             _resolve_evaluators_for_test_case(
@@ -1957,7 +2002,7 @@ async def run_model_tests(
                     include_default=(evaluation.get("type") == "response"),
                 ),
             )
-            if evaluation.get("type") in ("response", "conversation", "general")
+            if evaluation.get("type") in EVALUATOR_TEST_TYPES
             else None
         )
 
@@ -2137,29 +2182,46 @@ def validate_llm_eval_only_dataset(
             return False, f"Item {i}: 'test_case' must be an object"
         if not isinstance(out, dict):
             return False, f"Item {i}: 'output' must be an object"
-        if "history" not in tc or "evaluation" not in tc:
+        if "evaluation" not in tc:
             return (
                 False,
-                f"Item {i}: 'test_case' missing required fields 'history' and/or 'evaluation'",
+                f"Item {i}: 'test_case' missing required field 'evaluation'",
             )
-        if not isinstance(tc["history"], list):
-            return False, f"Item {i}: 'test_case.history' must be a list"
         if not isinstance(tc["evaluation"], dict):
             return False, f"Item {i}: 'test_case.evaluation' must be an object"
         ev_type = tc["evaluation"].get("type")
-        if ev_type not in ("response", "tool_call", "conversation", "general"):
+        if ev_type not in TEST_TYPES:
             return (
                 False,
-                f"Item {i}: 'test_case.evaluation.type' must be 'response', "
-                f"'tool_call', 'conversation', or 'general' (got {ev_type!r})",
+                f"Item {i}: 'test_case.evaluation.type' must be one of "
+                f"{', '.join(repr(t) for t in TEST_TYPES)} (got {ev_type!r})",
             )
-        if "response" not in out or "tool_calls" not in out:
-            return (
-                False,
-                f"Item {i}: 'output' must include 'response' (str) and 'tool_calls' (list)",
-            )
-        if not isinstance(out.get("tool_calls", []), list):
-            return False, f"Item {i}: 'output.tool_calls' must be a list"
+
+        if ev_type == "general":
+            try:
+                test_case_history(tc)
+            except ValueError as exc:
+                return False, f"Item {i}: {exc}"
+            if "response" not in out:
+                return (
+                    False,
+                    f"Item {i}: 'output' must include 'response' (str)",
+                )
+        else:
+            if "history" not in tc:
+                return (
+                    False,
+                    f"Item {i}: 'test_case' missing required field 'history'",
+                )
+            if not isinstance(tc["history"], list):
+                return False, f"Item {i}: 'test_case.history' must be a list"
+            if "response" not in out or "tool_calls" not in out:
+                return (
+                    False,
+                    f"Item {i}: 'output' must include 'response' (str) and 'tool_calls' (list)",
+                )
+            if not isinstance(out.get("tool_calls", []), list):
+                return False, f"Item {i}: 'output.tool_calls' must be a list"
 
     return True, ""
 
@@ -2210,12 +2272,12 @@ async def run_eval_only_tests(
                     include_default=(evaluation.get("type") == "response"),
                 ),
             )
-            if evaluation.get("type") in ("response", "conversation", "general")
+            if evaluation.get("type") in EVALUATOR_TEST_TYPES
             else None
         )
 
         preprocessed_history = preprocess_conversation_history(
-            test_case["history"], tools
+            test_case_history(test_case), tools
         )
         output = item["output"]
         metrics = await evaluate_test_case_output(

--- a/docs/cli/text-to-text.mdx
+++ b/docs/cli/text-to-text.mdx
@@ -36,9 +36,10 @@ An array of test cases to evaluate your agent on. Each test case has:
 
 | Key          | Type   | Description                                                                              |
 | ------------ | ------ | ---------------------------------------------------------------------------------------- |
-| `id`         | string | Optional unique test-case id. When provided, results include `test_case_id`.             |
-| `history`    | array  | Conversation history as context for the agent to generate the next output                |
-| `evaluation` | object | The criteria for evaluating the agent — a tool call, a response, or a whole conversation |
+| `id`         | string | Optional unique test-case id. When provided, results include `test_case_id`.              |
+| `history`    | array  | Conversation history as context for the agent to generate the next output. Used by every test type except `general`. |
+| `input`      | string | The single user message for a `general` test case. Used only by that type, which takes no `history`. |
+| `evaluation` | object | The criteria for evaluating the agent: a tool call, a response, a whole conversation, or a single-shot task |
 
 ### Tool call test
 
@@ -186,13 +187,35 @@ Like a [response test](#response-test), the agent is run on the `history` to pro
 
 See [`examples/llm/config-conversation.json`](https://github.com/ARTPARK-SAHAI-ORG/calibrate/blob/main/examples/llm/config-conversation.json) for a full template.
 
+### General test
+
+A single-shot task with no conversation. The agent receives one user message, taken from `input`, and its reply is graded as a plain input and output pair rather than as a turn in a chat. Use this for summarization, extraction, classification, rewriting, and similar tasks.
+
+```jsonc
+{
+  // general test — one input, the reply graded on its own
+  "id": "test-id-1",
+  "input": "Summarize this in one line: the order shipped on Monday and arrives Thursday.",
+  "evaluation": {
+    "type": "general",
+    "criteria": [{ "name": "faithful" }, { "name": "concise" }],
+  },
+}
+```
+
+A general test case carries `input` and no `history`. Supplying `history` is an error, as is an empty `input`.
+
+Its evaluators must be listed by name. There is no built-in evaluator for this type, so the plain criteria string that a [response test](#response-test) accepts is rejected here.
+
 ---
 
 ## Evaluators
 
-**Response** test cases can be evaluated by one or more text LLM judges (routed through [OpenRouter](https://openrouter.ai/), set `OPENROUTER_API_KEY` in your environment).
+**Response**, **conversation**, and **general** test cases are evaluated by one or more text LLM judges (routed through [OpenRouter](https://openrouter.ai/), set `OPENROUTER_API_KEY` in your environment).
 
-Each evaluator's `system_prompt` is sent to its own dedicated LLM judge call (one call per evaluator, run in parallel) with the conversation history and the agent's last response as the inputs.
+Each evaluator's `system_prompt` is sent to its own dedicated LLM judge call (one call per evaluator, run in parallel). Response tests pass the conversation history and the agent's last response as the inputs; general tests pass the `input` and the agent's reply.
+
+A test case that names no evaluators is rejected, since nothing would be graded.
 
 ### Defining custom evaluators
 

--- a/docs/cli/text-to-text.mdx
+++ b/docs/cli/text-to-text.mdx
@@ -207,6 +207,8 @@ A general test case carries `input` and no `history`. Supplying `history` is an 
 
 Its evaluators must be listed by name. There is no built-in evaluator for this type, so the plain criteria string that a [response test](#response-test) accepts is rejected here.
 
+See [`examples/llm/config-general.json`](https://github.com/ARTPARK-SAHAI-ORG/calibrate/blob/main/examples/llm/config-general.json) for a full template.
+
 ---
 
 ## Evaluators

--- a/examples/llm/config-general.json
+++ b/examples/llm/config-general.json
@@ -1,0 +1,33 @@
+{
+  "system_prompt": "You summarize customer support notes. Reply with a single sentence and nothing else.",
+  "evaluators": [
+    {
+      "name": "faithful",
+      "system_prompt": "You are a strict evaluator. You will be given an input note and a summary of it.\n\nMark True only if every fact in the summary appears in the input, with no invented details.",
+      "judge_model": "openai/gpt-4.1"
+    },
+    {
+      "name": "one_sentence",
+      "system_prompt": "You are a strict evaluator. You will be given an input note and a summary of it.\n\nMark True only if the summary is a single sentence.",
+      "judge_model": "openai/gpt-4.1"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "shipping-note",
+      "input": "Summarize this note: order ORD-12345 shipped on Monday from the Pune warehouse and is due to arrive on Thursday.",
+      "evaluation": {
+        "type": "general",
+        "criteria": [{ "name": "faithful" }, { "name": "one_sentence" }]
+      }
+    },
+    {
+      "id": "return-note",
+      "input": "Summarize this note: the customer returned a pair of headphones because the left earcup was silent, and a replacement was posted the same day.",
+      "evaluation": {
+        "type": "general",
+        "criteria": [{ "name": "faithful" }, { "name": "one_sentence" }]
+      }
+    }
+  ]
+}

--- a/tests/llm/test_benchmark.py
+++ b/tests/llm/test_benchmark.py
@@ -97,6 +97,14 @@ class TestCallTextAgentModelParams(unittest.IsolatedAsyncioTestCase):
 # Tests for run_test_external — model threaded through
 # ---------------------------------------------------------------------------
 
+def _correctness_evaluator():
+    return {
+        "name": "correctness",
+        "system_prompt": "Grade the reply.",
+        "judge_model": "openai/gpt-4.1",
+    }
+
+
 class TestRunTestExternalModelParams(unittest.IsolatedAsyncioTestCase):
 
     async def test_model_passed_to_agent_call(self):
@@ -117,6 +125,7 @@ class TestRunTestExternalModelParams(unittest.IsolatedAsyncioTestCase):
                 evaluation=evaluation,
                 agent=agent,
                 model="gemma-4-26b-a4b-it",
+                evaluators=[_correctness_evaluator()],
             )
 
         body = mock_client.post.call_args.kwargs["json"]
@@ -138,6 +147,7 @@ class TestRunTestExternalModelParams(unittest.IsolatedAsyncioTestCase):
                 chat_history=[{"role": "user", "content": "Hi"}],
                 evaluation={"type": "response", "criteria": "greet"},
                 agent=agent,
+                evaluators=[_correctness_evaluator()],
             )
 
         body = mock_client.post.call_args.kwargs["json"]

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -1375,6 +1375,58 @@ class TestEvaluateTestCaseOutput(unittest.IsolatedAsyncioTestCase):
 
 
 class TestGeneralEvaluationType(unittest.IsolatedAsyncioTestCase):
+    def test_history_built_from_plain_input(self):
+        from calibrate_agent.llm.run_tests import test_case_history
+
+        self.assertEqual(
+            test_case_history(
+                {"input": "summarize this", "evaluation": {"type": "general"}}
+            ),
+            [{"role": "user", "content": "summarize this"}],
+        )
+
+    def test_history_field_rejected(self):
+        from calibrate_agent.llm.run_tests import test_case_history
+
+        with self.assertRaisesRegex(ValueError, "must not carry a 'history'"):
+            test_case_history(
+                {
+                    "input": "hi",
+                    "history": [{"role": "user", "content": "hi"}],
+                    "evaluation": {"type": "general"},
+                }
+            )
+
+    def test_blank_input_rejected(self):
+        from calibrate_agent.llm.run_tests import test_case_history
+
+        for bad in ("", "   ", None, ["hi"]):
+            with self.subTest(input=bad):
+                with self.assertRaisesRegex(ValueError, "non-empty 'input' string"):
+                    test_case_history(
+                        {"input": bad, "evaluation": {"type": "general"}}
+                    )
+
+    def test_other_types_keep_their_history(self):
+        from calibrate_agent.llm.run_tests import test_case_history
+
+        history = [{"role": "user", "content": "hi"}]
+        self.assertEqual(
+            test_case_history(
+                {"history": history, "evaluation": {"type": "response"}}
+            ),
+            history,
+        )
+
+    def test_plain_criteria_string_rejected(self):
+        from calibrate_agent.llm.run_tests import _resolve_evaluators_for_test_case
+
+        with self.assertRaisesRegex(ValueError, "must list its evaluators by name"):
+            _resolve_evaluators_for_test_case(
+                {"type": "general", "criteria": "be helpful"},
+                {"helpful": _bin_ev("helpful")},
+            )
+
     async def test_judges_last_user_message_against_response(self):
         from calibrate_agent.llm.run_tests import evaluate_test_case_output
 
@@ -1429,6 +1481,58 @@ class TestGeneralEvaluationType(unittest.IsolatedAsyncioTestCase):
         ]
         aggregated = _aggregate_criteria(results, {"helpful": _bin_ev("helpful")})
         self.assertEqual(aggregated["helpful"]["pass_rate"], 100.0)
+
+    async def test_no_evaluators_raises_instead_of_passing(self):
+        from calibrate_agent.llm.run_tests import evaluate_test_case_output
+
+        with patch("calibrate_agent.llm.run_tests.general_judge", AsyncMock(return_value={})):
+            with self.assertRaisesRegex(ValueError, "names no evaluators"):
+                await evaluate_test_case_output(
+                    chat_history=[{"role": "user", "content": "hi"}],
+                    evaluation={"type": "general", "criteria": []},
+                    output={"response": "anything", "tool_calls": []},
+                    evaluators=[],
+                )
+
+    async def test_external_agent_path_resolves_evaluators(self):
+        """The SDK path a customer's own agent runs through."""
+        from calibrate_agent.llm import _Tests
+
+        agent = MagicMock()
+        agent.call = AsyncMock(
+            return_value={"response": "a summary", "tool_calls": []}
+        )
+        judge = AsyncMock(
+            return_value={"helpful": {"reasoning": "good", "match": True}}
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("calibrate_agent.llm.run_tests.general_judge", judge):
+                await _Tests._run_single_model(
+                    test_cases=[
+                        {
+                            "id": "row_a",
+                            "input": "summarize this",
+                            "evaluation": {
+                                "type": "general",
+                                "criteria": [{"name": "helpful"}],
+                            },
+                        }
+                    ],
+                    system_prompt="",
+                    tools=[],
+                    output_dir=tmp,
+                    model="",
+                    provider="",
+                    agent=agent,
+                    evaluators=[_bin_ev("helpful")],
+                )
+
+        self.assertEqual(
+            agent.call.await_args.args[0],
+            [{"role": "user", "content": "summarize this"}],
+        )
+        self.assertEqual(judge.await_args.args, ("summarize this", "a summary"))
+        self.assertEqual(judge.await_args.kwargs["evaluators"][0]["name"], "helpful")
 
 
 class TestAggregateCriteria(unittest.TestCase):

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -1374,6 +1374,63 @@ class TestEvaluateTestCaseOutput(unittest.IsolatedAsyncioTestCase):
         self.assertIn("Tool calls were generated", result["reasoning"])
 
 
+class TestGeneralEvaluationType(unittest.IsolatedAsyncioTestCase):
+    async def test_judges_last_user_message_against_response(self):
+        from calibrate_agent.llm.run_tests import evaluate_test_case_output
+
+        judge = AsyncMock(
+            return_value={"helpful": {"reasoning": "good", "match": True}}
+        )
+        with patch("calibrate_agent.llm.run_tests.general_judge", judge):
+            result = await evaluate_test_case_output(
+                chat_history=[{"role": "user", "content": "summarize this"}],
+                evaluation={"type": "general", "criteria": [{"name": "helpful"}]},
+                output={"response": "a summary", "tool_calls": []},
+                evaluators=[_bin_ev("helpful")],
+            )
+
+        self.assertTrue(result["passed"])
+        self.assertEqual(judge.await_args.args, ("summarize this", "a summary"))
+        self.assertEqual(judge.await_args.kwargs["evaluators"][0]["name"], "helpful")
+
+    async def test_no_response_fails_without_calling_judge(self):
+        from calibrate_agent.llm.run_tests import evaluate_test_case_output
+
+        judge = AsyncMock()
+        with patch("calibrate_agent.llm.run_tests.general_judge", judge):
+            result = await evaluate_test_case_output(
+                chat_history=[{"role": "user", "content": "hi"}],
+                evaluation={"type": "general", "criteria": [{"name": "helpful"}]},
+                output={"response": "", "tool_calls": []},
+                evaluators=[_bin_ev("helpful")],
+                no_response_reasoning_no_tool_calls="NONE",
+            )
+
+        judge.assert_not_awaited()
+        self.assertFalse(result["passed"])
+        self.assertEqual(result["reasoning"], "NONE")
+        self.assertFalse(result["judge_results"]["helpful"]["match"])
+
+    def test_scores_reach_metrics_aggregation(self):
+        from calibrate_agent.llm.run_tests import _aggregate_criteria
+
+        results = [
+            {
+                "metrics": {
+                    "judge_results": {"helpful": {"reasoning": "r", "match": True}}
+                },
+                "test_case": {
+                    "evaluation": {
+                        "type": "general",
+                        "criteria": [{"name": "helpful"}],
+                    }
+                },
+            }
+        ]
+        aggregated = _aggregate_criteria(results, {"helpful": _bin_ev("helpful")})
+        self.assertEqual(aggregated["helpful"]["pass_rate"], 100.0)
+
+
 class TestAggregateCriteria(unittest.TestCase):
     def test_binary_aggregation(self):
         from calibrate_agent.llm.run_tests import _aggregate_criteria

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -1494,6 +1494,77 @@ class TestGeneralEvaluationType(unittest.IsolatedAsyncioTestCase):
                     evaluators=[],
                 )
 
+    async def test_history_without_user_message_raises(self):
+        from calibrate_agent.llm.run_tests import evaluate_test_case_output
+
+        with patch("calibrate_agent.llm.run_tests.general_judge", AsyncMock()):
+            with self.assertRaisesRegex(ValueError, "needs a user message"):
+                await evaluate_test_case_output(
+                    chat_history=[{"role": "assistant", "content": "hello"}],
+                    evaluation={"type": "general", "criteria": [{"name": "helpful"}]},
+                    output={"response": "a summary", "tool_calls": []},
+                    evaluators=[_bin_ev("helpful")],
+                )
+
+    def test_saved_dataset_accepts_input_without_tool_calls(self):
+        from calibrate_agent.llm.run_tests import validate_llm_eval_only_dataset
+
+        is_valid, err = validate_llm_eval_only_dataset([
+            {
+                "test_case": {
+                    "input": "summarize this",
+                    "evaluation": {
+                        "type": "general",
+                        "criteria": [{"name": "helpful"}],
+                    },
+                },
+                "output": {"response": "a summary"},
+            }
+        ])
+        self.assertTrue(is_valid, err)
+
+    def test_saved_dataset_rejects_history_and_blank_input(self):
+        from calibrate_agent.llm.run_tests import validate_llm_eval_only_dataset
+
+        evaluation = {"type": "general", "criteria": [{"name": "helpful"}]}
+        with_history = {
+            "test_case": {
+                "input": "hi",
+                "history": [{"role": "user", "content": "hi"}],
+                "evaluation": evaluation,
+            },
+            "output": {"response": "a summary"},
+        }
+        is_valid, err = validate_llm_eval_only_dataset([with_history])
+        self.assertFalse(is_valid)
+        self.assertIn("must not carry a 'history'", err)
+
+        no_input = {
+            "test_case": {"evaluation": evaluation},
+            "output": {"response": "a summary"},
+        }
+        is_valid, err = validate_llm_eval_only_dataset([no_input])
+        self.assertFalse(is_valid)
+        self.assertIn("non-empty 'input' string", err)
+
+    def test_saved_dataset_requires_a_response(self):
+        from calibrate_agent.llm.run_tests import validate_llm_eval_only_dataset
+
+        is_valid, err = validate_llm_eval_only_dataset([
+            {
+                "test_case": {
+                    "input": "summarize this",
+                    "evaluation": {
+                        "type": "general",
+                        "criteria": [{"name": "helpful"}],
+                    },
+                },
+                "output": {"tool_calls": []},
+            }
+        ])
+        self.assertFalse(is_valid)
+        self.assertIn("must include 'response'", err)
+
     async def test_external_agent_path_resolves_evaluators(self):
         """The SDK path a customer's own agent runs through."""
         from calibrate_agent.llm import _Tests


### PR DESCRIPTION
## What
- A `general` test case sends its history to the agent and judges the reply as a plain input/output pair: the last user message is the input, the agent's text is the output, tool calls play no part.
- The eval-only dataset validator accepts `general`, and general cases feed the per-evaluator totals in `metrics.json`.

## Notes
- Evaluators must be referenced by name, `"criteria": [{"name": "helpful"}]`. A bare criteria string maps to the default LLM-test evaluator, which `general` does not include, so it fails as an unknown name.
- The request to the agent, the agent connection contract, and the config format are unchanged.
- Per-row variables in judge prompts are being handled separately.