### PR TITLE
Point docs links at docs.calibrate.artpark.ai

### DIFF
--- a/.cursor/rules/app-details.md
+++ b/.cursor/rules/app-details.md
@@ -958,7 +958,7 @@ cd docs
 mintlify dev
 ```
 
-**README.md** is intentionally minimal — it provides installation, links to the CLI docs on the docs site, and local docs setup instructions. All detailed usage documentation lives in `docs/` and on [docs.calibrate.dev](https://docs.calibrate.dev).
+**README.md** is intentionally minimal — it provides installation, links to the CLI docs on the docs site, and local docs setup instructions. All detailed usage documentation lives in `docs/` and on [docs.calibrate.artpark.ai](https://docs.calibrate.artpark.ai).
 
 ---
 
@@ -1045,7 +1045,7 @@ When resuming an evaluation (not using `--overwrite`), the eval scripts validate
 
 1. **Language selection** — user picks a language first
 2. **Provider selection** — only providers that support the chosen language are shown (filtered using `languages` in `providers.ts`, derived from the STT/TTS language dictionaries in `calibrate_agent/utils.py`). Uses `STT_PROVIDERS` or `TTS_PROVIDERS` based on mode.
-3. **Input path** — for TTS: path to `id,text` CSV file; for STT: path to directory containing `stt.csv` and `audios/`. **Full validation** runs before proceeding (CSV columns, audio file existence). A documentation link is displayed below the input prompt pointing to the relevant docs page (`https://calibrate.artpark.ai/cli/speech-to-text` or `https://calibrate.artpark.ai/cli/text-to-speech`).
+3. **Input path** — for TTS: path to `id,text` CSV file; for STT: path to directory containing `stt.csv` and `audios/`. **Full validation** runs before proceeding (CSV columns, audio file existence). A documentation link is displayed below the input prompt pointing to the relevant docs page (`https://docs.calibrate.artpark.ai/cli/speech-to-text` or `https://docs.calibrate.artpark.ai/cli/text-to-speech`).
 4. **Output directory** — optional, defaults to `./out`. **Prompts for overwrite confirmation** if provider directories already contain data. If confirmed, `--overwrite` is passed to the eval CLI.
 5. **API key setup** — checks `~/.calibrate_agent/credentials.json` and env vars; only prompts for missing keys; always requires `OPENAI_API_KEY` for the LLM judge
 6. **Evaluation** — The Ink UI's `RunStep` component spawns `calibrate <mode> -p <provider> ...` for each provider individually via `child_process.spawn`. **Max 2 providers run in parallel** to balance speed vs resource usage. Port availability is checked before starting each provider. The last provider's eval includes `--leaderboard` flag to generate the leaderboard. **Parallel provider logs are displayed side-by-side in vertical columns** (not stacked rows) for easy comparison. Real-time log streaming is enabled via `PYTHONUNBUFFERED=1` environment variable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,8 @@ Guidance for Claude Code when working in this repository.
 for voice agents. It benchmarks LLMs, STT providers, TTS providers, and runs
 agent simulations — all from a single CLI / Python library.
 
