### PR TITLE
Refuse a push whose changed lines are untested

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,13 +7,17 @@ if [ -n "$SKIP_COVERAGE" ]; then
     exit 0
 fi
 
-base=$(git merge-base origin/main HEAD 2>/dev/null || git merge-base main HEAD 2>/dev/null)
-if [ -z "$base" ]; then
-    exit 0
-fi
-
-if [ -z "$(git diff --name-only "$base"...HEAD -- calibrate_agent)" ]; then
-    echo "→ pre-push: no calibrate_agent/ changes — skipping the patch coverage check."
+# Deleting a remote branch or pushing tags pushes no commits worth checking.
+while read -r local_ref local_sha _remote_ref _remote_sha; do
+    case "$local_ref" in
+        refs/heads/*)
+            case "$local_sha" in
+                *[!0]*) has_commits=1 ;;
+            esac
+            ;;
+    esac
+done
+if [ -z "$has_commits" ]; then
     exit 0
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Codecov's patch check is blocking on PRs: changed lines must be covered by
+# tests. Catch that here instead of after the PR is opened.
+
+if [ -n "$SKIP_COVERAGE" ]; then
+    echo "→ pre-push: SKIP_COVERAGE set — skipping the patch coverage check."
+    exit 0
+fi
+
+base=$(git merge-base origin/main HEAD 2>/dev/null || git merge-base main HEAD 2>/dev/null)
+if [ -z "$base" ]; then
+    exit 0
+fi
+
+if [ -z "$(git diff --name-only "$base"...HEAD -- calibrate_agent)" ]; then
+    echo "→ pre-push: no calibrate_agent/ changes — skipping the patch coverage check."
+    exit 0
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "✗ uv not found on PATH — install uv or run 'pytest tests/' manually." >&2
+    exit 1
+fi
+
+echo "→ pre-push: checking that the lines this branch adds are covered..."
+exec uv run --extra dev python scripts/check_patch_coverage.py

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,14 +7,15 @@ if [ -n "$SKIP_COVERAGE" ]; then
     exit 0
 fi
 
-# Deleting a remote branch or pushing tags pushes no commits worth checking.
-while read -r local_ref local_sha _remote_ref _remote_sha; do
-    case "$local_ref" in
-        refs/heads/*)
-            case "$local_sha" in
-                *[!0]*) has_commits=1 ;;
-            esac
-            ;;
+# Deleting a remote branch (all-zero local sha) or pushing tags carries no
+# commits worth checking. The local ref is "HEAD" for `git push origin HEAD`,
+# so the remote ref is what tells a tag apart from a branch.
+while read -r _local_ref local_sha remote_ref _remote_sha; do
+    case "$remote_ref" in
+        refs/tags/*) continue ;;
+    esac
+    case "$local_sha" in
+        *[!0]*) has_commits=1 ;;
     esac
 done
 if [ -z "$has_commits" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,8 +373,9 @@ feature/fix work on a branch:
 `.githooks/pre-commit` runs `uv run --extra dev pytest tests/` **only when
 HEAD is on `main`**. Other branches commit instantly.
 
-`.githooks/pre-push` runs `scripts/check_patch_coverage.py` whenever the branch
-touches `calibrate_agent/`. `SKIP_COVERAGE=1 git push` bypasses it.
+`.githooks/pre-push` runs `scripts/check_patch_coverage.py` when a push carries
+commits, and the script itself does nothing unless the branch touches
+`calibrate_agent/`. `SKIP_COVERAGE=1 git push` bypasses it.
 
 Both are activated per-clone with `git config core.hooksPath .githooks` (also in
 the README).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ docs/                      # Mintlify docs site (.mdx)
 examples/                  # Example datasets + scripts users can run
 .github/workflows/         # tests.yml, publish.yml, claude.yml, claude-code-review.yml
 .githooks/pre-commit       # Runs pytest before commits to main
+.githooks/pre-push         # Checks the branch's new lines are covered by tests
 ```
 
 ## Conventions in this codebase
@@ -370,8 +371,13 @@ feature/fix work on a branch:
 
 ### Git hooks
 `.githooks/pre-commit` runs `uv run --extra dev pytest tests/` **only when
-HEAD is on `main`**. Other branches commit instantly. Activated per-clone
-with `git config core.hooksPath .githooks` (also in the README).
+HEAD is on `main`**. Other branches commit instantly.
+
+`.githooks/pre-push` runs `scripts/check_patch_coverage.py` whenever the branch
+touches `calibrate_agent/`. `SKIP_COVERAGE=1 git push` bypasses it.
+
+Both are activated per-clone with `git config core.hooksPath .githooks` (also in
+the README).
 
 ### CI
 - **`.github/workflows/tests.yml`** — runs on push to `main` and on every PR
@@ -404,7 +410,14 @@ For any function block you add or modify:
    slow. Confirm they pass. Don't rely on the type checker or "it looks right"
    — the test must actually exercise the new path. CI runs the full suite on
    the PR, so let that be the backstop for the complete run.
-3. **Only after tests pass** should you report the task as done. If a change
+3. **Run `uv run --extra dev python scripts/check_patch_coverage.py` before
+   you call the work done.** It runs the suite with coverage and then checks
+   that the lines this branch adds to `calibrate_agent/` are covered at least
+   as well as the codebase overall — which is what Codecov's `patch` check
+   does on the PR. It names every uncovered line it finds. `.githooks/pre-push`
+   runs the same check, so a push with untested lines is refused;
+   `SKIP_COVERAGE=1 git push` bypasses it.
+4. **Only after tests pass** should you report the task as done. If a change
    is genuinely untestable (e.g. a CLI flag wired through to a third-party
    SDK), say so explicitly in the response rather than implying coverage.
 

--- a/README.md
+++ b/README.md
@@ -49,16 +49,24 @@ Run the full test suite:
 uv run pytest tests/
 ```
 
-### Pre-commit
+### Git hooks
 
-Enable the project's git hooks so the pre-commit test
-runner fires on commits to `main`:
+Enable the project's git hooks so the pre-commit test runner fires on commits to
+`main`, and the pre-push check confirms the lines your branch adds are covered
+by tests:
 
 ```bash
 git config core.hooksPath .githooks
 ```
 
-Every contributor needs to run it once.
+Every contributor needs to run it once. To run the coverage check by hand:
+
+```bash
+uv run --extra dev python scripts/check_patch_coverage.py
+```
+
+Pass `--no-tests` to reuse an existing `coverage.xml` instead of re-running the
+suite, or set `SKIP_COVERAGE=1` to let a push through without the check.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "diff-cover>=9.0",
     "ipdb>=0.13.13",
     "ipython>=8.37.0",
     "pytest>=7.0",

--- a/scripts/check_patch_coverage.py
+++ b/scripts/check_patch_coverage.py
@@ -6,59 +6,90 @@ Codecov's patch target is `auto`, i.e. the base commit's coverage, so there is
 no fixed number to hardcode. This uses the run's own overall coverage as the
 local stand-in for the base: main is nearly all of the code, so its coverage
 and this run's overall coverage sit within a point of each other.
+
+Run with --no-tests to reuse an existing coverage.xml instead of re-running the
+suite.
 """
+
+from __future__ import annotations
 
 import subprocess
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parent.parent
+ROOT = Path(__file__).resolve().parents[1]
 COVERAGE_XML = ROOT / "coverage.xml"
+MEASURED_DIR = "calibrate_agent"
 
 
-def compare_branch():
+def _git(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=ROOT, capture_output=True, text=True, check=False
+    )
+
+
+def merge_base() -> tuple[str, str] | None:
+    """The branch to compare against and the commit it forked from."""
     for ref in ("origin/main", "main"):
-        if subprocess.run(
-            ["git", "merge-base", ref, "HEAD"], cwd=ROOT, capture_output=True
-        ).returncode == 0:
-            return ref
+        found = _git("merge-base", ref, "HEAD")
+        if found.returncode == 0:
+            return ref, found.stdout.strip()
     return None
 
 
-def main():
-    run_tests = "--no-tests" not in sys.argv
-    if run_tests:
+def measured_files_changed(base: str) -> bool:
+    """Has this branch touched the code coverage measures?"""
+    return bool(_git("diff", "--name-only", base, "--", MEASURED_DIR).stdout.strip())
+
+
+def overall_line_rate(coverage_xml: Path) -> float:
+    """Percentage of measured lines the whole run covered."""
+    rate = ET.parse(coverage_xml).getroot().get("line-rate")
+    if rate is None:
+        raise ValueError(f"{coverage_xml} has no line-rate — is it a coverage report?")
+    return float(rate) * 100
+
+
+def main(argv: list[str]) -> int:
+    found = merge_base()
+    if found is None:
+        print("No main branch to compare against — skipping the patch coverage check.")
+        return 0
+    ref, base = found
+
+    if not measured_files_changed(base):
+        print(f"No {MEASURED_DIR}/ changes — skipping the patch coverage check.")
+        return 0
+
+    if "--no-tests" not in argv:
         tests = subprocess.run(
             [
                 "uv", "run", "--extra", "dev", "pytest", "tests/", "-q",
                 "--cov=calibrate_agent", "--cov-report=xml", "--cov-report=term",
             ],
             cwd=ROOT,
+            check=False,
         )
         if tests.returncode != 0:
             return tests.returncode
 
     if not COVERAGE_XML.exists():
-        print("No coverage.xml — run this without --no-tests.", file=sys.stderr)
+        print(f"No {COVERAGE_XML.name} — run this without --no-tests.", file=sys.stderr)
         return 1
 
-    base = compare_branch()
-    if base is None:
-        print("No main branch to compare against — skipping patch coverage.")
-        return 0
-
-    overall = float(ET.parse(COVERAGE_XML).getroot().get("line-rate", 0)) * 100
-    print(f"Target (this run's overall coverage): {overall:.2f}%")
+    target = overall_line_rate(COVERAGE_XML)
+    print(f"Target (this run's overall coverage): {target:.2f}%")
 
     return subprocess.run(
         [
             "uv", "run", "--extra", "dev", "diff-cover", str(COVERAGE_XML),
-            f"--compare-branch={base}", f"--fail-under={overall:.2f}",
+            f"--compare-branch={ref}", f"--fail-under={target:.2f}",
         ],
         cwd=ROOT,
+        check=False,
     ).returncode
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check_patch_coverage.py
+++ b/scripts/check_patch_coverage.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+"""Local stand-in for Codecov's `patch` check: are the lines this branch adds
+covered by tests?
+
+Codecov's patch target is `auto`, i.e. the base commit's coverage, so there is
+no fixed number to hardcode. This uses the run's own overall coverage as the
+local stand-in for the base: main is nearly all of the code, so its coverage
+and this run's overall coverage sit within a point of each other.
+"""
+
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+COVERAGE_XML = ROOT / "coverage.xml"
+
+
+def compare_branch():
+    for ref in ("origin/main", "main"):
+        if subprocess.run(
+            ["git", "merge-base", ref, "HEAD"], cwd=ROOT, capture_output=True
+        ).returncode == 0:
+            return ref
+    return None
+
+
+def main():
+    run_tests = "--no-tests" not in sys.argv
+    if run_tests:
+        tests = subprocess.run(
+            [
+                "uv", "run", "--extra", "dev", "pytest", "tests/", "-q",
+                "--cov=calibrate_agent", "--cov-report=xml", "--cov-report=term",
+            ],
+            cwd=ROOT,
+        )
+        if tests.returncode != 0:
+            return tests.returncode
+
+    if not COVERAGE_XML.exists():
+        print("No coverage.xml — run this without --no-tests.", file=sys.stderr)
+        return 1
+
+    base = compare_branch()
+    if base is None:
+        print("No main branch to compare against — skipping patch coverage.")
+        return 0
+
+    overall = float(ET.parse(COVERAGE_XML).getroot().get("line-rate", 0)) * 100
+    print(f"Target (this run's overall coverage): {overall:.2f}%")
+
+    return subprocess.run(
+        [
+            "uv", "run", "--extra", "dev", "diff-cover", str(COVERAGE_XML),
+            f"--compare-branch={base}", f"--fail-under={overall:.2f}",
+        ],
+        cwd=ROOT,
+    ).returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_patch_coverage.py
+++ b/tests/test_check_patch_coverage.py
@@ -1,0 +1,166 @@
+"""Tests for scripts/check_patch_coverage.py (the local Codecov patch check)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import check_patch_coverage as cpc  # noqa: E402
+
+
+def _write_report(tmp_path: Path, line_rate: str | None) -> Path:
+    attr = "" if line_rate is None else f' line-rate="{line_rate}"'
+    path = tmp_path / "coverage.xml"
+    path.write_text(f"<coverage{attr}><packages/></coverage>")
+    return path
+
+
+class TestOverallLineRate:
+    def test_converts_the_rate_to_a_percentage(self, tmp_path: Path) -> None:
+        assert cpc.overall_line_rate(_write_report(tmp_path, "0.8861")) == pytest.approx(
+            88.61
+        )
+
+    def test_full_coverage_is_a_hundred(self, tmp_path: Path) -> None:
+        assert cpc.overall_line_rate(_write_report(tmp_path, "1")) == 100.0
+
+    def test_a_report_without_the_rate_is_an_error(self, tmp_path: Path) -> None:
+        # A silent 0% target would pass every branch while checking nothing.
+        with pytest.raises(ValueError, match="line-rate"):
+            cpc.overall_line_rate(_write_report(tmp_path, None))
+
+
+class TestMergeBase:
+    def test_prefers_the_remote_main(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            cpc, "_git", lambda *a: subprocess.CompletedProcess(a, 0, "sha1\n", "")
+        )
+        assert cpc.merge_base() == ("origin/main", "sha1")
+
+    def test_falls_back_to_the_local_main(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_git(*args: str) -> subprocess.CompletedProcess:
+            if "origin/main" in args:
+                return subprocess.CompletedProcess(args, 128, "", "no such ref")
+            return subprocess.CompletedProcess(args, 0, "sha2\n", "")
+
+        monkeypatch.setattr(cpc, "_git", fake_git)
+        assert cpc.merge_base() == ("main", "sha2")
+
+    def test_no_main_at_all(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            cpc, "_git", lambda *a: subprocess.CompletedProcess(a, 128, "", "")
+        )
+        assert cpc.merge_base() is None
+
+
+class TestMeasuredFilesChanged:
+    def test_true_when_the_diff_names_a_file(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            cpc,
+            "_git",
+            lambda *a: subprocess.CompletedProcess(a, 0, "calibrate_agent/utils.py\n", ""),
+        )
+        assert cpc.measured_files_changed("sha") is True
+
+    def test_false_when_the_diff_is_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            cpc, "_git", lambda *a: subprocess.CompletedProcess(a, 0, "\n", "")
+        )
+        assert cpc.measured_files_changed("sha") is False
+
+    def test_scopes_the_diff_to_the_measured_directory(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[tuple[str, ...]] = []
+
+        def fake_git(*args: str) -> subprocess.CompletedProcess:
+            seen.append(args)
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        monkeypatch.setattr(cpc, "_git", fake_git)
+        cpc.measured_files_changed("base_sha")
+        assert seen == [("diff", "--name-only", "base_sha", "--", "calibrate_agent")]
+
+
+class TestMain:
+    def test_skips_when_there_is_no_main_branch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(cpc, "merge_base", lambda: None)
+        monkeypatch.setattr(
+            cpc.subprocess, "run", lambda *a, **k: pytest.fail("nothing should run")
+        )
+        assert cpc.main([]) == 0
+
+    def test_skips_when_no_measured_file_changed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(cpc, "merge_base", lambda: ("origin/main", "sha"))
+        monkeypatch.setattr(cpc, "measured_files_changed", lambda base: False)
+        monkeypatch.setattr(
+            cpc.subprocess, "run", lambda *a, **k: pytest.fail("nothing should run")
+        )
+        assert cpc.main([]) == 0
+
+    def test_a_failing_suite_stops_before_the_coverage_check(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(cpc, "merge_base", lambda: ("origin/main", "sha"))
+        monkeypatch.setattr(cpc, "measured_files_changed", lambda base: True)
+        # A usable report, so only the early exit can stop the coverage check.
+        monkeypatch.setattr(cpc, "COVERAGE_XML", _write_report(tmp_path, "0.9"))
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 1)
+
+        monkeypatch.setattr(cpc.subprocess, "run", fake_run)
+        assert cpc.main([]) == 1
+        assert len(calls) == 1
+        assert "pytest" in calls[0]
+
+    def test_missing_report_with_no_tests(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(cpc, "merge_base", lambda: ("origin/main", "sha"))
+        monkeypatch.setattr(cpc, "measured_files_changed", lambda base: True)
+        monkeypatch.setattr(cpc, "COVERAGE_XML", tmp_path / "coverage.xml")
+        assert cpc.main(["--no-tests"]) == 1
+
+    def test_passes_the_overall_coverage_as_the_target(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(cpc, "merge_base", lambda: ("origin/main", "sha"))
+        monkeypatch.setattr(cpc, "measured_files_changed", lambda base: True)
+        monkeypatch.setattr(cpc, "COVERAGE_XML", _write_report(tmp_path, "0.8861"))
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(cpc.subprocess, "run", fake_run)
+        assert cpc.main(["--no-tests"]) == 0
+        assert calls[0][4] == "diff-cover"
+        assert "--compare-branch=origin/main" in calls[0]
+        assert "--fail-under=88.61" in calls[0]
+
+    def test_reports_the_coverage_check_failure(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(cpc, "merge_base", lambda: ("origin/main", "sha"))
+        monkeypatch.setattr(cpc, "measured_files_changed", lambda base: True)
+        monkeypatch.setattr(cpc, "COVERAGE_XML", _write_report(tmp_path, "0.9"))
+        monkeypatch.setattr(
+            cpc.subprocess, "run", lambda cmd, **k: subprocess.CompletedProcess(cmd, 1)
+        )
+        assert cpc.main(["--no-tests"]) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -372,6 +372,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "diff-cover" },
     { name = "ipdb" },
     { name = "ipython" },
     { name = "pytest" },
@@ -384,6 +385,7 @@ dev = [
 requires-dist = [
     { name = "backoff", specifier = ">=2.2.1" },
     { name = "cartesia", specifier = ">=2.0.15,<3" },
+    { name = "diff-cover", marker = "extra == 'dev'", specifier = ">=9.0" },
     { name = "elevenlabs", specifier = ">=2.31.0" },
     { name = "evaluate", specifier = ">=0.4.6" },
     { name = "indic-nlp-library", specifier = ">=0.92" },
@@ -523,6 +525,53 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "chardet"
+version = "7.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/cd61c567092a6cec796144510a68aff158ebfc1df82950a45bae65f28413/chardet-7.6.0.tar.gz", hash = "sha256:93d9df6089ded42ed1fe9f57e272c0b74bd0464d45c0c7d50f09f26f31105c3c", size = 914462, upload-time = "2026-08-14T20:36:59.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/2e/d8634bee23a07bf512512ddf6218a68e47f045ae061c0cc80657ed79dcc0/chardet-7.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6424512f576fa7e88b7431d38a42d57552c8f717465a975fc42e497cd280d833", size = 1088243, upload-time = "2026-08-14T20:36:17.135Z" },
+    { url = "https://files.pythonhosted.org/packages/55/95/bd6d59026638cec47dace85858171fbecadd2f9e58cb2b973dc515aa790c/chardet-7.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:284136186ff90735f901ed0a1c6d41e7af67c666841cc0eceb58482a21b7056c", size = 1068688, upload-time = "2026-08-14T20:36:19.183Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/4a/60ed03656b28c1f4d378bc3cfe8a6cdda62c7c289398f925610fbbabfd00/chardet-7.6.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e9b31b9ae93872d66439b046a1e08c2ea99791f3c254dce1e2633e395c5587c", size = 1487945, upload-time = "2026-08-14T20:36:20.64Z" },
+    { url = "https://files.pythonhosted.org/packages/03/25/9c8db4f951e974a4db5558d9eea62e1fd5b5889c9d0ad0315eed67c5cdb3/chardet-7.6.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aa03322e07ac08d520ec50bb50c73143d0892d1adc067d4c5e58f4ef4b2363a8", size = 1510112, upload-time = "2026-08-14T20:36:22.248Z" },
+    { url = "https://files.pythonhosted.org/packages/76/1b/59eb88a78d8f5855c27c25788088df82834ad067f3dddaf4d86ef03cf2d3/chardet-7.6.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0ad9bc6dab4f338673353fa3f0dc96122f559aaf746087408106e2fcbf132fe8", size = 1462470, upload-time = "2026-08-14T20:36:23.557Z" },
+    { url = "https://files.pythonhosted.org/packages/02/af/46c80c317f9b4dd61f15c33b1e073fbdd64d13c70fe19e34943071dc9e50/chardet-7.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:360260d074d8712ac1e9048fcafb0fdde246f9d0b12555748ad0017c5ecee43d", size = 1157092, upload-time = "2026-08-14T20:36:25.082Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/62/64da80dad0c804e743b4156f379183578f1e33918856ae928dc9248a6002/chardet-7.6.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:19fea52164e6e00f2a21ed418f42e4b0162a09199274c86d07ad3efd661317c4", size = 1094073, upload-time = "2026-08-14T20:36:26.53Z" },
+    { url = "https://files.pythonhosted.org/packages/44/99/934fb862d102c8756008597f4398323f32cef329f16e87fbb3bf76d4f4be/chardet-7.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a12023d48d0e207791c01161d03cb3c0d85c6a15f345eb9d3d56063a63d1e40f", size = 1071612, upload-time = "2026-08-14T20:36:28.067Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e9/b04e0ec576a77e79fe37279a9a5d5b1ae752d365e43df2eca0d0eee4cea5/chardet-7.6.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:249993b88ac7a58cad2781acea8f379152a28a719c9b401d614898c63a8c83da", size = 1489219, upload-time = "2026-08-14T20:36:29.357Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a2/c4d99299e9ce7fad561f8bb56babbbbdd3bb6b4fbd7c0ec674c1dbdd2cc5/chardet-7.6.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2cf0adaca8b1c4bacfade9d0a1e4f8f70b1bb122833d6f07ab90e3adc84eb13a", size = 1518293, upload-time = "2026-08-14T20:36:30.879Z" },
+    { url = "https://files.pythonhosted.org/packages/56/1d/49f13052b74303bab2789d098063cbd19758217949ea54ffa216b6098cb3/chardet-7.6.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cf6d08c2373b7772a558d141f9e8cee53fe1d222341bac612e4d558b04995f73", size = 1459077, upload-time = "2026-08-14T20:36:32.149Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/53/8da1f4758286efd8faf71356facddb382788ecf1bbd7c70d63e2e18a4898/chardet-7.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:406936df1328a3284fef366eaa2bfd1cccd0ef1b10cb99781dd5b022ea644b84", size = 1160778, upload-time = "2026-08-14T20:36:33.436Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/29/16a7419edfbd60e901e6a797cbc3e038cb2a81903bc16c029db755f0156f/chardet-7.6.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:57e6846cc13ce1ff59979f4ec9da770c57e12aa99046073f632de5a51d9a6f20", size = 1088449, upload-time = "2026-08-14T20:36:34.723Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/36/3a14b0f8ddeb302f157281ca656a3ce6874b78e2d6af03682f520b487245/chardet-7.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:089e3bb81a0a07e94f15461ded9f9ee66d349615b1a9fd557d4de1003e2fc12e", size = 1065126, upload-time = "2026-08-14T20:36:36.21Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4c/f59a39c2bfe4ac99baba8da842e8d2ea0b84dff7ba53a96e7ad8c71602d7/chardet-7.6.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:43ea433e43a23c55e8e17f3fad1e07f5cfe5450c73124b95b0d849c21ad379ee", size = 1482492, upload-time = "2026-08-14T20:36:37.649Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/eb/93e8036681157f2217a18769927a035984526e6dbd5e91f28a375ca41c14/chardet-7.6.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b5d31f9b7f793e15e81cca877e7ccd72bffffa2a3443a9d47be9dfee84fad69", size = 1514185, upload-time = "2026-08-14T20:36:39.119Z" },
+    { url = "https://files.pythonhosted.org/packages/10/04/0066d7ab2c135e404a6fa166bb7fa49d1c7bf7af07b86ed95b1c48a348c7/chardet-7.6.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c54b6a8d3b219560fa5cf4c28df932c37471afe047afdc152067104e741f38c1", size = 1454420, upload-time = "2026-08-14T20:36:40.549Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/9f/e965f1d9eddfb86cf118f980d329cbee43c4ac4b562448b369a6b6ef36af/chardet-7.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:b3b4c96c4df93899b3c8b9e8159e06b1f55c66d7ca384d91481108e251a06eb0", size = 1159067, upload-time = "2026-08-14T20:36:41.816Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/78/e14991c9487277ed7d006fff58f3084ac792ed94cced081788abb95df70c/chardet-7.6.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c6061adf247ab5dda173b67010e13904c6071717660c7c8077fb50aca362b264", size = 1087678, upload-time = "2026-08-14T20:36:43.2Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/40/0f95e04cb1820e0a582cd6d86bbf26be8302a94ccf330f8ba5f69735389d/chardet-7.6.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fc1e1571321baf8927582fe34363ad7f02279f11c8c2839c14b4c76894148db6", size = 1065310, upload-time = "2026-08-14T20:36:44.489Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/a1/04404dcc9d6e1253b02583e562d2c7ddca50a7e91f460d62eff7e1d07c92/chardet-7.6.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8900f6c7cf6b015b17a51767cc6144689059ba1cdceaa383d29eb037ac28579e", size = 1485028, upload-time = "2026-08-14T20:36:45.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/88/360064c4c7d9d0664561dae03b74c871d2f5332b329f5c99f1c997fb869a/chardet-7.6.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cedbc584789eb2edfde20fd03669972a833ce6019e60014ae613f9bfc440e8e3", size = 1510242, upload-time = "2026-08-14T20:36:47.206Z" },
+    { url = "https://files.pythonhosted.org/packages/43/4c/302869fa1c69a5a41e4e78782680b12552ffd4286c3ae3c839b7b8df53d4/chardet-7.6.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d5dc835e40e0e09c2c3eab43731a8b5127834f42786dda09ba2f4b699ccd527a", size = 1456456, upload-time = "2026-08-14T20:36:48.668Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a9/ff4fef15ed25fc3f945a3b981ae0f43c8559b3fbedb40267e59e583d105b/chardet-7.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:0f304de7041afaec0195ad6464937cd112392002e9d72ed15d55f20a9abd3a13", size = 1159103, upload-time = "2026-08-14T20:36:50.107Z" },
+    { url = "https://files.pythonhosted.org/packages/31/44/94e6f89485ce6c630e8fec6d388e3fa747e58b7246b0cc8c5c532ba98650/chardet-7.6.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a4f0a368ad04d5def08bdfaa17c7e15e71552f93923dc2aa9b2f7d9dee02fbb6", size = 1120302, upload-time = "2026-08-14T20:36:51.484Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/cd/8e68ba12f13aaf4ee82d54ef8a1f83d62942e7a6bc1e579dd2d530a3e26e/chardet-7.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:75d6c3a4d2046d49e83d2d2206eb073a1f390743e856d90c1bbc19949b26acf4", size = 1093157, upload-time = "2026-08-14T20:36:52.987Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f6/6a35342b9efa69dcceab0ea8966571c6442a59c336bf460f0a2af95ed234/chardet-7.6.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:459e2b1c98f9a86a4698112aa42dffa802bbbff883c1ff144071f87224125862", size = 1521213, upload-time = "2026-08-14T20:36:54.812Z" },
+    { url = "https://files.pythonhosted.org/packages/df/8c/8f09bfabbaedae45caa72b996e96d5e3f6436dfddc55c1311ffa2f6bd7d2/chardet-7.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bdb6f03107b7ace3f44e0edd91aa24456ee558787df265cc19daf45785b31c7", size = 1528427, upload-time = "2026-08-14T20:36:56.224Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/3d/2540627b193112e08b8045f3cad9295570866208555aa6625b63cc69c6cd/chardet-7.6.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:0c44a32da32cc8b23d6b20d98ace15ec7600950e4955d1bf5ab1f849b0187fdb", size = 1087374, upload-time = "2026-08-14T21:04:14.994Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/de/dac4f550cde73c4732b4916e72ec489ae36933fbbd1697e4122d3ae2e9dd/chardet-7.6.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:7bbc8a9652c7f859c593847f220c1d264f25749369abb1a267b404ee8cceb209", size = 1064688, upload-time = "2026-08-14T21:04:16.806Z" },
+    { url = "https://files.pythonhosted.org/packages/06/45/f4f3f288496797d2cf1d1e9036f920ed2b4c79787b21c42a3314f4a6d532/chardet-7.6.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83512a475a2f3886166aa0bca1bbb39343a4eb3186dd5532127d6f2591d09118", size = 1486320, upload-time = "2026-08-14T21:04:18.535Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/81/3ca30c16e6c6015b737fca22d9342957cc617d8a65329d3e963ad754a31b/chardet-7.6.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:271ab71ec1be61dbbce0436de0848895c03eae051c379e937a39573d9ce403d9", size = 1515374, upload-time = "2026-08-14T21:04:20.724Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/98/163a75b8b3372a6b6503f5f5a4154a222ac135c7a706b5d176f8e4b237a2/chardet-7.6.0-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da86fc1b40ff5996fbb5e4c2d2dca770eac2c893cef157dacc050b8b4d929846", size = 1469504, upload-time = "2026-08-14T21:04:22.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/4f/3ad1b1bd27ae7f0d3d13cf711366525cd781a9e067950d8a09aa280916cb/chardet-7.6.0-cp315-cp315-win_amd64.whl", hash = "sha256:b73f277c1ac09c4f8076c4214b816c7aa78a0a2f0cb7156742f4303f856bedc3", size = 1158551, upload-time = "2026-08-14T21:04:24.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/92/22a609c68c5123ebdccd8fe1a80e423609012ce20166de19a2ed3955b2f7/chardet-7.6.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:61238d5945b36af9a2ad13494f8969b7deb3c3b4abe223e54670c064e73f5328", size = 1119186, upload-time = "2026-08-14T21:04:25.761Z" },
+    { url = "https://files.pythonhosted.org/packages/29/35/75a90143e4200e197f4f6cf5895d379e22bc785d0c7711120df18fa5347c/chardet-7.6.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:f2ec3c78cc6b54bf8e091ec4ee885473078b5d7ef18ab1b01c86ae1e98bf88f7", size = 1092596, upload-time = "2026-08-14T21:04:27.884Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/2c/b6d5f47d878c46e04ae6fcb58e0969467925bc0819b333c682e0c41bbc5c/chardet-7.6.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:167d7ba3ee08b654e36d7b43ebd9a36606c9a12e2fabdb361757a095ca3b7e3d", size = 1516644, upload-time = "2026-08-14T21:04:29.624Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d2/2bc3f1066c6f27bc3fa3a98dfd8a2a9c1e969a9d6bdc1edcd35278791fc4/chardet-7.6.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f14f46ef1977e41ce1f4814ca6984cea7f8b6baf8cbc6626ef7bf3d13cf7ea13", size = 1533221, upload-time = "2026-08-14T21:04:31.39Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/6e/5a0b348fa4cd7847567a28c6e697ccf58391960bfd13a6e7473ee23ca2f2/chardet-7.6.0-py3-none-any.whl", hash = "sha256:4076d795897ce45239825956a1334e134322ecc4bfe84dbb12acd5390de0fbc1", size = 680279, upload-time = "2026-08-14T20:36:57.763Z" },
 ]
 
 [[package]]
@@ -924,6 +973,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/29/91/85360d998685fee6b570e12250e5ac74ca43420d5d22b44a865b6c3f2469/deepgram_sdk-6.1.1.tar.gz", hash = "sha256:78726f42b2386f80d9fdd92a22ac59ad5558b6c0475b29bb57273ddaaa344794", size = 202224, upload-time = "2026-03-27T19:59:57.202Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/7f/818ac35b40e38f225858cea38808c7fdd57292553479cabf0bebf7fcdc91/deepgram_sdk-6.1.1-py3-none-any.whl", hash = "sha256:329f45f2a084e8786d3e90d4a4aee630b85cf8770a3b2ee6323bedb176c47113", size = 576299, upload-time = "2026-03-27T19:59:55.949Z" },
+]
+
+[[package]]
+name = "diff-cover"
+version = "10.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "jinja2" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/74/b71a61b2610b5866aa29a9388bc1b58738e49600345dbe0598676b436717/diff_cover-10.5.1.tar.gz", hash = "sha256:f1c9417c62111e40a81c482c692c5cdd131ff93317baa993044cb291912ebba3", size = 113297, upload-time = "2026-08-16T18:09:19.466Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/da/ac0ad341c7377e82f7d6dcb18461029579da224c3923f73ff6537d8591cf/diff_cover-10.5.1-py3-none-any.whl", hash = "sha256:67ce07494e605b5d7d7b04aeec2cf524950ed0c12f026dd176883cf33c74fba0", size = 62924, upload-time = "2026-08-16T18:09:18.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
- Adds `scripts/check_patch_coverage.py`: runs the suite with coverage, then hands `coverage.xml` to `diff-cover` with the run's own overall coverage as the pass mark. That mirrors Codecov's `patch` check, whose target is the base commit's coverage rather than a fixed number. It skips itself when the branch touches nothing under `calibrate_agent/`.
- Runs it from `.githooks/pre-push`, so untested lines are caught before the PR exists instead of after. The hook reads the refs git hands it, so branch deletions and tag pushes skip the suite. `SKIP_COVERAGE=1 git push` bypasses it.
- Adds `diff-cover` to the `dev` extra, and a line in CLAUDE.md and the README telling the agent to run the check before calling work done.

## Notes
- The check covers `calibrate_agent/` only, matching what CI uploads to Codecov. The Ink UI's vitest suite has no coverage reporting and is not included.
- `tests/test_check_patch_coverage.py` covers the percentage parsing, the branch fallback, the skip paths, and the arguments handed to `diff-cover`. Each test was confirmed to fail when the behaviour it checks is broken.
- Verified end to end: adding an untested function to `calibrate_agent/utils.py` fails the check and names the lines (`Missing lines 2420-2422`, 25% against a target of 88.58%), removing it passes.