### PR TITLE
Let a text agent take a plain input instead of a conversation

### DIFF
--- a/calibrate_agent/cli.py
+++ b/calibrate_agent/cli.py
@@ -119,6 +119,7 @@ def _run_agent_verify(
     agent_headers_raw: str | None,
     models: list[str] | None = None,
     agent_inputs_raw: str | None = None,
+    agent_type: str = "conversation",
 ) -> None:
     """Verify an external agent connection and print the result."""
     from calibrate_agent.connections import TextAgentConnection
@@ -139,19 +140,25 @@ def _run_agent_verify(
             print("✗ --agent-inputs is not valid JSON")
             sys.exit(1)
 
-    agent = TextAgentConnection(
-        url=agent_url, headers=headers, default_inputs=default_inputs
-    )
+    try:
+        agent = TextAgentConnection(
+            url=agent_url,
+            headers=headers,
+            default_inputs=default_inputs,
+            type=agent_type,
+        )
+    except ValueError as e:
+        print(f"✗ --agent-type: {e}")
+        sys.exit(1)
 
     # If models provided, send the first model name in the verify request
     model_hint: str | None = models[0] if models else None
 
-    _preview_body: dict = {"messages": [{"role": "user", "content": "Hi"}]}
-    if default_inputs:
-        _preview_body.update(default_inputs)
-    if model_hint:
-        _preview_body["model"] = model_hint
-    body_preview = json.dumps(_preview_body)
+    body_preview = json.dumps(
+        agent._build_body(
+            [{"role": "user", "content": "Hi"}], model=model_hint
+        )
+    )
 
     print(f"\nVerifying agent connection: {agent_url}")
     print(f"Sending: {body_preview}")
@@ -398,6 +405,13 @@ Examples:
         type=str,
         default=None,
         help='Extra input fields sent with the verify request as a JSON string, e.g. \'{"condition_area": "cardiology"}\'',
+    )
+    llm_parser.add_argument(
+        "--agent-type",
+        type=str,
+        default="conversation",
+        choices=["conversation", "general"],
+        help="What the agent expects in the request body: 'conversation' sends the exchange so far as {\"messages\": [...]}, 'general' sends only the latest user text as {\"input\": \"...\"}",
     )
     llm_parser.add_argument(
         "--skip-verify",
@@ -693,6 +707,7 @@ Examples:
                 args.agent_headers,
                 models=args.model,
                 agent_inputs_raw=args.agent_inputs,
+                agent_type=getattr(args, "agent_type", "conversation"),
             )
         elif args.config is None:
             # No config → interactive mode
@@ -719,6 +734,7 @@ Examples:
                     url=_config["agent_url"],
                     headers=_config.get("agent_headers"),
                     default_inputs=_config.get("agent_default_inputs"),
+                    type=_config.get("agent_type", "conversation"),
                 )
                 _models = args.model if args.model else []
 

--- a/calibrate_agent/cli.py
+++ b/calibrate_agent/cli.py
@@ -119,10 +119,10 @@ def _run_agent_verify(
     agent_headers_raw: str | None,
     models: list[str] | None = None,
     agent_inputs_raw: str | None = None,
-    agent_type: str = "conversation",
+    agent_type: str | None = None,
 ) -> None:
     """Verify an external agent connection and print the result."""
-    from calibrate_agent.connections import TextAgentConnection
+    from calibrate_agent.connections import DEFAULT_AGENT_TYPE, TextAgentConnection
 
     headers = None
     if agent_headers_raw:
@@ -145,7 +145,7 @@ def _run_agent_verify(
             url=agent_url,
             headers=headers,
             default_inputs=default_inputs,
-            type=agent_type,
+            type=agent_type or DEFAULT_AGENT_TYPE,
         )
     except ValueError as e:
         print(f"✗ --agent-type: {e}")
