### PR TITLE
Resume eval-only runs and add --overwrite

### DIFF
--- a/calibrate_agent/cli.py
+++ b/calibrate_agent/cli.py
@@ -490,7 +490,12 @@ Examples:
         "--dataset",
         type=str,
         default=None,
-        help="Path to dataset JSON for --eval-only (list of {conversation_history, name?})",
+        help="Path to dataset JSON for --eval-only (list of {id, conversation_history, name?})",
+    )
+    sim_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Force a clean run instead of resuming completed simulations from a prior run (text simulations only)",
     )
 
     # Hidden internal subcommand for simulation leaderboard
@@ -526,6 +531,11 @@ Examples:
         type=str,
         default="./out",
         help="Output directory",
+    )
+    general_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Force a clean run instead of resuming completed rows from a prior run",
     )
 
     # ── Status ────────────────────────────────────────────────────
@@ -577,6 +587,8 @@ Examples:
                 argv.extend(["--config", args.config])
             if args.skip_llm_judges:
                 argv.append("--skip-llm-judges")
+            if args.overwrite:
+                argv.append("--overwrite")
 
             sys.argv = argv
             asyncio.run(stt_benchmark_main())
@@ -631,6 +643,8 @@ Examples:
             argv.extend(["-o", args.output_dir])
             if args.config:
                 argv.extend(["--config", args.config])
+            if args.overwrite:
+                argv.append("--overwrite")
 
             sys.argv = argv
             asyncio.run(tts_benchmark_main())
@@ -682,6 +696,8 @@ Examples:
             if getattr(args, "debug", False):
                 argv.append("-d")
                 argv.extend(["-dc", str(args.debug_count)])
+            if getattr(args, "overwrite", False):
+                argv.append("--overwrite")
             sys.argv = argv
             asyncio.run(llm_run_tests_main())
         elif getattr(args, "verify", False):
@@ -830,6 +846,7 @@ Examples:
                     "provider",
                     "parallel",
                     "port",
+                    "overwrite",
                 },
             )
             leaderboard_main()
@@ -896,6 +913,14 @@ Examples:
         elif args.type == "voice":
             from calibrate_agent.agent.run_simulation import main as agent_main
 
+            if getattr(args, "overwrite", False):
+                print(
+                    "\033[31mError: --overwrite is only supported for "
+                    "--type text. Voice simulations always run from the "
+                    "start.\033[0m"
+                )
+                sys.exit(1)
+
             # Pre-verify external WebSocket voice agent if config has a
             # ws:// or wss:// agent_url.
             if args.config:
@@ -935,6 +960,7 @@ Examples:
                     "agent_headers",
                     "eval_only",
                     "dataset",
+                    "overwrite",
                 },
             )
             asyncio.run(agent_main())
@@ -951,6 +977,8 @@ Examples:
 
         argv = ["calibrate-agent", "--dataset", args.dataset, "-c", args.config]
         argv.extend(["-o", args.output_dir])
+        if args.overwrite:
+            argv.append("--overwrite")
         sys.argv = argv
         asyncio.run(general_eval_main())
 