-- Website / docs: https://calibrate.artpark.ai
+- Website: https://calibrate.artpark.ai
+- Docs: https://docs.calibrate.artpark.ai
 - Built on top of [pipecat](https://github.com/pipecat-ai/pipecat).
 - The CLI entry point is `calibrate-agent` (defined in `pyproject.toml:scripts` →
   `calibrate_agent.cli:main`).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ calibrate-agent llm          # Interactive LLM evaluation
 calibrate-agent simulations  # Interactive text or voice simulations
 ```
 
-- [CLI Documentation](https://calibrate.artpark.ai/docs/cli/overview)
+- [CLI Documentation](https://docs.calibrate.artpark.ai/cli/overview)
 
 ## Contributing
 

--- a/calibrate_agent/ui/cli.bundle.mjs
+++ b/calibrate_agent/ui/cli.bundle.mjs
@@ -49226,7 +49226,7 @@ function SimulationsApp({ onBack }) {
                   if (hasAgentUrl && config.type === "voice") {
                     setConfigInput("");
                     setInitError(
-                      "Agent connection is not supported for voice simulations. Use a calibrate agent config instead (https://calibrate.artpark.ai/docs/cli/simulations#set-up-your-agent) with the system prompts, tools, etc. defined in the config itself."
+                      "Agent connection is not supported for voice simulations. Use a calibrate agent config instead (https://docs.calibrate.artpark.ai/cli/simulations#set-up-your-agent) with the system prompts, tools, etc. defined in the config itself."
                     );
                     return;
                   }
@@ -50111,7 +50111,7 @@ function ConfigInputStep({
   };
   const label = mode2 === "tts" ? "Input CSV" : "Input directory";
   const hint = mode2 === "tts" ? "CSV file with id and text columns. Press enter to confirm." : "Directory containing audio files and stt.csv. Press enter to confirm.";
-  const docsUrl = mode2 === "tts" ? "https://calibrate.artpark.ai/docs/cli/text-to-speech" : "https://calibrate.artpark.ai/docs/cli/speech-to-text";
+  const docsUrl = mode2 === "tts" ? "https://docs.calibrate.artpark.ai/cli/text-to-speech" : "https://docs.calibrate.artpark.ai/cli/speech-to-text";
   return /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(Box_default, { flexDirection: "column", padding: 1, children: [
     /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(Box_default, { marginBottom: 1, children: /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(Text, { bold: true, color: "cyan", children: "Configuration" }) }),
     /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(Box_default, { children: [
@@ -50251,7 +50251,7 @@ function ConfigFileStep({
     }
     onComplete(trimmed);
   };
-  const docsUrl = mode2 === "tts" ? "https://calibrate.artpark.ai/docs/cli/text-to-speech" : "https://calibrate.artpark.ai/docs/cli/speech-to-text";
+  const docsUrl = mode2 === "tts" ? "https://docs.calibrate.artpark.ai/cli/text-to-speech" : "https://docs.calibrate.artpark.ai/cli/speech-to-text";
   return /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(Box_default, { flexDirection: "column", padding: 1, children: [
     /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(Box_default, { marginBottom: 1, children: /* @__PURE__ */ (0, import_jsx_runtime4.jsx)(Text, { bold: true, color: "cyan", children: "Evaluator config (optional)" }) }),
     /* @__PURE__ */ (0, import_jsx_runtime4.jsxs)(Box_default, { children: [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dev = [
 ]
 
 [project.urls]
-Documentation = "https://calibrate.artpark.ai/docs"
+Documentation = "https://docs.calibrate.artpark.ai"
 
 [project.scripts]
 calibrate-agent = "calibrate_agent.cli:main"

--- a/ui/source/app.tsx
+++ b/ui/source/app.tsx
@@ -460,8 +460,8 @@ function ConfigInputStep({
       : "Directory containing audio files and stt.csv. Press enter to confirm.";
   const docsUrl =
     mode === "tts"
-      ? "https://calibrate.artpark.ai/docs/cli/text-to-speech"
-      : "https://calibrate.artpark.ai/docs/cli/speech-to-text";
+      ? "https://docs.calibrate.artpark.ai/cli/text-to-speech"
+      : "https://docs.calibrate.artpark.ai/cli/speech-to-text";
 
   return (
     <Box flexDirection="column" padding={1}>
@@ -663,8 +663,8 @@ function ConfigFileStep({
 
   const docsUrl =
     mode === "tts"
-      ? "https://calibrate.artpark.ai/docs/cli/text-to-speech"
-      : "https://calibrate.artpark.ai/docs/cli/speech-to-text";
+      ? "https://docs.calibrate.artpark.ai/cli/text-to-speech"
+      : "https://docs.calibrate.artpark.ai/cli/speech-to-text";
 
   return (
     <Box flexDirection="column" padding={1}>

--- a/ui/source/sim-app.tsx
+++ b/ui/source/sim-app.tsx
@@ -1012,7 +1012,7 @@ export function SimulationsApp({ onBack }: { onBack?: () => void }) {
                   if (hasAgentUrl && config.type === "voice") {
                     setConfigInput("");
                     setInitError(
-                      "Agent connection is not supported for voice simulations. Use a calibrate agent config instead (https://calibrate.artpark.ai/docs/cli/simulations#set-up-your-agent) with the system prompts, tools, etc. defined in the config itself.",
+                      "Agent connection is not supported for voice simulations. Use a calibrate agent config instead (https://docs.calibrate.artpark.ai/cli/simulations#set-up-your-agent) with the system prompts, tools, etc. defined in the config itself.",
                     );
                     return;
                   }


### PR DESCRIPTION
## What
- Docs moved to their own subdomain; `calibrate.artpark.ai` now refers to the app itself.
- Updated docs links in the terminal UI, README, `pyproject.toml`, and internal notes to `docs.calibrate.artpark.ai`.
- Regenerated the bundled UI file (`calibrate_agent/ui/cli.bundle.mjs`) so it matches the source.

## Notes
Also fixed a stale `docs.calibrate.dev` reference in `.cursor/rules/app-details.md` that predated this rename.