@@ -155,7 +155,7 @@ def _run_agent_verify(
     model_hint: str | None = models[0] if models else None
 
     body_preview = json.dumps(
-        agent._build_body(
+        agent.build_body(
             [{"role": "user", "content": "Hi"}], model=model_hint
         )
     )
@@ -177,7 +177,7 @@ def _run_agent_verify(
 
 def main():
     """Main CLI entry point that dispatches to component-specific scripts."""
-    from calibrate_agent.connections import AGENT_TYPES
+    from calibrate_agent.connections import AGENT_TYPES, DEFAULT_AGENT_TYPE
 
     # Load environment variables from .env file
     _load_cli_dotenv()
@@ -411,7 +411,7 @@ Examples:
     llm_parser.add_argument(
         "--agent-type",
         type=str,
-        default="conversation",
+        default=DEFAULT_AGENT_TYPE,
         choices=list(AGENT_TYPES),
         help="What the agent expects in the request body: 'conversation' sends the exchange so far as {\"messages\": [...]}, 'general' sends only the latest user text as {\"input\": \"...\"}",
     )
@@ -709,7 +709,7 @@ Examples:
                 args.agent_headers,
                 models=args.model,
                 agent_inputs_raw=args.agent_inputs,
-                agent_type=getattr(args, "agent_type", "conversation"),
+                agent_type=args.agent_type,
             )
         elif args.config is None:
             # No config → interactive mode
@@ -732,12 +732,16 @@ Examples:
                 from calibrate_agent.connections import TextAgentConnection
                 from calibrate_agent.llm import tests as _tests
 
-                _agent = TextAgentConnection(
-                    url=_config["agent_url"],
-                    headers=_config.get("agent_headers"),
-                    default_inputs=_config.get("agent_default_inputs"),
-                    type=_config.get("agent_type", "conversation"),
-                )
+                try:
+                    _agent = TextAgentConnection(
+                        url=_config["agent_url"],
+                        headers=_config.get("agent_headers"),
+                        default_inputs=_config.get("agent_default_inputs"),
+                        type=_config.get("agent_type", DEFAULT_AGENT_TYPE),
+                    )
+                except ValueError as _e:
+                    print(f"✗ config agent_type: {_e}")
+                    sys.exit(1)
                 _models = args.model if args.model else []
 
                 # Verify once per model (skip if already verified upstream e.g. interactive UI)
@@ -881,7 +885,7 @@ Examples:
 
                 with open(args.config) as _f:
                     _sim_config = _json.load(_f)
-                if _sim_config.get("agent_type", "conversation") != "conversation":
+                if _sim_config.get("agent_type", DEFAULT_AGENT_TYPE) != DEFAULT_AGENT_TYPE:
                     print(
                         "✗ Text simulation is not supported for an agent of type "
                         f"'{_sim_config['agent_type']}'. The simulator sends the "

--- a/calibrate_agent/cli.py
+++ b/calibrate_agent/cli.py
@@ -177,6 +177,8 @@ def _run_agent_verify(
 
 def main():
     """Main CLI entry point that dispatches to component-specific scripts."""
+    from calibrate_agent.connections import AGENT_TYPES
+
     # Load environment variables from .env file
     _load_cli_dotenv()
 
@@ -410,7 +412,7 @@ Examples:
         "--agent-type",
         type=str,
         default="conversation",
-        choices=["conversation", "general"],
+        choices=list(AGENT_TYPES),
         help="What the agent expects in the request body: 'conversation' sends the exchange so far as {\"messages\": [...]}, 'general' sends only the latest user text as {\"input\": \"...\"}",
     )
     llm_parser.add_argument(
@@ -879,6 +881,14 @@ Examples:
 
                 with open(args.config) as _f:
                     _sim_config = _json.load(_f)
+                if _sim_config.get("agent_type", "conversation") != "conversation":
+                    print(
+                        "✗ Text simulation is not supported for an agent of type "
+                        f"'{_sim_config['agent_type']}'. The simulator sends the "
+                        "conversation so far each turn, so the agent must be of "
+                        "type 'conversation'."
+                    )
+                    sys.exit(1)
                 if _sim_config.get("agent_default_inputs"):
                     print(
                         "✗ Text simulation is not supported for an agent configured "

--- a/calibrate_agent/connections.py
+++ b/calibrate_agent/connections.py
@@ -44,6 +44,7 @@ _BACKOFF_BASE_SECONDS = 1.0
 
 # What a text agent accepts in its request body. See TextAgentConnection.type.
 AGENT_TYPES = ("conversation", "general")
+DEFAULT_AGENT_TYPE = "conversation"
 
 
 class _AgentRequestError(Exception):
@@ -127,7 +128,7 @@ class TextAgentConnection:
     default_inputs: Optional[dict] = field(default=None)
     """Inputs merged into every request body to this agent (e.g. ``{"condition_area": "cardiology"}``)."""
 
-    type: str = field(default="conversation")
+    type: str = field(default=DEFAULT_AGENT_TYPE)
     """What the agent expects in the request body.
 
     ``"conversation"`` (default) sends the whole exchange so far as
@@ -142,9 +143,24 @@ class TextAgentConnection:
                 f"got {self.type!r}"
             )
 
-    def _build_body(self, messages, inputs=None, model=None) -> dict:
+    def build_body(self, messages, inputs=None, model=None) -> dict:
+        """Return the JSON body this agent is sent for ``messages``.
+
+        Raises:
+            ValueError: For a ``general`` agent, when ``messages`` is not a
+                single user message — that agent takes one instruction per call
+                and cannot be given a conversation.
+        """
         if self.type == "general":
-            body = {"input": messages[-1]["content"]}
+            if len(messages) != 1 or messages[0].get("role") != "user":
+                raise ValueError(
+                    f"An agent of type 'general' takes a single user message, "
+                    f"but it was given {len(messages)} message(s) "
+                    f"({', '.join(repr(m.get('role')) for m in messages)}). "
+                    f"Use an agent of type 'conversation' for multi-turn test "
+                    f"cases and simulations."
+                )
+            body = {"input": messages[0]["content"]}
         else:
             body = {"messages": messages}
         if self.default_inputs:
@@ -194,7 +210,7 @@ class TextAgentConnection:
         """
         input_messages = messages if messages is not None else _DEFAULT_VERIFY_MESSAGES
 
-        body = self._build_body(input_messages, inputs=inputs, model=model)
+        body = self.build_body(input_messages, inputs=inputs, model=model)
 
         # ── 1. POST to endpoint (retry transient failures) ───────────────
         try:
@@ -316,7 +332,7 @@ class TextAgentConnection:
                 timeouts, and HTTP 429/502/503/504) are retried with
                 exponential backoff before giving up.
         """
-        body = self._build_body(messages, inputs=inputs, model=model)
+        body = self.build_body(messages, inputs=inputs, model=model)
 
         try:
             resp = await self._post_with_retry(body, timeout=60.0)
@@ -477,4 +493,4 @@ class WebSocketAgentConnection:
         return {"ok": True, "error": None}
 
 
-__all__ = ["AGENT_TYPES", "TextAgentConnection", "WebSocketAgentConnection"]
+__all__ = ["AGENT_TYPES", "DEFAULT_AGENT_TYPE", "TextAgentConnection", "WebSocketAgentConnection"]

--- a/calibrate_agent/connections.py
+++ b/calibrate_agent/connections.py
@@ -144,7 +144,7 @@ class TextAgentConnection:
 
     def _build_body(self, messages, inputs=None, model=None) -> dict:
         if self.type == "general":
-            body = {"input": messages[-1]["content"] if messages else ""}
+            body = {"input": messages[-1]["content"]}
         else:
             body = {"messages": messages}
         if self.default_inputs:

--- a/calibrate_agent/connections.py
+++ b/calibrate_agent/connections.py
@@ -42,6 +42,10 @@ _MAX_ATTEMPTS = 4
 _BACKOFF_BASE_SECONDS = 1.0
 
 
+# What a text agent accepts in its request body. See TextAgentConnection.type.
+AGENT_TYPES = ("conversation", "general")
+
+
 class _AgentRequestError(Exception):
     """A transient request failure that exhausted all retry attempts."""
 
@@ -54,6 +58,8 @@ class TextAgentConnection:
     Calibrate sends a fixed request and expects a fixed response format.
 
     ── Request (POST to ``url``) ────────────────────────────────────────────
+    A ``conversation`` agent (the default) receives the whole exchange so far::
+
         {
             "messages": [
                 {"role": "user",      "content": "Hello"},
@@ -61,6 +67,10 @@ class TextAgentConnection:
                 {"role": "user",      "content": "What can you do?"}
             ]
         }
+
+    A ``general`` agent receives only the latest user text::
+
+        {"input": "What can you do?"}
 
     ── Response (agent must return) ────────────────────────────────────────
         {
@@ -117,8 +127,26 @@ class TextAgentConnection:
     default_inputs: Optional[dict] = field(default=None)
     """Inputs merged into every request body to this agent (e.g. ``{"condition_area": "cardiology"}``)."""
 
+    type: str = field(default="conversation")
+    """What the agent expects in the request body.
+
+    ``"conversation"`` (default) sends the whole exchange so far as
+    ``{"messages": [...]}``. ``"general"`` sends only the latest user text as
+    ``{"input": "..."}``, for agents that take one instruction per call.
+    """
+
+    def __post_init__(self) -> None:
+        if self.type not in AGENT_TYPES:
+            raise ValueError(
+                f"type must be one of {', '.join(repr(t) for t in AGENT_TYPES)}; "
+                f"got {self.type!r}"
+            )
+
     def _build_body(self, messages, inputs=None, model=None) -> dict:
-        body = {"messages": messages}
+        if self.type == "general":
+            body = {"input": messages[-1]["content"] if messages else ""}
+        else:
+            body = {"messages": messages}
         if self.default_inputs:
             body.update(self.default_inputs)
         if inputs:
@@ -449,4 +477,4 @@ class WebSocketAgentConnection:
         return {"ok": True, "error": None}
 
 
-__all__ = ["TextAgentConnection", "WebSocketAgentConnection"]
+__all__ = ["AGENT_TYPES", "TextAgentConnection", "WebSocketAgentConnection"]

--- a/docs/cli/agent-connections/chat.mdx
+++ b/docs/cli/agent-connections/chat.mdx
@@ -9,6 +9,7 @@ Connect a text chat agent to evaluate your agent's logic without placing calls b
 
 - **`agent_url`** — The URL where your agent receives messages
 - **`agent_headers`** — (optional) Authentication credentials for your API
+- **`agent_type`** — (optional) What your agent expects in the request body: `conversation` (default) or `general`
 
 ## Chat endpoint (required)
 
@@ -56,7 +57,7 @@ You must provide an HTTP, JSON-based endpoint. For both LLM tests and simulatio
 
 ### Request format
 
-Calibrate sends the full conversation history so far (including the latest simulated user input for simulations):
+A `conversation` agent, the default, receives the full conversation history so far (including the latest simulated user input for simulations):
 
 ```json
 {
@@ -66,6 +67,14 @@ Calibrate sends the full conversation history so far (including the latest simul
   ]
 }
 ```
+
+A `general` agent takes one instruction per call, so it receives only the latest user text:
+
+```json
+{ "input": "Check order ORD-12345" }
+```
+
+Set this with `agent_type` in your config, or `--agent-type general` when verifying a connection from the CLI. Simulations always send the conversation, so a `general` agent suits [per-turn tests](/cli/text-to-text) rather than [simulations](/cli/simulations).
 
 <Note>
   To benchmark across models, Calibrate adds a `model` field to each request

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -145,7 +145,7 @@ class TestRunAgentVerify(unittest.TestCase):
         fake_result = {"ok": True, "sample_output": {"response": "Hi", "tool_calls": []}}
         with patch("calibrate_agent.connections.TextAgentConnection") as MockConn:
             MockConn.return_value.verify = AsyncMock(return_value=fake_result)
-            MockConn.return_value._build_body.return_value = {}
+            MockConn.return_value.build_body.return_value = {}
             cli._run_agent_verify(
                 "http://x", None, agent_inputs_raw='{"condition_area": "cardiology"}'
             )
@@ -624,6 +624,19 @@ class TestMainDispatch(unittest.TestCase):
                 self._run_with_argv([
                     "calibrate_agent", "simulations", "--type", "text",
                     "-c", str(cfg), "-o", tmp,
+                ])
+
+    def test_llm_config_rejects_unknown_agent_type(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "cfg.json"
+            cfg.write_text(json.dumps({
+                "agent_url": "http://x",
+                "agent_type": "genral",
+                "test_cases": [],
+            }))
+            with self.assertRaises(SystemExit):
+                self._run_with_argv([
+                    "calibrate_agent", "llm", "-c", str(cfg), "-o", tmp,
                 ])
 
     def test_simulations_leaderboard(self):

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -145,6 +145,7 @@ class TestRunAgentVerify(unittest.TestCase):
         fake_result = {"ok": True, "sample_output": {"response": "Hi", "tool_calls": []}}
         with patch("calibrate_agent.connections.TextAgentConnection") as MockConn:
             MockConn.return_value.verify = AsyncMock(return_value=fake_result)
+            MockConn.return_value._build_body.return_value = {}
             cli._run_agent_verify(
                 "http://x", None, agent_inputs_raw='{"condition_area": "cardiology"}'
             )
@@ -152,6 +153,24 @@ class TestRunAgentVerify(unittest.TestCase):
             self.assertEqual(
                 kwargs.get("default_inputs"), {"condition_area": "cardiology"}
             )
+
+    def test_general_type_previews_input_body(self):
+        from calibrate_agent import cli
+
+        fake_result = {"ok": True, "sample_output": {"response": "Hi", "tool_calls": []}}
+        with patch("calibrate_agent.connections.TextAgentConnection.verify",
+                   AsyncMock(return_value=fake_result)):
+            with patch("builtins.print") as mock_print:
+                cli._run_agent_verify("http://x", None, agent_type="general")
+
+        printed = " ".join(str(c.args[0]) for c in mock_print.call_args_list if c.args)
+        self.assertIn('{"input": "Hi"}', printed)
+
+    def test_unknown_type_exits(self):
+        from calibrate_agent import cli
+
+        with self.assertRaises(SystemExit):
+            cli._run_agent_verify("http://x", None, agent_type="chat")
 
 
 class TestMainDispatch(unittest.TestCase):
@@ -587,6 +606,19 @@ class TestMainDispatch(unittest.TestCase):
             cfg.write_text(json.dumps({
                 "agent_url": "http://x",
                 "agent_default_inputs": {"condition_area": "cardiology"},
+            }))
+            with self.assertRaises(SystemExit):
+                self._run_with_argv([
+                    "calibrate_agent", "simulations", "--type", "text",
+                    "-c", str(cfg), "-o", tmp,
+                ])
+
+    def test_simulations_text_rejects_general_agent_type(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "cfg.json"
+            cfg.write_text(json.dumps({
+                "agent_url": "http://x",
+                "agent_type": "general",
             }))
             with self.assertRaises(SystemExit):
                 self._run_with_argv([

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -751,6 +751,32 @@ class TestAgentType(unittest.IsolatedAsyncioTestCase):
             {"input": "Hi", "lang": "hi", "model": "openai/gpt-4.1"},
         )
 
+    async def test_general_rejects_a_multi_turn_conversation(self):
+        from calibrate_agent.connections import TextAgentConnection
+
+        agent = TextAgentConnection(url="http://fake-agent/chat", type="general")
+
+        ctx, mock_client = _patch_httpx({"response": "ok"})
+        with ctx:
+            with self.assertRaises(ValueError) as cm:
+                await agent.call(
+                    [
+                        {"role": "user", "content": "Hi"},
+                        {"role": "assistant", "content": "Hello"},
+                    ]
+                )
+
+        self.assertIn("single user message", str(cm.exception))
+        mock_client.post.assert_not_awaited()
+
+    def test_general_rejects_a_non_user_message(self):
+        from calibrate_agent.connections import TextAgentConnection
+
+        agent = TextAgentConnection(url="http://fake-agent/chat", type="general")
+
+        with self.assertRaises(ValueError):
+            agent.build_body([{"role": "assistant", "content": "Hello"}])
+
     def test_unknown_type_is_rejected(self):
         from calibrate_agent.connections import TextAgentConnection
 

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -674,6 +674,91 @@ class TestTextAgentConnectionVerify(unittest.IsolatedAsyncioTestCase):
 
 
 # ---------------------------------------------------------------------------
+# Tests for the agent type (conversation vs general request body)
+# ---------------------------------------------------------------------------
+
+class TestAgentType(unittest.IsolatedAsyncioTestCase):
+
+    @staticmethod
+    def _sent_body(mock_client):
+        return mock_client.post.call_args.kwargs["json"]
+
+    async def test_conversation_is_the_default_and_sends_messages(self):
+        from calibrate_agent.connections import TextAgentConnection
+
+        agent = TextAgentConnection(url="http://fake-agent/chat")
+        self.assertEqual(agent.type, "conversation")
+
+        ctx, mock_client = _patch_httpx({"response": "ok"})
+        with ctx:
+            await agent.call(
+                [
+                    {"role": "user", "content": "Hi"},
+                    {"role": "assistant", "content": "Hello"},
+                    {"role": "user", "content": "Bye"},
+                ]
+            )
+
+        body = self._sent_body(mock_client)
+        self.assertEqual(len(body["messages"]), 3)
+        self.assertNotIn("input", body)
+
+    async def test_general_sends_latest_user_text_as_input(self):
+        from calibrate_agent.connections import TextAgentConnection
+
+        agent = TextAgentConnection(url="http://fake-agent/chat", type="general")
+
+        ctx, mock_client = _patch_httpx({"response": "ok"})
+        with ctx:
+            await agent.call([{"role": "user", "content": "Summarize this"}])
+
+        body = self._sent_body(mock_client)
+        self.assertEqual(body, {"input": "Summarize this"})
+
+    async def test_general_verify_sends_input(self):
+        from calibrate_agent.connections import TextAgentConnection
+
+        agent = TextAgentConnection(url="http://fake-agent/chat", type="general")
+
+        ctx, mock_client = _patch_httpx({"response": "ok"})
+        with ctx:
+            result = await agent.verify()
+
+        self.assertTrue(result["ok"])
+        body = self._sent_body(mock_client)
+        self.assertNotIn("messages", body)
+        self.assertIsInstance(body["input"], str)
+
+    async def test_general_still_merges_inputs_and_model(self):
+        from calibrate_agent.connections import TextAgentConnection
+
+        agent = TextAgentConnection(
+            url="http://fake-agent/chat",
+            type="general",
+            default_inputs={"lang": "en"},
+        )
+
+        ctx, mock_client = _patch_httpx({"response": "ok"})
+        with ctx:
+            await agent.call(
+                [{"role": "user", "content": "Hi"}],
+                model="openai/gpt-4.1",
+                inputs={"lang": "hi"},
+            )
+
+        self.assertEqual(
+            self._sent_body(mock_client),
+            {"input": "Hi", "lang": "hi", "model": "openai/gpt-4.1"},
+        )
+
+    def test_unknown_type_is_rejected(self):
+        from calibrate_agent.connections import TextAgentConnection
+
+        with self.assertRaises(ValueError):
+            TextAgentConnection(url="http://fake-agent/chat", type="chat")
+
+
+# ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## What
- `TextAgentConnection` gains a `type`. `conversation` (default) posts the exchange so far as `{"messages": [...]}`; `general` posts only the latest user text as `{"input": "..."}`.
- Set it with `agent_type` in the run config, or `--agent-type general` when verifying a connection from the CLI. The verify preview line shows the real body.
- Docs show both request shapes; 5 new tests cover the two body shapes, the input/model merge, and an unknown type.

## Notes
- The backend that writes the run config has to start emitting `"agent_type": "general"` and pin a version with this change.
- Simulations always send the conversation, so `general` applies to per-turn tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)