--- a/calibrate_agent/general/eval.py
+++ b/calibrate_agent/general/eval.py
@@ -21,7 +21,10 @@ from calibrate_agent.general.metrics import get_general_judge_score
 from calibrate_agent.judges import (
     PartialResultsWriter,
     evaluator_row_columns,
+    evaluator_row_from_columns,
+    read_existing_rows,
     require_unique_evaluator_names,
+    stored_scores_are_comparable,
     write_evaluator_config,
 )
 from calibrate_agent.utils import (
@@ -89,7 +92,9 @@ def validate_general_eval_dataset(
                         f"object mapping variable names to values",
                         [],
                     )
-        row_id = row["id"]
+        # Compared as text: ids are written to and read back from results.csv
+        # as text, so 1 and "1" are the same row there and must not both pass.
+        row_id = str(row["id"])
         if row_id in seen_ids:
             return False, f"Duplicate row id: {row_id!r}", []
         seen_ids.add(row_id)
@@ -120,6 +125,24 @@ def _resolve_evaluators(config: Optional[dict]) -> List[dict]:
     return evaluators
 
 
+def _matching_stored_row(
+    stored: Optional[dict], input_text: str, output_text: str
+) -> Optional[dict]:
+    """Return the stored row only when the judge would see the same text again.
+
+    The judge scored the ``input``/``output`` the stored row carries. If either
+    has changed in the dataset, that score describes text that is no longer
+    there, so the row counts as unjudged.
+    """
+    if not stored:
+        return None
+    if str(stored.get("input", "")) != input_text:
+        return None
+    if str(stored.get("output", "")) != output_text:
+        return None
+    return stored
+
+
 async def _score_and_write_results(
     ids: list,
     inputs: List[Optional[str]],
@@ -127,43 +150,60 @@ async def _score_and_write_results(
     evaluators: List[dict],
     output_dir: str,
     arguments_list: Optional[List[Optional[dict]]] = None,
+    existing_rows: Optional[dict] = None,
 ) -> dict:
     """Run the general judge over (input, output) pairs and write outputs.
 
     Writes ``results.csv`` and ``metrics.json`` plus the resolved evaluator
     ``config.json`` under ``output_dir``. Returns the metrics_data dict.
 
-    Each row is appended to ``results.csv`` as its judge result arrives, so a
+    Each row is written to ``results.csv`` as its judge result arrives, so a
     run killed part-way still leaves the graded rows on disk. Nothing else owns
-    that file here — the general task has no inference step and no resume, so
-    the judge is free to write it from the first row onwards.
+    that file here — the general task has no inference step, so the judge is
+    free to write it from the first row onwards.
 
     Args:
         arguments_list: Optional per-row ``arguments`` dicts (one entry per
             row, ``None`` for rows with no injection) forwarded to the judge to
             render evaluator ``{{var}}`` placeholders.
+        existing_rows: Rows from a prior run's ``results.csv``, keyed by id.
+            A row already scored on every configured evaluator, whose ``input``
+            and ``output`` still match the dataset, is carried over instead of
+            being judged again.
     """
     write_evaluator_config(output_dir, evaluators)
 
     evaluators_by_name = {ev["name"]: ev for ev in evaluators}
+    existing_rows = existing_rows or {}
+    matched = [
+        _matching_stored_row(existing_rows.get(str(_id)), input_text, output_text)
+        for _id, input_text, output_text in zip(ids, inputs, outputs)
+    ]
+    known = [
+        evaluator_row_from_columns(evaluators_by_name, stored) for stored in matched
+    ]
     partial_writer = PartialResultsWriter(
         join(output_dir, "results.csv"),
-        evaluators_by_name,
         [
             {"id": _id, "input": input_text, "output": output_text}
             for _id, input_text, output_text in zip(ids, inputs, outputs)
         ],
+        existing_rows={
+            str(_id): stored
+            for _id, stored, row in zip(ids, matched, known)
+            if row is not None and stored is not None
+        },
     )
-    try:
-        llm_results = await get_general_judge_score(
-            inputs,
-            outputs,
-            evaluators=evaluators,
-            arguments_list=arguments_list,
-            on_row=partial_writer.write,
-        )
-    finally:
-        partial_writer.close()
+    llm_results = await get_general_judge_score(
+        inputs,
+        outputs,
+        evaluators=evaluators,
+        arguments_list=arguments_list,
+        on_row=lambda index, row: partial_writer.update(
+            index, evaluator_row_columns(evaluators_by_name, row)
+        ),
+        known=known,
+    )
     for name, score_dict in llm_results["scores"].items():
         _log(f"  {name}: {score_dict['mean']:.4f}")
 
@@ -195,10 +235,13 @@ async def run_general_eval(
     dataset_path: str,
     output_dir: str,
     evaluators: List[dict],
+    overwrite: bool = False,
 ) -> dict:
     """Run general task evaluators on a dataset of ``{id, input, output}`` rows.
 
-    Writes ``metrics.json`` and ``results.csv`` under ``output_dir``.
+    Writes ``metrics.json`` and ``results.csv`` under ``output_dir``. A row
+    already scored in ``results.csv`` on every configured evaluator is carried
+    over rather than judged again.
 
     Args:
         dataset_path: Path to a JSON file with a list of {"id", "input",
@@ -206,11 +249,18 @@ async def run_general_eval(
         output_dir: Directory to write results and metrics.
         evaluators: List of evaluator dicts (each with ``name`` and
             ``system_prompt``).
+        overwrite: Discard any prior results and judge every row again.
 
     Returns:
         dict with ``status`` and, on success, ``metrics`` and ``output_dir``.
     """
     os.makedirs(output_dir, exist_ok=True)
+
+    results_path = join(output_dir, "results.csv")
+    if overwrite:
+        for path in (results_path, join(output_dir, "metrics.json")):
+            if exists(path):
+                os.remove(path)
 
     log_save_path = join(output_dir, "logs")
     if exists(log_save_path):
@@ -232,6 +282,17 @@ async def run_general_eval(
         outputs = [str(r["output"]) if r["output"] is not None else "" for r in rows]
         arguments_list = [r.get("arguments") for r in rows]
 
+        # Asked before ``_score_and_write_results`` writes the new config.json
+        # over the prior run's. An evaluator that kept its name but changed
+        # from pass/fail to a rating, or changed its rating range, makes every
+        # stored score unusable: they would be averaged with scores that mean
+        # something else.
+        existing_rows = (
+            read_existing_rows(results_path)
+            if stored_scores_are_comparable(output_dir, evaluators)
+            else {}
+        )
+
         metrics_data = await _score_and_write_results(
             ids=ids,
             inputs=inputs,
@@ -239,6 +300,7 @@ async def run_general_eval(
             evaluators=evaluators,
             output_dir=output_dir,
             arguments_list=arguments_list,
+            existing_rows=existing_rows,
         )
 
         return {
@@ -275,6 +337,11 @@ async def main():
         default="./out",
         help="Path to the output directory to save the results",
     )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Discard any prior results in the output directory and re-judge every row",
+    )
 
     args = parser.parse_args()
 
@@ -307,6 +374,7 @@ async def main():
         dataset_path=args.dataset,
         output_dir=args.output_dir,
         evaluators=evaluators,
+        overwrite=args.overwrite,
     )
 
     print(f"\n\033[92m{'='*60}\033[0m")

--- a/calibrate_agent/general/metrics.py
+++ b/calibrate_agent/general/metrics.py
@@ -95,11 +95,17 @@ async def get_general_judge_score(
     fallback_model: str = DEFAULT_GENERAL_JUDGE_MODEL,
     arguments_list: Optional[List[Optional[dict]]] = None,
     on_row: Optional[Callable] = None,
+    known: Optional[List[Optional[dict]]] = None,
 ) -> dict:
     """Run the general judge across all rows and aggregate per-evaluator scores.
 
     ``on_row`` is called with ``(row_index, row_result)`` as each row's judge
     finishes, so a caller can persist results as they arrive.
+
+    ``known`` optionally supplies an already-judged result per row (``None``
+    where the row still needs judging), so a resumed run only pays for the rows
+    it is missing. It must be the same length as ``inputs``; aggregation covers
+    every row either way, so the means match a single run over all rows.
 
     ``inputs`` and ``outputs`` are positionally paired; ``inputs[i]`` may be
     ``None`` to judge ``outputs[i]`` on its own.
@@ -150,15 +156,28 @@ async def get_general_judge_score(
             f"(got {len(arguments_list)} arguments, {len(inputs)} inputs)."
         )
 
+    if known is not None and len(known) != len(inputs):
+        raise ValueError(
+            f"known must be the same length as inputs "
+            f"(got {len(known)} known, {len(inputs)} inputs)."
+        )
+
     evaluator_names = {ev["name"] for ev in evaluators}
 
     coroutines = []
+    pending_indices = []
     for i, (input_text, output) in enumerate(zip(inputs, outputs)):
         row_arguments = arguments_list[i] if arguments_list is not None else None
         if row_arguments:
+            # Checked for every row, judged or not, so a misspelled evaluator
+            # name is caught the same way whether or not the row is being
+            # judged this time.
             ensure_known_evaluator_names(
                 row_arguments, evaluator_names, context=f"Row {i} arguments"
             )
+        if known is not None and known[i] is not None:
+            continue
+        if row_arguments:
             row_evaluators = [
                 render_evaluator(ev, row_arguments.get(ev["name"]))
                 for ev in evaluators
@@ -173,11 +192,23 @@ async def get_general_judge_score(
                 fallback_model=fallback_model,
             )
         )
+        pending_indices.append(i)
 
-    results = await tqdm_asyncio.gather(
-        *with_row_callback(coroutines, on_row),
+    # ``with_row_callback`` numbers coroutines by their position in the list it
+    # is given, which is not the dataset row once judged rows are skipped.
+    row_callback = (
+        (lambda position, result: on_row(pending_indices[position], result))
+        if on_row
+        else None
+    )
+    judged = await tqdm_asyncio.gather(
+        *with_row_callback(coroutines, row_callback),
         desc="Running general evaluators",
     )
+
+    results = list(known) if known is not None else [None] * len(inputs)
+    for i, result in zip(pending_indices, judged):
+        results[i] = result
 
     scores: dict = {}
     for ev in evaluators:

--- a/calibrate_agent/judges.py
+++ b/calibrate_agent/judges.py
@@ -41,6 +41,7 @@ import asyncio
 import base64
 import csv
 import json
+import math
 import os
 import re
 from typing import Callable, Optional
@@ -228,53 +229,156 @@ def with_row_callback(coroutines: list, on_row: Optional[Callable]) -> list:
     return [_run(index, coroutine) for index, coroutine in enumerate(coroutines)]
 
 
+def read_existing_rows(path: str) -> dict:
+    """Read a prior ``results.csv`` into ``{id: row}``.
+
+    Values come back as text, which is what keeps an id like ``"1"`` from
+    turning into the number ``1`` and failing to match the dataset it came
+    from. A missing or unreadable file reads as no rows at all, so a run that
+    cannot resume simply starts over.
+    """
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, newline="", encoding="utf-8") as f:
+            records = list(csv.DictReader(f))
+    except (OSError, csv.Error, UnicodeDecodeError) as e:
+        provider_log(f"Could not read existing results at {path}: {e}")
+        return {}
+    return {str(record["id"]): record for record in records if record.get("id")}
+
+
+def stored_cell(row: Optional[dict], column: str):
+    """Return one stored value, or None when it is absent or blank.
+
+    A row written before a judge ran has an empty cell for that judge, which
+    counts as still needing to be judged rather than as a score of zero.
+    """
+    if not row:
+        return None
+    value = row.get(column)
+    if value is None:
+        return None
+    if isinstance(value, float) and math.isnan(value):
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    return value
+
+
+def stored_bool(value) -> Optional[bool]:
+    """Read back a stored pass/fail value, or None when it is not one."""
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in ("true", "1", "1.0"):
+        return True
+    if text in ("false", "0", "0.0"):
+        return False
+    return None
+
+
+def evaluator_row_from_columns(
+    evaluators_by_name: dict, row: Optional[dict]
+) -> Optional[dict]:
+    """Rebuild one row's judge result from its ``results.csv`` columns.
+
+    The inverse of :func:`evaluator_row_columns`. Returns None unless every
+    configured evaluator has a usable value in the row, so a row scored under a
+    different set of evaluators is judged again instead of being mixed with the
+    current set.
+    """
+    if not row:
+        return None
+    judge_row: dict = {}
+    for name, evaluator in evaluators_by_name.items():
+        value = stored_cell(row, name)
+        if value is None:
+            return None
+        reasoning = stored_cell(row, f"{name}_reasoning") or ""
+        if is_rating(evaluator):
+            try:
+                score = float(value)
+            except (TypeError, ValueError):
+                return None
+            # Keep whole numbers whole so a resumed run's file matches a
+            # single run's byte for byte.
+            judge_row[name] = {
+                "score": int(score) if score.is_integer() else score,
+                "reasoning": reasoning,
+            }
+        else:
+            match = stored_bool(value)
+            if match is None:
+                return None
+            judge_row[name] = {"match": match, "reasoning": reasoning}
+    return judge_row
+
+
 class PartialResultsWriter:
-    """Append each row to ``results.csv`` as its judge result arrives.
+    """Keep ``results.csv`` current as each judge result arrives.
 
-    A run that is killed part-way then leaves the rows already graded on disk
-    instead of an empty directory, and a reader watching the file sees results
-    accumulate. The full-table write at the end of a run replaces the file, so
-    this only ever holds a prefix of the final columns (no WER, latency, or
-    other post-judge columns).
+    Rows are held by dataset index and the whole file is rewritten whenever one
+    gains a value. That lets several judges fill different columns of the same
+    row, keeps rows in dataset order regardless of which judge finishes first,
+    and lets a resumed run carry forward the rows it started with instead of
+    emptying the file. A run that is killed part-way leaves the rows already
+    graded on disk instead of an empty directory.
 
-    ``base_rows`` supplies the non-evaluator columns per row index, in dataset
-    order. Rows are appended in completion order, which need not match dataset
-    order; the ``id`` column identifies each one.
+    ``base_rows`` supplies the non-judge columns per row index, in dataset
+    order. ``existing_rows`` maps an id to a row from a prior run; its judge
+    columns seed the matching row so they survive into the new file.
     """
 
     def __init__(
-        self, path: str, evaluators_by_name: dict, base_rows: list[dict]
+        self,
+        path: str,
+        base_rows: list[dict],
+        existing_rows: Optional[dict] = None,
     ):
         self._path = path
-        self._evaluators_by_name = evaluators_by_name
-        self._base_rows = base_rows
-        self._file = None
-        self._writer = None
+        self._rows: list[dict] = []
+        self._filled: set[int] = set()
+        self._columns: list[str] = []
+        existing_rows = existing_rows or {}
+        for index, base in enumerate(base_rows):
+            row = dict(base)
+            stored = existing_rows.get(str(base.get("id")))
+            if stored:
+                for column in stored:
+                    # The dataset owns its own columns; only judge results are
+                    # carried over.
+                    if column in base:
+                        continue
+                    if stored_cell(stored, column) is not None:
+                        row[column] = stored[column]
+                self._filled.add(index)
+            self._track(row)
+            self._rows.append(row)
 
-    def write(self, index: int, judge_row: dict) -> None:
-        """Append one judged row. Never raises: a failure here must not take
-        down the run whose results it is only mirroring."""
+    def _track(self, row: dict) -> None:
+        for column in row:
+            if column not in self._columns:
+                self._columns.append(column)
+
+    def update(self, index: int, columns: dict) -> None:
+        """Merge ``columns`` into one row and rewrite the file.
+
+        Never raises: a failure here must not take down the run whose results
+        it is only mirroring.
+        """
         try:
-            row = {
-                **self._base_rows[index],
-                **evaluator_row_columns(self._evaluators_by_name, judge_row),
-            }
-            if self._writer is None:
-                self._file = open(self._path, "w", newline="", encoding="utf-8")
-                self._writer = csv.DictWriter(self._file, fieldnames=list(row))
-                self._writer.writeheader()
-            self._writer.writerow(row)
-            self._file.flush()
+            self._rows[index].update(columns)
+            self._track(self._rows[index])
+            self._filled.add(index)
+            with open(self._path, "w", newline="", encoding="utf-8") as f:
+                writer = csv.DictWriter(f, fieldnames=self._columns, restval="")
+                writer.writeheader()
+                for row_index, row in enumerate(self._rows):
+                    if row_index in self._filled:
+                        writer.writerow(row)
         except Exception as e:
-            provider_log(f"Failed to append partial result row {index}: {e}")
-
-    def close(self) -> None:
-        if self._file is not None:
-            try:
-                self._file.close()
-            finally:
-                self._file = None
-                self._writer = None
+            provider_log(f"Failed to write partial result row {index}: {e}")
 
 
 def attach_evaluator_id(evaluator: dict, result: dict) -> dict:
@@ -299,6 +403,55 @@ def evaluator_config_payload(
         if ev.get("id") is not None and ev.get("name")
     }
     return payload
+
+
+def evaluator_scoring_shape(evaluators: list[dict]) -> dict:
+    """Map each evaluator name to what its stored score means.
+
+    Two evaluators sharing a name still produce values that cannot be averaged
+    together when one is a pass/fail and the other a 1-to-5 rating, or when the
+    rating range differs.
+    """
+    shape = {}
+    for ev in evaluators or []:
+        if not isinstance(ev, dict) or not ev.get("name"):
+            continue
+        if is_rating(ev):
+            shape[ev["name"]] = ("rating", ev.get("scale_min"), ev.get("scale_max"))
+        else:
+            shape[ev["name"]] = ("binary", None, None)
+    return shape
+
+
+def stored_scores_are_comparable(output_dir: str, evaluators: list[dict]) -> bool:
+    """Report whether a prior run's evaluator scores can be reused as they are.
+
+    Compares the evaluators recorded in the prior run's ``config.json`` with the
+    ones about to run. Scores are only reusable when each shared name still
+    scores the same way, so a rating that changed range or became a pass/fail is
+    judged again rather than averaged into a number that means nothing. A
+    missing or unreadable config leaves the stored scores unusable, because
+    nothing proves what they measured.
+
+    Call before :func:`write_evaluator_config` replaces the file.
+    """
+    path = os.path.join(output_dir, "config.json")
+    if not os.path.exists(path):
+        return False
+    try:
+        with open(path) as f:
+            stored = json.load(f)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return False
+    if not isinstance(stored, dict):
+        return False
+    stored_shape = evaluator_scoring_shape(stored.get("evaluators") or [])
+    current_shape = evaluator_scoring_shape(evaluators)
+    return all(
+        stored_shape.get(name) == expected
+        for name, expected in current_shape.items()
+        if name in stored_shape
+    )
 
 
 def write_evaluator_config(

--- a/calibrate_agent/llm/run_simulation.py
+++ b/calibrate_agent/llm/run_simulation.py
@@ -1,5 +1,6 @@
 import asyncio
 import argparse
+import hashlib
 import json
 import sys
 import uuid
@@ -911,7 +912,12 @@ async def main():
         "--dataset",
         type=str,
         default=None,
-        help="Path to dataset JSON for --eval-only (list of {conversation_history, name?})",
+        help="Path to dataset JSON for --eval-only (list of {id, conversation_history, name?})",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Judge every conversation again instead of reusing scores already in the output directory",
     )
 
     args = parser.parse_args()
@@ -956,6 +962,7 @@ async def main():
             dataset=dataset,
             output_dir=output_dir,
             parallel=args.parallel,
+            overwrite=args.overwrite,
         )
         if failed_count:
             print(f"\n\033[31m{failed_count} simulation(s) failed\033[0m")
@@ -1066,18 +1073,41 @@ def _aggregate_and_write_simulation_results(results: list, output_dir: str) -> l
 def validate_simulation_eval_only_dataset(dataset: object) -> tuple[bool, str]:
     """Validate the shape of a text-simulation eval-only dataset.
 
-    Each item must be ``{"conversation_history": list, "name"?: str}``.
-    Returns ``(is_valid, error_message)``.
+    Each item must be ``{"id": str|int, "conversation_history": list,
+    "name"?: str}``. ``id`` identifies a conversation across runs — a rerun
+    reuses the scores already stored for that id — so it has to be unique
+    within the dataset. Returns ``(is_valid, error_message)``.
     """
     if not isinstance(dataset, list):
         return (
             False,
-            "Dataset must be a JSON list of {conversation_history, name?} items",
+            "Dataset must be a JSON list of {id, conversation_history, name?} items",
         )
 
+    if not dataset:
+        return False, "Dataset is empty — provide at least one conversation"
+
+    seen_ids: set = set()
     for i, item in enumerate(dataset):
         if not isinstance(item, dict):
             return False, f"Item {i}: must be an object"
+        if "id" not in item:
+            return (
+                False,
+                f"Item {i}: missing required field 'id'. Add an 'id' to each "
+                f"conversation in the dataset: a string or number that is "
+                f"unique within the dataset.",
+            )
+        if not isinstance(item["id"], (str, int)) or isinstance(item["id"], bool):
+            return False, f"Item {i}: 'id' must be a string or a number"
+        item_id = str(item["id"])
+        if item_id in seen_ids:
+            return (
+                False,
+                f"Item {i}: duplicate id {item_id!r}. Each conversation needs "
+                f"an 'id' that no other conversation in the dataset uses.",
+            )
+        seen_ids.add(item_id)
         if "conversation_history" not in item:
             return False, f"Item {i}: missing required field 'conversation_history'"
         if not isinstance(item["conversation_history"], list):
@@ -1096,38 +1126,26 @@ async def run_eval_only_simulation_task(
     output_dir: str,
     fallback_judge_model: str = DEFAULT_SIMULATION_JUDGE_MODEL,
 ):
-    """Evaluate a single pre-existing transcript and write per-simulation files.
+    """Evaluate a single pre-existing transcript.
 
-    ``item`` schema: ``{"conversation_history": [...], "name": str?}``. Only
-    ``conversation_history`` is required — it's the sole input to the
+    ``item`` schema: ``{"id": str|int, "conversation_history": [...],
+    "name": str?}``. ``conversation_history`` is the sole input to the
     evaluators. ``name`` is optional metadata preserved into the aggregated
     outputs and ``dataset_map.json`` for traceability.
 
-    The per-simulation output subdirectory is derived from a stable internal
-    ``row_id`` (``row_<1-based-index>``), not from the user-provided ``name``,
-    so duplicate or empty names cannot collide on disk.
+    Returns ``(simulation_metrics, evaluation_results)``; the caller writes the
+    per-conversation output folder.
     """
     async with semaphore:
         transcript = item["conversation_history"]
         row_id = f"row_{item_index + 1}"
         display_name = item.get("name") or row_id
 
-        simulation_output_dir = join(output_dir, row_id)
-        if exists(simulation_output_dir):
-            shutil.rmtree(simulation_output_dir)
-        os.makedirs(simulation_output_dir)
-
         evaluation_results = await _judge_and_emit(
             transcript,
             evaluators,
             fallback_judge_model,
             emit=lambda line: print(f"[{display_name}] {line}"),
-        )
-
-        save_transcript(simulation_output_dir, transcript)
-
-        pd.DataFrame(evaluation_results).to_csv(
-            join(simulation_output_dir, "evaluation_results.csv"), index=False
         )
 
         simulation_metrics = {"row_id": row_id, "name": display_name}
@@ -1137,27 +1155,231 @@ async def run_eval_only_simulation_task(
         return simulation_metrics, evaluation_results
 
 
+EVAL_ONLY_ROW_FILE_NAME = "row.json"
+
+
+def _eval_only_row_dirs(output_dir: str) -> list[str]:
+    """Every per-conversation folder under ``output_dir``, path-sorted."""
+    if not exists(output_dir):
+        return []
+    return sorted(
+        join(output_dir, name)
+        for name in os.listdir(output_dir)
+        if name.startswith("row_") and os.path.isdir(join(output_dir, name))
+    )
+
+
+def _score_signature(rows) -> set:
+    """``(name, type, scale_min, scale_max)`` for each score row.
+
+    Two sets of scores are comparable only when this matches: a rubric that
+    keeps an evaluator's name but turns it from pass/fail into a 1-5 rating
+    produces different numbers that must not be averaged together.
+    """
+
+    def as_int(value):
+        return None if value is None else int(value)
+
+    return {
+        (
+            row["name"],
+            row.get("type", "binary"),
+            as_int(row.get("scale_min")),
+            as_int(row.get("scale_max")),
+        )
+        for row in rows
+    }
+
+
+def _evaluator_signature(evaluators: list[dict]) -> set:
+    """The score signature the configured evaluators produce."""
+    return _score_signature(
+        {
+            "name": ev["name"],
+            "type": "rating" if is_rating(ev) else "binary",
+            "scale_min": ev.get("scale_min") if is_rating(ev) else None,
+            "scale_max": ev.get("scale_max") if is_rating(ev) else None,
+        }
+        for ev in evaluators
+    )
+
+
+def _transcript_fingerprint(conversation_history: list) -> str:
+    """A fingerprint of a conversation's text, so an edited one is spotted."""
+    return hashlib.sha256(
+        json.dumps(conversation_history, sort_keys=True, ensure_ascii=False).encode()
+    ).hexdigest()
+
+
+def _load_eval_only_rows(output_dir: str, evaluator_signature: set) -> dict:
+    """Read already-judged conversations as ``{id: stored row}``.
+
+    A folder is kept only when its stored scores match the configured
+    evaluators by name, type and rating scale, so scores from a different
+    rubric are judged again instead of being mixed with the current ones.
+    """
+    stored_rows: dict = {}
+    for row_dir in _eval_only_row_dirs(output_dir):
+        try:
+            with open(join(row_dir, EVAL_ONLY_ROW_FILE_NAME)) as f:
+                stored = json.load(f)
+            row_id = str(stored["id"])
+            signature = _score_signature(stored["evaluation_results"])
+            has_fingerprint = isinstance(stored.get("fingerprint"), str)
+        except (OSError, ValueError, KeyError, TypeError):
+            continue
+        if has_fingerprint and signature == evaluator_signature:
+            stored_rows[row_id] = stored
+    return stored_rows
+
+
+def _write_eval_only_row(
+    row_dir: str,
+    item: dict,
+    evaluation_results: Optional[list[dict]] = None,
+    error: Optional[str] = None,
+) -> None:
+    """Write one conversation's folder: transcript, scores, and its id.
+
+    With ``error`` set the folder records the failure instead of scores, so a
+    conversation the judge could not score is visible on disk and is judged
+    again on the next run.
+    """
+    os.makedirs(row_dir, exist_ok=True)
+    save_transcript(row_dir, item["conversation_history"])
+    stored = {
+        "id": str(item["id"]),
+        "name": item.get("name"),
+        "fingerprint": _transcript_fingerprint(item["conversation_history"]),
+    }
+    if error is None:
+        pd.DataFrame(evaluation_results).to_csv(
+            join(row_dir, "evaluation_results.csv"), index=False
+        )
+        stored["evaluation_results"] = evaluation_results
+    else:
+        stored["error"] = error
+    with open(join(row_dir, EVAL_ONLY_ROW_FILE_NAME), "w") as f:
+        json.dump(stored, f, indent=4, ensure_ascii=False)
+
+
 async def run_eval_only_simulations(
     config: dict,
     dataset: list[dict],
     output_dir: str,
     parallel: Optional[int] = None,
+    overwrite: bool = False,
 ) -> int:
     """Run evaluators on a pre-existing dataset of simulation transcripts.
+
+    A conversation whose ``id`` already has scores under ``output_dir`` keeps
+    them and is not judged again, as long as its text and the configured
+    evaluators are unchanged; pass ``overwrite=True`` to clear the output
+    directory and judge every conversation. Every conversation's folder is
+    written from the merged scores, so folder positions always match the
+    dataset order.
 
     Returns the number of failed simulations.
     """
     evaluators = config.get("evaluators") or []
     require_simulation_evaluators(evaluators)
 
+    is_valid, error = validate_simulation_eval_only_dataset(dataset)
+    if not is_valid:
+        raise ValueError(error)
+
     os.makedirs(output_dir, exist_ok=True)
     write_evaluator_config(output_dir, evaluators)
 
+    if overwrite:
+        for row_dir in _eval_only_row_dirs(output_dir):
+            shutil.rmtree(row_dir)
+        for name in ("results.csv", "metrics.json"):
+            if exists(join(output_dir, name)):
+                os.remove(join(output_dir, name))
+
+    stored_rows = _load_eval_only_rows(output_dir, _evaluator_signature(evaluators))
+
+    def reusable(item: dict) -> Optional[list[dict]]:
+        """The stored scores for ``item``, if they were given to this same text."""
+        stored = stored_rows.get(str(item["id"]))
+        if stored is None or stored["fingerprint"] != _transcript_fingerprint(
+            item["conversation_history"]
+        ):
+            return None
+        return stored["evaluation_results"]
+
+    semaphore = asyncio.Semaphore(_resolve_simulation_parallel(parallel))
+    reused = {i: reusable(item) for i, item in enumerate(dataset)}
+    pending = [(i, item) for i, item in enumerate(dataset) if reused[i] is None]
+    judged = dict(
+        zip(
+            [i for i, _ in pending],
+            await asyncio.gather(
+                *[
+                    run_eval_only_simulation_task(
+                        semaphore=semaphore,
+                        item=item,
+                        item_index=i,
+                        evaluators=evaluators,
+                        output_dir=output_dir,
+                    )
+                    for i, item in pending
+                ],
+                return_exceptions=True,
+            ),
+        )
+    )
+
+    # Each folder is built beside its final name first and only then swapped in,
+    # so an interrupted run never leaves a conversation's scores nowhere on
+    # disk, and a reordered dataset cannot leave a folder holding another
+    # conversation's transcript.
+    results: list = []
+    staged: list[tuple[str, str]] = []
+    for i, item in enumerate(dataset):
+        staging_dir = join(output_dir, f"row_{i + 1}.new")
+        if exists(staging_dir):
+            shutil.rmtree(staging_dir)
+        outcome = judged.get(i)
+        if isinstance(outcome, BaseException):
+            _write_eval_only_row(staging_dir, item, error=str(outcome))
+            results.append(outcome)
+            staged.append((staging_dir, join(output_dir, f"row_{i + 1}")))
+            continue
+        if outcome is not None:
+            simulation_metrics, evaluation_results = outcome
+        else:
+            evaluation_results = reused[i]
+            simulation_metrics = {
+                "row_id": f"row_{i + 1}",
+                "name": item.get("name") or f"row_{i + 1}",
+            }
+            for metric_dict in evaluation_results:
+                simulation_metrics[metric_dict["name"]] = float(metric_dict["value"])
+        simulation_metrics["id"] = str(item["id"])
+        _write_eval_only_row(staging_dir, item, evaluation_results)
+        staged.append((staging_dir, join(output_dir, f"row_{i + 1}")))
+        results.append((simulation_metrics, evaluation_results))
+
+    for staging_dir, final_dir in staged:
+        if exists(final_dir):
+            shutil.rmtree(final_dir)
+        os.rename(staging_dir, final_dir)
+
+    kept = {basename(final_dir) for _, final_dir in staged}
+    for row_dir in _eval_only_row_dirs(output_dir):
+        if basename(row_dir) not in kept:
+            shutil.rmtree(row_dir)
+
     # Map internal row_id ↔ original dataset row, so the caller can correlate
-    # per-simulation subdirectories back to whatever name/index they passed in.
+    # per-simulation subdirectories back to whatever id/name they passed in.
+    # Written after the folders so it can never describe folders that a killed
+    # run had not written yet.
     dataset_map = {
         f"row_{i + 1}": {
             "index": i,
+            "id": str(item["id"]),
             "name": item.get("name"),
         }
         for i, item in enumerate(dataset)
@@ -1165,19 +1387,6 @@ async def run_eval_only_simulations(
     with open(join(output_dir, "dataset_map.json"), "w") as f:
         json.dump(dataset_map, f, indent=4)
 
-    semaphore = asyncio.Semaphore(_resolve_simulation_parallel(parallel))
-    tasks = [
-        run_eval_only_simulation_task(
-            semaphore=semaphore,
-            item=item,
-            item_index=i,
-            evaluators=evaluators,
-            output_dir=output_dir,
-        )
-        for i, item in enumerate(dataset)
-    ]
-
-    results = await asyncio.gather(*tasks, return_exceptions=True)
     failed = _aggregate_and_write_simulation_results(results, output_dir)
     return len(failed)
 

--- a/calibrate_agent/llm/run_tests.py
+++ b/calibrate_agent/llm/run_tests.py
@@ -2127,6 +2127,7 @@ async def run_eval_only_tests(
     dataset: list[dict],
     output_dir: str,
     test_parallel: Optional[int] = None,
+    overwrite: bool = False,
 ) -> dict:
     """Run evaluators on a pre-existing dataset of (test_case, output) pairs.
 
@@ -2134,8 +2135,13 @@ async def run_eval_only_tests(
     dataset item must have a ``test_case`` (with ``history`` and
     ``evaluation``) and an ``output`` (with ``response`` and ``tool_calls``).
 
-    Writes ``results.json`` and ``metrics.json`` to ``output_dir``.
+    Writes ``results.json`` and ``metrics.json`` to ``output_dir``. When
+    ``overwrite`` is False, test cases already completed in a prior
+    ``results.json`` are reused instead of being evaluated again.
     """
+    test_cases = [item["test_case"] for item in dataset]
+    require_unique_test_case_ids(test_cases)
+
     os.makedirs(output_dir, exist_ok=True)
 
     name_to_evaluator = _get_name_to_evaluator_dict(config)
@@ -2154,6 +2160,11 @@ async def run_eval_only_tests(
     _print_and_log("\n\033[94mEval-only\033[0m\n", print_log_save_path)
 
     results_file_path = join(output_dir, "results.json")
+
+    if overwrite:
+        for stale in (results_file_path, join(output_dir, "metrics.json")):
+            if exists(stale):
+                os.remove(stale)
 
     tools = config.get("tools", []) or []
 
@@ -2199,8 +2210,30 @@ async def run_eval_only_tests(
             result["test_case_id"] = test_case["id"]
         return result
 
+    initial_results = _load_resumable_results(
+        results_file_path, test_cases, overwrite
+    )
+    # The graded answer is supplied by the dataset, not produced by a model, so
+    # a stored verdict is only valid while the answer it was judged against is
+    # unchanged. Edit the answer under the same id and that case is re-judged.
+    initial_results = [
+        prior if prior is not None and prior.get("output") == item["output"] else None
+        for prior, item in zip(initial_results, dataset)
+    ]
+    resumed_count = sum(1 for r in initial_results if r is not None)
+    if resumed_count:
+        _print_and_log(
+            f"↻ Resuming: {resumed_count}/{len(dataset)} "
+            f"test case(s) already completed; re-running the rest",
+            print_log_save_path,
+        )
+
     results = await _run_items_parallel(
-        dataset, process, results_file_path, test_parallel
+        dataset,
+        process,
+        results_file_path,
+        test_parallel,
+        initial_results=initial_results,
     )
 
     passed, total = _write_test_results_outputs(results, output_dir, name_to_evaluator)
@@ -2272,6 +2305,11 @@ async def main():
         help="Number of test cases to evaluate in debug mode (default: 5)",
     )
     parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Force a clean run instead of resuming completed test cases from a prior results.json",
+    )
+    parser.add_argument(
         "--eval-only",
         action="store_true",
         help="Skip LLM inference and run evaluators on a dataset of (test_case, output) pairs",
@@ -2313,12 +2351,17 @@ async def main():
         print("")
 
         os.makedirs(args.output_dir, exist_ok=True)
-        result = await run_eval_only_tests(
-            config=config,
-            dataset=dataset,
-            output_dir=args.output_dir,
-            test_parallel=args.parallel,
-        )
+        try:
+            result = await run_eval_only_tests(
+                config=config,
+                dataset=dataset,
+                output_dir=args.output_dir,
+                test_parallel=args.parallel,
+                overwrite=args.overwrite,
+            )
+        except ValueError as e:
+            print(f"\033[31mDataset validation error: {e}\033[0m")
+            sys.exit(1)
         passed = result["passed"]
         total = result["total"]
         pct = (passed / total * 100) if total else 0.0
@@ -2352,6 +2395,7 @@ async def main():
         config=config,
         output_dir=args.output_dir,
         test_parallel=args.parallel,
+        overwrite=args.overwrite,
     )
 
     # Print summary

--- a/calibrate_agent/stt/benchmark.py
+++ b/calibrate_agent/stt/benchmark.py
@@ -316,6 +316,7 @@ async def main():
             judge_evaluators=judge_evaluators,
             language=args.language,
             run_llm_judges=not args.skip_llm_judges,
+            overwrite=args.overwrite,
         )
 
         print(f"\n\033[92m{'='*60}\033[0m")

--- a/calibrate_agent/stt/eval.py
+++ b/calibrate_agent/stt/eval.py
@@ -49,7 +49,10 @@ from calibrate_agent._cli_args import add_stt_eval_args
 from calibrate_agent.judges import (
     PartialResultsWriter,
     evaluator_row_columns,
+    evaluator_row_from_columns,
+    read_existing_rows,
     require_unique_evaluator_names,
+    stored_cell,
     write_evaluator_config,
 )
 from calibrate_agent.langfuse import (
@@ -1311,9 +1314,13 @@ async def run_single_provider_eval(
                 return {"provider": provider, "status": "error", "error": error_msg}
 
         # Delete existing results if overwrite is set
-        if overwrite and exists(results_csv_path):
-            os.remove(results_csv_path)
-            _log("Overwrite enabled - deleted existing results.csv")
+        if overwrite:
+            if exists(results_csv_path):
+                os.remove(results_csv_path)
+                _log("Overwrite enabled - deleted existing results.csv")
+            verdicts_path = join(provider_output_dir, LLM_WER_VERDICTS_FILE)
+            if exists(verdicts_path):
+                os.remove(verdicts_path)
 
         gt = pd.read_csv(gt_file)
 
@@ -1466,6 +1473,7 @@ def validate_stt_eval_only_dataset(dataset_path: str) -> tuple[bool, str, list[d
         return False, "Dataset must be a JSON list of objects", []
 
     required = {"id", "gt", "pred"}
+    seen_ids: set = set()
     for i, row in enumerate(data):
         if not isinstance(row, dict):
             return False, f"Row {i} is not an object", []
@@ -1476,8 +1484,166 @@ def validate_stt_eval_only_dataset(dataset_path: str) -> tuple[bool, str, list[d
                 f"Row {i} missing required fields: {sorted(missing)}. Each row needs 'id', 'gt', 'pred'.",
                 [],
             )
+        row_id = row["id"]
+        if not isinstance(row_id, (str, int, float)):
+            return (
+                False,
+                f"Row {i} has an unusable id: {row_id!r}. An id must be text or "
+                f"a number.",
+                [],
+            )
+        # Everything downstream keys on the id as text, so ids that differ only
+        # by type (1 and "1") would read back as the same row on resume.
+        row_id = str(row_id)
+        if row_id in seen_ids:
+            return (
+                False,
+                f"Duplicate row id: {row_id!r}. Ids must be unique so a resumed "
+                f"run can tell the rows apart.",
+                [],
+            )
+        seen_ids.add(row_id)
 
     return True, "", data
+
+
+LLM_WER_VERDICTS_FILE = "llm_wer_verdicts.json"
+
+
+def intent_entity_columns(row: dict) -> dict:
+    """Flatten one intent/entity result into its ``results.csv`` columns."""
+    return {
+        "sarvam_intent_score": int(row["intent_score"]),
+        "sarvam_intent_reasoning": row["intent_explanation"],
+        "sarvam_entity_score": float(row["entity_score"]),
+        "sarvam_entity_reasoning": row["entity_explanation"],
+    }
+
+
+def intent_entity_row_from_columns(row: dict | None) -> dict | None:
+    """Rebuild one intent/entity result from its ``results.csv`` columns.
+
+    The inverse of :func:`intent_entity_columns`. Returns None when the row
+    holds no usable scores, which marks it as still needing the judge.
+    """
+    intent = stored_cell(row, "sarvam_intent_score")
+    entity = stored_cell(row, "sarvam_entity_score")
+    if intent is None or entity is None:
+        return None
+    try:
+        intent_score = int(float(intent))
+        entity_score = float(entity)
+    except (TypeError, ValueError):
+        return None
+    return {
+        "intent_score": intent_score,
+        "intent_explanation": stored_cell(row, "sarvam_intent_reasoning") or "",
+        "entity_score": entity_score,
+        "entity_explanation": stored_cell(row, "sarvam_entity_reasoning") or "",
+    }
+
+
+def llm_wer_columns(row: dict) -> dict:
+    """Flatten one LLM-WER/CER result into its ``results.csv`` columns."""
+    return {
+        "sarvam_llm_wer": float(row["llm_wer"]),
+        "sarvam_llm_cer": float(row["llm_cer"]),
+        "sarvam_llm_wer_reasoning": json.dumps(row["segments"], ensure_ascii=False),
+    }
+
+
+def llm_wer_row_from_columns(row: dict | None) -> dict | None:
+    """Rebuild one LLM-WER/CER result from its ``results.csv`` columns.
+
+    The inverse of :func:`llm_wer_columns`. Returns None when the row holds no
+    usable scores or its stored segment list cannot be read back.
+    """
+    llm_wer = stored_cell(row, "sarvam_llm_wer")
+    llm_cer = stored_cell(row, "sarvam_llm_cer")
+    segments = stored_cell(row, "sarvam_llm_wer_reasoning")
+    if llm_wer is None or llm_cer is None or segments is None:
+        return None
+    try:
+        segments = json.loads(segments) if isinstance(segments, str) else segments
+        scores = {"llm_wer": float(llm_wer), "llm_cer": float(llm_cer)}
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(segments, list) or any(
+        not isinstance(seg, dict)
+        or not {"reference", "prediction", "equivalent"} <= seg.keys()
+        for seg in segments
+    ):
+        return None
+    return {**scores, "segments": segments}
+
+
+def semantic_wer_columns(row: dict) -> dict:
+    """Flatten one semantic-WER result into its ``results.csv`` columns."""
+    return {
+        "semantic_wer": float(row["semantic_wer"]),
+        "semantic_wer_metadata": json.dumps(
+            {
+                "substitutions": row["substitutions"],
+                "deletions": row["deletions"],
+                "insertions": row["insertions"],
+                "reference_words": row["reference_words"],
+                "normalized_reference": row["normalized_reference"],
+                "normalized_hypothesis": row["normalized_hypothesis"],
+            },
+            ensure_ascii=False,
+        ),
+        "semantic_wer_reasoning": row["reasoning"],
+    }
+
+
+def semantic_wer_row_from_columns(row: dict | None) -> dict | None:
+    """Rebuild one semantic-WER result from its ``results.csv`` columns.
+
+    The inverse of :func:`semantic_wer_columns`. Returns None when the row holds
+    no score or its stored counts cannot be read back.
+    """
+    score = stored_cell(row, "semantic_wer")
+    metadata = stored_cell(row, "semantic_wer_metadata")
+    if score is None or metadata is None:
+        return None
+    try:
+        metadata = json.loads(metadata) if isinstance(metadata, str) else metadata
+        result = {
+            "semantic_wer": float(score),
+            "substitutions": int(metadata["substitutions"]),
+            "deletions": int(metadata["deletions"]),
+            "insertions": int(metadata["insertions"]),
+            "reference_words": int(metadata["reference_words"]),
+            "normalized_reference": metadata["normalized_reference"],
+            "normalized_hypothesis": metadata["normalized_hypothesis"],
+            "reasoning": stored_cell(row, "semantic_wer_reasoning") or "",
+        }
+    except (TypeError, ValueError, KeyError, AttributeError):
+        return None
+    return result
+
+
+def read_llm_wer_verdicts(path: str) -> dict:
+    """Read saved equivalence verdicts into ``{(reference, prediction): verdict}``.
+
+    A missing or unreadable file reads as no verdicts, so a run that cannot
+    reuse them simply judges those segments again.
+    """
+    if not exists(path):
+        return {}
+    try:
+        with open(path, encoding="utf-8") as f:
+            saved = json.load(f)
+        return {
+            (entry["reference"], entry["prediction"]): {
+                "equivalent": bool(entry["equivalent"]),
+                "reasoning": entry.get("reasoning", ""),
+            }
+            for entry in saved
+        }
+    except Exception as e:
+        _log(f"Could not read saved LLM-WER verdicts at {path}: {e}")
+        return {}
 
 
 async def _score_and_write_results(
@@ -1493,6 +1659,7 @@ async def _score_and_write_results(
     audio_durations: list[float | None] | None = None,
     ttfs_values: list = None,
     stream_rows: bool = False,
+    existing_rows: dict | None = None,
 ) -> dict:
     """Run WER/CER (and optional LLM-judge evaluators) over (gt, pred) pairs.
 
@@ -1515,12 +1682,73 @@ async def _score_and_write_results(
     Only safe when nothing else owns that file: the full evaluation writes its
     transcriptions there as it goes and resumes from them, and overwriting it
     mid-judge would cost a re-transcription of every row not yet graded.
+
+    ``existing_rows`` maps an id to that row's results from an earlier run.
+    Every judge reuses the results already stored for a row and only pays for
+    the rows still missing. WER and CER are computed locally for every row.
     """
     wer_results = get_wer_score(gt_transcripts, pred_transcripts, language=language)
     _log(f"WER: {wer_results['score']}", to_terminal=False)
 
     cer_results = get_cer_score(gt_transcripts, pred_transcripts, language=language)
     _log(f"CER: {cer_results['score']}", to_terminal=False)
+
+    existing_rows = existing_rows or {}
+
+    def _stored_row(_id, gt_text, pred_text):
+        """Return a prior run's row only when the judges saw the same text.
+
+        A row whose ``gt`` or ``pred`` was edited since it was scored counts as
+        never judged, so its scores are recomputed instead of showing the old
+        verdict beside the new text.
+        """
+        stored = existing_rows.get(str(_id))
+        if stored is None:
+            return None
+        if str(stored.get("gt", "")) != str(gt_text):
+            return None
+        if str(stored.get("pred", "")) != str(pred_text):
+            return None
+        return stored
+
+    stored_by_row = [
+        _stored_row(_id, gt_text, pred_text)
+        for _id, gt_text, pred_text in zip(ids, gt_transcripts, pred_transcripts)
+    ]
+    reusable_rows = {
+        str(_id): stored
+        for _id, stored in zip(ids, stored_by_row)
+        if stored is not None
+    }
+
+    known_intent_entity = [intent_entity_row_from_columns(r) for r in stored_by_row]
+    known_llm_wer = [llm_wer_row_from_columns(r) for r in stored_by_row]
+    known_semantic_wer = [semantic_wer_row_from_columns(r) for r in stored_by_row]
+    known_evaluator_rows: list = [None] * len(ids)
+
+    base_rows = [
+        {"id": _id, "gt": gt_text, "pred": pred_text, "wer": wer, "cer": cer}
+        for _id, gt_text, pred_text, wer, cer in zip(
+            ids,
+            gt_transcripts,
+            pred_transcripts,
+            wer_results["per_row"],
+            cer_results["per_row"],
+        )
+    ]
+    partial_writer = (
+        PartialResultsWriter(
+            join(output_dir, "results.csv"), base_rows, reusable_rows
+        )
+        if stream_rows
+        else None
+    )
+
+    def _row_writer(to_columns):
+        """Build an ``on_row`` callback that stores one judge's columns."""
+        if partial_writer is None:
+            return None
+        return lambda index, row: partial_writer.update(index, to_columns(row))
 
     # Each judge below runs independently and is isolated: a failure in one
     # (Sarvam intent/entity, Sarvam LLM-WER/CER, or the LLM judge) is logged and
@@ -1535,7 +1763,11 @@ async def _score_and_write_results(
     if run_llm_judges:
         try:
             intent_entity_results = await get_intent_entity_score(
-                gt_transcripts, pred_transcripts, language=language
+                gt_transcripts,
+                pred_transcripts,
+                language=language,
+                known=known_intent_entity,
+                on_row=_row_writer(intent_entity_columns),
             )
             _log(
                 f"Sarvam Intent Score: {intent_entity_results['intent']:.4f}  Sarvam Entity Score: {intent_entity_results['entity']:.4f}",
@@ -1545,8 +1777,36 @@ async def _score_and_write_results(
             intent_entity_results = None
             _log(f"Sarvam intent/entity judge failed, skipping: {e}")
         try:
+            verdicts_path = join(output_dir, LLM_WER_VERDICTS_FILE)
+            saved_verdicts = read_llm_wer_verdicts(verdicts_path)
+
+            def _save_verdict(reference, prediction, verdict):
+                saved_verdicts[(reference, prediction)] = verdict
+                try:
+                    with open(verdicts_path, "w", encoding="utf-8") as f:
+                        json.dump(
+                            [
+                                {
+                                    "reference": ref,
+                                    "prediction": pred,
+                                    "equivalent": saved["equivalent"],
+                                    "reasoning": saved["reasoning"],
+                                }
+                                for (ref, pred), saved in saved_verdicts.items()
+                            ],
+                            f,
+                            ensure_ascii=False,
+                        )
+                except OSError as e:
+                    _log(f"Could not save LLM-WER verdict: {e}")
+
             llm_wer_results = await get_llm_wer_cer_score(
-                gt_transcripts, pred_transcripts, language=language
+                gt_transcripts,
+                pred_transcripts,
+                language=language,
+                known=known_llm_wer,
+                verdicts=saved_verdicts,
+                on_verdict=_save_verdict,
             )
             _log(
                 f"Sarvam LLM WER: {llm_wer_results['llm_wer']:.4f}  Sarvam LLM CER: {llm_wer_results['llm_cer']:.4f}",
@@ -1561,7 +1821,10 @@ async def _score_and_write_results(
     if run_llm_judges:
         try:
             semantic_wer_results = await get_semantic_wer_score(
-                gt_transcripts, pred_transcripts
+                gt_transcripts,
+                pred_transcripts,
+                known=known_semantic_wer,
+                on_row=_row_writer(semantic_wer_columns),
             )
             _log(
                 f"Semantic WER: {semantic_wer_results['semantic_wer']:.4f}",
@@ -1581,38 +1844,32 @@ async def _score_and_write_results(
         require_unique_evaluator_names(_evaluators)
         write_evaluator_config(evaluator_config_dir, _evaluators)
         evaluators_by_name = {ev["name"]: ev for ev in _evaluators}
-        partial_writer = (
-            PartialResultsWriter(
-                join(output_dir, "results.csv"),
-                evaluators_by_name,
-                [
-                    {"id": _id, "gt": gt_text, "pred": pred_text}
-                    for _id, gt_text, pred_text in zip(
-                        ids, gt_transcripts, pred_transcripts
-                    )
-                ],
-            )
-            if stream_rows
-            else None
-        )
+        known_evaluator_rows = [
+            evaluator_row_from_columns(evaluators_by_name, r) for r in stored_by_row
+        ]
         try:
             llm_results = await get_llm_judge_score(
                 gt_transcripts,
                 pred_transcripts,
                 evaluators=_evaluators,
-                on_row=partial_writer.write if partial_writer else None,
+                known=known_evaluator_rows,
+                on_row=_row_writer(
+                    lambda row: evaluator_row_columns(evaluators_by_name, row)
+                ),
             )
             for name, score_dict in llm_results["scores"].items():
                 _log(f"  {name}: {score_dict['mean']:.4f}")
         except Exception as e:
             llm_results = None
             _log(f"LLM judge failed, skipping evaluator columns: {e}")
-        finally:
-            if partial_writer:
-                partial_writer.close()
 
-    # Only surface evaluator columns for judges that actually produced results.
-    _evaluators_by_name = evaluators_by_name if llm_results is not None else {}
+    # Surface evaluator columns when the judge produced results, and also when
+    # an earlier run's results are being carried forward.
+    _evaluators_by_name = (
+        evaluators_by_name
+        if llm_results is not None or any(r is not None for r in known_evaluator_rows)
+        else {}
+    )
 
     metrics_data = {
         "wer": wer_results["score"],
@@ -1645,23 +1902,24 @@ async def _score_and_write_results(
         if ttfs_stats is not None:
             metrics_data["ttfs"] = ttfs_stats
 
+    # A judge that failed or was skipped falls back to what an earlier run
+    # already stored, so results.csv keeps the scores already paid for. Rows
+    # that judge never scored stay blank.
     ie_per_row = (
         intent_entity_results["per_row"]
         if intent_entity_results is not None
-        else [None] * len(ids)
+        else known_intent_entity
     )
     llm_wer_per_row = (
-        llm_wer_results["per_row"]
-        if llm_wer_results is not None
-        else [None] * len(ids)
+        llm_wer_results["per_row"] if llm_wer_results is not None else known_llm_wer
     )
     llm_per_row = (
-        llm_results["per_row"] if llm_results is not None else [None] * len(ids)
+        llm_results["per_row"] if llm_results is not None else known_evaluator_rows
     )
     semantic_wer_per_row = (
         semantic_wer_results["per_row"]
         if semantic_wer_results is not None
-        else [None] * len(ids)
+        else known_semantic_wer
     )
 
     audio_durations = list(audio_durations or [])
@@ -1708,31 +1966,13 @@ async def _score_and_write_results(
         if has_ttfs:
             row["ttfs"] = ttfs_row
         if ie_row is not None:
-            row["sarvam_intent_score"] = int(ie_row["intent_score"])
-            row["sarvam_intent_reasoning"] = ie_row["intent_explanation"]
-            row["sarvam_entity_score"] = float(ie_row["entity_score"])
-            row["sarvam_entity_reasoning"] = ie_row["entity_explanation"]
+            row.update(intent_entity_columns(ie_row))
         if llm_wer_row is not None:
-            row["sarvam_llm_wer"] = float(llm_wer_row["llm_wer"])
-            row["sarvam_llm_cer"] = float(llm_wer_row["llm_cer"])
-            row["sarvam_llm_wer_reasoning"] = json.dumps(
-                llm_wer_row["segments"], ensure_ascii=False
-            )
+            row.update(llm_wer_columns(llm_wer_row))
         if semantic_wer_row is not None:
-            row["semantic_wer"] = float(semantic_wer_row["semantic_wer"])
-            row["semantic_wer_metadata"] = json.dumps(
-                {
-                    "substitutions": semantic_wer_row["substitutions"],
-                    "deletions": semantic_wer_row["deletions"],
-                    "insertions": semantic_wer_row["insertions"],
-                    "reference_words": semantic_wer_row["reference_words"],
-                    "normalized_reference": semantic_wer_row["normalized_reference"],
-                    "normalized_hypothesis": semantic_wer_row["normalized_hypothesis"],
-                },
-                ensure_ascii=False,
-            )
-            row["semantic_wer_reasoning"] = semantic_wer_row["reasoning"]
-        row.update(evaluator_row_columns(_evaluators_by_name, llm_row))
+            row.update(semantic_wer_columns(semantic_wer_row))
+        if llm_row is not None:
+            row.update(evaluator_row_columns(_evaluators_by_name, llm_row))
         data.append(row)
 
     with open(join(output_dir, "metrics.json"), "w") as f:
@@ -1749,11 +1989,17 @@ async def run_eval_only(
     judge_evaluators: list[dict] = None,
     language: str = "english",
     run_llm_judges: bool = True,
+    overwrite: bool = False,
 ) -> dict:
     """Run evaluators only on a pre-existing dataset of (gt, pred) pairs.
 
     Skips STT inference. Writes ``metrics.json`` and ``results.csv`` directly
     under ``output_dir``.
+
+    A run picks up where an earlier one stopped: every row already scored in
+    ``results.csv`` keeps its scores and only the rows still missing are sent to
+    the judges. ``overwrite`` clears those results first and scores every row
+    again.
 
     Args:
         dataset_path: Path to a JSON file with a list of {"id", "gt", "pred"} rows.
@@ -1765,11 +2011,23 @@ async def run_eval_only(
         run_llm_judges: Run the Sarvam intent/entity judge (default True).
             Setting it to False skips the normalizer model load and the judge
             calls entirely.
+        overwrite: Discard any results from an earlier run and score every row
+            again.
 
     Returns:
         dict with status, metrics, and output_dir.
     """
     os.makedirs(output_dir, exist_ok=True)
+
+    results_path = join(output_dir, "results.csv")
+    if overwrite:
+        for path in (
+            results_path,
+            join(output_dir, "metrics.json"),
+            join(output_dir, LLM_WER_VERDICTS_FILE),
+        ):
+            if exists(path):
+                os.remove(path)
 
     log_save_path = join(output_dir, "logs")
     if exists(log_save_path):
@@ -1800,6 +2058,7 @@ async def run_eval_only(
             language=language,
             run_llm_judges=run_llm_judges,
             stream_rows=True,
+            existing_rows=read_existing_rows(results_path),
         )
 
         return {

--- a/calibrate_agent/stt/metrics.py
+++ b/calibrate_agent/stt/metrics.py
@@ -183,6 +183,26 @@ def _resolve_evaluators(evaluators: Optional[List[dict]]) -> List[dict]:
     return list(evaluators) if evaluators else [DEFAULT_STT_EVALUATOR]
 
 
+def _pending_indices(known: Optional[List], total: int) -> tuple[List[Optional[dict]], List[int]]:
+    """Split rows into what is already known and what still needs judging.
+
+    ``known`` holds one already-computed per-row result per row, or None where
+    the row has not been judged. Returns that list (padded to ``total``) plus
+    the indices still to judge, so a resumed run only pays for the rows it is
+    missing.
+    """
+    rows: List[Optional[dict]] = list(known) if known is not None else []
+    rows = (rows + [None] * total)[:total]
+    return rows, [i for i, row in enumerate(rows) if row is None]
+
+
+def _on_original_index(on_row: Optional[Callable], indices: List[int]) -> Optional[Callable]:
+    """Report a judged row under its dataset index rather than its judge order."""
+    if on_row is None:
+        return None
+    return lambda position, result: on_row(indices[position], result)
+
+
 def _edit_metric(
     metric_fn,
     transform,
@@ -255,12 +275,44 @@ def _score_edit_metric(
     return {"score": float(score), "per_row": per_row}
 
 
+def _semantic_wer_row(res: dict) -> dict:
+    """Turn one semantic-WER judge response into its per-row result."""
+    s = int(res.get("substitutions", 0))
+    d = int(res.get("deletions", 0))
+    i = int(res.get("insertions", 0))
+    # The judge always sets reference_words; default to 1 (not 0) only to
+    # stay consistent with its own default and pipecat's call site.
+    ref_words = int(res.get("reference_words", 1))
+    errors = s + d + i
+    if ref_words == 0:
+        row_wer = 0.0 if errors == 0 else float("inf")
+    else:
+        row_wer = errors / ref_words
+    return {
+        "semantic_wer": float(row_wer),
+        "substitutions": s,
+        "deletions": d,
+        "insertions": i,
+        "reference_words": ref_words,
+        "normalized_reference": res.get("normalized_reference", ""),
+        "normalized_hypothesis": res.get("normalized_hypothesis", ""),
+        "reasoning": res.get("reasoning", ""),
+    }
+
+
 async def get_semantic_wer_score(
     references: List[str],
     predictions: List[str],
     model: Optional[str] = None,
+    on_row: Optional[Callable] = None,
+    known: Optional[List] = None,
 ) -> dict:
     """Compute pipecat-style semantic WER over (reference, prediction) pairs.
+
+    ``on_row`` is called with ``(row_index, row_result)`` as each row finishes.
+    ``known`` carries one already-judged per-row dict per row (None where the
+    row still needs judging); those rows are pooled from their stored counts
+    without a judge call.
 
     One judge call per row via pipecat's reason-then-tool loop (see
     ``stt/semantic_wer``): the model normalizes, aligns, applies the semantic
@@ -304,47 +356,35 @@ async def get_semantic_wer_score(
     if model is None:
         model = DEFAULT_SEMANTIC_WER_MODEL
 
-    coroutines = [
-        _semantic_wer.semantic_wer_judge(str(reference), str(prediction), model=model)
-        for reference, prediction in zip(references, predictions)
-    ]
-    results = await tqdm_asyncio.gather(
-        *coroutines,
+    per_row, pending = _pending_indices(known, len(references))
+
+    async def _judge_row(index: int) -> dict:
+        res = await _semantic_wer.semantic_wer_judge(
+            str(references[index]), str(predictions[index]), model=model
+        )
+        return _semantic_wer_row(res)
+
+    judged = await tqdm_asyncio.gather(
+        *with_row_callback(
+            [_judge_row(i) for i in pending], _on_original_index(on_row, pending)
+        ),
         desc="Running semantic WER judge",
     )
+    for i, row in zip(pending, judged):
+        per_row[i] = row
 
     total_errors = 0
     total_ref_words = 0
-    per_row: List[dict] = []
-    for res in results:
-        s = int(res.get("substitutions", 0))
-        d = int(res.get("deletions", 0))
-        i = int(res.get("insertions", 0))
-        # The judge always sets reference_words; default to 1 (not 0) only to
-        # stay consistent with its own default and pipecat's call site.
-        ref_words = int(res.get("reference_words", 1))
-        errors = s + d + i
-        if ref_words == 0:
-            row_wer = 0.0 if errors == 0 else float("inf")
-        else:
-            row_wer = errors / ref_words
-        per_row.append(
-            {
-                "semantic_wer": float(row_wer),
-                "substitutions": s,
-                "deletions": d,
-                "insertions": i,
-                "reference_words": ref_words,
-                "normalized_reference": res.get("normalized_reference", ""),
-                "normalized_hypothesis": res.get("normalized_hypothesis", ""),
-                "reasoning": res.get("reasoning", ""),
-            }
+    for row in per_row:
+        errors = (
+            int(row["substitutions"]) + int(row["deletions"]) + int(row["insertions"])
         )
         # Pool only finite-WER rows, matching pipecat's compute_pooled_wer
         # (``valid = [m for m in metrics if m.wer < inf]``). A ``ref_words==0``
         # row with errors is ``inf`` and is excluded entirely — otherwise its
         # errors would inflate the numerator with nothing in the denominator.
-        if row_wer != float("inf"):
+        if float(row["semantic_wer"]) != float("inf"):
+            ref_words = int(row["reference_words"])
             total_errors += errors
             total_ref_words += ref_words
 
@@ -443,11 +483,15 @@ async def get_llm_judge_score(
     evaluators: Optional[List[dict]] = None,
     fallback_model: str = DEFAULT_STT_JUDGE_MODEL,
     on_row: Optional[Callable] = None,
+    known: Optional[List] = None,
 ) -> dict:
     """Run STT judge across all rows and aggregate per-evaluator scores.
 
     ``on_row`` is called with ``(row_index, row_result)`` as each row's judge
     finishes, so callers can persist results while the run is still going.
+
+    ``known`` carries one already-judged result per row (None where the row
+    still needs judging); those rows are aggregated without a judge call.
 
     Returns:
         {
@@ -468,20 +512,24 @@ async def get_llm_judge_score(
     """
     evaluators = _resolve_evaluators(evaluators)
 
+    results, pending = _pending_indices(known, len(references))
+
     coroutines = [
         stt_llm_judge(
-            str(reference),
-            str(prediction),
+            str(references[i]),
+            str(predictions[i]),
             evaluators=evaluators,
             fallback_model=fallback_model,
         )
-        for reference, prediction in zip(references, predictions)
+        for i in pending
     ]
 
-    results = await tqdm_asyncio.gather(
-        *with_row_callback(coroutines, on_row),
+    judged = await tqdm_asyncio.gather(
+        *with_row_callback(coroutines, _on_original_index(on_row, pending)),
         desc="Running STT evaluators",
     )
+    for i, row in zip(pending, judged):
+        results[i] = row
 
     # Aggregate per-evaluator scores — mean of 0/1 for binary, mean of scores for rating.
     scores: dict = {}
@@ -516,8 +564,14 @@ async def get_intent_entity_score(
     predictions: List[str],
     language: str = "english",
     model: Optional[str] = None,
+    on_row: Optional[Callable] = None,
+    known: Optional[List] = None,
 ) -> dict:
     """Normalize, judge, and aggregate intent/entity preservation.
+
+    ``on_row`` is called with ``(row_index, row_result)`` as each row finishes.
+    ``known`` carries one already-judged result per row (None where the row
+    still needs judging); those rows skip both normalization and the judge call.
 
     Mirrors Sarvam's flow: reference and prediction are first run through the
     vendored ``IndicNormalizer``, then each normalized pair is scored by the
@@ -551,23 +605,35 @@ async def get_intent_entity_score(
     if model is None:
         model = DEFAULT_INTENT_ENTITY_MODEL
 
-    norm_references, norm_predictions = await asyncio.to_thread(
-        _normalize_pairs, references, predictions, language
-    )
+    results, pending = _pending_indices(known, len(references))
+
+    # The vendored normalizer is expensive, so only the rows that still need
+    # judging are put through it.
+    if pending:
+        norm_references, norm_predictions = await asyncio.to_thread(
+            _normalize_pairs,
+            [references[i] for i in pending],
+            [predictions[i] for i in pending],
+            language,
+        )
+    else:
+        norm_references, norm_predictions = [], []
 
     coroutines = [
         sarvam_intent_entity.intent_entity_judge(
-            str(reference), str(prediction), model=model, index=i
+            str(reference), str(prediction), model=model, index=index
         )
-        for i, (reference, prediction) in enumerate(
-            zip(norm_references, norm_predictions)
+        for index, reference, prediction in zip(
+            pending, norm_references, norm_predictions
         )
     ]
 
-    results = await tqdm_asyncio.gather(
-        *coroutines,
+    judged = await tqdm_asyncio.gather(
+        *with_row_callback(coroutines, _on_original_index(on_row, pending)),
         desc="Running intent/entity judge",
     )
+    for i, row in zip(pending, judged):
+        results[i] = row
 
     intent_scores = [int(row["intent_score"]) for row in results]
     entity_scores = [float(row["entity_score"]) for row in results]
@@ -584,8 +650,19 @@ async def get_llm_wer_cer_score(
     predictions: List[str],
     language: str = "english",
     model: Optional[str] = None,
+    known: Optional[List] = None,
+    verdicts: Optional[dict] = None,
+    on_verdict: Optional[Callable] = None,
 ) -> dict:
     """Normalize, judge segment equivalence, forgive, and re-score WER/CER.
+
+    ``known`` carries one already-computed per-row dict per row (None where the
+    row has not been judged); its ``segments`` supply the verdicts that row
+    already paid for, so only the segment pairs with no verdict yet are sent to
+    the judge. ``verdicts`` seeds further ``(reference, prediction) -> verdict``
+    pairs from an earlier run. ``on_verdict(reference, prediction, verdict)``
+    fires as each new verdict arrives. Word alignment and the final WER/CER
+    scoring always run over every row, so the numbers match a single run.
 
     Reference and prediction are first normalized with the same Vistaar path as
     ``get_wer_score``/``get_cer_score`` (NFC + lightweight indic-nlp for Indic
@@ -663,23 +740,38 @@ async def get_llm_wer_cer_score(
             ):
                 unique_pairs.setdefault((seg["reference"], seg["prediction"]), None)
 
-    pair_list = list(unique_pairs.keys())
-    coroutines = [
-        sarvam_llm_wer.equivalence_judge(ref, pred, model=model)
-        for ref, pred in pair_list
-    ]
-    judge_results = await tqdm_asyncio.gather(
-        *coroutines,
-        desc="Running LLM-WER equivalence judge",
-    )
+    # Verdicts already paid for: those handed in from an earlier run, plus the
+    # segments stored on the rows that were judged then.
+    seeded: dict = dict(verdicts or {})
+    for row in known or []:
+        for seg in (row or {}).get("segments", []):
+            seeded.setdefault(
+                (seg["reference"], seg["prediction"]),
+                {
+                    "equivalent": bool(seg["equivalent"]),
+                    "reasoning": seg.get("reasoning", ""),
+                },
+            )
 
-    verdicts = {
-        pair: {
+    pair_list = [pair for pair in unique_pairs if pair not in seeded]
+
+    async def _judge_pair(ref: str, pred: str) -> dict:
+        res = await sarvam_llm_wer.equivalence_judge(ref, pred, model=model)
+        verdict = {
             "equivalent": bool(res["equivalent"]),
             "reasoning": res["reasoning"],
         }
-        for pair, res in zip(pair_list, judge_results)
-    }
+        if on_verdict is not None:
+            on_verdict(ref, pred, verdict)
+        return verdict
+
+    judge_results = await tqdm_asyncio.gather(
+        *[_judge_pair(ref, pred) for ref, pred in pair_list],
+        desc="Running LLM-WER equivalence judge",
+    )
+
+    verdicts = dict(seeded)
+    verdicts.update(zip(pair_list, judge_results))
 
     # Reconstruct corrected reference/prediction per row: forgive equivalent
     # segments by rewriting the prediction side to the reference.

--- a/calibrate_agent/tts/benchmark.py
+++ b/calibrate_agent/tts/benchmark.py
@@ -250,6 +250,7 @@ async def main():
             dataset_path=args.dataset,
             output_dir=args.output_dir,
             judge_evaluators=judge_evaluators,
+            overwrite=args.overwrite,
         )
 
         print(f"\n\033[92m{'='*60}\033[0m")

--- a/calibrate_agent/tts/eval.py
+++ b/calibrate_agent/tts/eval.py
@@ -42,7 +42,10 @@ from calibrate_agent.judges import (
     DEFAULT_TTS_EVALUATOR,
     PartialResultsWriter,
     evaluator_row_columns,
+    evaluator_row_from_columns,
+    read_existing_rows,
     require_unique_evaluator_names,
+    stored_scores_are_comparable,
     write_evaluator_config,
 )
 from calibrate_agent.langfuse import (
@@ -859,6 +862,23 @@ TTS_LANGUAGES = [
 ]
 
 
+def _matching_stored_row(stored: dict, text: str, audio_path: str) -> dict:
+    """Return the stored row only when the judge would hear and read the same
+    thing again.
+
+    The stored score describes the ``text`` and the audio file the row carried
+    when it was judged. If either has changed, that score no longer describes
+    this row, so it counts as unjudged.
+    """
+    if not stored:
+        return None
+    if str(stored.get("text", "")) != str(text):
+        return None
+    if str(stored.get("audio_path", "")) != str(audio_path):
+        return None
+    return stored
+
+
 async def _score_and_write_results(
     ids: list,
     texts: list[str],
@@ -869,6 +889,7 @@ async def _score_and_write_results(
     ttfb_values: list = None,
     cost_metrics: dict = None,
     stream_rows: bool = False,
+    existing_rows: dict = None,
 ) -> dict:
     """Run the TTS audio judge over (audio_path, text) pairs and write outputs.
 
@@ -888,6 +909,12 @@ async def _score_and_write_results(
     carries no ``ttfb``, so replacing that file mid-judge leaves it missing a
     column ``validate_existing_results_csv`` requires — the next run stops with
     an error until ``--overwrite``, which re-synthesizes every row.
+
+    ``existing_rows`` maps an id to its row from a prior run's ``results.csv``.
+    A row whose every configured evaluator already has a value, and whose
+    ``text`` and ``audio_path`` still match the dataset, is carried over
+    instead of being judged again. Rows in ``existing_rows`` that are not in
+    ``ids``, and rows that have to be judged again, are left out of the output.
     """
     _log("Running evaluators...")
     _evaluators = judge_evaluators if judge_evaluators else [DEFAULT_TTS_EVALUATOR]
@@ -895,28 +922,46 @@ async def _score_and_write_results(
     write_evaluator_config(evaluator_config_dir, _evaluators)
     # Map evaluator name → evaluator dict (for per-row value extraction).
     _evaluators_by_name = {ev["name"]: ev for ev in _evaluators}
+    existing_rows = existing_rows or {}
+    matched = [
+        _matching_stored_row(existing_rows.get(str(_id)), text, audio_path)
+        for _id, text, audio_path in zip(ids, texts, audio_paths)
+    ]
+    known = [
+        evaluator_row_from_columns(_evaluators_by_name, stored) for stored in matched
+    ]
     partial_writer = (
         PartialResultsWriter(
             join(output_dir, "results.csv"),
-            _evaluators_by_name,
             [
                 {"id": _id, "text": text, "audio_path": audio_path}
                 for _id, text, audio_path in zip(ids, texts, audio_paths)
             ],
+            # Only rows this run carries over as they are. A row that has to be
+            # judged again would otherwise show its old scores in results.csv
+            # before any judging has happened.
+            {
+                str(_id): stored
+                for _id, stored, row in zip(ids, matched, known)
+                if row is not None and stored is not None
+            },
         )
         if stream_rows
         else None
     )
-    try:
-        llm_judge_results = await get_tts_llm_judge_score(
-            audio_paths,
-            texts,
-            evaluators=_evaluators,
-            on_row=partial_writer.write if partial_writer else None,
+
+    def _on_row(index: int, judge_row: dict) -> None:
+        partial_writer.update(
+            index, evaluator_row_columns(_evaluators_by_name, judge_row)
         )
-    finally:
-        if partial_writer:
-            partial_writer.close()
+
+    llm_judge_results = await get_tts_llm_judge_score(
+        audio_paths,
+        texts,
+        evaluators=_evaluators,
+        on_row=_on_row if partial_writer else None,
+        known=known,
+    )
     for name, score_dict in llm_judge_results["scores"].items():
         _log(f"  {name}: {score_dict['mean']:.4f}")
 
@@ -1091,7 +1136,8 @@ def validate_tts_eval_only_dataset(run_dir: str) -> tuple[bool, str, list[dict]]
     ignored. Each ``audio_path`` is resolved to an existing absolute path,
     tried as given (relative to the CWD) and, as a fallback, under
     ``{run_dir}/audios/{basename}`` (the fixed run layout) so it resolves
-    regardless of the CWD.
+    regardless of the CWD. Ids must be unique — a resumed run matches its
+    stored results by id.
 
     Returns:
         tuple[bool, str, list[dict]]: (is_valid, error_message, parsed_rows)
@@ -1123,7 +1169,17 @@ def validate_tts_eval_only_dataset(run_dir: str) -> tuple[bool, str, list[dict]]
         return False, f"results.csv is empty: {csv_path}", []
 
     rows = []
+    seen_ids: set = set()
     for i, r in df[["id", "text", "audio_path"]].iterrows():
+        row_id = str(r["id"])
+        if row_id in seen_ids:
+            return (
+                False,
+                f"Duplicate row id: {row_id!r}. Ids must be unique so a "
+                f"resumed run can tell the rows apart.",
+                [],
+            )
+        seen_ids.add(row_id)
         audio_path = str(r["audio_path"])
         candidates = [audio_path]
         if not os.path.isabs(audio_path):
@@ -1142,6 +1198,7 @@ async def run_eval_only(
     dataset_path: str,
     output_dir: str,
     judge_evaluators: list[dict] = None,
+    overwrite: bool = False,
 ) -> dict:
     """Run the TTS audio judge only, on a prior run's audio. Skips synthesis
     and reads the run directory's ``results.csv`` directly. Writes
@@ -1154,6 +1211,9 @@ async def run_eval_only(
         output_dir: Directory to write results and metrics.
         judge_evaluators: Optional list of evaluator dicts. Defaults to the
             built-in TTS evaluator (``DEFAULT_TTS_EVALUATOR``) when omitted.
+        overwrite: Delete ``output_dir``'s ``results.csv`` and ``metrics.json``
+            first, so every row is judged again. Without it, rows already
+            scored by every configured evaluator are carried over.
 
     Returns:
         dict with status, metrics, and output_dir.
@@ -1170,6 +1230,12 @@ async def run_eval_only(
         }
 
     os.makedirs(output_dir, exist_ok=True)
+
+    results_csv_path = join(output_dir, "results.csv")
+    if overwrite:
+        for path in (results_csv_path, join(output_dir, "metrics.json")):
+            if exists(path):
+                os.remove(path)
 
     log_save_path = join(output_dir, "logs")
     if exists(log_save_path):
@@ -1190,6 +1256,19 @@ async def run_eval_only(
         texts = [str(r["text"]) for r in rows]
         audio_paths = [r["audio_path"] for r in rows]
 
+        # Asked before ``_score_and_write_results`` writes the new config.json
+        # over the prior run's. An evaluator that kept its name but changed
+        # from pass/fail to a rating, or changed its rating range, makes every
+        # stored score unusable: they would be averaged with scores that mean
+        # something else.
+        existing_rows = (
+            read_existing_rows(results_csv_path)
+            if stored_scores_are_comparable(
+                output_dir, judge_evaluators or [DEFAULT_TTS_EVALUATOR]
+            )
+            else {}
+        )
+
         # No synthesis here, so no TTFB: ttfb_values=None omits the column and
         # the percentile metrics. Metrics + results + evaluator config all land
         # in ``output_dir``.
@@ -1202,6 +1281,7 @@ async def run_eval_only(
             judge_evaluators=judge_evaluators,
             ttfb_values=None,
             stream_rows=True,
+            existing_rows=existing_rows,
         )
 
         return {

--- a/calibrate_agent/tts/metrics.py
+++ b/calibrate_agent/tts/metrics.py
@@ -70,11 +70,17 @@ async def get_tts_llm_judge_score(
     evaluators: Optional[List[dict]] = None,
     fallback_model: str = DEFAULT_TTS_JUDGE_MODEL,
     on_row: Optional[Callable] = None,
+    known: Optional[List] = None,
 ) -> dict:
     """Run TTS judge across all rows and aggregate per-evaluator scores.
 
     ``on_row`` is called with ``(row_index, row_result)`` as each row's judge
     finishes, so a caller can persist results as they arrive.
+
+    ``known`` holds one entry per row: the judge result a previous run already
+    produced for it, or None when the row still has to be judged. Only the None
+    rows cost a judge call; the rest are slotted back into dataset order so the
+    aggregated means match a single run over every row.
 
     Returns:
         {
@@ -91,20 +97,33 @@ async def get_tts_llm_judge_score(
     """
     evaluators = _resolve_evaluators(evaluators)
 
+    known = list(known) if known else [None] * len(audio_paths)
+    pending = [index for index, row in enumerate(known) if row is None]
+
     coroutines = [
         tts_llm_judge(
-            audio_path,
-            reference_text,
+            audio_paths[index],
+            reference_texts[index],
             evaluators=evaluators,
             fallback_model=fallback_model,
         )
-        for audio_path, reference_text in zip(audio_paths, reference_texts)
+        for index in pending
     ]
 
-    results = await tqdm_asyncio.gather(
-        *with_row_callback(coroutines, on_row),
+    # ``with_row_callback`` counts the coroutines it is given; map that count
+    # back to the row it came from so callers always see dataset positions.
+    row_callback = (
+        (lambda position, row: on_row(pending[position], row)) if on_row else None
+    )
+
+    judged = await tqdm_asyncio.gather(
+        *with_row_callback(coroutines, row_callback),
         desc="Running TTS evaluators",
     )
+
+    results = list(known)
+    for index, row in zip(pending, judged):
+        results[index] = row
 
     # Aggregate per-evaluator scores — binary: mean 0/1, rating: mean score
     scores: dict = {}

--- a/examples/agent/simulation/sample_text_dataset.json
+++ b/examples/agent/simulation/sample_text_dataset.json
@@ -1,5 +1,6 @@
 [
     {
+        "id": "simulation_1",
         "name": "simulation_1",
         "conversation_history": [
             {"role": "assistant", "content": "Hello! How can I help you today?"},
@@ -11,6 +12,7 @@
         ]
     },
     {
+        "id": "simulation_2",
         "name": "simulation_2",
         "conversation_history": [
             {"role": "assistant", "content": "Hello! How can I help you today?"},

--- a/tests/general/test_eval.py
+++ b/tests/general/test_eval.py
@@ -352,6 +352,393 @@ class TestGeneralPartialResults(unittest.IsolatedAsyncioTestCase):
             )
             self.assertEqual([bool(v) for v in df["faithful"]], [True, False])
 
+    async def test_partial_file_drops_scores_from_a_removed_evaluator(self):
+        from calibrate_agent.general.eval import _score_and_write_results
+
+        with tempfile.TemporaryDirectory() as out_dir:
+            results_path = os.path.join(out_dir, "results.csv")
+            seen = {}
+
+            async def fake_judge(_input, output, **kwargs):
+                if output == "sum B":
+                    await asyncio.sleep(0.05)
+                    seen["partial"] = pd.read_csv(results_path)
+                return {"faithful": {"reasoning": output, "match": True}}
+
+            with patch(
+                "calibrate_agent.general.metrics.general_judge",
+                AsyncMock(side_effect=fake_judge),
+            ):
+                await _score_and_write_results(
+                    ids=["row_a", "row_b"],
+                    inputs=["doc A", "doc B"],
+                    outputs=["sum A", "sum B"],
+                    evaluators=[BINARY_EV],
+                    output_dir=out_dir,
+                    existing_rows={
+                        "row_a": {
+                            "id": "row_a",
+                            "input": "doc A",
+                            "output": "sum A",
+                            "concise": "True",
+                            "concise_reasoning": "from the old evaluator",
+                        }
+                    },
+                )
+
+            self.assertNotIn("concise", seen["partial"].columns)
+
+
+def _write_results_csv(out_dir, rows, evaluators=None) -> str:
+    """Stand in for a prior run: its results.csv plus the config.json it wrote.
+
+    Both are needed to resume — the config records how the stored scores were
+    produced, and without it they cannot be trusted.
+    """
+    from calibrate_agent.judges import write_evaluator_config
+
+    write_evaluator_config(out_dir, evaluators or [BINARY_EV])
+    path = os.path.join(out_dir, "results.csv")
+    pd.DataFrame(rows).to_csv(path, index=False)
+    return path
+
+
+async def _fake_judge(_input, output, **kwargs):
+    """Score every row from its own output text, so completion order cannot mix rows."""
+    return {"faithful": {"reasoning": f"why {output}", "match": output.endswith("A")}}
+
+
+class TestGeneralResume(unittest.IsolatedAsyncioTestCase):
+    """A rerun keeps the rows already scored and judges only what is missing."""
+
+    async def test_resumed_run_only_judges_missing_rows(self):
+        rows = [
+            {"id": "row_a", "input": "doc A", "output": "sum A"},
+            {"id": "row_b", "input": "doc B", "output": "sum B"},
+        ]
+        dataset_path = _write_json(rows)
+        judge = AsyncMock(side_effect=_fake_judge)
+        try:
+            with tempfile.TemporaryDirectory() as out_dir:
+                _write_results_csv(
+                    out_dir,
+                    [
+                        {
+                            "id": "row_a",
+                            "input": "doc A",
+                            "output": "sum A",
+                            "faithful": True,
+                            "faithful_reasoning": "why sum A",
+                        }
+                    ],
+                )
+                with patch(
+                    "calibrate_agent.general.metrics.general_judge", judge
+                ):
+                    result = await run_general_eval(
+                        dataset_path=dataset_path,
+                        output_dir=out_dir,
+                        evaluators=[BINARY_EV],
+                    )
+
+                self.assertEqual(result["status"], "completed")
+                self.assertEqual(judge.await_count, 1)
+                self.assertEqual(judge.await_args.args[1], "sum B")
+
+                df = pd.read_csv(os.path.join(out_dir, "results.csv"))
+                self.assertEqual(list(df["id"]), ["row_a", "row_b"])
+                self.assertEqual([bool(v) for v in df["faithful"]], [True, False])
+                self.assertEqual(
+                    list(df["faithful_reasoning"]), ["why sum A", "why sum B"]
+                )
+        finally:
+            os.unlink(dataset_path)
+
+    async def test_resumed_metrics_match_a_single_run(self):
+        rows = [
+            {"id": "row_a", "input": "doc A", "output": "sum A"},
+            {"id": "row_b", "input": "doc B", "output": "sum B"},
+        ]
+        dataset_path = _write_json(rows)
+        try:
+            with tempfile.TemporaryDirectory() as fresh_dir, patch(
+                "calibrate_agent.general.metrics.general_judge",
+                AsyncMock(side_effect=_fake_judge),
+            ):
+                await run_general_eval(
+                    dataset_path=dataset_path,
+                    output_dir=fresh_dir,
+                    evaluators=[BINARY_EV],
+                )
+                with open(os.path.join(fresh_dir, "metrics.json")) as f:
+                    single_run = json.load(f)
+
+            with tempfile.TemporaryDirectory() as out_dir, patch(
+                "calibrate_agent.general.metrics.general_judge",
+                AsyncMock(side_effect=_fake_judge),
+            ):
+                _write_results_csv(
+                    out_dir,
+                    [
+                        {
+                            "id": "row_a",
+                            "input": "doc A",
+                            "output": "sum A",
+                            "faithful": True,
+                            "faithful_reasoning": "why sum A",
+                        }
+                    ],
+                )
+                await run_general_eval(
+                    dataset_path=dataset_path,
+                    output_dir=out_dir,
+                    evaluators=[BINARY_EV],
+                )
+                with open(os.path.join(out_dir, "metrics.json")) as f:
+                    resumed = json.load(f)
+        finally:
+            os.unlink(dataset_path)
+
+        self.assertEqual(resumed, single_run)
+        self.assertAlmostEqual(resumed["faithful"]["mean"], 0.5)
+
+    async def test_overwrite_rejudges_every_row(self):
+        rows = [
+            {"id": "row_a", "input": "doc A", "output": "sum A"},
+            {"id": "row_b", "input": "doc B", "output": "sum B"},
+        ]
+        dataset_path = _write_json(rows)
+        judge = AsyncMock(side_effect=_fake_judge)
+        try:
+            with tempfile.TemporaryDirectory() as out_dir:
+                _write_results_csv(
+                    out_dir,
+                    [
+                        {
+                            "id": "row_a",
+                            "input": "doc A",
+                            "output": "sum A",
+                            "faithful": True,
+                            "faithful_reasoning": "stale",
+                        }
+                    ],
+                )
+                with open(os.path.join(out_dir, "metrics.json"), "w") as f:
+                    json.dump({"stale": True}, f)
+
+                with patch("calibrate_agent.general.metrics.general_judge", judge):
+                    await run_general_eval(
+                        dataset_path=dataset_path,
+                        output_dir=out_dir,
+                        evaluators=[BINARY_EV],
+                        overwrite=True,
+                    )
+
+                self.assertEqual(judge.await_count, 2)
+                df = pd.read_csv(os.path.join(out_dir, "results.csv"))
+                self.assertEqual(list(df["id"]), ["row_a", "row_b"])
+                self.assertEqual(
+                    list(df["faithful_reasoning"]), ["why sum A", "why sum B"]
+                )
+                with open(os.path.join(out_dir, "metrics.json")) as f:
+                    metrics = json.load(f)
+                self.assertNotIn("stale", metrics)
+        finally:
+            os.unlink(dataset_path)
+
+    async def test_changed_evaluator_set_is_not_mixed_with_the_old_one(self):
+        rows = [{"id": "row_a", "input": "doc A", "output": "sum A"}]
+        dataset_path = _write_json(rows)
+        judge = AsyncMock(side_effect=_fake_judge)
+        try:
+            with tempfile.TemporaryDirectory() as out_dir:
+                _write_results_csv(
+                    out_dir,
+                    [
+                        {
+                            "id": "row_a",
+                            "input": "doc A",
+                            "output": "sum A",
+                            "concise": True,
+                            "concise_reasoning": "from the old evaluator",
+                        }
+                    ],
+                )
+                with patch("calibrate_agent.general.metrics.general_judge", judge):
+                    await run_general_eval(
+                        dataset_path=dataset_path,
+                        output_dir=out_dir,
+                        evaluators=[BINARY_EV],
+                    )
+
+                self.assertEqual(judge.await_count, 1)
+                df = pd.read_csv(os.path.join(out_dir, "results.csv"))
+                self.assertNotIn("concise", df.columns)
+                self.assertEqual(list(df["faithful_reasoning"]), ["why sum A"])
+        finally:
+            os.unlink(dataset_path)
+
+    async def test_numeric_looking_id_resumes(self):
+        rows = [
+            {"id": 1, "input": "doc A", "output": "sum A"},
+            {"id": 2, "input": "doc B", "output": "sum B"},
+        ]
+        dataset_path = _write_json(rows)
+        judge = AsyncMock(side_effect=_fake_judge)
+        try:
+            with tempfile.TemporaryDirectory() as out_dir:
+                _write_results_csv(
+                    out_dir,
+                    [
+                        {
+                            "id": 1,
+                            "input": "doc A",
+                            "output": "sum A",
+                            "faithful": True,
+                            "faithful_reasoning": "why sum A",
+                        }
+                    ],
+                )
+                with patch("calibrate_agent.general.metrics.general_judge", judge):
+                    await run_general_eval(
+                        dataset_path=dataset_path,
+                        output_dir=out_dir,
+                        evaluators=[BINARY_EV],
+                    )
+
+                self.assertEqual(judge.await_count, 1)
+                self.assertEqual(judge.await_args.args[1], "sum B")
+                df = pd.read_csv(os.path.join(out_dir, "results.csv"))
+                self.assertEqual(list(df["id"]), [1, 2])
+        finally:
+            os.unlink(dataset_path)
+
+    async def test_row_with_blank_score_is_judged_again(self):
+        rows = [{"id": "row_a", "input": "doc A", "output": "sum A"}]
+        dataset_path = _write_json(rows)
+        judge = AsyncMock(side_effect=_fake_judge)
+        try:
+            with tempfile.TemporaryDirectory() as out_dir:
+                _write_results_csv(
+                    out_dir,
+                    [
+                        {
+                            "id": "row_a",
+                            "input": "doc A",
+                            "output": "sum A",
+                            "faithful": "",
+                            "faithful_reasoning": "",
+                        }
+                    ],
+                )
+                with patch("calibrate_agent.general.metrics.general_judge", judge):
+                    await run_general_eval(
+                        dataset_path=dataset_path,
+                        output_dir=out_dir,
+                        evaluators=[BINARY_EV],
+                    )
+
+                self.assertEqual(judge.await_count, 1)
+                df = pd.read_csv(os.path.join(out_dir, "results.csv"))
+                self.assertEqual(list(df["faithful_reasoning"]), ["why sum A"])
+        finally:
+            os.unlink(dataset_path)
+
+    async def test_row_missing_from_the_dataset_is_dropped(self):
+        rows = [{"id": "row_a", "input": "doc A", "output": "sum A"}]
+        dataset_path = _write_json(rows)
+        try:
+            with tempfile.TemporaryDirectory() as out_dir:
+                _write_results_csv(
+                    out_dir,
+                    [
+                        {
+                            "id": "row_a",
+                            "input": "doc A",
+                            "output": "sum A",
+                            "faithful": True,
+                            "faithful_reasoning": "why sum A",
+                        },
+                        {
+                            "id": "row_gone",
+                            "input": "doc X",
+                            "output": "sum X",
+                            "faithful": True,
+                            "faithful_reasoning": "why sum X",
+                        },
+                    ],
+                )
+                with patch(
+                    "calibrate_agent.general.metrics.general_judge",
+                    AsyncMock(side_effect=_fake_judge),
+                ):
+                    result = await run_general_eval(
+                        dataset_path=dataset_path,
+                        output_dir=out_dir,
+                        evaluators=[BINARY_EV],
+                    )
+
+                df = pd.read_csv(os.path.join(out_dir, "results.csv"))
+                self.assertEqual(list(df["id"]), ["row_a"])
+                self.assertAlmostEqual(result["metrics"]["faithful"]["mean"], 1.0)
+        finally:
+            os.unlink(dataset_path)
+
+    async def test_row_arguments_still_match_their_row_on_a_resumed_run(self):
+        templated = {
+            "name": "faithful",
+            "system_prompt": "check against {{reference}}",
+            "judge_model": "openai/gpt-4.1",
+        }
+        rows = [
+            {"id": "row_a", "input": "doc A", "output": "sum A",
+             "arguments": {"faithful": {"reference": "REF-A"}}},
+            {"id": "row_b", "input": "doc B", "output": "sum B",
+             "arguments": {"faithful": {"reference": "REF-B"}}},
+            {"id": "row_c", "input": "doc C", "output": "sum C",
+             "arguments": {"faithful": {"reference": "REF-C"}}},
+        ]
+        dataset_path = _write_json(rows)
+        prompts_by_output = {}
+
+        async def capture(_input, output, **kwargs):
+            prompts_by_output[output] = kwargs["evaluators"][0]["system_prompt"]
+            return await _fake_judge(_input, output, **kwargs)
+
+        try:
+            with tempfile.TemporaryDirectory() as out_dir:
+                _write_results_csv(
+                    out_dir,
+                    [
+                        {
+                            "id": "row_a",
+                            "input": "doc A",
+                            "output": "sum A",
+                            "faithful": True,
+                            "faithful_reasoning": "why sum A",
+                        }
+                    ],
+                )
+                with patch(
+                    "calibrate_agent.general.metrics.general_judge",
+                    AsyncMock(side_effect=capture),
+                ):
+                    await run_general_eval(
+                        dataset_path=dataset_path,
+                        output_dir=out_dir,
+                        evaluators=[templated],
+                    )
+        finally:
+            os.unlink(dataset_path)
+
+        self.assertEqual(
+            prompts_by_output,
+            {
+                "sum B": "check against REF-B",
+                "sum C": "check against REF-C",
+            },
+        )
+
 
 class TestMain(unittest.IsolatedAsyncioTestCase):
     """Cover the CLI entry point branches of calibrate_agent.general.eval.main()."""
@@ -442,6 +829,52 @@ class TestMain(unittest.IsolatedAsyncioTestCase):
                 run_mock.call_args.kwargs["evaluators"][0]["name"], "faithful"
             )
 
+    async def test_overwrite_flag_rejudges_every_row(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            ds = _write_json([{"id": "row_a", "input": "doc A", "output": "sum A"}])
+            cfg = _write_json({"evaluators": [BINARY_EV]})
+            _write_results_csv(
+                out_dir,
+                [
+                    {
+                        "id": "row_a",
+                        "input": "doc A",
+                        "output": "sum A",
+                        "faithful": True,
+                        "faithful_reasoning": "stale",
+                    }
+                ],
+            )
+            judge = AsyncMock(side_effect=_fake_judge)
+            argv = self._argv(ds, cfg, out_dir) + ["--overwrite"]
+            try:
+                with patch.object(sys, "argv", argv), patch(
+                    "calibrate_agent.general.metrics.general_judge", judge
+                ):
+                    await eval_main()
+            finally:
+                os.unlink(ds)
+                os.unlink(cfg)
+            self.assertEqual(judge.await_count, 1)
+            df = pd.read_csv(os.path.join(out_dir, "results.csv"))
+            self.assertEqual(list(df["faithful_reasoning"]), ["why sum A"])
+
+    async def test_overwrite_defaults_to_off(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            ds = _write_json([{"id": "1", "input": "a", "output": "b"}])
+            cfg = _write_json({"evaluators": [BINARY_EV]})
+            completed = {"status": "completed", "metrics": {}, "output_dir": out_dir}
+            run_mock = AsyncMock(return_value=completed)
+            try:
+                with patch.object(sys, "argv", self._argv(ds, cfg, out_dir)), patch(
+                    "calibrate_agent.general.eval.run_general_eval", run_mock
+                ):
+                    await eval_main()
+            finally:
+                os.unlink(ds)
+                os.unlink(cfg)
+            self.assertFalse(run_mock.call_args.kwargs["overwrite"])
+
     async def test_success_with_no_scores_prints_placeholder(self):
         with tempfile.TemporaryDirectory() as out_dir:
             ds = _write_json([{"id": "1", "input": "a", "output": "b"}])
@@ -494,6 +927,190 @@ class TestCliDispatch(unittest.TestCase):
             with self.assertRaises(SystemExit) as cm:
                 cli.main()
         self.assertEqual(cm.exception.code, 1)
+
+
+class TestGeneralResumeRejudges(unittest.IsolatedAsyncioTestCase):
+    """A stored score is only reused when it still describes this run."""
+
+    DATASET = [
+        {"id": "row_a", "input": "doc A", "output": "sum A"},
+        {"id": "row_b", "input": "doc B", "output": "sum B"},
+    ]
+
+    def _write_prior_run(self, out_dir, stored_evaluators, stored_row):
+        from calibrate_agent.judges import write_evaluator_config
+
+        write_evaluator_config(out_dir, stored_evaluators)
+        pd.DataFrame([stored_row]).to_csv(
+            os.path.join(out_dir, "results.csv"), index=False
+        )
+
+    async def _run(self, out_dir, evaluators, judge):
+        dataset_path = _write_json(self.DATASET)
+        try:
+            with patch("calibrate_agent.general.metrics.general_judge", judge):
+                return await run_general_eval(
+                    dataset_path=dataset_path,
+                    output_dir=out_dir,
+                    evaluators=evaluators,
+                )
+        finally:
+            os.unlink(dataset_path)
+
+    async def test_evaluator_that_became_a_rating_rejudges_every_row(self):
+        rating_ev = {
+            "name": "faithful",
+            "system_prompt": "judge faithfulness",
+            "judge_model": "openai/gpt-4.1",
+            "type": "rating",
+            "scale_min": 1,
+            "scale_max": 5,
+        }
+
+        async def fake(_input, output, **kwargs):
+            return {"faithful": {"reasoning": f"why {output}", "score": 4}}
+
+        judge = AsyncMock(side_effect=fake)
+        with tempfile.TemporaryDirectory() as out_dir:
+            self._write_prior_run(
+                out_dir,
+                [BINARY_EV],
+                {
+                    "id": "row_a",
+                    "input": "doc A",
+                    "output": "sum A",
+                    "faithful": True,
+                    "faithful_reasoning": "pass/fail from the old run",
+                },
+            )
+            await self._run(out_dir, [rating_ev], judge)
+
+            self.assertEqual(judge.await_count, 2)
+            df = pd.read_csv(os.path.join(out_dir, "results.csv"))
+            self.assertEqual(list(df["faithful"]), [4, 4])
+            with open(os.path.join(out_dir, "metrics.json")) as f:
+                metrics = json.load(f)
+            self.assertEqual(metrics["faithful"]["mean"], 4.0)
+
+    async def test_widened_rating_range_rejudges_every_row(self):
+        def rating(scale_max):
+            return {
+                "name": "faithful",
+                "system_prompt": "judge faithfulness",
+                "judge_model": "openai/gpt-4.1",
+                "type": "rating",
+                "scale_min": 1,
+                "scale_max": scale_max,
+            }
+
+        async def fake(_input, output, **kwargs):
+            return {"faithful": {"reasoning": f"why {output}", "score": 9}}
+
+        judge = AsyncMock(side_effect=fake)
+        with tempfile.TemporaryDirectory() as out_dir:
+            self._write_prior_run(
+                out_dir,
+                [rating(5)],
+                {
+                    "id": "row_a",
+                    "input": "doc A",
+                    "output": "sum A",
+                    "faithful": 5,
+                    "faithful_reasoning": "top of the old range",
+                },
+            )
+            await self._run(out_dir, [rating(10)], judge)
+
+            self.assertEqual(judge.await_count, 2)
+            df = pd.read_csv(os.path.join(out_dir, "results.csv"))
+            self.assertEqual(list(df["faithful"]), [9, 9])
+
+    async def test_reworded_prompt_still_reuses_stored_scores(self):
+        reworded = dict(BINARY_EV, system_prompt="judge faithfulness, carefully")
+
+        async def fake(_input, output, **kwargs):
+            return {"faithful": {"reasoning": f"why {output}", "match": False}}
+
+        judge = AsyncMock(side_effect=fake)
+        with tempfile.TemporaryDirectory() as out_dir:
+            self._write_prior_run(
+                out_dir,
+                [BINARY_EV],
+                {
+                    "id": "row_a",
+                    "input": "doc A",
+                    "output": "sum A",
+                    "faithful": True,
+                    "faithful_reasoning": "kept",
+                },
+            )
+            await self._run(out_dir, [reworded], judge)
+
+            self.assertEqual(judge.await_count, 1)
+            df = pd.read_csv(os.path.join(out_dir, "results.csv"))
+            self.assertEqual(list(df["faithful_reasoning"]), ["kept", "why sum B"])
+
+    async def test_changed_output_text_is_judged_again(self):
+        async def fake(_input, output, **kwargs):
+            return {"faithful": {"reasoning": f"why {output}", "match": False}}
+
+        judge = AsyncMock(side_effect=fake)
+        with tempfile.TemporaryDirectory() as out_dir:
+            self._write_prior_run(
+                out_dir,
+                [BINARY_EV],
+                {
+                    "id": "row_a",
+                    "input": "doc A",
+                    "output": "an older summary",
+                    "faithful": True,
+                    "faithful_reasoning": "scored the older summary",
+                },
+            )
+            await self._run(out_dir, [BINARY_EV], judge)
+
+            self.assertEqual(judge.await_count, 2)
+            df = pd.read_csv(os.path.join(out_dir, "results.csv"))
+            self.assertEqual(
+                list(df["faithful_reasoning"]), ["why sum A", "why sum B"]
+            )
+
+    async def test_changed_input_text_is_judged_again(self):
+        async def fake(_input, output, **kwargs):
+            return {"faithful": {"reasoning": f"why {output}", "match": False}}
+
+        judge = AsyncMock(side_effect=fake)
+        with tempfile.TemporaryDirectory() as out_dir:
+            self._write_prior_run(
+                out_dir,
+                [BINARY_EV],
+                {
+                    "id": "row_a",
+                    "input": "an older document",
+                    "output": "sum A",
+                    "faithful": True,
+                    "faithful_reasoning": "scored the older document",
+                },
+            )
+            await self._run(out_dir, [BINARY_EV], judge)
+
+            self.assertEqual(judge.await_count, 2)
+
+
+class TestGeneralDuplicateIdTypes(unittest.TestCase):
+    def test_ids_that_differ_only_in_type_are_duplicates(self):
+        path = _write_json(
+            [
+                {"id": 1, "input": "a", "output": "b"},
+                {"id": "1", "input": "c", "output": "d"},
+            ]
+        )
+        try:
+            ok, err, _ = validate_general_eval_dataset(path)
+        finally:
+            os.unlink(path)
+        self.assertFalse(ok)
+        self.assertIn("Duplicate row id", err)
 
 
 if __name__ == "__main__":

--- a/tests/general/test_metrics.py
+++ b/tests/general/test_metrics.py
@@ -300,5 +300,117 @@ class TestGeneralJudgeOnRow(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class TestGetGeneralJudgeScoreKnown(unittest.IsolatedAsyncioTestCase):
+    """``known`` rows are carried through without being judged again."""
+
+    @staticmethod
+    async def _fake(_input, output, **kwargs):
+        return {"faithful": {"reasoning": output, "match": output == "o3"}}
+
+    async def test_known_rows_are_not_judged_again(self):
+        judge = AsyncMock(side_effect=self._fake)
+        carried = {"faithful": {"reasoning": "from disk", "match": True}}
+        with patch("calibrate_agent.general.metrics.general_judge", judge):
+            result = await get_general_judge_score(
+                inputs=["i1", "i2", "i3"],
+                outputs=["o1", "o2", "o3"],
+                evaluators=[BINARY_EV],
+                known=[carried, None, None],
+            )
+        self.assertEqual(judge.await_count, 2)
+        self.assertEqual(
+            [row["faithful"]["reasoning"] for row in result["per_row"]],
+            ["from disk", "o2", "o3"],
+        )
+        # Mean covers every row: True, False, True.
+        self.assertAlmostEqual(result["scores"]["faithful"]["mean"], 2 / 3)
+
+    async def test_all_rows_known_skips_the_judge(self):
+        judge = AsyncMock(side_effect=self._fake)
+        rows = [
+            {"faithful": {"reasoning": "a", "match": True}},
+            {"faithful": {"reasoning": "b", "match": False}},
+        ]
+        with patch("calibrate_agent.general.metrics.general_judge", judge):
+            result = await get_general_judge_score(
+                inputs=["i1", "i2"],
+                outputs=["o1", "o2"],
+                evaluators=[BINARY_EV],
+                known=list(rows),
+            )
+        judge.assert_not_awaited()
+        self.assertEqual(result["per_row"], rows)
+        self.assertAlmostEqual(result["scores"]["faithful"]["mean"], 0.5)
+
+    async def test_on_row_uses_the_dataset_index(self):
+        seen = []
+        with patch(
+            "calibrate_agent.general.metrics.general_judge",
+            AsyncMock(side_effect=self._fake),
+        ):
+            await get_general_judge_score(
+                inputs=["i1", "i2", "i3"],
+                outputs=["o1", "o2", "o3"],
+                evaluators=[BINARY_EV],
+                known=[{"faithful": {"reasoning": "x", "match": True}}, None, None],
+                on_row=lambda index, row: seen.append(
+                    (index, row["faithful"]["reasoning"])
+                ),
+            )
+        self.assertEqual(sorted(seen), [(1, "o2"), (2, "o3")])
+
+    async def test_arguments_stay_with_their_row_when_rows_are_skipped(self):
+        seen_by_output = {}
+
+        async def fake(_input, output, evaluators, **kwargs):
+            seen_by_output[output] = evaluators[0]["system_prompt"]
+            return {"faithful": {"reasoning": output, "match": True}}
+
+        with patch(
+            "calibrate_agent.general.metrics.general_judge", AsyncMock(side_effect=fake)
+        ):
+            await get_general_judge_score(
+                inputs=["i1", "i2", "i3"],
+                outputs=["o1", "o2", "o3"],
+                evaluators=[TEMPLATED_EV],
+                arguments_list=[
+                    {"faithful": {"reference": "gold-A"}},
+                    {"faithful": {"reference": "gold-B"}},
+                    {"faithful": {"reference": "gold-C"}},
+                ],
+                known=[{"faithful": {"reasoning": "x", "match": True}}, None, None],
+            )
+        self.assertEqual(
+            seen_by_output,
+            {"o2": "judge against gold-B", "o3": "judge against gold-C"},
+        )
+
+    async def test_unknown_evaluator_name_is_caught_on_an_already_judged_row(self):
+        """A misspelled name stops the run whether or not that row is judged."""
+        judge = AsyncMock(side_effect=self._fake)
+        with patch("calibrate_agent.general.metrics.general_judge", judge):
+            with self.assertRaises(ValueError) as ctx:
+                await get_general_judge_score(
+                    inputs=["i1", "i2"],
+                    outputs=["o1", "o2"],
+                    evaluators=[TEMPLATED_EV],
+                    arguments_list=[
+                        {"fathful": {"reference": "gold-A"}},
+                        {"faithful": {"reference": "gold-B"}},
+                    ],
+                    known=[{"faithful": {"reasoning": "x", "match": True}}, None],
+                )
+        self.assertIn("fathful", str(ctx.exception))
+
+    async def test_known_length_mismatch_raises(self):
+        with self.assertRaises(ValueError):
+            await get_general_judge_score(
+                inputs=["i1", "i2"],
+                outputs=["o1", "o2"],
+                evaluators=[BINARY_EV],
+                known=[None],
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/llm/test_run_simulation_extra.py
+++ b/tests/llm/test_run_simulation_extra.py
@@ -70,7 +70,7 @@ class TestValidateSimulationEvalOnlyDataset(unittest.TestCase):
         from calibrate_agent.llm.run_simulation import validate_simulation_eval_only_dataset
 
         ok, _ = validate_simulation_eval_only_dataset([
-            {"conversation_history": [{"role": "user", "content": "hi"}]}
+            {"id": "row_a", "conversation_history": [{"role": "user", "content": "hi"}]}
         ])
         self.assertTrue(ok)
 
@@ -153,8 +153,15 @@ class TestRunEvalOnlySimulations(unittest.IsolatedAsyncioTestCase):
                 failed = await run_eval_only_simulations(
                     config={"evaluators": [_bin_ev("x")]},
                     dataset=[
-                        {"conversation_history": [{"role": "user", "content": "hi"}], "name": "a"},
-                        {"conversation_history": [{"role": "user", "content": "hi2"}]},
+                        {
+                            "id": "row_a",
+                            "conversation_history": [{"role": "user", "content": "hi"}],
+                            "name": "a",
+                        },
+                        {
+                            "id": "row_b",
+                            "conversation_history": [{"role": "user", "content": "hi2"}],
+                        },
                     ],
                     output_dir=str(out),
                     parallel=2,
@@ -270,7 +277,7 @@ class TestMainEvalOnly(unittest.IsolatedAsyncioTestCase):
             cfg.write_text(json.dumps({"evaluators": [_bin_ev("x")]}))
             ds = Path(tmp) / "ds.json"
             ds.write_text(json.dumps([
-                {"conversation_history": [{"role": "user", "content": "hi"}]}
+                {"id": "row_a", "conversation_history": [{"role": "user", "content": "hi"}]}
             ]))
             argv = ["sim.py", "-c", str(cfg), "-o", str(Path(tmp) / "out"),
                     "--eval-only", "--dataset", str(ds)]

--- a/tests/llm/test_run_simulation_resume.py
+++ b/tests/llm/test_run_simulation_resume.py
@@ -1,0 +1,472 @@
+"""
+Tests for resuming the text-simulation eval-only run
+(``calibrate_agent.llm.run_simulation.run_eval_only_simulations``).
+
+The judge is replaced by a counting stand-in, so no API calls are made.
+"""
+
+import asyncio
+import json
+
+import pandas as pd
+import pytest
+from unittest.mock import patch
+
+import calibrate_agent.llm.run_simulation as run_simulation
+from calibrate_agent.llm.run_simulation import (
+    run_eval_only_simulations,
+    validate_simulation_eval_only_dataset,
+)
+
+
+def _evaluator(name="helpfulness"):
+    return {
+        "name": name,
+        "system_prompt": "Evaluate whether the agent was helpful.",
+        "judge_model": "openai/gpt-4.1",
+    }
+
+
+def _conversation(conversation_id, content):
+    """One dataset item whose score is decided by ``content``."""
+    return {
+        "id": conversation_id,
+        "name": f"conv {conversation_id}",
+        "conversation_history": [{"role": "user", "content": content}],
+    }
+
+
+class _CountingJudge:
+    """Stand-in for ``evaluate_simuation``: a transcript saying "good" passes."""
+
+    def __init__(self):
+        self.transcripts = []
+
+    async def __call__(self, transcript, evaluators, fallback_model=None):
+        self.transcripts.append(transcript)
+        passed = transcript[-1]["content"] == "good"
+        return {
+            ev["name"]: {"match": passed, "reasoning": "because"} for ev in evaluators
+        }
+
+    @property
+    def call_count(self):
+        return len(self.transcripts)
+
+
+def _run(dataset, output_dir, evaluators=None, overwrite=False):
+    """Run the eval-only pass and return the judge stand-in used."""
+    judge = _CountingJudge()
+    with patch("calibrate_agent.llm.run_simulation.evaluate_simuation", judge):
+        failed = asyncio.run(
+            run_eval_only_simulations(
+                config={"evaluators": evaluators or [_evaluator()]},
+                dataset=dataset,
+                output_dir=str(output_dir),
+                parallel=2,
+                overwrite=overwrite,
+            )
+        )
+    assert failed == 0, f"Expected no failures, got {failed}"
+    return judge
+
+
+def _results(output_dir):
+    return pd.read_csv(output_dir / "results.csv", dtype={"id": str})
+
+
+def _metrics(output_dir):
+    with open(output_dir / "metrics.json") as f:
+        return json.load(f)
+
+
+def _row_dirs(output_dir):
+    return sorted(d.name for d in output_dir.iterdir() if d.name.startswith("row_"))
+
+
+def _transcript(output_dir, row_name):
+    with open(output_dir / row_name / "transcript.json") as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# Resuming
+# ---------------------------------------------------------------------------
+
+
+def test_resumed_run_only_judges_the_missing_conversations(tmp_path):
+    out = tmp_path / "out"
+    first = _run([_conversation("a", "good"), _conversation("b", "bad")], out)
+    assert first.call_count == 2
+
+    second = _run(
+        [
+            _conversation("a", "good"),
+            _conversation("b", "bad"),
+            _conversation("c", "good"),
+        ],
+        out,
+    )
+    assert second.call_count == 1, (
+        f"Expected only the new conversation to be judged, got "
+        f"{second.call_count} judge calls"
+    )
+    assert second.transcripts[0][-1]["content"] == "good"
+
+
+def test_resumed_run_writes_every_row_to_results_csv(tmp_path):
+    out = tmp_path / "out"
+    _run([_conversation("a", "good"), _conversation("b", "bad")], out)
+    _run(
+        [
+            _conversation("a", "good"),
+            _conversation("b", "bad"),
+            _conversation("c", "good"),
+        ],
+        out,
+    )
+
+    df = _results(out)
+    assert list(df["id"]) == ["a", "b", "c"], f"Unexpected rows: {df.to_dict()}"
+    assert list(df["row_id"]) == ["row_1", "row_2", "row_3"]
+    assert list(df["helpfulness"]) == [True, False, True]
+    assert _row_dirs(out) == ["row_1", "row_2", "row_3"]
+
+
+def test_resumed_metrics_match_a_single_run(tmp_path):
+    dataset = [
+        _conversation("a", "good"),
+        _conversation("b", "bad"),
+        _conversation("c", "good"),
+    ]
+
+    resumed = tmp_path / "resumed"
+    _run(dataset[:2], resumed)
+    _run(dataset, resumed)
+
+    single = tmp_path / "single"
+    _run(dataset, single)
+
+    assert _metrics(resumed) == _metrics(single)
+    assert _metrics(single)["helpfulness"]["mean"] == pytest.approx(2 / 3)
+
+
+def test_numeric_looking_id_resumes(tmp_path):
+    out = tmp_path / "out"
+    dataset = [_conversation("1", "good"), _conversation("2", "bad")]
+    _run(dataset, out)
+
+    second = _run(dataset, out)
+    assert second.call_count == 0, (
+        f"Expected nothing to be judged again, got {second.call_count} judge calls"
+    )
+    assert list(_results(out)["id"]) == ["1", "2"]
+
+
+def test_reordered_dataset_reuses_each_conversations_own_scores(tmp_path):
+    out = tmp_path / "out"
+    _run([_conversation("a", "good"), _conversation("b", "bad")], out)
+
+    reordered = [
+        _conversation("c", "bad"),
+        _conversation("a", "good"),
+        _conversation("b", "bad"),
+    ]
+    second = _run(reordered, out)
+
+    assert second.call_count == 1, (
+        f"Expected only conversation 'c' to be judged, got "
+        f"{second.call_count} judge calls"
+    )
+
+    df = _results(out)
+    assert list(df["id"]) == ["c", "a", "b"]
+    assert list(df["helpfulness"]) == [False, True, False], (
+        f"Scores followed positions instead of ids: {df.to_dict()}"
+    )
+    assert _row_dirs(out) == ["row_1", "row_2", "row_3"]
+    assert _transcript(out, "row_1")[-1]["content"] == "bad"
+    assert _transcript(out, "row_2")[-1]["content"] == "good"
+
+
+def test_conversation_dropped_from_the_dataset_is_dropped_from_results(tmp_path):
+    out = tmp_path / "out"
+    _run([_conversation("a", "good"), _conversation("b", "bad")], out)
+
+    _run([_conversation("a", "good")], out)
+
+    df = _results(out)
+    assert list(df["id"]) == ["a"]
+    assert _row_dirs(out) == ["row_1"], (
+        f"Stale conversation folder left behind: {_row_dirs(out)}"
+    )
+
+
+def test_changed_evaluator_set_is_not_mixed_with_the_old_one(tmp_path):
+    out = tmp_path / "out"
+    dataset = [_conversation("a", "good"), _conversation("b", "bad")]
+    _run(dataset, out, evaluators=[_evaluator("old_check")])
+
+    second = _run(dataset, out, evaluators=[_evaluator("new_check")])
+    assert second.call_count == 2, (
+        f"Expected both conversations to be judged again under the new "
+        f"evaluator, got {second.call_count} judge calls"
+    )
+
+    metrics = _metrics(out)
+    assert set(metrics) == {"new_check"}
+    df = _results(out)
+    assert "old_check" not in df.columns
+
+
+# ---------------------------------------------------------------------------
+# Overwrite
+# ---------------------------------------------------------------------------
+
+
+def test_overwrite_starts_clean(tmp_path):
+    out = tmp_path / "out"
+    dataset = [_conversation("a", "good"), _conversation("b", "bad")]
+    _run(dataset, out)
+
+    second = _run(dataset, out, overwrite=True)
+    assert second.call_count == 2, (
+        f"Expected every conversation to be judged again, got "
+        f"{second.call_count} judge calls"
+    )
+    assert _row_dirs(out) == ["row_1", "row_2"]
+    assert list(_results(out)["id"]) == ["a", "b"]
+
+
+def test_overwrite_removes_folders_of_conversations_no_longer_in_the_dataset(tmp_path):
+    out = tmp_path / "out"
+    _run([_conversation("a", "good"), _conversation("b", "bad")], out)
+
+    _run([_conversation("a", "good")], out, overwrite=True)
+    assert _row_dirs(out) == ["row_1"]
+
+
+# ---------------------------------------------------------------------------
+# Dataset validation
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_without_id_is_rejected(tmp_path):
+    dataset = [{"conversation_history": [{"role": "user", "content": "hi"}]}]
+
+    is_valid, error = validate_simulation_eval_only_dataset(dataset)
+    assert is_valid is False
+    assert "'id'" in error, f"Error does not mention the id field: {error}"
+
+    with pytest.raises(ValueError, match="'id'"):
+        asyncio.run(
+            run_eval_only_simulations(
+                config={"evaluators": [_evaluator()]},
+                dataset=dataset,
+                output_dir=str(tmp_path / "out"),
+            )
+        )
+
+
+def test_duplicate_ids_are_rejected(tmp_path):
+    dataset = [_conversation("a", "good"), _conversation("a", "bad")]
+
+    is_valid, error = validate_simulation_eval_only_dataset(dataset)
+    assert is_valid is False
+    assert "duplicate id" in error.lower(), f"Unclear error message: {error}"
+
+    with pytest.raises(ValueError, match="duplicate id"):
+        asyncio.run(
+            run_eval_only_simulations(
+                config={"evaluators": [_evaluator()]},
+                dataset=dataset,
+                output_dir=str(tmp_path / "out"),
+            )
+        )
+
+
+def test_valid_dataset_passes_validation():
+    is_valid, error = validate_simulation_eval_only_dataset(
+        [_conversation("a", "good"), _conversation(2, "bad")]
+    )
+    assert is_valid, error
+
+
+def test_empty_dataset_is_rejected(tmp_path):
+    is_valid, error = validate_simulation_eval_only_dataset([])
+    assert is_valid is False
+    assert "empty" in error.lower(), f"Unclear error message: {error}"
+
+    out = tmp_path / "out"
+    _run([_conversation("a", "good")], out)
+
+    with pytest.raises(ValueError, match="empty"):
+        asyncio.run(
+            run_eval_only_simulations(
+                config={"evaluators": [_evaluator()]},
+                dataset=[],
+                output_dir=str(out),
+            )
+        )
+    assert _row_dirs(out) == ["row_1"], (
+        f"An empty dataset wiped the stored conversations: {_row_dirs(out)}"
+    )
+    assert list(_results(out)["id"]) == ["a"]
+
+
+# ---------------------------------------------------------------------------
+# Reuse only when the rubric and the conversation are unchanged
+# ---------------------------------------------------------------------------
+
+
+def _rating_evaluator(name="helpfulness", scale_max=5):
+    return {
+        "name": name,
+        "system_prompt": "Rate how helpful the agent was.",
+        "judge_model": "openai/gpt-4.1",
+        "type": "rating",
+        "scale_min": 1,
+        "scale_max": scale_max,
+    }
+
+
+class _RatingJudge:
+    """Stand-in for ``evaluate_simuation`` that always returns the top rating."""
+
+    def __init__(self):
+        self.transcripts = []
+
+    async def __call__(self, transcript, evaluators, fallback_model=None):
+        self.transcripts.append(transcript)
+        return {
+            ev["name"]: {"score": int(ev["scale_max"]), "reasoning": "because"}
+            for ev in evaluators
+        }
+
+    @property
+    def call_count(self):
+        return len(self.transcripts)
+
+
+def _run_rating(dataset, output_dir, evaluators):
+    judge = _RatingJudge()
+    with patch("calibrate_agent.llm.run_simulation.evaluate_simuation", judge):
+        failed = asyncio.run(
+            run_eval_only_simulations(
+                config={"evaluators": evaluators},
+                dataset=dataset,
+                output_dir=str(output_dir),
+                parallel=2,
+            )
+        )
+    assert failed == 0, f"Expected no failures, got {failed}"
+    return judge
+
+
+def test_evaluator_turned_into_a_rating_is_judged_again(tmp_path):
+    out = tmp_path / "out"
+    dataset = [_conversation("a", "good"), _conversation("b", "bad")]
+    _run(dataset, out, evaluators=[_evaluator("helpfulness")])
+
+    second = _run_rating(dataset, out, evaluators=[_rating_evaluator("helpfulness")])
+    assert second.call_count == 2, (
+        f"Pass/fail scores were reused under a rating rubric of the same name, "
+        f"got {second.call_count} judge calls"
+    )
+
+    metrics = _metrics(out)["helpfulness"]
+    assert metrics["type"] == "rating", metrics
+    assert metrics["mean"] == pytest.approx(5.0), metrics
+
+
+def test_changed_rating_scale_is_judged_again(tmp_path):
+    out = tmp_path / "out"
+    dataset = [_conversation("a", "good")]
+    _run_rating(dataset, out, evaluators=[_rating_evaluator(scale_max=5)])
+
+    second = _run_rating(dataset, out, evaluators=[_rating_evaluator(scale_max=10)])
+    assert second.call_count == 1, (
+        f"Scores from the 1-5 scale were reused on the 1-10 scale, got "
+        f"{second.call_count} judge calls"
+    )
+    assert _metrics(out)["helpfulness"]["mean"] == pytest.approx(10.0)
+
+
+def test_edited_conversation_with_the_same_id_is_judged_again(tmp_path):
+    out = tmp_path / "out"
+    _run([_conversation("a", "good"), _conversation("b", "bad")], out)
+
+    second = _run([_conversation("a", "bad"), _conversation("b", "bad")], out)
+    assert second.call_count == 1, (
+        f"Expected the edited conversation to be judged again, got "
+        f"{second.call_count} judge calls"
+    )
+
+    df = _results(out)
+    assert list(df["helpfulness"]) == [False, False], (
+        f"The edited conversation kept the old conversation's score: {df.to_dict()}"
+    )
+    assert _transcript(out, "row_1")[-1]["content"] == "bad"
+
+
+# ---------------------------------------------------------------------------
+# Interrupted runs and failed judging
+# ---------------------------------------------------------------------------
+
+
+def test_interrupted_write_keeps_the_reused_scores_on_disk(tmp_path):
+    out = tmp_path / "out"
+    _run([_conversation("a", "good"), _conversation("b", "bad")], out)
+
+    real_write = run_simulation._write_eval_only_row
+    calls = {"n": 0}
+
+    def failing_write(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise OSError("disk full")
+        return real_write(*args, **kwargs)
+
+    reordered = [
+        _conversation("b", "bad"),
+        _conversation("a", "good"),
+        _conversation("c", "good"),
+    ]
+    with patch.object(run_simulation, "_write_eval_only_row", failing_write):
+        with pytest.raises(OSError):
+            _run(reordered, out)
+
+    third = _run(reordered, out)
+    assert third.call_count == 1, (
+        f"An interrupted run lost scores that were already paid for: "
+        f"{third.call_count} judge calls instead of 1"
+    )
+
+
+def test_conversation_the_judge_fails_on_leaves_a_folder_recording_the_failure(
+    tmp_path,
+):
+    out = tmp_path / "out"
+
+    async def judge(transcript, evaluators, fallback_model=None):
+        if transcript[-1]["content"] == "boom":
+            raise RuntimeError("judge exploded")
+        return {ev["name"]: {"match": True, "reasoning": "ok"} for ev in evaluators}
+
+    with patch("calibrate_agent.llm.run_simulation.evaluate_simuation", judge):
+        failed = asyncio.run(
+            run_eval_only_simulations(
+                config={"evaluators": [_evaluator()]},
+                dataset=[_conversation("a", "good"), _conversation("b", "boom")],
+                output_dir=str(out),
+            )
+        )
+
+    assert failed == 1
+    assert _row_dirs(out) == ["row_1", "row_2"], (
+        f"The failed conversation left no folder: {_row_dirs(out)}"
+    )
+    with open(out / "row_2" / "row.json") as f:
+        stored = json.load(f)
+    assert "judge exploded" in stored["error"], stored
+    assert "evaluation_results" not in stored, stored

--- a/tests/llm/test_run_tests_extra.py
+++ b/tests/llm/test_run_tests_extra.py
@@ -1,6 +1,8 @@
 """Extra coverage for calibrate_agent/llm/run_tests.py — helpers, aggregation, eval-only flow."""
 
 import asyncio
+import contextlib
+import io
 import json
 import sys
 import tempfile
@@ -2909,6 +2911,267 @@ class TestRunItemsParallelResume(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(sorted(processed), [0, 1])
         self.assertEqual(len(results), 2)
+
+
+def _eval_only_item(tc_id, response="Hi!"):
+    test_case = {
+        "history": [{"role": "user", "content": "hi"}],
+        "evaluation": {"type": "response", "criteria": "polite"},
+    }
+    if tc_id is not None:
+        test_case["id"] = tc_id
+    return {"test_case": test_case, "output": {"response": response, "tool_calls": []}}
+
+
+class TestRunEvalOnlyResume(unittest.IsolatedAsyncioTestCase):
+    def _judge(self):
+        return AsyncMock(
+            return_value={"correctness": {"reasoning": "ok", "match": True}}
+        )
+
+    async def _run(self, tmp, dataset, judge, **kwargs):
+        from calibrate_agent.llm.run_tests import run_eval_only_tests
+
+        with patch(
+            "calibrate_agent.llm.run_tests.test_response_llm_judge", judge
+        ):
+            return await run_eval_only_tests(
+                config={"evaluators": []},
+                dataset=dataset,
+                output_dir=tmp,
+                **kwargs,
+            )
+
+    async def test_resume_only_evaluates_missing_test_cases(self):
+        dataset = [_eval_only_item("tc1"), _eval_only_item("tc2")]
+        judge = self._judge()
+        with tempfile.TemporaryDirectory() as tmp:
+            prior = [{
+                "test_case_id": "tc1",
+                "output": dataset[0]["output"],
+                "metrics": {"passed": True, "judge_results": {}},
+                "test_case": dataset[0]["test_case"],
+            }]
+            (Path(tmp) / "results.json").write_text(json.dumps(prior))
+
+            result = await self._run(tmp, dataset, judge)
+
+            written = json.loads((Path(tmp) / "results.json").read_text())
+
+        self.assertEqual(judge.await_count, 1)
+        self.assertEqual(result["total"], 2)
+        self.assertEqual(
+            [r["test_case_id"] for r in written], ["tc1", "tc2"]
+        )
+        self.assertEqual(written[0]["metrics"], prior[0]["metrics"])
+
+    async def test_resumed_metrics_match_single_full_run(self):
+        dataset = [
+            _eval_only_item("tc1", response="good"),
+            _eval_only_item("tc2", response="bad"),
+        ]
+
+        async def judge_by_response(**kwargs):
+            match = kwargs["response"] == "good"
+            return {"correctness": {"reasoning": "r", "match": match}}
+
+        # The resumed run judges only tc2; a fail-always judge here proves the
+        # tc1 pass came off disk rather than from a fresh evaluation.
+        fail_judge = AsyncMock(
+            return_value={"correctness": {"reasoning": "r", "match": False}}
+        )
+
+        with tempfile.TemporaryDirectory() as full_dir, \
+             tempfile.TemporaryDirectory() as resume_dir:
+            await self._run(full_dir, dataset, AsyncMock(side_effect=judge_by_response))
+            full_metrics = json.loads((Path(full_dir) / "metrics.json").read_text())
+            full_results = json.loads((Path(full_dir) / "results.json").read_text())
+
+            (Path(resume_dir) / "results.json").write_text(
+                json.dumps(full_results[:1])
+            )
+            await self._run(resume_dir, dataset, fail_judge)
+            resumed_metrics = json.loads(
+                (Path(resume_dir) / "metrics.json").read_text()
+            )
+
+        self.assertEqual(full_metrics["passed"], 1)
+
+        self.assertEqual(resumed_metrics["passed"], full_metrics["passed"])
+        self.assertEqual(resumed_metrics["total"], full_metrics["total"])
+        self.assertEqual(resumed_metrics["criteria"], full_metrics["criteria"])
+
+    async def test_overwrite_reruns_everything_and_clears_stale_files(self):
+        dataset = [_eval_only_item("tc1"), _eval_only_item("tc2")]
+        judge = self._judge()
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "results.json").write_text(json.dumps([{
+                "test_case_id": "tc1",
+                "output": {"response": "stale", "tool_calls": []},
+                "metrics": {"passed": True, "judge_results": {}},
+            }]))
+            (Path(tmp) / "metrics.json").write_text(json.dumps({"total": 99}))
+
+            await self._run(tmp, dataset, judge, overwrite=True)
+
+            written = json.loads((Path(tmp) / "results.json").read_text())
+            metrics = json.loads((Path(tmp) / "metrics.json").read_text())
+
+        self.assertEqual(judge.await_count, 2)
+        self.assertEqual(metrics["total"], 2)
+        self.assertNotIn("stale", json.dumps(written))
+
+    async def test_test_cases_without_ids_do_not_resume(self):
+        dataset = [_eval_only_item(None), _eval_only_item(None)]
+        judge = self._judge()
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "results.json").write_text(json.dumps([{
+                "output": {"response": "Hi!", "tool_calls": []},
+                "metrics": {"passed": True, "judge_results": {}},
+                "test_case": dataset[0]["test_case"],
+            }]))
+            await self._run(tmp, dataset, judge)
+        self.assertEqual(judge.await_count, 2)
+
+    async def test_duplicate_ids_raise(self):
+        dataset = [_eval_only_item("tc1"), _eval_only_item("tc1")]
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(ValueError) as ctx:
+                await self._run(tmp, dataset, self._judge())
+        self.assertIn("Duplicate test case id 'tc1'", str(ctx.exception))
+
+    async def test_duplicate_ids_leave_previous_files_intact(self):
+        dataset = [_eval_only_item("tc1"), _eval_only_item("tc1")]
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "logs").write_text("old logs")
+            (Path(tmp) / "results.log").write_text("old results log")
+            with self.assertRaises(ValueError):
+                await self._run(tmp, dataset, self._judge())
+
+            self.assertEqual((Path(tmp) / "logs").read_text(), "old logs")
+            self.assertEqual(
+                (Path(tmp) / "results.log").read_text(), "old results log"
+            )
+            self.assertFalse((Path(tmp) / "config.json").exists())
+
+    async def test_changed_answer_is_rejudged_unchanged_answer_resumes(self):
+        dataset = [
+            _eval_only_item("tc1", response="corrected"),
+            _eval_only_item("tc2", response="Hi!"),
+        ]
+
+        async def judge_by_response(**kwargs):
+            return {
+                "correctness": {
+                    "reasoning": "r",
+                    "match": kwargs["response"] == "corrected",
+                }
+            }
+
+        judge = AsyncMock(side_effect=judge_by_response)
+        with tempfile.TemporaryDirectory() as tmp:
+            prior = [
+                {
+                    "test_case_id": "tc1",
+                    "output": {"response": "wrong", "tool_calls": []},
+                    "metrics": {"passed": False, "judge_results": {}},
+                    "test_case": dataset[0]["test_case"],
+                },
+                {
+                    "test_case_id": "tc2",
+                    "output": dataset[1]["output"],
+                    "metrics": {"passed": False, "judge_results": {}},
+                    "test_case": dataset[1]["test_case"],
+                },
+            ]
+            (Path(tmp) / "results.json").write_text(json.dumps(prior))
+
+            await self._run(tmp, dataset, judge)
+            written = json.loads((Path(tmp) / "results.json").read_text())
+
+        by_id = {r["test_case_id"]: r for r in written}
+        # Only the changed answer is judged again.
+        self.assertEqual(judge.await_count, 1)
+        self.assertEqual(by_id["tc1"]["output"]["response"], "corrected")
+        self.assertTrue(by_id["tc1"]["metrics"]["passed"])
+        # The untouched answer keeps its stored verdict.
+        self.assertFalse(by_id["tc2"]["metrics"]["passed"])
+
+    async def test_numeric_looking_id_resumes(self):
+        dataset = [_eval_only_item("1"), _eval_only_item("2")]
+        judge = self._judge()
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "results.json").write_text(json.dumps([{
+                "test_case_id": "1",
+                "output": dataset[0]["output"],
+                "metrics": {"passed": True, "judge_results": {}},
+                "test_case": dataset[0]["test_case"],
+            }]))
+            await self._run(tmp, dataset, judge)
+            written = json.loads((Path(tmp) / "results.json").read_text())
+
+        self.assertEqual(judge.await_count, 1)
+        self.assertEqual([r["test_case_id"] for r in written], ["1", "2"])
+
+
+class TestRunTestsMainOverwriteFlag(unittest.IsolatedAsyncioTestCase):
+    async def _run_main(self, argv_extra):
+        from calibrate_agent.llm import run_tests
+
+        captured = {}
+
+        async def fake_eval(**kwargs):
+            captured.update(kwargs)
+            return {"passed": 1, "total": 1}
+
+        dataset = [{
+            "test_case": {"history": [], "evaluation": {}},
+            "output": {"response": "x", "tool_calls": []},
+        }]
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "c.json"
+            cfg.write_text("{}")
+            ds = Path(tmp) / "d.json"
+            ds.write_text(json.dumps(dataset))
+            argv = [
+                "calibrate_agent", "-c", str(cfg), "-o", tmp,
+                "--eval-only", "--dataset", str(ds),
+            ] + argv_extra
+            with patch.object(sys, "argv", argv), \
+                patch("calibrate_agent.llm.run_tests.run_eval_only_tests",
+                      side_effect=fake_eval), \
+                patch("calibrate_agent.llm.run_tests.validate_llm_eval_only_dataset",
+                      return_value=(True, "")):
+                await run_tests.main()
+        return captured
+
+    async def test_overwrite_flag_forwarded(self):
+        self.assertTrue((await self._run_main(["--overwrite"]))["overwrite"])
+
+    async def test_overwrite_defaults_false(self):
+        self.assertFalse((await self._run_main([]))["overwrite"])
+
+    async def test_duplicate_ids_exit_with_message(self):
+        from calibrate_agent.llm import run_tests
+
+        dataset = [_eval_only_item("tc1"), _eval_only_item("tc1")]
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "c.json"
+            cfg.write_text("{}")
+            ds = Path(tmp) / "d.json"
+            ds.write_text(json.dumps(dataset))
+            argv = [
+                "calibrate_agent", "-c", str(cfg), "-o", tmp,
+                "--eval-only", "--dataset", str(ds),
+            ]
+            out = io.StringIO()
+            with patch.object(sys, "argv", argv), \
+                    contextlib.redirect_stdout(out), \
+                    self.assertRaises(SystemExit) as ctx:
+                await run_tests.main()
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("Duplicate test case id 'tc1'", out.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/stt/test_eval.py
+++ b/tests/stt/test_eval.py
@@ -232,7 +232,7 @@ class TestTranscribeAudioRouter(unittest.IsolatedAsyncioTestCase):
 def _fake_intent_entity(intent=1, entity=1.0):
     """Build a fake ``get_intent_entity_score`` returning fixed scores per row."""
 
-    async def _fn(refs, preds, language="english", model=None):
+    async def _fn(refs, preds, language="english", model=None, **kwargs):
         return {
             "intent": float(intent),
             "entity": float(entity),
@@ -256,7 +256,7 @@ def _fake_intent_entity(intent=1, entity=1.0):
 def _fake_llm_wer(llm_wer=0.05, llm_cer=0.03):
     """Build a fake ``get_llm_wer_cer_score`` returning fixed scores per row."""
 
-    async def _fn(refs, preds, language="english", model=None):
+    async def _fn(refs, preds, language="english", model=None, **kwargs):
         return {
             "llm_wer": float(llm_wer),
             "llm_cer": float(llm_cer),
@@ -276,7 +276,7 @@ def _fake_llm_wer(llm_wer=0.05, llm_cer=0.03):
 def _fake_semantic_wer():
     """Fake ``get_semantic_wer_score`` (part of the default LLM-judge group)."""
 
-    async def _sem(references, predictions, model=None):
+    async def _sem(references, predictions, model=None, **kwargs):
         return {
             "semantic_wer": 0.0,
             "per_row": [
@@ -304,7 +304,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
     async def test_writes_metrics_and_results(self):
         from calibrate_agent.stt import eval as stt_eval
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None, **kwargs):
             return {
                 "scores": {
                     "semantic_match": {"type": "binary", "mean": 1.0}
@@ -383,7 +383,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             }
         ]
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None, **kwargs):
             return {
                 "scores": {"completeness": {"type": "binary", "mean": 0.5}},
                 "score": 0.5,
@@ -425,7 +425,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
     async def test_sarvam_judges_run_by_default(self):
         from calibrate_agent.stt import eval as stt_eval
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None, **kwargs):
             return {
                 "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                 "score": 1.0,
@@ -472,7 +472,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
     async def test_sarvam_judges_skipped_when_disabled(self):
         from calibrate_agent.stt import eval as stt_eval
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None, **kwargs):
             return {
                 "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                 "score": 1.0,
@@ -683,7 +683,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
     async def test_sarvam_failure_still_writes_wer_cer_and_evaluator(self):
         from calibrate_agent.stt import eval as stt_eval
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None, **kwargs):
             return {
                 "scores": {"semantic_match": {"type": "binary", "mean": 1.0}},
                 "score": 1.0,
@@ -769,7 +769,7 @@ class TestSTTScoreAndWriteResults(unittest.IsolatedAsyncioTestCase):
             "scale_max": 5,
         }
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None, **kwargs):
             return {
                 "scores": {
                     "accuracy": {
@@ -816,7 +816,7 @@ class TestSTTRunEvalOnly(unittest.IsolatedAsyncioTestCase):
     async def test_runs_evaluator_on_dataset(self):
         from calibrate_agent.stt import eval as stt_eval
 
-        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None):
+        async def fake_judge(refs, preds, evaluators=None, fallback_model=None, on_row=None, **kwargs):
             return {
                 "scores": {"semantic_match": {"type": "binary", "mean": 0.5}},
                 "score": 0.5,
@@ -916,6 +916,626 @@ class TestSTTRunEvalOnly(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(result["status"], "error")
         self.assertIn("does not exist", result["error"])
+
+
+_RESUME_ROWS = {
+    "row_a": ("doctor ne bola", "daktar ne bola"),
+    "row_b": ("hello world", "hello word"),
+    "row_c": ("doctor ne bola", "daktar ne bola"),
+    "row_d": ("good morning", "gud morning"),
+}
+
+# Per-reference semantic-WER counts: (substitutions, deletions, insertions,
+# reference_words). Deliberately uneven so a pooled score differs from a mean.
+_SEMANTIC_COUNTS = {
+    "doctor ne bola": (1, 0, 0, 3),
+    "hello world": (1, 0, 0, 2),
+    "good morning": (2, 1, 0, 2),
+}
+
+# Equivalence verdicts per differing word segment.
+_EQUIVALENT_SEGMENTS = {
+    ("doctor", "daktar"): True,
+    ("world", "word"): False,
+    ("good", "gud"): True,
+}
+
+
+def _dataset(path, row_ids):
+    """Write a ``run_eval_only`` dataset holding the named rows."""
+    path.write_text(
+        json.dumps(
+            [
+                {"id": row_id, "gt": _RESUME_ROWS[row_id][0], "pred": _RESUME_ROWS[row_id][1]}
+                for row_id in row_ids
+            ]
+        )
+    )
+
+
+class _StubRowJudges:
+    """Patch the four per-row STT judges with counting stubs.
+
+    Every stub answers from a fixed table, so a resumed run and a single run
+    over the same rows produce the same numbers.
+    """
+
+    def __init__(self, equivalence_judge=None):
+        from calibrate_agent.stt import metrics as stt_metrics
+        from calibrate_agent.stt import sarvam_intent_entity as sie
+        from calibrate_agent.stt import sarvam_llm_wer as slw
+        from calibrate_agent.stt import semantic_wer as sw
+
+        async def evaluator(reference, prediction, evaluators=None, fallback_model=None):
+            return {
+                ev["name"]: {
+                    "match": reference == prediction,
+                    "reasoning": f"{reference}|{prediction}",
+                }
+                for ev in evaluators
+            }
+
+        async def intent_entity(reference, prediction, model=None, index=0, context=""):
+            same = reference == prediction
+            return {
+                "intent_score": 1 if same else 0,
+                "intent_explanation": f"intent {reference}",
+                "entity_score": 1.0 if same else 0.5,
+                "ground_truth_entities": "NA",
+                "preserved_entities": "NA",
+                "missing_entities": "",
+                "entity_explanation": f"entity {reference}",
+            }
+
+        async def semantic(reference, prediction, model=None):
+            s, d, i, ref_words = _SEMANTIC_COUNTS[reference]
+            return {
+                "substitutions": s,
+                "deletions": d,
+                "insertions": i,
+                "reference_words": ref_words,
+                "normalized_reference": reference,
+                "normalized_hypothesis": prediction,
+                "reasoning": f"semantic {reference}",
+            }
+
+        async def equivalence(reference, prediction, model=None):
+            return {
+                "index": 0,
+                "equivalent": _EQUIVALENT_SEGMENTS[(reference, prediction)],
+                "reasoning": f"equivalence {reference}",
+            }
+
+        self.evaluator = AsyncMock(side_effect=evaluator)
+        self.intent_entity = AsyncMock(side_effect=intent_entity)
+        self.semantic = AsyncMock(side_effect=semantic)
+        self.equivalence = AsyncMock(side_effect=equivalence_judge or equivalence)
+
+        normalizer = MagicMock()
+        normalizer.normalize_texts.side_effect = (
+            lambda texts, langs, n_jobs=1: list(texts)
+        )
+        self._patches = [
+            patch.object(stt_metrics, "stt_llm_judge", self.evaluator),
+            patch.object(stt_metrics, "_get_indic_normalizer", return_value=normalizer),
+            patch.object(sie, "intent_entity_judge", self.intent_entity),
+            patch.object(sw, "semantic_wer_judge", self.semantic),
+            patch.object(slw, "equivalence_judge", self.equivalence),
+        ]
+
+    def __enter__(self):
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *exc):
+        for p in self._patches:
+            p.stop()
+        return False
+
+    def reset(self):
+        for mock in (self.evaluator, self.intent_entity, self.semantic, self.equivalence):
+            mock.reset_mock()
+
+    @property
+    def counts(self):
+        return {
+            "evaluator": self.evaluator.await_count,
+            "intent_entity": self.intent_entity.await_count,
+            "semantic": self.semantic.await_count,
+            "equivalence": self.equivalence.await_count,
+        }
+
+
+_RESUME_EVALUATOR = {
+    "name": "semantic_match",
+    "system_prompt": "match",
+    "judge_model": "openai/gpt-4.1",
+}
+
+
+class TestSTTEvalOnlyResume(unittest.IsolatedAsyncioTestCase):
+    """Resuming an eval-only run: pay once per row, land on the same numbers."""
+
+    async def _run(
+        self,
+        out,
+        ds_path,
+        evaluators=None,
+        overwrite=False,
+        run_llm_judges=True,
+    ):
+        from calibrate_agent.stt import eval as stt_eval
+
+        return await stt_eval.run_eval_only(
+            dataset_path=str(ds_path),
+            output_dir=str(out),
+            judge_evaluators=[evaluators or _RESUME_EVALUATOR],
+            run_llm_judges=run_llm_judges,
+            overwrite=overwrite,
+        )
+
+    def _read(self, out):
+        rows = pd.read_csv(out / "results.csv").sort_values("id")
+        return json.loads((out / "metrics.json").read_text()), rows
+
+    async def test_resume_pays_only_for_missing_rows_and_matches_a_single_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            first_ds = base / "first.json"
+            full_ds = base / "full.json"
+            _dataset(first_ds, ["row_a", "row_b"])
+            _dataset(full_ds, ["row_a", "row_b", "row_c", "row_d"])
+
+            resumed_dir = base / "resumed"
+            single_dir = base / "single"
+
+            with _StubRowJudges() as stubs:
+                await self._run(resumed_dir, first_ds)
+                stubs.reset()
+                result = await self._run(resumed_dir, full_ds)
+
+                self.assertEqual(result["status"], "completed")
+                # Only row_c and row_d are new. row_c repeats row_a's text, so
+                # its word segment already has a verdict and costs nothing; only
+                # row_d's ("good", "gud") segment is judged.
+                self.assertEqual(
+                    stubs.counts,
+                    {
+                        "evaluator": 2,
+                        "intent_entity": 2,
+                        "semantic": 2,
+                        "equivalence": 1,
+                    },
+                )
+
+                await self._run(single_dir, full_ds)
+
+            resumed_metrics, resumed_rows = self._read(resumed_dir)
+            single_metrics, single_rows = self._read(single_dir)
+
+            self.assertEqual(
+                sorted(resumed_rows["id"]), ["row_a", "row_b", "row_c", "row_d"]
+            )
+            for key in (
+                "sarvam_intent_score",
+                "sarvam_entity_score",
+                "sarvam_llm_wer",
+                "sarvam_llm_cer",
+                "semantic_wer",
+            ):
+                self.assertEqual(resumed_metrics[key], single_metrics[key], key)
+            self.assertEqual(
+                resumed_metrics["semantic_match"], single_metrics["semantic_match"]
+            )
+            self.assertEqual(resumed_metrics, single_metrics)
+            self.assertEqual(
+                resumed_rows.to_dict(orient="records"),
+                single_rows.to_dict(orient="records"),
+            )
+
+    async def test_overwrite_starts_clean(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            ds = base / "ds.json"
+            _dataset(ds, ["row_a", "row_b"])
+            out = base / "out"
+
+            with _StubRowJudges() as stubs:
+                await self._run(out, ds)
+                (out / "results.csv").write_text("id,gt,pred\nstale,,\n")
+                stubs.reset()
+                await self._run(out, ds, overwrite=True)
+
+                # Every row is judged again, including the word segments whose
+                # verdicts the earlier run had saved.
+                self.assertEqual(
+                    stubs.counts,
+                    {
+                        "evaluator": 2,
+                        "intent_entity": 2,
+                        "semantic": 2,
+                        "equivalence": 2,
+                    },
+                )
+
+            _, rows = self._read(out)
+            self.assertEqual(sorted(rows["id"]), ["row_a", "row_b"])
+
+    async def test_changed_evaluator_set_is_judged_again(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            ds = base / "ds.json"
+            _dataset(ds, ["row_a", "row_b"])
+            out = base / "out"
+
+            with _StubRowJudges() as stubs:
+                await self._run(out, ds)
+                stubs.reset()
+                await self._run(
+                    out,
+                    ds,
+                    evaluators={
+                        "name": "accuracy",
+                        "system_prompt": "accurate?",
+                        "judge_model": "openai/gpt-4.1",
+                    },
+                )
+
+                # The stored scores belong to a different evaluator, so both
+                # rows go back to the judge; the other judges are untouched.
+                self.assertEqual(stubs.evaluator.await_count, 2)
+                self.assertEqual(stubs.intent_entity.await_count, 0)
+
+            _, rows = self._read(out)
+            self.assertIn("accuracy", rows.columns)
+            self.assertNotIn("semantic_match", rows.columns)
+
+    async def test_numeric_looking_id_resumes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            ds = base / "ds.json"
+            ds.write_text(
+                json.dumps(
+                    [
+                        {"id": "1", "gt": "hello world", "pred": "hello word"},
+                        {"id": "2", "gt": "good morning", "pred": "gud morning"},
+                    ]
+                )
+            )
+            out = base / "out"
+
+            with _StubRowJudges() as stubs:
+                await self._run(out, ds)
+                stubs.reset()
+                await self._run(out, ds)
+
+                self.assertEqual(
+                    stubs.counts,
+                    {
+                        "evaluator": 0,
+                        "intent_entity": 0,
+                        "semantic": 0,
+                        "equivalence": 0,
+                    },
+                )
+
+            _, rows = self._read(out)
+            self.assertEqual(sorted(str(v) for v in rows["id"]), ["1", "2"])
+
+    async def test_duplicate_ids_fail_with_a_clear_message(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            ds = base / "ds.json"
+            ds.write_text(
+                json.dumps(
+                    [
+                        {"id": "row_a", "gt": "a", "pred": "a"},
+                        {"id": "row_a", "gt": "b", "pred": "b"},
+                    ]
+                )
+            )
+            result = await stt_eval.run_eval_only(
+                dataset_path=str(ds), output_dir=str(base / "out")
+            )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Duplicate row id", result["error"])
+        self.assertIn("row_a", result["error"])
+
+    async def test_blank_score_cell_is_judged_again(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            ds = base / "ds.json"
+            _dataset(ds, ["row_a", "row_b"])
+            out = base / "out"
+
+            with _StubRowJudges() as stubs:
+                await self._run(out, ds)
+
+                rows = pd.read_csv(out / "results.csv")
+                rows["semantic_match"] = rows["semantic_match"].astype(object)
+                rows.loc[rows["id"] == "row_a", "semantic_match"] = ""
+                rows.to_csv(out / "results.csv", index=False)
+
+                stubs.reset()
+                await self._run(out, ds)
+
+                self.assertEqual(stubs.evaluator.await_count, 1)
+                self.assertEqual(stubs.intent_entity.await_count, 0)
+
+            _, rows = self._read(out)
+            self.assertEqual(sorted(rows["id"]), ["row_a", "row_b"])
+            self.assertEqual(list(rows["semantic_match"]), [False, False])
+
+    async def test_row_missing_from_the_dataset_is_dropped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            both_ds = base / "both.json"
+            one_ds = base / "one.json"
+            _dataset(both_ds, ["row_a", "row_b"])
+            _dataset(one_ds, ["row_a"])
+            out = base / "out"
+
+            with _StubRowJudges():
+                await self._run(out, both_ds)
+                await self._run(out, one_ds)
+
+            _, rows = self._read(out)
+            self.assertEqual(list(rows["id"]), ["row_a"])
+
+    async def test_built_in_judge_rows_land_in_results_csv_while_the_run_is_going(self):
+        """The intent/entity judge writes each row as it finishes, not at the end."""
+        import asyncio
+
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            ds = base / "ds.json"
+            _dataset(ds, ["row_a", "row_b"])
+            out = base / "out"
+            results_path = out / "results.csv"
+            seen = {}
+
+            with _StubRowJudges() as stubs:
+                first = stubs.intent_entity.side_effect
+
+                async def wait_for_the_other_row(
+                    reference, prediction, model=None, index=0, context=""
+                ):
+                    if reference == "hello world":
+                        for _ in range(200):
+                            text = (
+                                results_path.read_text()
+                                if results_path.exists()
+                                else ""
+                            )
+                            if "sarvam_intent_score" in text:
+                                seen["csv"] = text
+                                break
+                            await asyncio.sleep(0.01)
+                    return await first(reference, prediction, model=model, index=index)
+
+                stubs.intent_entity.side_effect = wait_for_the_other_row
+                await stt_eval.run_eval_only(
+                    dataset_path=str(ds),
+                    output_dir=str(out),
+                    run_llm_judges=True,
+                )
+
+            self.assertIn("doctor ne bola", seen.get("csv", ""))
+
+    async def test_verdicts_survive_a_failed_llm_wer_judge(self):
+        """A killed LLM-WER judge keeps the segment verdicts it paid for."""
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            ds = base / "ds.json"
+            _dataset(ds, ["row_a", "row_b"])
+            out = base / "out"
+
+            async def half_failing(reference, prediction, model=None):
+                if reference == "world":
+                    raise RuntimeError("judge died")
+                return {
+                    "index": 0,
+                    "equivalent": _EQUIVALENT_SEGMENTS[(reference, prediction)],
+                    "reasoning": f"equivalence {reference}",
+                }
+
+            with _StubRowJudges(equivalence_judge=half_failing):
+                await self._run(out, ds)
+
+            verdicts = json.loads((out / "llm_wer_verdicts.json").read_text())
+            self.assertEqual(
+                [(v["reference"], v["prediction"]) for v in verdicts],
+                [("doctor", "daktar")],
+            )
+
+            with _StubRowJudges() as stubs:
+                await self._run(out, ds)
+                # Only the segment the failed run never got a verdict for.
+                self.assertEqual(stubs.equivalence.await_count, 1)
+                self.assertEqual(
+                    stubs.equivalence.await_args.args[:2], ("world", "word")
+                )
+
+    async def test_stored_rows_supply_the_verdicts_without_the_saved_file(self):
+        """A judged row's stored segments pay for the same phrase in a new row."""
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            first_ds = base / "first.json"
+            full_ds = base / "full.json"
+            _dataset(first_ds, ["row_a"])
+            # row_c repeats row_a's words, so its one differing segment already
+            # has a verdict stored on row_a.
+            _dataset(full_ds, ["row_a", "row_c"])
+            out = base / "out"
+
+            with _StubRowJudges() as stubs:
+                await self._run(out, first_ds)
+                (out / "llm_wer_verdicts.json").unlink()
+                stubs.reset()
+                await self._run(out, full_ds)
+
+                self.assertEqual(stubs.equivalence.await_count, 0)
+
+            _, rows = self._read(out)
+            self.assertEqual(list(rows["id"]), ["row_a", "row_c"])
+            self.assertEqual(
+                json.loads(rows["sarvam_llm_wer_reasoning"].iloc[1]),
+                json.loads(rows["sarvam_llm_wer_reasoning"].iloc[0]),
+            )
+
+    async def test_a_failing_judge_keeps_the_rows_it_already_scored(self):
+        """One judge dying on a new row must not wipe the rows already paid for."""
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            first_ds = base / "first.json"
+            full_ds = base / "full.json"
+            _dataset(first_ds, ["row_a", "row_b"])
+            _dataset(full_ds, ["row_a", "row_b", "row_d"])
+            out = base / "out"
+
+            with _StubRowJudges() as stubs:
+                await self._run(out, first_ds)
+                _, first_rows = self._read(out)
+                stored = dict(
+                    zip(first_rows["id"], first_rows["semantic_wer"], strict=True)
+                )
+
+                stubs.semantic.side_effect = RuntimeError("judge died")
+                await self._run(out, full_ds)
+
+            metrics, rows = self._read(out)
+            by_id = dict(zip(rows["id"], rows["semantic_wer"], strict=True))
+            self.assertEqual(by_id["row_a"], stored["row_a"])
+            self.assertEqual(by_id["row_b"], stored["row_b"])
+            self.assertTrue(pd.isna(by_id["row_d"]))
+            # The judge produced no dataset score this run, so none is reported.
+            self.assertNotIn("semantic_wer", metrics)
+            # The judges that did run still cover every row.
+            self.assertEqual(list(rows["sarvam_intent_score"].isna()), [False] * 3)
+
+    async def test_skipping_the_built_in_judges_keeps_their_stored_scores(self):
+        """Resuming with the built-in judges off keeps the scores already stored."""
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            ds = base / "ds.json"
+            _dataset(ds, ["row_a", "row_b"])
+            out = base / "out"
+
+            with _StubRowJudges() as stubs:
+                await self._run(out, ds)
+                _, first_rows = self._read(out)
+                stubs.reset()
+                await self._run(out, ds, run_llm_judges=False)
+
+                self.assertEqual(stubs.counts["semantic"], 0)
+                self.assertEqual(stubs.counts["intent_entity"], 0)
+
+            metrics, rows = self._read(out)
+            for column in (
+                "semantic_wer",
+                "sarvam_intent_score",
+                "sarvam_entity_score",
+                "sarvam_llm_wer",
+                "sarvam_llm_cer",
+            ):
+                self.assertIn(column, rows.columns)
+                self.assertEqual(list(rows[column]), list(first_rows[column]))
+            # No judge ran, so no dataset-level score is reported for one.
+            self.assertNotIn("semantic_wer", metrics)
+            self.assertNotIn("sarvam_intent_score", metrics)
+
+    async def test_an_edited_prediction_is_judged_again(self):
+        """A row whose text changed cannot keep the verdict on the old text."""
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            ds = base / "ds.json"
+            out = base / "out"
+            _dataset(ds, ["row_a"])
+
+            with _StubRowJudges() as stubs:
+                await self._run(out, ds, run_llm_judges=False)
+                _, first_rows = self._read(out)
+                self.assertEqual(list(first_rows["semantic_match"]), [False])
+
+                # Same id, corrected prediction.
+                ds.write_text(
+                    json.dumps(
+                        [{"id": "row_a", "gt": "doctor ne bola", "pred": "doctor ne bola"}]
+                    )
+                )
+                stubs.reset()
+                await self._run(out, ds, run_llm_judges=False)
+                self.assertEqual(stubs.evaluator.await_count, 1)
+
+            _, rows = self._read(out)
+            self.assertEqual(list(rows["pred"]), ["doctor ne bola"])
+            self.assertEqual(list(rows["semantic_match"]), [True])
+
+    async def test_ids_differing_only_by_type_fail_with_a_clear_message(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            ds = base / "ds.json"
+            ds.write_text(
+                json.dumps(
+                    [
+                        {"id": 1, "gt": "a", "pred": "a"},
+                        {"id": "1", "gt": "b", "pred": "b"},
+                    ]
+                )
+            )
+            result = await stt_eval.run_eval_only(
+                dataset_path=str(ds), output_dir=str(base / "out")
+            )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Duplicate row id", result["error"])
+
+    async def test_an_unusable_id_reports_the_row_instead_of_crashing(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            ds = base / "ds.json"
+            ds.write_text(
+                json.dumps(
+                    [
+                        {"id": "row_a", "gt": "a", "pred": "a"},
+                        {"id": ["row_b"], "gt": "b", "pred": "b"},
+                    ]
+                )
+            )
+            result = await stt_eval.run_eval_only(
+                dataset_path=str(ds), output_dir=str(base / "out")
+            )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Row 1", result["error"])
+        self.assertIn("unusable id", result["error"])
+
+    async def test_run_eval_only_asks_for_row_by_row_writing(self):
+        from calibrate_agent.stt import eval as stt_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            ds = base / "ds.json"
+            _dataset(ds, ["row_a"])
+            scorer = AsyncMock(return_value={})
+            with patch.object(stt_eval, "_score_and_write_results", scorer):
+                await stt_eval.run_eval_only(
+                    dataset_path=str(ds), output_dir=str(base / "out")
+                )
+
+        self.assertIs(scorer.await_args.kwargs.get("stream_rows"), True)
 
 
 class _FakeSarvamWS:

--- a/tests/stt/test_eval_extra.py
+++ b/tests/stt/test_eval_extra.py
@@ -16,7 +16,7 @@ import pandas as pd
 def _fake_intent_entity(intent=1, entity=1.0):
     """Adaptive ``get_intent_entity_score`` mock — one row per input pair."""
 
-    async def _fn(refs, preds, language="english", model=None):
+    async def _fn(refs, preds, language="english", model=None, **kwargs):
         return {
             "intent": float(intent),
             "entity": float(entity),
@@ -37,7 +37,7 @@ def _fake_intent_entity(intent=1, entity=1.0):
 def _fake_llm_wer(llm_wer=0.05, llm_cer=0.03):
     """Adaptive ``get_llm_wer_cer_score`` mock — one row per input pair."""
 
-    async def _fn(refs, preds, language="english", model=None):
+    async def _fn(refs, preds, language="english", model=None, **kwargs):
         return {
             "llm_wer": float(llm_wer),
             "llm_cer": float(llm_cer),
@@ -703,7 +703,7 @@ class TestScoreAndWrite(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         from calibrate_agent.stt import eval as E
 
-        async def _sem(references, predictions, model=None):
+        async def _sem(references, predictions, model=None, **kwargs):
             return {
                 "semantic_wer": 0.0,
                 "per_row": [

--- a/tests/stt/test_eval_more.py
+++ b/tests/stt/test_eval_more.py
@@ -13,7 +13,7 @@ import pandas as pd
 def _fake_intent_entity(intent=1, entity=1.0):
     """Adaptive ``get_intent_entity_score`` mock — one row per input pair."""
 
-    async def _fn(refs, preds, language="english", model=None):
+    async def _fn(refs, preds, language="english", model=None, **kwargs):
         return {
             "intent": float(intent),
             "entity": float(entity),

--- a/tests/stt/test_semantic_wer.py
+++ b/tests/stt/test_semantic_wer.py
@@ -334,7 +334,7 @@ class TestScoreAndWriteSemanticWER(unittest.IsolatedAsyncioTestCase):
     async def test_semantic_wer_in_metrics_and_results_when_enabled(self):
         from calibrate_agent.stt import eval as stt_eval
 
-        async def fake_sem(references, predictions, model=None):
+        async def fake_sem(references, predictions, model=None, **kwargs):
             return {
                 "semantic_wer": 0.05,
                 "per_row": [

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -622,6 +622,156 @@ class TestMainDispatch(unittest.TestCase):
                    AsyncMock(return_value={"openai": {"status": "pass"}})):
             self._run_with_argv(["calibrate_agent", "status", "--table"])
 
+    def _capture_argv(self):
+        captured = {}
+
+        async def fake_main():
+            captured["argv"] = list(sys.argv)
+
+        return captured, fake_main
+
+    def _run_stt_eval_only(self, extra):
+        captured, fake_main = self._capture_argv()
+        with tempfile.TemporaryDirectory() as tmp:
+            ds = Path(tmp) / "ds.json"
+            ds.write_text("[]")
+            with patch("calibrate_agent.stt.benchmark.main",
+                       AsyncMock(side_effect=fake_main)):
+                self._run_with_argv([
+                    "calibrate_agent", "stt", "--eval-only", "--dataset", str(ds),
+                    "-o", tmp,
+                ] + extra)
+        return captured["argv"]
+
+    def test_stt_eval_only_forwards_overwrite(self):
+        self.assertIn("--overwrite", self._run_stt_eval_only(["--overwrite"]))
+
+    def test_stt_eval_only_omits_overwrite_by_default(self):
+        self.assertNotIn("--overwrite", self._run_stt_eval_only([]))
+
+    def _run_tts_eval_only(self, extra):
+        captured, fake_main = self._capture_argv()
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("calibrate_agent.tts.benchmark.main",
+                       AsyncMock(side_effect=fake_main)):
+                self._run_with_argv([
+                    "calibrate_agent", "tts", "--eval-only", "--dataset", tmp,
+                    "-o", str(Path(tmp) / "out"),
+                ] + extra)
+        return captured["argv"]
+
+    def test_tts_eval_only_forwards_overwrite(self):
+        self.assertIn("--overwrite", self._run_tts_eval_only(["--overwrite"]))
+
+    def test_tts_eval_only_omits_overwrite_by_default(self):
+        self.assertNotIn("--overwrite", self._run_tts_eval_only([]))
+
+    def _run_llm_eval_only(self, extra):
+        captured, fake_main = self._capture_argv()
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "config.json"
+            cfg.write_text("{}")
+            ds = Path(tmp) / "ds.json"
+            ds.write_text("[]")
+            with patch("calibrate_agent.llm.run_tests.main",
+                       AsyncMock(side_effect=fake_main)):
+                self._run_with_argv([
+                    "calibrate_agent", "llm", "--eval-only",
+                    "-c", str(cfg), "--dataset", str(ds), "-o", tmp,
+                ] + extra)
+        return captured["argv"]
+
+    def test_llm_eval_only_forwards_overwrite(self):
+        self.assertIn("--overwrite", self._run_llm_eval_only(["--overwrite"]))
+
+    def test_llm_eval_only_omits_overwrite_by_default(self):
+        self.assertNotIn("--overwrite", self._run_llm_eval_only([]))
+
+    def _run_general(self, extra):
+        captured, fake_main = self._capture_argv()
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "config.json"
+            cfg.write_text("{}")
+            ds = Path(tmp) / "ds.json"
+            ds.write_text("[]")
+            with patch("calibrate_agent.general.eval.main",
+                       AsyncMock(side_effect=fake_main)):
+                self._run_with_argv([
+                    "calibrate_agent", "general",
+                    "--dataset", str(ds), "-c", str(cfg), "-o", tmp,
+                ] + extra)
+        return captured["argv"]
+
+    def test_general_forwards_overwrite(self):
+        self.assertIn("--overwrite", self._run_general(["--overwrite"]))
+
+    def test_general_omits_overwrite_by_default(self):
+        self.assertNotIn("--overwrite", self._run_general([]))
+
+    def _run_sim_text_eval_only(self, extra):
+        captured, fake_main = self._capture_argv()
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "cfg.json"
+            cfg.write_text("{}")
+            ds = Path(tmp) / "ds.json"
+            ds.write_text("[]")
+            with patch("calibrate_agent.llm.run_simulation.main",
+                       AsyncMock(side_effect=fake_main)):
+                self._run_with_argv([
+                    "calibrate_agent", "simulations", "--type", "text",
+                    "-c", str(cfg), "--eval-only", "--dataset", str(ds), "-o", tmp,
+                ] + extra)
+        return captured["argv"]
+
+    def test_simulations_text_eval_only_forwards_overwrite(self):
+        self.assertIn("--overwrite", self._run_sim_text_eval_only(["--overwrite"]))
+
+    def test_simulations_text_eval_only_omits_overwrite_by_default(self):
+        self.assertNotIn("--overwrite", self._run_sim_text_eval_only([]))
+
+    def test_simulations_voice_rejects_overwrite(self):
+        captured, fake_main = self._capture_argv()
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "cfg.json"
+            cfg.write_text("{}")
+            with patch("calibrate_agent.agent.run_simulation.main",
+                       AsyncMock(side_effect=fake_main)):
+                with self.assertRaises(SystemExit) as ctx:
+                    self._run_with_argv([
+                        "calibrate_agent", "simulations", "--type", "voice",
+                        "-c", str(cfg), "-o", tmp, "--overwrite",
+                    ])
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertNotIn("argv", captured)
+
+    def test_simulations_voice_runs_without_overwrite(self):
+        captured, fake_main = self._capture_argv()
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "cfg.json"
+            cfg.write_text("{}")
+            with patch("calibrate_agent.agent.run_simulation.main",
+                       AsyncMock(side_effect=fake_main)):
+                self._run_with_argv([
+                    "calibrate_agent", "simulations", "--type", "voice",
+                    "-c", str(cfg), "-o", tmp,
+                ])
+        self.assertNotIn("--overwrite", captured["argv"])
+
+    def test_simulations_leaderboard_ignores_overwrite(self):
+        seen = {}
+
+        def fake_leaderboard(output_dir, save_dir):
+            seen["dirs"] = (output_dir, save_dir)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("calibrate_agent.llm.simulation_leaderboard.generate_leaderboard",
+                       fake_leaderboard):
+                self._run_with_argv([
+                    "calibrate_agent", "simulations", "--overwrite", "leaderboard",
+                    "-o", tmp, "-s", tmp,
+                ])
+        self.assertIn("dirs", seen)
+
     def test_agent_test_runs(self):
         with tempfile.TemporaryDirectory() as tmp:
             cfg = Path(tmp) / "cfg.json"

--- a/tests/test_judges.py
+++ b/tests/test_judges.py
@@ -13,6 +13,8 @@ Run with:
     python -m pytest tests/test_judges.py -v
 """
 
+import os
+import tempfile
 import unittest
 from unittest.mock import patch, AsyncMock, MagicMock
 
@@ -26,6 +28,14 @@ from calibrate_agent.judges import (
     audio_judge,
     is_rating,
     evaluator_result_value,
+    evaluator_row_columns,
+    evaluator_row_from_columns,
+    read_existing_rows,
+    stored_bool,
+    stored_cell,
+    stored_scores_are_comparable,
+    write_evaluator_config,
+    PartialResultsWriter,
     render_template,
     render_evaluator,
     ensure_known_evaluator_names,
@@ -889,6 +899,249 @@ class TestDefaultEvaluators(unittest.TestCase):
         self.assertEqual(
             DEFAULT_TTS_EVALUATOR["judge_model"], DEFAULT_AUDIO_JUDGE_MODEL
         )
+
+
+class TestReadExistingRows(unittest.TestCase):
+    def _write(self, directory, text):
+        path = os.path.join(directory, "results.csv")
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            f.write(text)
+        return path
+
+    def test_numeric_looking_ids_stay_text(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, "id,gt,q\n1,a,True\n02,b,False\n")
+            rows = read_existing_rows(path)
+        self.assertEqual(set(rows), {"1", "02"})
+
+    def test_missing_file_reads_as_no_rows(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(
+                read_existing_rows(os.path.join(tmp, "absent.csv")), {}
+            )
+
+    def test_rows_without_an_id_are_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, "id,q\n,True\nrow_a,False\n")
+            self.assertEqual(set(read_existing_rows(path)), {"row_a"})
+
+
+class TestStoredCell(unittest.TestCase):
+    def test_blank_and_missing_read_as_nothing(self):
+        row = {"a": "", "b": "   ", "c": float("nan"), "d": None}
+        for column in ("a", "b", "c", "d", "absent"):
+            self.assertIsNone(stored_cell(row, column), column)
+
+    def test_zero_is_a_real_value(self):
+        self.assertEqual(stored_cell({"a": 0}, "a"), 0)
+        self.assertEqual(stored_cell({"a": "0"}, "a"), "0")
+
+    def test_no_row_reads_as_nothing(self):
+        self.assertIsNone(stored_cell(None, "a"))
+
+
+class TestStoredBool(unittest.TestCase):
+    def test_recognised_values(self):
+        for value in (True, "True", "true", "1", "1.0"):
+            self.assertIs(stored_bool(value), True, value)
+        for value in (False, "False", "false", "0", "0.0"):
+            self.assertIs(stored_bool(value), False, value)
+
+    def test_unrecognised_value(self):
+        self.assertIsNone(stored_bool("maybe"))
+
+
+class TestEvaluatorRowFromColumns(unittest.TestCase):
+    BINARY = {"q": {"name": "q"}}
+    RATING = {"r": {"name": "r", "type": "rating", "scale_min": 1, "scale_max": 5}}
+
+    def test_round_trips_what_evaluator_row_columns_wrote(self):
+        judge_row = {"q": {"match": True, "reasoning": "ok"}}
+        columns = evaluator_row_columns(self.BINARY, judge_row)
+        self.assertEqual(evaluator_row_from_columns(self.BINARY, columns), judge_row)
+
+    def test_whole_number_ratings_stay_whole(self):
+        rebuilt = evaluator_row_from_columns(
+            self.RATING, {"r": "4.0", "r_reasoning": "good"}
+        )
+        self.assertEqual(rebuilt, {"r": {"score": 4, "reasoning": "good"}})
+        self.assertIsInstance(rebuilt["r"]["score"], int)
+
+    def test_a_different_evaluator_set_is_not_reused(self):
+        columns = evaluator_row_columns(
+            self.BINARY, {"q": {"match": True, "reasoning": "ok"}}
+        )
+        self.assertIsNone(
+            evaluator_row_from_columns({"other": {"name": "other"}}, columns)
+        )
+
+    def test_a_blank_score_counts_as_unjudged(self):
+        self.assertIsNone(
+            evaluator_row_from_columns(self.BINARY, {"q": "", "q_reasoning": ""})
+        )
+
+    def test_an_unreadable_score_counts_as_unjudged(self):
+        self.assertIsNone(
+            evaluator_row_from_columns(self.RATING, {"r": "high", "r_reasoning": ""})
+        )
+        self.assertIsNone(
+            evaluator_row_from_columns(self.BINARY, {"q": "maybe", "q_reasoning": ""})
+        )
+
+    def test_missing_reasoning_reads_as_empty(self):
+        self.assertEqual(
+            evaluator_row_from_columns(self.BINARY, {"q": "True"}),
+            {"q": {"match": True, "reasoning": ""}},
+        )
+
+
+class TestStoredScoresAreComparable(unittest.TestCase):
+    BINARY = {"name": "q", "system_prompt": "p"}
+    RATING = {
+        "name": "q",
+        "system_prompt": "p",
+        "type": "rating",
+        "scale_min": 1,
+        "scale_max": 5,
+    }
+
+    def _run_dir(self, tmp, evaluators):
+        write_evaluator_config(tmp, evaluators)
+        return tmp
+
+    def test_an_unchanged_evaluator_is_comparable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._run_dir(tmp, [self.BINARY])
+            self.assertTrue(stored_scores_are_comparable(tmp, [self.BINARY]))
+
+    def test_a_reworded_prompt_is_still_comparable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._run_dir(tmp, [self.BINARY])
+            reworded = {**self.BINARY, "system_prompt": "something else"}
+            self.assertTrue(stored_scores_are_comparable(tmp, [reworded]))
+
+    def test_a_different_judge_model_is_still_comparable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._run_dir(tmp, [{**self.BINARY, "judge_model": "a"}])
+            self.assertTrue(
+                stored_scores_are_comparable(tmp, [{**self.BINARY, "judge_model": "b"}])
+            )
+
+    def test_pass_fail_turned_into_a_rating_is_not_comparable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._run_dir(tmp, [self.BINARY])
+            self.assertFalse(stored_scores_are_comparable(tmp, [self.RATING]))
+
+    def test_a_widened_rating_range_is_not_comparable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._run_dir(tmp, [self.RATING])
+            widened = {**self.RATING, "scale_max": 10}
+            self.assertFalse(stored_scores_are_comparable(tmp, [widened]))
+
+    def test_an_evaluator_the_prior_run_did_not_have_is_comparable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._run_dir(tmp, [self.BINARY])
+            added = {"name": "extra", "system_prompt": "p"}
+            self.assertTrue(stored_scores_are_comparable(tmp, [self.BINARY, added]))
+
+    def test_no_prior_config_is_not_comparable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertFalse(stored_scores_are_comparable(tmp, [self.BINARY]))
+
+    def test_an_unreadable_config_is_not_comparable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with open(os.path.join(tmp, "config.json"), "w") as f:
+                f.write("{not json")
+            self.assertFalse(stored_scores_are_comparable(tmp, [self.BINARY]))
+
+
+class TestPartialResultsWriter(unittest.TestCase):
+    EVALUATORS = {"q": {"name": "q"}}
+    BASE = [{"id": "1", "gt": "a"}, {"id": "row_b", "gt": "b"}]
+
+    def _judged(self, match, reasoning):
+        return evaluator_row_columns(
+            self.EVALUATORS, {"q": {"match": match, "reasoning": reasoning}}
+        )
+
+    def test_only_judged_rows_are_written(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "results.csv")
+            writer = PartialResultsWriter(path, self.BASE)
+            writer.update(1, self._judged(True, "ok"))
+            rows = read_existing_rows(path)
+            self.assertEqual(set(rows), {"row_b"})
+            writer.update(0, self._judged(False, "no"))
+            self.assertEqual(set(read_existing_rows(path)), {"1", "row_b"})
+
+    def test_rows_are_written_in_dataset_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "results.csv")
+            writer = PartialResultsWriter(path, self.BASE)
+            writer.update(1, self._judged(True, "ok"))
+            writer.update(0, self._judged(False, "no"))
+            self.assertEqual(list(read_existing_rows(path)), ["1", "row_b"])
+
+    def test_several_judges_fill_one_row(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "results.csv")
+            writer = PartialResultsWriter(path, self.BASE)
+            writer.update(0, {"semantic_wer": 0.1})
+            writer.update(0, self._judged(True, "ok"))
+            row = read_existing_rows(path)["1"]
+            self.assertEqual(row["semantic_wer"], "0.1")
+            self.assertEqual(row["q"], "True")
+
+    def test_a_resumed_run_keeps_the_rows_it_started_with(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "results.csv")
+            first = PartialResultsWriter(path, self.BASE)
+            first.update(0, self._judged(False, "no"))
+
+            second = PartialResultsWriter(path, self.BASE, read_existing_rows(path))
+            second.update(1, self._judged(True, "ok"))
+
+            rows = read_existing_rows(path)
+            self.assertEqual(set(rows), {"1", "row_b"})
+            self.assertEqual(rows["1"]["q"], "False")
+            self.assertEqual(rows["1"]["q_reasoning"], "no")
+
+    def test_a_row_not_in_the_dataset_is_dropped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "results.csv")
+            writer = PartialResultsWriter(
+                path, self.BASE, {"ghost": {"id": "ghost", "q": "True"}}
+            )
+            writer.update(0, self._judged(True, "ok"))
+            self.assertEqual(set(read_existing_rows(path)), {"1"})
+
+    def test_the_dataset_owns_its_own_columns(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "results.csv")
+            stale = {"1": {"id": "1", "gt": "stale", "q": "True"}}
+            writer = PartialResultsWriter(path, self.BASE, stale)
+            writer.update(1, self._judged(True, "ok"))
+            self.assertEqual(read_existing_rows(path)["1"]["gt"], "a")
+
+    def test_a_blank_stored_value_is_not_carried_over(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "results.csv")
+            stale = {"1": {"id": "1", "gt": "a", "q": "", "q_reasoning": ""}}
+            writer = PartialResultsWriter(path, self.BASE, stale)
+            writer.update(1, self._judged(True, "ok"))
+            self.assertIsNone(stored_cell(read_existing_rows(path)["1"], "q"))
+
+    def test_nothing_is_written_before_the_first_result(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "results.csv")
+            PartialResultsWriter(path, self.BASE)
+            self.assertFalse(os.path.exists(path))
+
+    def test_a_write_failure_does_not_take_down_the_run(self):
+        writer = PartialResultsWriter(
+            os.path.join("no", "such", "dir", "results.csv"), self.BASE
+        )
+        writer.update(0, self._judged(True, "ok"))
 
 
 if __name__ == "__main__":

--- a/tests/tts/test_benchmark.py
+++ b/tests/tts/test_benchmark.py
@@ -29,10 +29,11 @@ class TestTTSBenchmarkEvalOnly(unittest.IsolatedAsyncioTestCase):
     async def test_success_calls_run_eval_only(self):
         captured = {}
 
-        async def fake_run_eval_only(*, dataset_path, output_dir, judge_evaluators):
+        async def fake_run_eval_only(*, dataset_path, output_dir, judge_evaluators, overwrite):
             captured["dataset_path"] = dataset_path
             captured["output_dir"] = output_dir
             captured["judge_evaluators"] = judge_evaluators
+            captured["overwrite"] = overwrite
             return {
                 "status": "completed",
                 "metrics": {"quality": {"type": "binary", "mean": 0.9}},
@@ -51,11 +52,32 @@ class TestTTSBenchmarkEvalOnly(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(captured["output_dir"], out)
         # No config passed → evaluators default to None.
         self.assertIsNone(captured["judge_evaluators"])
+        self.assertFalse(captured["overwrite"])
+
+    async def test_overwrite_flag_forwarded(self):
+        captured = {}
+
+        async def fake_run_eval_only(
+            *, dataset_path, output_dir, judge_evaluators, overwrite
+        ):
+            captured["overwrite"] = overwrite
+            return {"status": "completed", "metrics": {}, "output_dir": output_dir}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch(
+                "calibrate_agent.tts.benchmark.run_eval_only",
+                AsyncMock(side_effect=fake_run_eval_only),
+            ):
+                await self._run_main(
+                    ["--dataset", tmp, "-o", os.path.join(tmp, "out"), "--overwrite"]
+                )
+
+        self.assertTrue(captured["overwrite"])
 
     async def test_config_forwards_evaluators(self):
         captured = {}
 
-        async def fake_run_eval_only(*, dataset_path, output_dir, judge_evaluators):
+        async def fake_run_eval_only(*, dataset_path, output_dir, judge_evaluators, overwrite):
             captured["judge_evaluators"] = judge_evaluators
             return {"status": "completed", "metrics": {}, "output_dir": output_dir}
 
@@ -73,7 +95,7 @@ class TestTTSBenchmarkEvalOnly(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(captured["judge_evaluators"], [{"name": "q", "system_prompt": "p"}])
 
     async def test_error_result_exits(self):
-        async def fake_run_eval_only(*, dataset_path, output_dir, judge_evaluators):
+        async def fake_run_eval_only(*, dataset_path, output_dir, judge_evaluators, overwrite):
             return {"status": "error", "error": "boom"}
 
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/tts/test_eval.py
+++ b/tests/tts/test_eval.py
@@ -6,6 +6,7 @@ Run with:
 """
 
 import asyncio
+import json
 import os
 import tempfile
 import unittest
@@ -719,6 +720,496 @@ class TestTTSPartialResults(unittest.IsolatedAsyncioTestCase):
                 )
 
             self.assertEqual(seen["mid_run"], synthesis_csv)
+
+
+QUALITY_EVALUATOR = {
+    "name": "quality",
+    "system_prompt": "judge quality",
+    "judge_model": "openai/gpt-audio",
+    "type": "binary",
+}
+
+
+def _make_eval_only_run_dir(tmp: str, rows: list[dict]) -> str:
+    """Create a run dir whose results.csv holds ``rows`` (id + text), one WAV each."""
+    run_dir = os.path.join(tmp, "openai")
+    os.makedirs(os.path.join(run_dir, "audios"), exist_ok=True)
+    records = []
+    for row in rows:
+        name = f"{row['id']}.wav"
+        _write_wav(os.path.join(run_dir, "audios", name))
+        records.append(
+            {"id": row["id"], "text": row["text"], "audio_path": f"audios/{name}"}
+        )
+    pd.DataFrame(records).to_csv(os.path.join(run_dir, "results.csv"), index=False)
+    return run_dir
+
+
+def _audio(run_dir: str, row_id: str) -> str:
+    """The audio path an eval-only run stores for a row: resolved and absolute."""
+    return os.path.abspath(os.path.join(run_dir, "audios", f"{row_id}.wav"))
+
+
+def _write_prior_eval(out: str, rows: list[dict], evaluators=None) -> None:
+    """Stand in for an eval-only run that was killed part-way.
+
+    Writes both files such a run leaves behind: the config.json recording how
+    its scores were produced, and the results.csv holding them.
+    """
+    from calibrate_agent.judges import write_evaluator_config
+
+    os.makedirs(out, exist_ok=True)
+    write_evaluator_config(out, evaluators or [QUALITY_EVALUATOR])
+    pd.DataFrame(rows).to_csv(os.path.join(out, "results.csv"), index=False)
+
+
+class TestTTSEvalOnlyResume(unittest.IsolatedAsyncioTestCase):
+    """Eval-only picks up where a killed run stopped, and --overwrite starts over."""
+
+    def setUp(self):
+        from calibrate_agent.tts import metrics as tts_metrics
+
+        self.tts_metrics = tts_metrics
+
+    async def _run(self, run_dir, out, judge, evaluators=None, overwrite=False):
+        from calibrate_agent.tts import eval as tts_eval
+
+        with patch.object(self.tts_metrics, "tts_llm_judge", judge):
+            return await tts_eval.run_eval_only(
+                dataset_path=run_dir,
+                output_dir=out,
+                judge_evaluators=evaluators or [QUALITY_EVALUATOR],
+                overwrite=overwrite,
+            )
+
+    @staticmethod
+    def _judge(name="quality"):
+        async def fake_judge(audio_path, reference_text, **kwargs):
+            return {
+                name: {
+                    "match": reference_text == "first",
+                    "reasoning": f"{name}:{reference_text}",
+                }
+            }
+
+        return AsyncMock(side_effect=fake_judge)
+
+    async def test_only_missing_rows_are_judged_and_all_rows_land_in_results(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_eval_only_run_dir(
+                tmp,
+                [
+                    {"id": "row_a", "text": "first"},
+                    {"id": "row_b", "text": "second"},
+                ],
+            )
+            out = os.path.join(tmp, "eval")
+            _write_prior_eval(
+                out,
+                [
+                    {
+                        "id": "row_a",
+                        "text": "first",
+                        "audio_path": _audio(run_dir, "row_a"),
+                        "quality": True,
+                        "quality_reasoning": "kept",
+                    }
+                ],
+            )
+
+            judge = self._judge()
+            result = await self._run(run_dir, out, judge)
+
+            self.assertEqual(result["status"], "completed")
+            self.assertEqual(judge.await_count, 1)
+            df = pd.read_csv(os.path.join(out, "results.csv"))
+            self.assertEqual(list(df["id"]), ["row_a", "row_b"])
+            self.assertEqual(list(df["quality_reasoning"]), ["kept", "quality:second"])
+            self.assertTrue(df.iloc[0]["audio_path"].endswith("audios/row_a.wav"))
+
+    async def test_row_whose_audio_file_changed_is_judged_again(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_eval_only_run_dir(tmp, [{"id": "row_a", "text": "first"}])
+            out = os.path.join(tmp, "eval")
+            _write_prior_eval(
+                out,
+                [
+                    {
+                        "id": "row_a",
+                        "text": "first",
+                        "audio_path": os.path.join(tmp, "older", "row_a.wav"),
+                        "quality": True,
+                        "quality_reasoning": "scored the older audio",
+                    }
+                ],
+            )
+
+            judge = self._judge()
+            await self._run(run_dir, out, judge)
+
+            self.assertEqual(judge.await_count, 1)
+            df = pd.read_csv(os.path.join(out, "results.csv"))
+            self.assertEqual(list(df["quality_reasoning"]), ["quality:first"])
+
+    async def test_row_whose_text_changed_is_judged_again(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_eval_only_run_dir(tmp, [{"id": "row_a", "text": "first"}])
+            out = os.path.join(tmp, "eval")
+            _write_prior_eval(
+                out,
+                [
+                    {
+                        "id": "row_a",
+                        "text": "an older line",
+                        "audio_path": _audio(run_dir, "row_a"),
+                        "quality": True,
+                        "quality_reasoning": "scored the older line",
+                    }
+                ],
+            )
+
+            judge = self._judge()
+            await self._run(run_dir, out, judge)
+
+            self.assertEqual(judge.await_count, 1)
+            df = pd.read_csv(os.path.join(out, "results.csv"))
+            self.assertEqual(list(df["quality_reasoning"]), ["quality:first"])
+
+    async def test_rows_to_be_judged_again_are_left_out_of_the_partial_file(self):
+        """A row that must be judged again shows no score until it is judged."""
+        seen = {}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_eval_only_run_dir(
+                tmp,
+                [
+                    {"id": "row_a", "text": "first"},
+                    {"id": "row_b", "text": "second"},
+                ],
+            )
+            out = os.path.join(tmp, "eval")
+            results_path = os.path.join(out, "results.csv")
+            # Prior run scored both rows on ``quality`` only. Adding a second
+            # evaluator means every row has to be judged again.
+            _write_prior_eval(
+                out,
+                [
+                    {
+                        "id": row_id,
+                        "text": text,
+                        "audio_path": _audio(run_dir, row_id),
+                        "quality": True,
+                        "quality_reasoning": "from the old run",
+                    }
+                    for row_id, text in (("row_a", "first"), ("row_b", "second"))
+                ],
+            )
+
+            async def fake_judge(audio_path, reference_text, **kwargs):
+                if reference_text == "second":
+                    await asyncio.sleep(0.05)
+                    seen["partial"] = pd.read_csv(results_path)
+                return {
+                    "quality": {"match": True, "reasoning": "new"},
+                    "clarity": {"match": True, "reasoning": "new"},
+                }
+
+            await self._run(
+                run_dir,
+                out,
+                AsyncMock(side_effect=fake_judge),
+                evaluators=[
+                    QUALITY_EVALUATOR,
+                    dict(QUALITY_EVALUATOR, name="clarity"),
+                ],
+            )
+
+            self.assertEqual(list(seen["partial"]["id"]), ["row_a"])
+            self.assertEqual(list(seen["partial"]["quality_reasoning"]), ["new"])
+
+    async def test_resumed_metrics_match_a_single_run(self):
+        rows = [
+            {"id": "row_a", "text": "first"},
+            {"id": "row_b", "text": "second"},
+            {"id": "row_c", "text": "third"},
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_eval_only_run_dir(tmp, rows)
+
+            whole = os.path.join(tmp, "whole")
+            await self._run(run_dir, whole, self._judge())
+            with open(os.path.join(whole, "metrics.json")) as f:
+                whole_metrics = json.load(f)
+
+            partial = os.path.join(tmp, "partial")
+            _write_prior_eval(
+                partial,
+                [
+                    {
+                        "id": "row_a",
+                        "text": "first",
+                        "audio_path": _audio(run_dir, "row_a"),
+                        "quality": True,
+                        "quality_reasoning": "quality:first",
+                    }
+                ],
+            )
+            judge = self._judge()
+            await self._run(run_dir, partial, judge)
+            with open(os.path.join(partial, "metrics.json")) as f:
+                partial_metrics = json.load(f)
+
+            self.assertEqual(judge.await_count, 2)
+            self.assertEqual(partial_metrics, whole_metrics)
+            self.assertAlmostEqual(partial_metrics["quality"]["mean"], 1 / 3)
+
+    async def test_overwrite_starts_clean(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_eval_only_run_dir(
+                tmp,
+                [{"id": "row_a", "text": "first"}, {"id": "row_b", "text": "second"}],
+            )
+            out = os.path.join(tmp, "eval")
+            _write_prior_eval(
+                out,
+                [
+                    {
+                        "id": "row_a",
+                        "text": "first",
+                        "audio_path": _audio(run_dir, "row_a"),
+                        "quality": True,
+                        "quality_reasoning": "stale",
+                    }
+                ],
+            )
+            with open(os.path.join(out, "metrics.json"), "w") as f:
+                json.dump({"quality": {"type": "binary", "mean": 0.0}}, f)
+
+            judge = self._judge()
+            await self._run(run_dir, out, judge, overwrite=True)
+
+            self.assertEqual(judge.await_count, 2)
+            df = pd.read_csv(os.path.join(out, "results.csv"))
+            self.assertEqual(
+                list(df["quality_reasoning"]), ["quality:first", "quality:second"]
+            )
+            with open(os.path.join(out, "metrics.json")) as f:
+                self.assertAlmostEqual(json.load(f)["quality"]["mean"], 0.5)
+
+    async def test_changed_evaluator_set_is_rejudged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_eval_only_run_dir(tmp, [{"id": "row_a", "text": "first"}])
+            out = os.path.join(tmp, "eval")
+            _write_prior_eval(
+                out,
+                [
+                    {
+                        "id": "row_a",
+                        "text": "first",
+                        "audio_path": _audio(run_dir, "row_a"),
+                        "quality": True,
+                        "quality_reasoning": "old evaluator",
+                    }
+                ],
+            )
+
+            judge = self._judge(name="clarity")
+            await self._run(
+                run_dir,
+                out,
+                judge,
+                evaluators=[dict(QUALITY_EVALUATOR, name="clarity")],
+            )
+
+            self.assertEqual(judge.await_count, 1)
+            df = pd.read_csv(os.path.join(out, "results.csv"))
+            self.assertEqual(list(df["clarity_reasoning"]), ["clarity:first"])
+
+    async def test_numeric_looking_id_resumes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_eval_only_run_dir(
+                tmp, [{"id": "1", "text": "first"}, {"id": "2", "text": "second"}]
+            )
+            out = os.path.join(tmp, "eval")
+            _write_prior_eval(
+                out,
+                [
+                    {
+                        "id": "1",
+                        "text": "first",
+                        "audio_path": _audio(run_dir, "1"),
+                        "quality": True,
+                        "quality_reasoning": "kept",
+                    }
+                ],
+            )
+
+            judge = self._judge()
+            await self._run(run_dir, out, judge)
+
+            self.assertEqual(judge.await_count, 1)
+            df = pd.read_csv(os.path.join(out, "results.csv"))
+            self.assertEqual(list(df["quality_reasoning"]), ["kept", "quality:second"])
+
+    async def test_blank_score_cell_is_rejudged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_eval_only_run_dir(tmp, [{"id": "row_a", "text": "first"}])
+            out = os.path.join(tmp, "eval")
+            _write_prior_eval(
+                out,
+                [
+                    {
+                        "id": "row_a",
+                        "text": "first",
+                        "audio_path": _audio(run_dir, "row_a"),
+                        "quality": "",
+                        "quality_reasoning": "",
+                    }
+                ],
+            )
+
+            judge = self._judge()
+            await self._run(run_dir, out, judge)
+
+            self.assertEqual(judge.await_count, 1)
+            df = pd.read_csv(os.path.join(out, "results.csv"))
+            self.assertEqual(list(df["quality_reasoning"]), ["quality:first"])
+
+    async def test_row_missing_from_dataset_is_dropped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_eval_only_run_dir(tmp, [{"id": "row_a", "text": "first"}])
+            out = os.path.join(tmp, "eval")
+            _write_prior_eval(
+                out,
+                [
+                    {
+                        "id": "row_gone",
+                        "text": "removed",
+                        "audio_path": _audio(run_dir, "row_gone"),
+                        "quality": True,
+                        "quality_reasoning": "old",
+                    }
+                ],
+            )
+
+            await self._run(run_dir, out, self._judge())
+
+            df = pd.read_csv(os.path.join(out, "results.csv"))
+            self.assertEqual(list(df["id"]), ["row_a"])
+
+    async def test_evaluator_that_became_a_rating_rejudges_every_row(self):
+        rating_ev = dict(
+            QUALITY_EVALUATOR, type="rating", scale_min=1, scale_max=5
+        )
+
+        async def fake_judge(audio_path, reference_text, **kwargs):
+            return {"quality": {"score": 4, "reasoning": "rated"}}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_eval_only_run_dir(tmp, [{"id": "row_a", "text": "first"}])
+            out = os.path.join(tmp, "eval")
+            _write_prior_eval(
+                out,
+                [
+                    {
+                        "id": "row_a",
+                        "text": "first",
+                        "audio_path": _audio(run_dir, "row_a"),
+                        "quality": True,
+                        "quality_reasoning": "pass/fail from the old run",
+                    }
+                ],
+            )
+
+            judge = AsyncMock(side_effect=fake_judge)
+            await self._run(run_dir, out, judge, evaluators=[rating_ev])
+
+            self.assertEqual(judge.await_count, 1)
+            df = pd.read_csv(os.path.join(out, "results.csv"))
+            self.assertEqual(list(df["quality"]), [4])
+            with open(os.path.join(out, "metrics.json")) as f:
+                metrics = json.load(f)
+            self.assertEqual(metrics["quality"]["mean"], 4.0)
+
+    async def test_widened_rating_range_rejudges_every_row(self):
+        def rating(scale_max):
+            return dict(
+                QUALITY_EVALUATOR, type="rating", scale_min=1, scale_max=scale_max
+            )
+
+        async def fake_judge(audio_path, reference_text, **kwargs):
+            return {"quality": {"score": 9, "reasoning": "rated"}}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_eval_only_run_dir(tmp, [{"id": "row_a", "text": "first"}])
+            out = os.path.join(tmp, "eval")
+            _write_prior_eval(
+                out,
+                [
+                    {
+                        "id": "row_a",
+                        "text": "first",
+                        "audio_path": _audio(run_dir, "row_a"),
+                        "quality": 5,
+                        "quality_reasoning": "top of the old range",
+                    }
+                ],
+                evaluators=[rating(5)],
+            )
+
+            judge = AsyncMock(side_effect=fake_judge)
+            await self._run(run_dir, out, judge, evaluators=[rating(10)])
+
+            self.assertEqual(judge.await_count, 1)
+            df = pd.read_csv(os.path.join(out, "results.csv"))
+            self.assertEqual(list(df["quality"]), [9])
+
+    async def test_reworded_prompt_still_reuses_stored_scores(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_eval_only_run_dir(tmp, [{"id": "row_a", "text": "first"}])
+            out = os.path.join(tmp, "eval")
+            _write_prior_eval(
+                out,
+                [
+                    {
+                        "id": "row_a",
+                        "text": "first",
+                        "audio_path": _audio(run_dir, "row_a"),
+                        "quality": True,
+                        "quality_reasoning": "kept",
+                    }
+                ],
+            )
+
+            judge = self._judge()
+            await self._run(
+                run_dir,
+                out,
+                judge,
+                evaluators=[
+                    dict(QUALITY_EVALUATOR, system_prompt="judge quality, carefully")
+                ],
+            )
+
+            judge.assert_not_awaited()
+            df = pd.read_csv(os.path.join(out, "results.csv"))
+            self.assertEqual(list(df["quality_reasoning"]), ["kept"])
+
+    async def test_duplicate_ids_rejected(self):
+        from calibrate_agent.tts import eval as tts_eval
+
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = _make_eval_only_run_dir(
+                tmp, [{"id": "row_a", "text": "first"}, {"id": "row_a", "text": "again"}]
+            )
+            result = await tts_eval.run_eval_only(
+                dataset_path=run_dir,
+                output_dir=os.path.join(tmp, "eval"),
+                judge_evaluators=[QUALITY_EVALUATOR],
+            )
+            self.assertEqual(result["status"], "error")
+            self.assertIn("Duplicate row id", result["error"])
+            self.assertIn("row_a", result["error"])
 
 
 if __name__ == "__main__":

--- a/tests/tts/test_metrics.py
+++ b/tests/tts/test_metrics.py
@@ -162,6 +162,36 @@ class TestTTSJudgeOnRow(unittest.IsolatedAsyncioTestCase):
             [row["quality"]["reasoning"] for row in result["per_row"]], ["hi", "bye"]
         )
 
+    async def test_known_rows_skip_the_judge_and_keep_dataset_positions(self):
+        from calibrate_agent.tts import metrics as tts_metrics
+
+        judge = AsyncMock(
+            side_effect=lambda audio_path, reference_text, **kwargs: {
+                "quality": {"match": False, "reasoning": reference_text}
+            }
+        )
+        seen = []
+        with patch.object(tts_metrics, "tts_llm_judge", judge):
+            result = await tts_metrics.get_tts_llm_judge_score(
+                audio_paths=["/tmp/a.wav", "/tmp/b.wav", "/tmp/c.wav"],
+                reference_texts=["hi", "bye", "ciao"],
+                evaluators=self.EVALUATORS,
+                on_row=lambda index, row: seen.append(index),
+                known=[
+                    None,
+                    {"quality": {"match": True, "reasoning": "from a prior run"}},
+                    None,
+                ],
+            )
+
+        self.assertEqual(judge.await_count, 2)
+        self.assertEqual(sorted(seen), [0, 2])
+        self.assertEqual(
+            [row["quality"]["reasoning"] for row in result["per_row"]],
+            ["hi", "from a prior run", "ciao"],
+        )
+        self.assertAlmostEqual(result["scores"]["quality"]["mean"], 1 / 3)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What this does

Every `--eval-only` run can now pick up where it left off. It reads back the prior `results.csv` (or `results.json`) and sends only the rows that still need judging to the paid judges. `--overwrite` forces a clean run.

Covers all five: `stt`, `tts`, `general`, `llm`, and `simulations -t text`.

"Done" is decided per judge, not per row. A row can keep the scores from your evaluators while a judge that never ran on it still runs. For speech-to-text that includes the built-in Sarvam intent/entity, Sarvam LLM-WER and semantic-WER judges.

## How a stored row is reused

A stored row is only reused when both of these hold, so a resumed run's averages match a single run over the same dataset:

- The text the judge saw is unchanged. Edit a row and keep its id, and it is judged again.
- The evaluator still scores the same way. A rating range that changed from 1-5 to 1-10 is judged again rather than averaged into a number that means nothing. A reworded prompt under the same name is not a reason to re-judge.

## Notable pieces

- `judges.py` holds the shared reading and writing. `PartialResultsWriter` keeps rows by dataset index and rewrites the file on each update, so several judges can fill different columns of one row and a resumed run keeps the rows it started with instead of emptying the file.
- A judge that fails or is skipped falls back to the stored values instead of dropping its columns. Without this a single failed judge would erase work an earlier run had already paid for.
- The speech-to-text built-in judges write each row as it returns. The LLM-WER judge pools its score across the whole dataset from corrected sentences that are not stored, so it saves each equivalence verdict to `llm_wer_verdicts.json` and a later run replays them to rebuild the exact same number without paying again. Word alignment is plain text comparison, so it is free to redo.
- Ids are compared as text throughout, so an id like `"1"` survives the round trip. Duplicate ids are rejected with a clear message.

## Breaking change

Simulations eval-only datasets now require a unique `id` on each conversation. A dataset without one fails with a message saying to add it. This is what lets a resumed run reuse each conversation's own scores rather than whatever sits at that position. The shipped example dataset is updated.

## Tests

944 passing across `tests/stt`, `tests/tts`, `tests/general`, `tests/llm`, `tests/test_judges.py` and `tests/test_cli_main.py`.

Each new test was mutation-checked: the behaviour was broken on purpose and the test watched to fail before being kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)