### PR TITLE
Add changelog link to docs sidebar

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -345,6 +345,11 @@
           "anchor": "WhatsApp",
           "href": "https://chat.whatsapp.com/JygDNcZ943a3VmZDXYMg5Z",
           "icon": "whatsapp"
+        },
+        {
+          "anchor": "Changelog",
+          "href": "https://calibrate.artpark.ai/changelog",
+          "icon": "clock-rotate-left"
         }
       ]
     }


### PR DESCRIPTION
## What
- Adds a "Changelog" anchor next to GitHub and WhatsApp in the docs sidebar, pointing at https://calibrate.artpark.ai/changelog.