### PR TITLE
Document the general agent type across the CLI docs

### DIFF
--- a/docs/cli/agent-connections/chat.mdx
+++ b/docs/cli/agent-connections/chat.mdx
@@ -13,7 +13,7 @@ Connect a text chat agent to evaluate your agent's logic without placing calls b
 
 ## Chat endpoint (required)
 
-The primary URL where Calibrate sends conversation messages during a test or a simulation. Set it as `agent_url`.
+The primary URL where Calibrate sends each request during a test or a simulation. Set it as `agent_url`.
 
 **Format:** Full HTTP(S) URL
 
@@ -53,7 +53,7 @@ Authentication credentials sent with every request. Add them under `agent_header
 
 ## Protocol
 
-You must provide an HTTP, JSON-based endpoint. For both LLM tests and simulations, Calibrate sends a `POST` request to your chat endpoint with a list of messages. Your endpoint should reply in the expected response format given below.
+You must provide an HTTP, JSON-based endpoint. For both LLM tests and simulations, Calibrate sends a `POST` request to your chat endpoint. What the body carries depends on `agent_type`. Your endpoint should reply in the expected response format given below.
 
 ### Request format
 
@@ -74,13 +74,21 @@ A `general` agent takes one instruction per call, so it receives only the latest
 { "input": "Check order ORD-12345" }
 ```
 
-Set this with `agent_type` in your config, or `--agent-type general` when verifying a connection from the CLI. Simulations always send the conversation, so a `general` agent suits [per-turn tests](/cli/text-to-text) rather than [simulations](/cli/simulations).
+Set this with `agent_type` in your config, or `--agent-type general` when verifying a connection with `calibrate-agent llm --verify`.
+
+A `general` agent is sent exactly one user message per call, so it works with:
+
+- [general tests](/cli/text-to-text#general-test), whose `input` is that single message
+- any [tool call](/cli/text-to-text#tool-call-test), [response](/cli/text-to-text#response-test), or [conversation](/cli/text-to-text#conversation-test) test whose `history` is a single user message
+
+A longer `history` is rejected before the request is sent, with an error naming the roles it was given. [Simulations](/cli/simulations) build a multi-turn exchange and send it back on every turn, so they need `agent_type` to be `conversation`.
 
 <Note>
-  To benchmark across models, Calibrate adds a `model` field to each request
-  (`{ "messages": [...], "model": "..." }`). Your agent must read it and route
-  to the right model — the easiest way is a framework like OpenRouter. For a
-  Calibrate agent, the model is selected directly.
+  To benchmark across models, Calibrate adds a `model` field to the request
+  body: `{ "messages": [...], "model": "..." }` for a `conversation` agent,
+  `{ "input": "...", "model": "..." }` for a `general` one. Your agent must
+  read it and route to the right model — the easiest way is a framework like
+  OpenRouter. For a Calibrate agent, the model is selected directly.
 </Note>
 
 ### Expected response format

--- a/docs/cli/agent-connections/overview.mdx
+++ b/docs/cli/agent-connections/overview.mdx
@@ -30,6 +30,15 @@ calibrate-agent simulations --verify --agent-url https://your-agent.example.com/
   --agent-headers '{"Authorization": "Bearer YOUR_API_KEY"}'
 ```
 
+The sample request carries the conversation as `{"messages": [...]}`. For an agent that takes a plain `{"input": "..."}` instead, verify it with `calibrate-agent llm --verify` and pass `--agent-type general`:
+
+```bash
+calibrate-agent llm --verify --agent-url https://your-agent.example.com/chat \
+  --agent-type general
+```
+
+`--agent-type` is available on `calibrate-agent llm --verify` only. Simulations always send the conversation, so they verify a `conversation` agent. See [Chat agent](/cli/agent-connections/chat#request-format) for both request formats.
+
 **Outbound voice agent** — Calibrate opens the WebSocket and confirms the handshake automatically before each voice run. This is a reachability check only and does not confirm whether the frame protocol or serializer is compatible.
 
 <Note>

--- a/docs/cli/simulations.mdx
+++ b/docs/cli/simulations.mdx
@@ -241,6 +241,8 @@ For voice simulations, specify the STT, LLM, and TTS providers:
 
     Refer to [Agent Connections → Chat agent](/cli/agent-connections/chat) for the full reference.
 
+    A simulation sends the conversation so far on every turn, so the agent must accept `{"messages": [...]}`. A config whose `agent_type` is `general` is rejected before the run starts.
+
     ```json
     {
       "agent_url": "https://your-agent.com/chat",

--- a/docs/cli/text-to-text.mdx
+++ b/docs/cli/text-to-text.mdx
@@ -205,6 +205,8 @@ A single-shot task with no conversation. The agent receives one user message, ta
 
 A general test case carries `input` and no `history`. Supplying `history` is an error, as is an empty `input`.
 
+With an [agent connection](/cli/agent-connections/chat), the `input` is sent as a single user message. An agent that takes a plain instruction rather than a conversation can receive it as `{"input": "..."}` instead, by setting `agent_type` to `general` in the config.
+
 Its evaluators must be listed by name. There is no built-in evaluator for this type, so the plain criteria string that a [response test](#response-test) accepts is rejected here.
 
 See [`examples/llm/config-general.json`](https://github.com/ARTPARK-SAHAI-ORG/calibrate/blob/main/examples/llm/config-general.json) for a full template.
@@ -683,16 +685,19 @@ calibrate-agent llm -c config.json -m openai/gpt-4.1 claude-sonnet-4-5 -p openro
 
 **Agent connection:**
 
-Your config must include `agent_url` and optionally `agent_headers`:
+Your config must include `agent_url`, and optionally `agent_headers` and `agent_type`:
 
 ```json
 {
   "agent_url": "https://your-agent.com/chat",
   "agent_headers": {
     "Authorization": "Bearer YOUR_API_KEY"
-  }
+  },
+  "agent_type": "conversation"
 }
 ```
+
+`agent_type` sets what the request body carries: `conversation`, the default, sends the test case's messages as `{"messages": [...]}`; `general` sends the single user message as `{"input": "..."}`, for an agent that takes one instruction per call. A `general` agent accepts a test case of exactly one user message, so it pairs with [general tests](#general-test). See [Chat agent](/cli/agent-connections/chat#request-format).
 
 Single run (use the default model of the agent):
 


### PR DESCRIPTION
## What

- The chat-agent page states which test cases a `general` agent accepts, that a longer history is rejected before the request is sent, and that simulations require a `conversation` agent.
- The connection overview shows how to verify a `general` agent, and that `--agent-type` exists only on `calibrate-agent llm --verify`.
- The text-to-text page documents `agent_type` in the config; the simulations page states the `conversation` requirement.

## Notes

The interactive UI never passes `agent_type` to its verify step (`ui/source/llm-app.tsx`, the verify args are built from `agent_url` and `agent_headers` only), so a `general` agent fails verification there even though the run itself honors the config. `agent_type` is therefore left out of the interactive-mode docs. Fixing it needs the UI bundle rebuilt, so it is not in this PR.

The cloud docs (`core-concepts`, `quickstart`, `sdk`, `mcp`, `cli/calibrate`) are untouched: the backend agent config has no type field, so this is offline-CLI only.